### PR TITLE
Create event for file load and tie it up to populate switch level

### DIFF
--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -488,6 +488,7 @@ namespace trview
             return;
         }
 
+        on_file_loaded(filename);
         _settings.add_recent_file(filename);
         on_recent_files_changed(_settings.recent_files);
         save_user_settings(_settings);

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -74,6 +74,7 @@ namespace trview
         void toggle_highlight();
 
         UserSettings settings() const;
+        Event<std::wstring> on_file_loaded;
         Event<std::list<std::wstring>> on_recent_files_changed;
 
         // Resize the window and the rendering system.

--- a/trview/trview.cpp
+++ b/trview/trview.cpp
@@ -154,6 +154,8 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     SetCurrentDirectory(get_exe_directory().c_str());
 
     viewer = std::make_unique<trview::Viewer>(window);
+    // Register to know when a file has been succesfully loaded by the viewer.
+    viewer->on_file_loaded += populate_directory_listing_menu;
     // Register for future updates to the recent files list.
     viewer->on_recent_files_changed += update_menu;
     // Make sure the menu has the values loaded from the settings file.
@@ -227,7 +229,6 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
                     memset(&filename, 0, sizeof(filename));
                     DragQueryFile((HDROP)msg.wParam, 0, filename, MAX_PATH);
                     viewer->open(filename);
-                    populate_directory_listing_menu(filename);
                     break;
                 }
             }
@@ -319,7 +320,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                 {
                     const auto file = recent_files[index];
                     viewer->open(file);
-                    populate_directory_listing_menu(file);
                 }
                 break;
             }
@@ -360,8 +360,6 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                 {
                     SetCurrentDirectory(cd);
                     viewer->open(ofn.lpstrFile);
-
-                    populate_directory_listing_menu(ofn.lpstrFile);
                 }
                 break;
             } 


### PR DESCRIPTION
This way switch level always knows about the level load and doesn't get set up when the level fails to load.
#144