### PR TITLE
Fix the issue with the timer returning incorrect values

### DIFF
--- a/trview.common/Timer.cpp
+++ b/trview.common/Timer.cpp
@@ -37,11 +37,14 @@ namespace trview
         LARGE_INTEGER frequency;
         QueryPerformanceFrequency(&frequency);
 
-        return [frequency]()
+        LARGE_INTEGER start;
+        QueryPerformanceCounter(&start);
+
+        return [frequency, start]()
         {
             LARGE_INTEGER tick;
             QueryPerformanceCounter(&tick);
-            return static_cast<float>(tick.QuadPart) / frequency.QuadPart;
+            return static_cast<float>(tick.QuadPart - start.QuadPart) / static_cast<float>(frequency.QuadPart);
         };
     }
 }


### PR DESCRIPTION
It was applying a frequency to an absolute value rather than to a difference of two values.
Keep track of when we started counting in order to get a delta value.
Fixes #209 