### PR TITLE
Add a shortcut to open a file

### DIFF
--- a/trview/resource.h
+++ b/trview/resource.h
@@ -38,6 +38,7 @@
 #define ID_EXIT                         32773
 #define ID_FILE_SWITCHLEVEL             32774
 #define ID_HELP_GITHUB                  32776
+#define ID_ACCEL_FILE_OPEN              32777
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
@@ -46,7 +47,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        149
-#define _APS_NEXT_COMMAND_VALUE         32777
+#define _APS_NEXT_COMMAND_VALUE         32779
 #define _APS_NEXT_CONTROL_VALUE         1000
 #define _APS_NEXT_SYMED_VALUE           110
 #endif

--- a/trview/trview.cpp
+++ b/trview/trview.cpp
@@ -177,6 +177,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                 DialogBox(hInst, MAKEINTRESOURCE(IDD_ABOUTBOX), hWnd, About);
                 break;
             case ID_FILE_OPEN:
+            case ID_ACCEL_FILE_OPEN:
             {
                 wchar_t cd[MAX_PATH];
                 GetCurrentDirectoryW(MAX_PATH, cd);

--- a/trview/trview.rc
+++ b/trview/trview.rc
@@ -45,7 +45,7 @@ IDC_TRVIEW MENU
 BEGIN
     POPUP "&File"
     BEGIN
-        MENUITEM "Open",                        ID_FILE_OPEN
+        MENUITEM "Open\tCtrl+O",                ID_FILE_OPEN
         MENUITEM "Open Recent",                 ID_FILE_OPENRECENT
         MENUITEM "Switch &Level",               ID_FILE_SWITCHLEVEL
         MENUITEM "E&xit",                       IDM_EXIT
@@ -65,8 +65,9 @@ END
 
 IDC_TRVIEW ACCELERATORS
 BEGIN
-    "?",            IDM_ABOUT,              ASCII,  ALT
-    "/",            IDM_ABOUT,              ASCII,  ALT
+    "/",            IDM_ABOUT,              ASCII,  ALT, NOINVERT
+    "?",            IDM_ABOUT,              ASCII,  ALT, NOINVERT
+    "^O",           ID_ACCEL_FILE_OPEN,     ASCII,  NOINVERT
 END
 
 


### PR DESCRIPTION
#238 - Ctrl + O to open a level file.

The NOINVERT attributes were added automatically, but according to [this](https://docs.microsoft.com/en-us/windows/desktop/menurc/accelerators-resource) they're obsolete, so I don't think it matters.