### PR TITLE
Reset the flip checkbox when opening a level

### DIFF
--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -509,6 +509,7 @@ namespace trview
         // Reset UI buttons
         _room_navigator->set_max_rooms(rooms.size());
         _room_navigator->set_highlight(false);
+        _room_navigator->set_flip(false);
         select_room(0);
 
         _neighbours->set_enabled(false);


### PR DESCRIPTION
This stops it getting out of sync when it is enabled and another level is loaded.
#115