### PR TITLE
Check if level is null in flip hotkey

### DIFF
--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -274,7 +274,10 @@ namespace trview
                 }
                 case 'P':
                 {
-                    set_alternate_mode(!_level->alternate_mode());
+                    if (_level)
+                    {
+                        set_alternate_mode(!_level->alternate_mode());
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
Only do something if there is a level loaded.
Issue: #146