### PR TITLE
Create the neighbours control

### DIFF
--- a/trview/Neighbours.cpp
+++ b/trview/Neighbours.cpp
@@ -1,0 +1,43 @@
+#include "stdafx.h"
+#include "Neighbours.h"
+
+#include "ITextureStorage.h"
+
+#include <trview.ui/Control.h>
+#include <trview.ui/GroupBox.h>
+#include <trview.ui/Button.h>
+#include <trview.ui/Label.h>
+#include <trview.ui/NumericUpDown.h>
+
+namespace trview
+{
+    Neighbours::Neighbours(ui::Control& parent, const ITextureStorage& texture_storage)
+    {
+        using namespace ui;
+
+        auto red = texture_storage.coloured(0xff0000ff);
+        auto green = texture_storage.coloured(0xff00ff00);
+
+        auto group = std::make_unique<GroupBox>(Point(), Size(140, 50), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Neighbours");
+        auto enabled = std::make_unique<Button>(Point(12, 20), Size(16, 16), red, green);
+        enabled->on_click += [&](bool value) { on_enabled_changed(value); };
+        _enabled = enabled.get();
+
+        auto depth_label = std::make_unique<Label>(Point(32, 20), Size(40, 16), Colour(1.0f, 0.5f, 0.5f, 0.5f), L"Depth", 10.f, TextAlignment::Left, ParagraphAlignment::Centre);
+        auto depth = std::make_unique<NumericUpDown>(Point(90, 16), Size(40, 20), Colour(1.0f, 0.4f, 0.4f, 0.4f), red, green, 0, 10);
+        depth->set_value(1);
+        depth->on_value_changed += [&](int value) { on_depth_changed(value); };
+
+        group->add_child(std::move(enabled));
+        group->add_child(std::move(depth_label));
+        group->add_child(std::move(depth));
+        parent.add_child(std::move(group));
+    }
+
+    // Set whether neighbours are enabled. This will not raise the on_enabled_changed event.
+    // value: Whether neighbours are enabled.
+    void Neighbours::set_enabled(bool value)
+    {
+        _enabled->set_state(value);
+    }
+}

--- a/trview/Neighbours.h
+++ b/trview/Neighbours.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <trview.common/Event.h>
+#include <cstdint>
+
+namespace trview
+{
+    namespace ui
+    {
+        class Control;
+        class Button;
+    }
+
+    struct ITextureStorage;
+
+    // The neighbours control has settings for whether neighbour mode is enabled and to allow
+    // the user to select the depth of neighbours to display.
+    class Neighbours
+    {
+    public:
+        Neighbours(ui::Control& control, const ITextureStorage& texture_storage);
+
+        // Event raised when the user has enabled or disabled neighbour mode.
+        // enabled: Whether neighbours mode is enabled.
+        Event<bool> on_enabled_changed;
+
+        // Event raised when the user has changed the depth of neighbour to display.
+        // depth: The new depth.
+        Event<uint32_t> on_depth_changed;
+
+        // Set whether neighbours are enabled. This will not raise the on_enabled_changed event.
+        // value: Whether neighbours are enabled.
+        void set_enabled(bool value);
+    private:
+        ui::Button* _enabled;
+    };
+}

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -5,7 +5,6 @@
 #include <atlbase.h>
 #include <cstdint>
 
-#include <vector>
 #include <string>
 #include <memory>
 
@@ -27,7 +26,6 @@
 
 #include <trview.input/Keyboard.h>
 #include <trview.input/Mouse.h>
-#include <trview.ui/Control.h>
 
 #include <trview.ui.render/Renderer.h>
 #include <trview.ui.render/FontFactory.h>
@@ -36,13 +34,13 @@ namespace trview
 {
     namespace ui
     {
+        class Control;
         class Label;
-        class Button;
-        class NumericUpDown;
     }
 
     class RoomNavigator;
     class CameraControls;
+    class Neighbours;
     struct ITextureStorage;
 
     class Viewer
@@ -71,10 +69,7 @@ namespace trview
         Event<std::list<std::wstring>> on_recent_files_changed;
     private:
         void generate_ui();
-
         void generate_tool_window();
-
-        std::unique_ptr<ui::Window> generate_neighbours_window();
 
         void initialise_d3d();
         void initialise_input();
@@ -87,8 +82,6 @@ namespace trview
         void render_scene();
         // Draw the user interface elements of the scene.
         void render_ui();
-
-        Texture create_coloured_texture(uint32_t colour);
 
         void select_room(uint32_t room);
 
@@ -135,8 +128,6 @@ namespace trview
         std::unique_ptr<ui::Control> _control;
         std::unique_ptr<ui::render::Renderer> _ui_renderer;
 
-        ui::Button* _room_neighbours;
-
         CameraMode _camera_mode{ CameraMode::Orbit };
         bool _free_forward{ false };
         bool _free_left{ false };
@@ -145,9 +136,9 @@ namespace trview
         bool _free_up{ false };
         bool _free_down{ false };
 
-        // Room nav
         std::unique_ptr<RoomNavigator> _room_navigator;
         std::unique_ptr<CameraControls> _camera_controls;
+        std::unique_ptr<Neighbours> _neighbours;
         std::unique_ptr<ITextureStorage> _texture_storage;
 
         UserSettings _settings;

--- a/trview/trview.vcxproj
+++ b/trview/trview.vcxproj
@@ -163,6 +163,7 @@
     <ClInclude Include="Level.h" />
     <ClInclude Include="Mesh.h" />
     <ClInclude Include="MeshStorage.h" />
+    <ClInclude Include="Neighbours.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="Room.h" />
     <ClInclude Include="RoomInfo.h" />
@@ -191,6 +192,7 @@
     <ClCompile Include="Level.cpp" />
     <ClCompile Include="Mesh.cpp" />
     <ClCompile Include="MeshStorage.cpp" />
+    <ClCompile Include="Neighbours.cpp" />
     <ClCompile Include="Room.cpp" />
     <ClCompile Include="RoomNavigator.cpp" />
     <ClCompile Include="UserSettings.cpp" />

--- a/trview/trview.vcxproj.filters
+++ b/trview/trview.vcxproj.filters
@@ -121,6 +121,9 @@
     <ClInclude Include="CameraMode.h">
       <Filter>Program\Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Neighbours.h">
+      <Filter>Program\Windows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Viewer.cpp">
@@ -187,6 +190,9 @@
       <Filter>Program</Filter>
     </ClCompile>
     <ClCompile Include="CameraControls.cpp">
+      <Filter>Program\Windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Neighbours.cpp">
       <Filter>Program\Windows</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
Create a neighbours class to create and manage the UI for neighbours.
All UI code moved from viewer.
Deleted create_coloured_texture as it is now done by ITextureStorage.coloured (has been for a while, but neighbours used it).
Also tidied up includes in Viewer.h/cpp.
#68 