### PR TITLE
Static meshes now take into account room highlight

### DIFF
--- a/trview/Mesh.cpp
+++ b/trview/Mesh.cpp
@@ -181,7 +181,7 @@ namespace trview
 
     }
 
-    void Mesh::render(CComPtr<ID3D11DeviceContext> context, const DirectX::XMMATRIX& world_view_projection, const ILevelTextureStorage& texture_storage)
+    void Mesh::render(CComPtr<ID3D11DeviceContext> context, const DirectX::XMMATRIX& world_view_projection, const ILevelTextureStorage& texture_storage, const DirectX::XMFLOAT4& colour)
     {
         // There are no vertices.
         if (!_vertex_buffer)
@@ -200,7 +200,6 @@ namespace trview
             DirectX::XMFLOAT4 colour;
         };
 
-        XMFLOAT4 colour{ 1,1,1,1 };
         Data data{ world_view_projection, colour };
 
         context->Map(_matrix_buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped_resource);

--- a/trview/Mesh.h
+++ b/trview/Mesh.h
@@ -15,7 +15,7 @@ namespace trview
     public:
         explicit Mesh(const trlevel::tr_mesh& mesh, CComPtr<ID3D11Device> device, const ILevelTextureStorage& texture_storage);
 
-        void render(CComPtr<ID3D11DeviceContext> context, const DirectX::XMMATRIX& world_view_projection, const ILevelTextureStorage& texture_storage);
+        void render(CComPtr<ID3D11DeviceContext> context, const DirectX::XMMATRIX& world_view_projection, const ILevelTextureStorage& texture_storage, const DirectX::XMFLOAT4& colour);
     private:
         CComPtr<ID3D11Buffer>              _vertex_buffer;
         std::vector<uint32_t>              _index_counts;

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -138,7 +138,7 @@ namespace trview
 
         for (const auto& mesh : _static_meshes)
         {
-            mesh->render(context, view_projection, texture_storage);
+            mesh->render(context, view_projection, texture_storage, colour);
         }
     }
 

--- a/trview/StaticMesh.cpp
+++ b/trview/StaticMesh.cpp
@@ -16,11 +16,11 @@ namespace trview
         _position = XMVectorSet(static_mesh.x / 1024.0f, static_mesh.y / -1024.0f, static_mesh.z / 1024.0f, 1);
     }
 
-    void StaticMesh::render(CComPtr<ID3D11DeviceContext> context, const DirectX::XMMATRIX& view_projection, const ILevelTextureStorage& texture_storage)
+    void StaticMesh::render(CComPtr<ID3D11DeviceContext> context, const DirectX::XMMATRIX& view_projection, const ILevelTextureStorage& texture_storage, const DirectX::XMFLOAT4& colour)
     {
         using namespace DirectX;
         auto world_view_projection = 
             XMMatrixMultiply(XMMatrixMultiply(XMMatrixRotationY(_rotation),XMMatrixTranslationFromVector(_position)), view_projection);
-        _mesh->render(context, world_view_projection, texture_storage);
+        _mesh->render(context, world_view_projection, texture_storage, colour);
     }
 }

--- a/trview/StaticMesh.h
+++ b/trview/StaticMesh.h
@@ -17,7 +17,7 @@ namespace trview
     public:
         StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, Mesh* mesh);
 
-        void render(CComPtr<ID3D11DeviceContext> context, const DirectX::XMMATRIX& view_projection, const ILevelTextureStorage& texture_storage);
+        void render(CComPtr<ID3D11DeviceContext> context, const DirectX::XMMATRIX& view_projection, const ILevelTextureStorage& texture_storage, const DirectX::XMFLOAT4& colour);
     private:
         float             _rotation;
         DirectX::XMVECTOR _position;


### PR DESCRIPTION
Pass colour through to static mesh render function so that room highlighting can be appropriately applied.
Also works with neighbour mode.
#59