### PR TITLE
Don't parse floordata when there isn't any

### DIFF
--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -363,6 +363,12 @@ namespace trview
 
             uint32_t index = sector.floordata_index;
 
+            // There's no floordata for this sector.
+            if (index == 0)
+            {
+                continue;
+            }
+
             bool end_data = false;
 
             do


### PR DESCRIPTION
Fixes a problem where incorrect neighbours get added.
#81