### PR TITLE
Fix a bug where if there are no transparent triangles, it crashes

### DIFF
--- a/trview/TransparencyBuffer.cpp
+++ b/trview/TransparencyBuffer.cpp
@@ -33,7 +33,7 @@ namespace trview
 
     void TransparencyBuffer::render(CComPtr<ID3D11DeviceContext> context, const ICamera& camera, const ILevelTextureStorage& texture_storage)
     {
-        if (!_triangles.size())
+        if (!_vertices.size())
         {
             return;
         }
@@ -79,6 +79,11 @@ namespace trview
     void TransparencyBuffer::create_buffer()
     {
         _vertex_buffer = nullptr;
+
+        if (_vertices.empty())
+        {
+            return;
+        }
 
         // Generate the buffers.
         D3D11_BUFFER_DESC vertex_desc;


### PR DESCRIPTION
Do not try to create a buffer when there are no vertices
#98