### PR TITLE
Split Device class up to allow for rendering to multiple windows

### DIFF
--- a/trview.app/WindowResizer.cpp
+++ b/trview.app/WindowResizer.cpp
@@ -40,7 +40,7 @@ namespace trview
     bool WindowResizer::has_size_changed()
     {
         Size new_size = Window(window()).size();
-        if (new_size.width == _previous_size.width && new_size.height == _previous_size.height)
+        if (new_size == _previous_size)
         {
             return false;
         }

--- a/trview.app/WindowResizer.cpp
+++ b/trview.app/WindowResizer.cpp
@@ -3,7 +3,7 @@
 namespace trview
 {
     WindowResizer::WindowResizer(HWND window)
-        : MessageHandler(window)
+        : MessageHandler(window), _previous_size(window)
     {
     }
 
@@ -18,7 +18,7 @@ namespace trview
             }
             case WM_SIZE:
             {
-                if (!_resizing && (wParam == SIZE_MAXIMIZED || wParam == SIZE_RESTORED))
+                if (!_resizing && (wParam == SIZE_MAXIMIZED || wParam == SIZE_RESTORED) && has_size_changed())
                 {
                     on_resize();
                 }
@@ -27,9 +27,23 @@ namespace trview
             case WM_EXITSIZEMOVE:
             {
                 _resizing = false;
-                on_resize();
+                if (has_size_changed())
+                {
+                    on_resize();
+                }
                 break;
             }
         }
+    }
+
+    bool WindowResizer::has_size_changed()
+    {
+        Window new_size{ window() };
+        if (new_size.width() == _previous_size.width() && new_size.height() == _previous_size.height())
+        {
+            return false;
+        }
+        _previous_size = new_size;
+        return true;
     }
 }

--- a/trview.app/WindowResizer.cpp
+++ b/trview.app/WindowResizer.cpp
@@ -1,9 +1,10 @@
 #include "WindowResizer.h"
+#include <trview.common/Window.h>
 
 namespace trview
 {
     WindowResizer::WindowResizer(HWND window)
-        : MessageHandler(window), _previous_size(window)
+        : MessageHandler(window), _previous_size(Window(window).size())
     {
     }
 
@@ -38,8 +39,8 @@ namespace trview
 
     bool WindowResizer::has_size_changed()
     {
-        Window new_size{ window() };
-        if (new_size.width() == _previous_size.width() && new_size.height() == _previous_size.height())
+        Size new_size = Window(window()).size();
+        if (new_size.width == _previous_size.width && new_size.height == _previous_size.height)
         {
             return false;
         }

--- a/trview.app/WindowResizer.h
+++ b/trview.app/WindowResizer.h
@@ -6,6 +6,7 @@
 
 #include <trview.common/MessageHandler.h>
 #include <trview.common/Event.h>
+#include <trview.common/Window.h>
 
 namespace trview
 {
@@ -30,6 +31,9 @@ namespace trview
         /// Event that is raised when the window has resized.
         Event<> on_resize;
     private:
+        bool has_size_changed();
+
         bool _resizing{ false };
+        Window _previous_size;
     };
 }

--- a/trview.app/WindowResizer.h
+++ b/trview.app/WindowResizer.h
@@ -6,7 +6,7 @@
 
 #include <trview.common/MessageHandler.h>
 #include <trview.common/Event.h>
-#include <trview.common/Window.h>
+#include <trview.common/Size.h>
 
 namespace trview
 {
@@ -34,6 +34,6 @@ namespace trview
         bool has_size_changed();
 
         bool _resizing{ false };
-        Window _previous_size;
+        Size _previous_size;
     };
 }

--- a/trview.common/Size.cpp
+++ b/trview.common/Size.cpp
@@ -33,4 +33,9 @@ namespace trview
     {
         return Size(width / divisor, height / divisor);
     }
+
+    bool Size::operator==(const Size& size) const
+    {
+        return width == size.width && height == size.height;
+    }
 }

--- a/trview.common/Size.h
+++ b/trview.common/Size.h
@@ -38,6 +38,10 @@ namespace trview
         /// @returns The new size.
         Size operator/(float divisor) const;
 
+        /// Determines whether two sizes are equal.
+        /// @param size The size to compare.
+        bool operator==(const Size& size) const;
+
         float width, height;
     };
 }

--- a/trview.common/Window.cpp
+++ b/trview.common/Window.cpp
@@ -6,20 +6,13 @@ namespace trview
     Window::Window(HWND window)
         : _window(window)
     {
+    }
+
+    Size Window::size() const
+    {
         RECT rectangle;
         GetClientRect(_window, &rectangle);
-        _width = rectangle.right - rectangle.left;
-        _height = rectangle.bottom - rectangle.top;
-    }
-
-    uint32_t Window::width() const
-    {
-        return _width;
-    }
-
-    uint32_t Window::height() const
-    {
-        return _height;
+        return Size(rectangle.right - rectangle.left, rectangle.bottom - rectangle.top);
     }
 
     HWND Window::window() const
@@ -49,7 +42,8 @@ namespace trview
     bool cursor_outside_window(const Window& window) noexcept
     {
         const Point cursor_pos = client_cursor_position(window);
-        return cursor_pos.x < 0 || cursor_pos.y < 0 || cursor_pos.x > window.width() || cursor_pos.y > window.height();
+        const Size size = window.size();
+        return cursor_pos.x < 0 || cursor_pos.y < 0 || cursor_pos.x > size.width || cursor_pos.y > size.height;
     }
 
     // Determines whether the window is minimsed.

--- a/trview.common/Window.h
+++ b/trview.common/Window.h
@@ -2,7 +2,7 @@
 
 #include <Windows.h>
 #include <cstdint>
-
+#include "Size.h"
 #include "Point.h"
 
 namespace trview
@@ -11,8 +11,7 @@ namespace trview
     {
     public:
         Window(HWND window);
-        uint32_t width() const;
-        uint32_t height() const;
+        Size size() const;
         HWND window() const;
         operator HWND () const;
     private:

--- a/trview.graphics/Device.h
+++ b/trview.graphics/Device.h
@@ -17,24 +17,20 @@ namespace trview
     namespace graphics
     {
         class RenderTarget;
+        class DeviceWindow;
 
         /// Wraps the D3D device and manages common D3D operations.
         class Device final
         {
         public:
-            /// Create a new device to render to the specified window.
-            /// @param window The window to render to.
-            Device(const Window& window);
+            /// Create a new device.
+            Device();
 
             /// Destructor for the Device class.
             ~Device();
 
-            /// Begin rendering to the main render target.
+            /// Begin rendering.
             void begin();
-
-            /// Clear the render target with the specified colour.
-            /// @param colour The colour to with which to clear the render target.
-            void clear(const DirectX::SimpleMath::Color& colour);
 
             /// Gets the D3D device interface.
             /// @returns The D3D device interface.
@@ -44,22 +40,15 @@ namespace trview
             /// @returns The D3D device context.
             const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context() const;
 
-            /// Presents the rendered output to the swap chain.
-            /// @param vsync Whether vsync is enabled.
-            void present(bool vsync);
-
-            /// Resizes the device and any associated resources.
-            void resize();
+            /// Create a device window to render to a specific window.
+            /// @param window The window to render to.
+            /// @returns The device window object.
+            std::unique_ptr<DeviceWindow> create_for_window(HWND window) const;
         private:
-            /// Create the render target based on the current swap chain.
-            void create_render_target();
-
-            Microsoft::WRL::ComPtr<IDXGISwapChain>      _swap_chain;
             Microsoft::WRL::ComPtr<ID3D11Device>        _device;
             Microsoft::WRL::ComPtr<ID3D11DeviceContext> _context;
             Microsoft::WRL::ComPtr<ID3D11BlendState>    _blend_state;
             Microsoft::WRL::ComPtr<ID3D11DepthStencilState> _depth_stencil_state;
-            std::unique_ptr<graphics::RenderTarget>     _render_target;
         };
     }
 }

--- a/trview.graphics/DeviceWindow.cpp
+++ b/trview.graphics/DeviceWindow.cpp
@@ -15,8 +15,8 @@ namespace trview
             DXGI_SWAP_CHAIN_DESC swap_chain_desc{};
             swap_chain_desc.BufferCount = 1;
             swap_chain_desc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
-            swap_chain_desc.BufferDesc.Height = window.height();
-            swap_chain_desc.BufferDesc.Width = window.width();
+            swap_chain_desc.BufferDesc.Height = static_cast<uint32_t>(window.size().height);
+            swap_chain_desc.BufferDesc.Width = static_cast<uint32_t>(window.size().width);
             swap_chain_desc.BufferDesc.RefreshRate.Numerator = 1;
             swap_chain_desc.BufferDesc.RefreshRate.Denominator = 60;
             swap_chain_desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;

--- a/trview.graphics/DeviceWindow.cpp
+++ b/trview.graphics/DeviceWindow.cpp
@@ -1,0 +1,72 @@
+#include "DeviceWindow.h"
+#include "RenderTarget.h"
+#include "Device.h"
+
+using namespace Microsoft::WRL;
+
+namespace trview
+{
+    namespace graphics
+    {
+        DeviceWindow::DeviceWindow(const Device& device, const Window& window)
+            : _device(device.device()), _context(device.context())
+        {
+            // Swap chain description.
+            DXGI_SWAP_CHAIN_DESC swap_chain_desc{};
+            swap_chain_desc.BufferCount = 1;
+            swap_chain_desc.BufferDesc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+            swap_chain_desc.BufferDesc.Height = window.height();
+            swap_chain_desc.BufferDesc.Width = window.width();
+            swap_chain_desc.BufferDesc.RefreshRate.Numerator = 1;
+            swap_chain_desc.BufferDesc.RefreshRate.Denominator = 60;
+            swap_chain_desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+            swap_chain_desc.OutputWindow = window.window();
+            swap_chain_desc.Windowed = TRUE;
+            swap_chain_desc.SwapEffect = DXGI_SWAP_EFFECT_DISCARD;
+            swap_chain_desc.SampleDesc.Count = 1;
+            swap_chain_desc.SampleDesc.Quality = 0;
+
+            ComPtr<IDXGIDevice> dxgi_device;
+            _device.As(&dxgi_device);
+            ComPtr<IDXGIAdapter> dxgi_adapter;
+            dxgi_device->GetAdapter(&dxgi_adapter);
+            ComPtr<IDXGIFactory> factory;
+            dxgi_adapter->GetParent(__uuidof(IDXGIFactory), &factory);
+            factory->CreateSwapChain(_device.Get(), &swap_chain_desc, &_swap_chain);
+
+            create_render_target();
+        }
+
+        // Create the render target view from the swap chain that has been created.
+        void DeviceWindow::create_render_target()
+        {
+            ComPtr<ID3D11Texture2D> back_buffer;
+            _swap_chain->GetBuffer(0, __uuidof(ID3D11Texture2D), reinterpret_cast<void**>(back_buffer.GetAddressOf()));
+            _render_target = std::make_unique<graphics::RenderTarget>(_device, back_buffer, graphics::RenderTarget::DepthStencilMode::Enabled);
+        }
+
+        void DeviceWindow::begin()
+        {
+            _render_target->apply(_context);
+        }
+
+        void DeviceWindow::clear(const DirectX::SimpleMath::Color& colour)
+        {
+            _render_target->clear(_context, colour);
+        }
+
+        void DeviceWindow::resize()
+        {
+            _context->ClearState();
+            _render_target.reset();
+
+            _swap_chain->ResizeBuffers(0, 0, 0, DXGI_FORMAT_UNKNOWN, 0);
+            create_render_target();
+        }
+
+        void DeviceWindow::present(bool vsync)
+        {
+            _swap_chain->Present(vsync ? 1 : 0, 0);
+        }
+    }
+}

--- a/trview.graphics/DeviceWindow.h
+++ b/trview.graphics/DeviceWindow.h
@@ -1,0 +1,50 @@
+/// @file DeviceWindow.h
+/// @brief Wraps the D3D resources for rendering to a window.
+
+#pragma once
+
+#include <memory>
+#include <wrl/client.h>
+#include <d3d11.h>
+#include <trview.common/Window.h>
+#include <trview.common/Colour.h>
+
+namespace trview
+{
+    namespace graphics
+    {
+        class RenderTarget;
+        class Device;
+
+        /// Wraps the D3D resources for rendering to a window.
+        class DeviceWindow final
+        {
+        public:
+            /// Create a new device window.
+            /// @param device The device to use to render.
+            /// @param window The window to render to.
+            explicit DeviceWindow(const Device& device, const Window& window);
+
+            /// Begin rendering to the main render target.
+            void begin();
+
+            /// Clear the render target with the specified colour.
+            /// @param colour The colour to with which to clear the render target.
+            void clear(const DirectX::SimpleMath::Color& colour);
+
+            /// Presents the rendered output to the swap chain.
+            /// @param vsync Whether vsync is enabled.
+            void present(bool vsync);
+
+            /// Resizes the device and any associated resources.
+            void resize();
+        private:
+            void create_render_target();
+
+            Microsoft::WRL::ComPtr<ID3D11Device> _device;
+            Microsoft::WRL::ComPtr<ID3D11DeviceContext> _context;
+            Microsoft::WRL::ComPtr<IDXGISwapChain> _swap_chain;
+            std::unique_ptr<RenderTarget> _render_target;
+        };
+    }
+}

--- a/trview.graphics/RenderTarget.cpp
+++ b/trview.graphics/RenderTarget.cpp
@@ -118,5 +118,10 @@ namespace trview
         {
             return _height;
         }
+
+        Size RenderTarget::size() const
+        {
+            return Size(static_cast<float>(_width), static_cast<float>(_height));
+        }
     }
 }

--- a/trview.graphics/RenderTarget.h
+++ b/trview.graphics/RenderTarget.h
@@ -4,6 +4,7 @@
 #include <d3d11.h>
 #include <wrl/client.h>
 #include <SimpleMath.h>
+#include <trview.common/Size.h>
 #include <memory>
 
 #include "Texture.h"
@@ -67,6 +68,10 @@ namespace trview
             // Get the height of the render target in pixels.
             // Returns: The height.
             uint32_t height() const;
+
+            // Get the size of the render target in pixels.
+            // Returns: The size of the render target.
+            Size size() const;
         private:
             Texture _texture;
             Microsoft::WRL::ComPtr<ID3D11RenderTargetView>   _view;

--- a/trview.graphics/Sprite.cpp
+++ b/trview.graphics/Sprite.cpp
@@ -25,8 +25,8 @@ namespace trview
             };
         }
 
-        Sprite::Sprite(const ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, uint32_t width, uint32_t height)
-            : _host_width(width), _host_height(height)
+        Sprite::Sprite(const ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const Size& host_size)
+            : _host_size(host_size)
         {
             using namespace DirectX::SimpleMath;
 
@@ -84,10 +84,9 @@ namespace trview
             create_matrix(device);
         }
 
-        void Sprite::set_host_size(uint32_t width, uint32_t height)
+        void Sprite::set_host_size(const Size& size)
         {
-            _host_width = width;
-            _host_height = height;
+            _host_size = size;
         }
 
         void Sprite::render(const ComPtr<ID3D11DeviceContext>& context, const Texture& texture, float x, float y, float width, float height, DirectX::SimpleMath::Color colour)
@@ -137,10 +136,10 @@ namespace trview
             // Need to scale the quad so that it is a certain size. Will need to know the 
             // size of the host window as well as the size that we want the texture window
             // to be. Then create a scaling matrix and throw it in to the shader.
-            auto scaling = Matrix::CreateScale(width / _host_width, height / _host_height, 1);
+            auto scaling = Matrix::CreateScale(width / _host_size.width, height / _host_size.height, 1);
 
             // Try to make the appropriate translation matrix to move it to the top left of the screen.
-            auto translation = Matrix::CreateTranslation(-1.f + width / _host_width + (x * 2) / _host_width, 1.f - height / _host_height - (y * 2) / _host_height, 0);
+            auto translation = Matrix::CreateTranslation(-1.f + width / _host_size.width + (x * 2) / _host_size.width, 1.f - height / _host_size.height - (y * 2) / _host_size.height, 0);
 
             Data data{ scaling * translation, colour };
 
@@ -149,14 +148,9 @@ namespace trview
             context->Unmap(_matrix_buffer.Get(), 0);
         }
 
-        uint32_t Sprite::host_width() const
+        Size Sprite::host_size() const
         {
-            return _host_width;
-        }
-
-        uint32_t Sprite::host_height() const 
-        {
-            return _host_height;
+            return _host_size;
         }
     }
 }

--- a/trview.graphics/Sprite.h
+++ b/trview.graphics/Sprite.h
@@ -3,6 +3,7 @@
 #include <wrl/client.h>
 #include <d3d11.h>
 #include <cstdint>
+#include <trview.common/Size.h>
 
 #include <SimpleMath.h>
 
@@ -17,15 +18,13 @@ namespace trview
         class Sprite
         {
         public:
-            Sprite(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const uint32_t width, uint32_t height);
+            Sprite(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const Size& host_size);
 
             void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, const Texture& texture, float x, float y, float width, float height, DirectX::SimpleMath::Color colour = { 1,1,1,1 });
 
-            uint32_t host_width() const;
+            Size host_size() const;
 
-            uint32_t host_height() const;
-
-            void set_host_size(uint32_t width, uint32_t height);
+            void set_host_size(const Size& size);
 
             Sprite(const Sprite&) = delete;
             Sprite& operator=(const Sprite&) = delete;
@@ -40,8 +39,7 @@ namespace trview
             Microsoft::WRL::ComPtr<ID3D11Buffer>       _matrix_buffer;
             graphics::IShader*          _vertex_shader;
             graphics::IShader*          _pixel_shader;
-            uint32_t                    _host_width;
-            uint32_t                    _host_height;
+            Size                        _host_size;
         };
     }
 }

--- a/trview.graphics/SpriteSizeStore.cpp
+++ b/trview.graphics/SpriteSizeStore.cpp
@@ -8,19 +8,18 @@ namespace trview
         // Begin a sprite size store operation, setting the sprite to the new size specified
         // after storing the old host size for later restoration.
         // sprite: The sprite to operate on.
-        // new_width: The new host width of the sprite.
-        // new_height: The new host height of the sprite.
-        SpriteSizeStore::SpriteSizeStore(Sprite& sprite, uint32_t new_width, uint32_t new_height)
-            : _sprite(sprite), _width(sprite.host_width()), _height(sprite.host_height())
+        // new_size: The new host size of the sprite.
+        SpriteSizeStore::SpriteSizeStore(Sprite& sprite, const Size& new_size)
+            : _sprite(sprite), _size(sprite.host_size())
         {
-            _sprite.set_host_size(new_width, new_height);
+            _sprite.set_host_size(new_size);
         }
 
         // When this executes it will restore the host size of the sprite to what it was when
         // the SpriteSizeStore was created.
         SpriteSizeStore::~SpriteSizeStore()
         {
-            _sprite.set_host_size(_width, _height);
+            _sprite.set_host_size(_size);
         }
     }
 }

--- a/trview.graphics/SpriteSizeStore.h
+++ b/trview.graphics/SpriteSizeStore.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <trview.common/Size.h>
 
 namespace trview
 {
@@ -16,17 +17,15 @@ namespace trview
             // Begin a sprite size store operation, setting the sprite to the new size specified
             // after storing the old host size for later restoration.
             // sprite: The sprite to operate on.
-            // new_width: The new host width of the sprite.
-            // new_height: The new host height of the sprite.
-            explicit SpriteSizeStore(Sprite& sprite, uint32_t new_width, uint32_t new_height);
+            // new_size: The new host size of the sprite.
+            explicit SpriteSizeStore(Sprite& sprite, const Size& new_size);
 
             // When this executes it will restore the host size of the sprite to what it was when
             // the SpriteSizeStore was created.
             ~SpriteSizeStore();
         private:
             Sprite& _sprite;
-            uint32_t _width;
-            uint32_t _height;
+            Size _size;
         };
     }
 }

--- a/trview.graphics/trview.graphics.vcxproj
+++ b/trview.graphics/trview.graphics.vcxproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ClInclude Include="DepthStencil.h" />
     <ClInclude Include="Device.h" />
+    <ClInclude Include="DeviceWindow.h" />
     <ClInclude Include="Font.h" />
     <ClInclude Include="FontFactory.h" />
     <ClInclude Include="IShader.h" />
@@ -40,6 +41,7 @@
   <ItemGroup>
     <ClCompile Include="DepthStencil.cpp" />
     <ClCompile Include="Device.cpp" />
+    <ClCompile Include="DeviceWindow.cpp" />
     <ClCompile Include="Font.cpp" />
     <ClCompile Include="FontFactory.cpp" />
     <ClCompile Include="IShaderStorage.cpp" />

--- a/trview.graphics/trview.graphics.vcxproj.filters
+++ b/trview.graphics/trview.graphics.vcxproj.filters
@@ -52,6 +52,9 @@
     <ClInclude Include="TextAlignment.h">
       <Filter>Font</Filter>
     </ClInclude>
+    <ClInclude Include="DeviceWindow.h">
+      <Filter>Device</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="IShaderStorage.cpp">
@@ -97,6 +100,9 @@
       <Filter>Font</Filter>
     </ClCompile>
     <ClCompile Include="Device.cpp">
+      <Filter>Device</Filter>
+    </ClCompile>
+    <ClCompile Include="DeviceWindow.cpp">
       <Filter>Device</Filter>
     </ClCompile>
   </ItemGroup>

--- a/trview.ui.render/ButtonNode.cpp
+++ b/trview.ui.render/ButtonNode.cpp
@@ -34,7 +34,7 @@ namespace trview
 
                 graphics::RenderTargetStore rt_store(context);
                 graphics::ViewportStore vp_store(context);
-                graphics::SpriteSizeStore s_store(sprite, _render_target->width(), _render_target->height());
+                graphics::SpriteSizeStore s_store(sprite, _render_target->size());
                 _render_target->apply(context);
 
                 sprite.render(context, _blank, thickness, thickness, _button->size().width - 2.0f * thickness, _button->size().height - 2.0f * thickness,

--- a/trview.ui.render/ImageNode.cpp
+++ b/trview.ui.render/ImageNode.cpp
@@ -28,7 +28,7 @@ namespace trview
                 {
                     graphics::RenderTargetStore rt_store(context);
                     graphics::ViewportStore vp_store(context);
-                    graphics::SpriteSizeStore s_store(sprite, _render_target->width(), _render_target->height());
+                    graphics::SpriteSizeStore s_store(sprite, _render_target->size());
                     _render_target->apply(context);
 
                     auto size = _image->size();

--- a/trview.ui.render/MapRenderer.cpp
+++ b/trview.ui.render/MapRenderer.cpp
@@ -12,11 +12,11 @@ namespace trview
     {
         namespace render
         {
-            MapRenderer::MapRenderer(const ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, int width, int height)
+            MapRenderer::MapRenderer(const ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const Size& window_size)
                 : _device(device),
-                _window_width(width), 
-                _window_height(height),
-                _sprite(device, shader_storage, width, height)
+                _window_width(static_cast<int>(window_size.width)), 
+                _window_height(static_cast<int>(window_size.height)),
+                _sprite(device, shader_storage, window_size)
             {
                 TextureStorage texture_storage{ device };
                 _texture = texture_storage.coloured(0xFFFFFFFF);
@@ -38,7 +38,7 @@ namespace trview
                     graphics::RenderTargetStore rs_store(context);
                     graphics::ViewportStore vp_store(context);
                     // Set the host size to match the render target as we will have adjusted the viewport.
-                    graphics::SpriteSizeStore s_store(_sprite, _render_target->width(), _render_target->height());
+                    graphics::SpriteSizeStore s_store(_sprite, _render_target->size());
 
                     _render_target->apply(context);
                     render_internal(context);
@@ -171,11 +171,11 @@ namespace trview
             }
 
             void 
-            MapRenderer::set_window_size(int width, int height)
+            MapRenderer::set_window_size(const Size& size)
             {
-                _window_width = width;
-                _window_height = height;
-                _sprite.set_host_size(width, height);
+                _window_width = static_cast<int>(size.width);
+                _window_height = static_cast<int>(size.height);
+                _sprite.set_host_size(size);
                 update_map_position();
             }
 

--- a/trview.ui.render/MapRenderer.h
+++ b/trview.ui.render/MapRenderer.h
@@ -60,7 +60,7 @@ namespace trview
             class MapRenderer
             {
             public:
-                MapRenderer(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, int width, int height);
+                MapRenderer(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const Size& window_size);
 
                 // Renders the map 
                 void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context);
@@ -87,7 +87,7 @@ namespace trview
                 inline bool loaded() const { return _loaded; }
 
                 // Set the size of the host window.
-                void set_window_size(int width, int height);
+                void set_window_size(const Size& size);
             private:
                 // Determines the position (on screen) to draw a sector 
                 Point get_position(const Sector& sector); 

--- a/trview.ui.render/RenderNode.cpp
+++ b/trview.ui.render/RenderNode.cpp
@@ -54,7 +54,7 @@ namespace trview
 
                 graphics::RenderTargetStore render_target_store(context);
                 graphics::ViewportStore vp_store(context);
-                graphics::SpriteSizeStore s_store(sprite, _render_target->width(), _render_target->height());
+                graphics::SpriteSizeStore s_store(sprite, _render_target->size());
                 _render_target->apply(context);
 
                 render_self(context, sprite);

--- a/trview.ui.render/Renderer.cpp
+++ b/trview.ui.render/Renderer.cpp
@@ -18,12 +18,11 @@ namespace trview
     {
         namespace render
         {
-            Renderer::Renderer(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, uint32_t host_width, uint32_t host_height)
+            Renderer::Renderer(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const Size& host_size)
                 : _device(device), 
                 _font_factory(font_factory),
-                _sprite(std::make_unique<graphics::Sprite>(device, shader_storage, host_width, host_height)),
-                _host_width(host_width), 
-                _host_height(host_height)
+                _sprite(std::make_unique<graphics::Sprite>(device, shader_storage, host_size)),
+                _host_size(host_size)
             {
                 D3D11_DEPTH_STENCIL_DESC ui_depth_stencil_desc;
                 memset(&ui_depth_stencil_desc, 0, sizeof(ui_depth_stencil_desc));
@@ -98,19 +97,17 @@ namespace trview
                     auto texture = _root_node->node_texture();
                     if (texture.can_use_as_resource())
                     {
-                        _sprite->render(context, texture, 0, 0, static_cast<float>(_host_width), static_cast<float>(_host_height));
+                        _sprite->render(context, texture, 0, 0, _host_size.width, _host_size.height);
                     }
                 }
             }
 
             // Set the size of the host render area.
-            // width: The width of the render area.
-            // height: The height of the render area.
-            void Renderer::set_host_size(uint32_t width, uint32_t height)
+            // size: The size of the render area
+            void Renderer::set_host_size(const Size& size)
             {
-                _host_width = width;
-                _host_height = height;
-                _sprite->set_host_size(width, height);
+                _host_size = size;
+                _sprite->set_host_size(size);
             }
         }
     }

--- a/trview.ui.render/Renderer.h
+++ b/trview.ui.render/Renderer.h
@@ -25,7 +25,7 @@ namespace trview
             class Renderer
             {
             public:
-                explicit Renderer(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, uint32_t host_width, uint32_t host_height);
+                explicit Renderer(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const Size& host_size);
 
                 ~Renderer();
 
@@ -37,9 +37,8 @@ namespace trview
                 void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context);
 
                 // Set the size of the host render area.
-                // width: The width of the render area.
-                // height: The height of the render area.
-                void set_host_size(uint32_t width, uint32_t height);
+                // width: The size of the render area.
+                void set_host_size(const Size& size);
             private:
                 std::unique_ptr<RenderNode> process_control(Control* control);
 
@@ -48,8 +47,7 @@ namespace trview
                 Microsoft::WRL::ComPtr<ID3D11Device>            _device;
                 Microsoft::WRL::ComPtr<ID3D11DepthStencilState> _depth_stencil_state;
                 const graphics::FontFactory&                    _font_factory;
-                uint32_t                                        _host_width;
-                uint32_t                                        _host_height;
+                Size                                            _host_size;
             };
         }
     }

--- a/trview/Camera.cpp
+++ b/trview/Camera.cpp
@@ -11,9 +11,9 @@ namespace trview
         const float min_zoom = 0.1f;
     }
 
-    Camera::Camera(uint32_t width, uint32_t height)
+    Camera::Camera(const Size& size)
     {
-        calculate_projection_matrix(width, height);
+        calculate_projection_matrix(size);
     }
 
     DirectX::SimpleMath::Vector3 Camera::target() const
@@ -36,10 +36,10 @@ namespace trview
         return _zoom;
     }
 
-    void Camera::calculate_projection_matrix(uint32_t width, uint32_t height)
+    void Camera::calculate_projection_matrix(const Size& size)
     {
         using namespace DirectX;
-        float aspect_ratio = static_cast<float>(width) / static_cast<float>(height);
+        float aspect_ratio = size.width / size.height;
         _projection = XMMatrixPerspectiveFovLH(XM_PIDIV4, aspect_ratio, 0.1f, 10000.0f);
         _view_projection = _view * _projection;
     }
@@ -128,8 +128,8 @@ namespace trview
         return to;
     }
 
-    void Camera::set_view_size(uint32_t width, uint32_t height)
+    void Camera::set_view_size(const Size& size)
     {
-        calculate_projection_matrix(width, height);
+        calculate_projection_matrix(size);
     }
 }

--- a/trview/Camera.h
+++ b/trview/Camera.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trview.common/Size.h>
+
 #include "ICamera.h"
 
 namespace trview
@@ -7,7 +9,7 @@ namespace trview
     class Camera : public ICamera
     {
     public:
-        Camera(uint32_t width, uint32_t height);
+        explicit Camera(const Size& size);
         virtual ~Camera() = default;
         float rotation_yaw() const override;
         float rotation_pitch() const override;
@@ -26,11 +28,10 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 forward() const override;
 
         // Set the dimensions of the render target for the camera.
-        // width: The width in pixels of the render target.
-        // height: The width in height of the render target.
-        void set_view_size(uint32_t width, uint32_t height);
+        // size: The size in pixels of the render target.
+        void set_view_size(const Size& size);
     private:
-        void calculate_projection_matrix(uint32_t width, uint32_t height);
+        void calculate_projection_matrix(const Size& size);
         void calculate_view_matrix();
 
         const float default_pitch = 0.78539f;

--- a/trview/FreeCamera.cpp
+++ b/trview/FreeCamera.cpp
@@ -5,16 +5,16 @@
 
 namespace trview
 {
-    FreeCamera::FreeCamera(uint32_t width, uint32_t height)
+    FreeCamera::FreeCamera(const Size& size)
     {
         calculate_view_matrix();
-        calculate_projection_matrix(width, height);
+        calculate_projection_matrix(size);
     }
 
-    void FreeCamera::calculate_projection_matrix(uint32_t width, uint32_t height)
+    void FreeCamera::calculate_projection_matrix(const Size& size)
     {
         using namespace DirectX;
-        float aspect_ratio = static_cast<float>(width) / static_cast<float>(height);
+        float aspect_ratio = size.width / size.height;
         _projection = XMMatrixPerspectiveFovLH(XM_PIDIV4, aspect_ratio, 0.1f, 10000.0f);
         _view_projection = _view * _projection;
     }
@@ -131,10 +131,9 @@ namespace trview
     }
 
     // Set the dimensions of the render target for the camera.
-    // width: The width in pixels of the render target.
-    // height: The width in height of the render target.
-    void FreeCamera::set_view_size(uint32_t width, uint32_t height)
+    // size: The size in pixels of the render target.
+    void FreeCamera::set_view_size(const Size& size)
     {
-        calculate_projection_matrix(width, height);
+        calculate_projection_matrix(size);
     }
 }

--- a/trview/FreeCamera.h
+++ b/trview/FreeCamera.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trview.common/Size.h>
+
 #include <cstdint>
 #include "ICamera.h"
 #include "CameraMode.h"
@@ -15,7 +17,7 @@ namespace trview
             Axis
         };
 
-        FreeCamera(uint32_t width, uint32_t height);
+        explicit FreeCamera(const Size& size);
         virtual ~FreeCamera() = default;
         void move(DirectX::SimpleMath::Vector3 movement);
         virtual DirectX::SimpleMath::Matrix   view() const override;
@@ -38,11 +40,10 @@ namespace trview
         void set_alignment(Alignment alignment);
 
         // Set the dimensions of the render target for the camera.
-        // width: The width in pixels of the render target.
-        // height: The width in height of the render target.
-        void set_view_size(uint32_t width, uint32_t height);
+        // size: The size in pixels of the render target.
+        void set_view_size(const Size& size);
     private:
-        void calculate_projection_matrix(uint32_t width, uint32_t height);
+        void calculate_projection_matrix(const Size& size);
         void calculate_view_matrix();
 
         DirectX::SimpleMath::Matrix _view;

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -30,8 +30,8 @@
 
 namespace trview
 {
-    Viewer::Viewer(Window window)
-        : _window(window), _camera(window.width(), window.height()), _free_camera(window.width(), window.height()),
+    Viewer::Viewer(const Window& window)
+        : _window(window), _camera(window.size()), _free_camera(window.size()),
         _timer(default_time_source()), _keyboard(window), _mouse(window), _level_switcher(window),
         _window_resizer(window), _recent_files(window), _file_dropper(window)
     {
@@ -42,7 +42,11 @@ namespace trview
         _level_switcher.on_switch_level += [=](const auto& file) { open(file); };
         on_file_loaded += [&](const auto& file) { _level_switcher.open_file(file); };
 
-        _window_resizer.on_resize += [=]() { resize(); };
+        _window_resizer.on_resize += [=]()
+        {
+            _main_window->resize();
+            resize_elements();
+        };
 
         _recent_files.on_file_open += [=](const auto& file) { open(file); };
         _recent_files.set_recent_files(_settings.recent_files);
@@ -78,7 +82,7 @@ namespace trview
     {
         // Create the user interface window. At the moment this is going to be a bar on the side, 
         // but this can change over time. For now make a really boring gray window.
-        _control = std::make_unique<ui::Window>(Point(), Size(static_cast<float>(_window.width()), static_cast<float>(_window.height())), Colour(0.f, 0.f, 0.f, 0.f)); 
+        _control = std::make_unique<ui::Window>(Point(), _window.size(), Colour(0.f, 0.f, 0.f, 0.f)); 
         _control->set_handles_input(false);
 
         generate_tool_window();
@@ -123,10 +127,10 @@ namespace trview
         _settings_window->set_invert_map_controls(_settings.invert_map_controls);
 
         // Create the renderer for the UI based on the controls created.
-        _ui_renderer = std::make_unique<ui::render::Renderer>(_device.device(), *_shader_storage.get(), *_font_factory.get(), _window.width(), _window.height());
+        _ui_renderer = std::make_unique<ui::render::Renderer>(_device.device(), *_shader_storage.get(), *_font_factory.get(), _window.size());
         _ui_renderer->load(_control.get());
 
-        _map_renderer = std::make_unique<ui::render::MapRenderer>(_device.device(), *_shader_storage.get(), _window.width(), _window.height());
+        _map_renderer = std::make_unique<ui::render::MapRenderer>(_device.device(), *_shader_storage.get(), _window.size());
     }
 
     void Viewer::generate_tool_window()
@@ -444,8 +448,9 @@ namespace trview
         auto view = camera.view();
 
         Point mouse_pos = client_cursor_position(_window);
+        const auto window_size = _window.size();
 
-        Vector3 direction = XMVector3Unproject(Vector3(mouse_pos.x, mouse_pos.y, 1), 0, 0, static_cast<float>(_window.width()), static_cast<float>(_window.height()), 0, 1.0f, projection, view, world);
+        Vector3 direction = XMVector3Unproject(Vector3(mouse_pos.x, mouse_pos.y, 1), 0, 0, window_size.width, window_size.height, 0, 1.0f, projection, view, world);
         direction.Normalize();
 
         auto result = _level->pick(position, direction);
@@ -453,7 +458,7 @@ namespace trview
         _picking->set_visible(result.hit);
         if (result.hit)
         {
-            Vector3 screen_pos = XMVector3Project(result.position, 0, 0, static_cast<float>(_window.width()), static_cast<float>(_window.height()), 0, 1.0f, projection, view, XMMatrixIdentity());
+            Vector3 screen_pos = XMVector3Project(result.position, 0, 0, window_size.width, window_size.height, 0, 1.0f, projection, view, XMMatrixIdentity());
             _picking->set_position(Point(screen_pos.x - _picking->size().width, screen_pos.y - _picking->size().height));
             _picking->set_text(std::to_wstring(result.room));
         }
@@ -563,30 +568,15 @@ namespace trview
         }
     }
 
-    // Resize the window and the rendering system.
-    void Viewer::resize()
-    {
-        // If the window is the same size as before, do nothing.
-        Window window{ _window.window() };
-        if (window.width() == _window.width() && window.height() == _window.height())
-        {
-            return;
-        }
-
-        // Refresh the window so that the new size is known.
-        _window = Window(_window.window());
-        _main_window->resize();
-        resize_elements();
-    }
-
     void Viewer::resize_elements()
     {
+        const auto size = _window.size();
         // Inform elements that need to know that the device has been resized.
-        _camera.set_view_size(_window.width(), _window.height());
-        _free_camera.set_view_size(_window.width(), _window.height());
-        _control->set_size(Size(static_cast<float>(_window.width()), static_cast<float>(_window.height())));
-        _ui_renderer->set_host_size(_window.width(), _window.height());
-        _map_renderer->set_window_size(_window.width(), _window.height());
+        _camera.set_view_size(size);
+        _free_camera.set_view_size(size);
+        _control->set_size(size);
+        _ui_renderer->set_host_size(size);
+        _map_renderer->set_window_size(size);
     }
 
     // Set up keyboard and mouse input for the camera.

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -8,6 +8,7 @@
 #include <trlevel/trlevel.h>
 #include <trview.graphics/ShaderStorage.h>
 #include <trview.graphics/FontFactory.h>
+#include <trview.graphics/DeviceWindow.h>
 #include <trview.ui/Control.h>
 #include <trview.ui/StackPanel.h>
 #include <trview.ui/Window.h>
@@ -31,9 +32,11 @@ namespace trview
 {
     Viewer::Viewer(Window window)
         : _window(window), _camera(window.width(), window.height()), _free_camera(window.width(), window.height()),
-        _timer(default_time_source()), _keyboard(window), _mouse(window), _device(window), _level_switcher(window),
+        _timer(default_time_source()), _keyboard(window), _mouse(window), _level_switcher(window),
         _window_resizer(window), _recent_files(window), _file_dropper(window)
     {
+        _main_window = _device.create_for_window(window);
+
         _settings = load_user_settings();
 
         _level_switcher.on_switch_level += [=](const auto& file) { open(file); };
@@ -401,13 +404,14 @@ namespace trview
         pick();
 
         _device.begin();
-        _device.clear(DirectX::SimpleMath::Color(0.0f, 0.2f, 0.4f, 1.0f));
+        _main_window->begin();
+        _main_window->clear(DirectX::SimpleMath::Color(0.0f, 0.2f, 0.4f, 1.0f));
 
         render_scene();
         _ui_renderer->render(_device.context());
         render_map();
 
-        _device.present(_settings.vsync);
+        _main_window->present(_settings.vsync);
     }
 
     // Determines whether the cursor is over a UI element that would take any input.
@@ -571,7 +575,7 @@ namespace trview
 
         // Refresh the window so that the new size is known.
         _window = Window(_window.window());
-        _device.resize();
+        _main_window->resize();
         resize_elements();
     }
 

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -64,7 +64,7 @@ namespace trview
     public:
         /// Create a new viewer.
         /// @param window The window that the viewer should use.
-        explicit Viewer(Window window);
+        explicit Viewer(const Window& window);
 
         /// Destructor for the viewer.
         ~Viewer();
@@ -87,9 +87,6 @@ namespace trview
         /// Event raised when the recent files list is updated.
         /// @remarks The list of filenames is passed as a parameter to the listener functions.
         Event<std::list<std::wstring>> on_recent_files_changed;
-
-        /// Update the viewer and the rendering system after a window has changed size.
-        void resize();
     private:
         void generate_ui();
         void generate_tool_window();

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -55,6 +55,7 @@ namespace trview
     {
         struct IShaderStorage;
         class FontFactory;
+        class DeviceWindow;
     }
 
     /// Class that coordinates all the parts of the application.
@@ -115,6 +116,8 @@ namespace trview
         void setup_camera_input();
 
         graphics::Device _device;
+        std::unique_ptr<graphics::DeviceWindow> _main_window;
+
         std::unique_ptr<TextureWindow> _texture_window;
         std::unique_ptr<trlevel::ILevel> _current_level;
         std::unique_ptr<Level> _level;


### PR DESCRIPTION
The items window will be a separate window, so we need to be able to render to it as well using the same D3D device. This takes out the swap chain and render target from the `Device` class and moves them into the `DeviceWindow` class. We can make one of these for each window we render to.

I also changed the `WindowResizer` class to detect whether the window size has changed and only raise the event if it has done. This means that some code can be removed from the `Viewer` class. As a result of this change I made a bunch of functions take a `Size` instead of `width` and `height`.

Can start working on the items window after this.

Issue: #251 - Item search/list window