### PR TITLE
Move file drop logic to FileDropper trview.app

### DIFF
--- a/trview.app.tests/FileDropperTests.cpp
+++ b/trview.app.tests/FileDropperTests.cpp
@@ -1,0 +1,70 @@
+#include "CppUnitTest.h"
+
+#include <trview.app/FileDropper.h>
+#include <trview.tests.common/Window.h>
+#include <shellapi.h>
+#include <ShlObj.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace Microsoft
+{
+    namespace VisualStudio
+    {
+        namespace CppUnitTestFramework
+        {
+            std::wstring ToString(LONG_PTR ptr)
+            {
+                return std::to_wstring(ptr);
+            }
+        }
+    }
+}
+
+namespace trview
+{
+    namespace tests
+    {
+        TEST_CLASS(FileDropperTests)
+        {
+            // Tests that sending a dropfile message to the dropper raises the event.
+            TEST_METHOD(DropFile)
+            {
+                HWND window = create_test_window(L"TRViewFileDropperTests");
+                FileDropper dropper(window);
+
+                uint32_t times_called = 0;
+                std::wstring file_opened;
+                dropper.on_file_dropped += [&](const auto& file)
+                {
+                    ++times_called;
+                    file_opened = file;
+                };
+
+                std::string filename("test_filename");
+                // +2 for the double null terminated list of names.
+                HGLOBAL global = GlobalAlloc(GHND, sizeof(DROPFILES) + filename.size() + 2);
+                DROPFILES* dropfiles = static_cast<DROPFILES*>(GlobalLock(global));
+                dropfiles->pFiles = sizeof(DROPFILES);
+                strcpy_s(reinterpret_cast<char*>(dropfiles + 1), filename.size() + 1, filename.c_str());
+                GlobalUnlock(global);
+
+                dropper.process_message(window, WM_DROPFILES, (WPARAM)global, 0);
+
+                GlobalFree(global);
+
+                Assert::AreEqual(1u, times_called);
+                Assert::AreEqual(std::wstring(L"test_filename"), file_opened);
+            }
+
+            // Tests that the class enables drag and drop
+            TEST_METHOD(EnableDragDrop)
+            {
+                HWND window = create_test_window(L"TRViewFileDropperTests");
+                FileDropper dropper(window);
+                LONG_PTR style = GetWindowLongPtr(window, GWL_EXSTYLE);
+                Assert::AreEqual<LONG_PTR>(WS_EX_ACCEPTFILES, style & WS_EX_ACCEPTFILES);
+            }
+        };
+    }
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="FileDropperTests.cpp" />
     <ClCompile Include="RecentFilesTests.cpp" />
     <ClCompile Include="WindowResizerTests.cpp" />
   </ItemGroup>

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -3,5 +3,6 @@
   <ItemGroup>
     <ClCompile Include="WindowResizerTests.cpp" />
     <ClCompile Include="RecentFilesTests.cpp" />
+    <ClCompile Include="FileDropperTests.cpp" />
   </ItemGroup>
 </Project>

--- a/trview.app/FileDropper.cpp
+++ b/trview.app/FileDropper.cpp
@@ -1,0 +1,22 @@
+#include "FileDropper.h"
+
+namespace trview
+{
+    FileDropper::FileDropper(HWND window)
+        : MessageHandler(window)
+    {
+        // Makes this window accept dropped files.
+        DragAcceptFiles(window, TRUE);
+    }
+
+    void FileDropper::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    {
+        if(message == WM_DROPFILES)
+        {
+            wchar_t filename[MAX_PATH];
+            memset(&filename, 0, sizeof(filename));
+            DragQueryFile((HDROP)wParam, 0, filename, MAX_PATH);
+            on_file_dropped(filename);
+        }
+    }
+}

--- a/trview.app/FileDropper.h
+++ b/trview.app/FileDropper.h
@@ -1,0 +1,33 @@
+/// @file FileDropper.h
+/// @brief When the user drags a file on to the window this will raise the appropriate event.
+
+#pragma once
+
+#include <trview.common/MessageHandler.h>
+#include <trview.common/Event.h>
+#include <string>
+
+namespace trview
+{
+    /// Raises events when the user drops a file on to the window.
+    class FileDropper final : public MessageHandler
+    {
+    public:
+        /// Create a new FileDropper.
+        /// @param window The window that the user can drop files on to.
+        explicit FileDropper(HWND window);
+
+        /// Destructor for FileDropper.
+        virtual ~FileDropper() = default;
+
+        /// Handles a window message.
+        /// @param window The window that received the message.
+        /// @param message The message that was received.
+        /// @param wParam The WPARAM for the message.
+        /// @param lParam The LPARAM for the message.
+        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+
+        /// Event raised when the user drops a file on to the window. The file dropped is passed as a parameter.
+        Event<std::wstring> on_file_dropped;
+    };
+}

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -19,10 +19,12 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="FileDropper.cpp" />
     <ClCompile Include="RecentFiles.cpp" />
     <ClCompile Include="WindowResizer.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="FileDropper.h" />
     <ClInclude Include="RecentFiles.h" />
     <ClInclude Include="WindowIDs.h" />
     <ClInclude Include="WindowResizer.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -3,10 +3,12 @@
   <ItemGroup>
     <ClCompile Include="WindowResizer.cpp" />
     <ClCompile Include="RecentFiles.cpp" />
+    <ClCompile Include="FileDropper.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="WindowResizer.h" />
     <ClInclude Include="RecentFiles.h" />
     <ClInclude Include="WindowIDs.h" />
+    <ClInclude Include="FileDropper.h" />
   </ItemGroup>
 </Project>

--- a/trview.common/MessageHandler.cpp
+++ b/trview.common/MessageHandler.cpp
@@ -58,6 +58,7 @@ namespace trview
         _window = other._window;
         _subclass_id = next_subclass_id(_window);
         SetWindowSubclass(_window, HandlerProc, _subclass_id, reinterpret_cast<DWORD_PTR>(this));
+        return *this;
     }
 
     MessageHandler& MessageHandler::operator=(MessageHandler&& other)
@@ -65,6 +66,7 @@ namespace trview
         _window = other._window;
         _subclass_id = other._subclass_id;
         SetWindowSubclass(_window, HandlerProc, _subclass_id, reinterpret_cast<DWORD_PTR>(this));
+        return *this;
     }
 
     MessageHandler::~MessageHandler()

--- a/trview.common/Window.cpp
+++ b/trview.common/Window.cpp
@@ -27,6 +27,11 @@ namespace trview
         return _window;
     }
 
+    Window::operator HWND () const
+    {
+        return _window;
+    }
+
     // Get the position of the cursor in client coordinates.
     // window: The client window.
     // Returns: The point in client coordinates.

--- a/trview.common/Window.h
+++ b/trview.common/Window.h
@@ -14,6 +14,7 @@ namespace trview
         uint32_t width() const;
         uint32_t height() const;
         HWND window() const;
+        operator HWND () const;
     private:
         HWND        _window;
         uint32_t    _width;

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -29,8 +29,8 @@ namespace trview
 {
     Viewer::Viewer(Window window)
         : _window(window), _camera(window.width(), window.height()), _free_camera(window.width(), window.height()),
-        _timer(default_time_source()), _keyboard(window.window()), _mouse(window.window()), _device(window),
-        _level_switcher(window.window()), _window_resizer(window.window()), _recent_files(window.window())
+        _timer(default_time_source()), _keyboard(window), _mouse(window), _device(window), _level_switcher(window),
+        _window_resizer(window), _recent_files(window), _file_dropper(window)
     {
         _settings = load_user_settings();
 
@@ -42,6 +42,8 @@ namespace trview
         _recent_files.on_file_open += [=](const auto& file) { open(file); };
         _recent_files.set_recent_files(_settings.recent_files);
         on_recent_files_changed += [&](const auto& files) { _recent_files.set_recent_files(files); };
+
+        _file_dropper.on_file_dropped += [&](const auto& file) { open(file); };
 
         initialise_input();
 

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -26,6 +26,7 @@
 #include "LevelSwitcher.h"
 #include <trview.app/WindowResizer.h>
 #include <trview.app/RecentFiles.h>
+#include <trview.app/FileDropper.h>
 
 namespace trview
 {
@@ -145,6 +146,7 @@ namespace trview
         LevelSwitcher _level_switcher;
         WindowResizer _window_resizer;
         RecentFiles _recent_files;
+        FileDropper _file_dropper;
     };
 }
 

--- a/trview/trview.cpp
+++ b/trview/trview.cpp
@@ -64,8 +64,6 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     SetCurrentDirectory(get_exe_directory().c_str());
 
     viewer = std::make_unique<trview::Viewer>(window);
-    // Makes this window accept dropped files.
-    DragAcceptFiles(window, TRUE);
 
     // Open the level passed in on the command line, if there is one.
     int number_of_arguments = 0;
@@ -91,18 +89,6 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
             {
                 TranslateMessage(&msg);
                 DispatchMessage(&msg);
-            }
-
-            switch (msg.message)
-            {
-                case WM_DROPFILES:
-                {
-                    wchar_t filename[MAX_PATH];
-                    memset(&filename, 0, sizeof(filename));
-                    DragQueryFile((HDROP)msg.wParam, 0, filename, MAX_PATH);
-                    viewer->open(filename);
-                    break;
-                }
             }
         }
 


### PR DESCRIPTION
Moved to the trview.app project.
Added tests in the trview.app.tests project.
Fixed MessageHandler copy and move constructors not returning a value (only broke debug builds, probably because they aren't used yet).
Add FileDropper to Viewer
Add HWND operator to Window to make the Viewer initialization list shorter.
Issues: #220