### PR TITLE
Don't add duplicates to recent files

### DIFF
--- a/trview/UserSettings.cpp
+++ b/trview/UserSettings.cpp
@@ -3,6 +3,7 @@
 
 #include <ShlObj.h>
 #include <fstream>
+#include <algorithm>
 
 namespace trview
 {
@@ -25,6 +26,14 @@ namespace trview
 
     void UserSettings::add_recent_file(const std::wstring& file)
     {
+        // If the file already exists in the recent files list, remove it from where it is
+        // and move it to the to avoid duplicates and to make it ordered by most recent.
+        auto existing = std::find(recent_files.begin(), recent_files.end(), file);
+        if (existing != recent_files.end())
+        {
+            recent_files.erase(existing);
+        }
+
         recent_files.push_front(file);
         if (recent_files.size() > MaxRecentFiles)
         {


### PR DESCRIPTION
If the file being added to recent files is already in the list, remove it from where it is.
It then adds it to the front as normal.
This means that there are no duplicates and it is sorted most recent -> least recent.
#57