### PR TITLE
Create blank items window

### DIFF
--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -1,0 +1,72 @@
+#include "ItemsWindow.h"
+#include <Windows.h>
+#include <trview/resource.h>
+#include <trview.graphics/DeviceWindow.h>
+#include <SimpleMath.h>
+
+using namespace trview::graphics;
+
+namespace trview
+{
+    namespace
+    {
+        LRESULT CALLBACK items_window_procedure(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
+        {
+            return DefWindowProc(hWnd, message, wParam, lParam);
+        }
+
+        HWND init_items_instance(HWND parent, HINSTANCE hInstance, int nCmdShow)
+        {
+            HWND items_window = CreateWindowW(L"trview.items", L"trview", WS_OVERLAPPEDWINDOW,
+                CW_USEDEFAULT, 0, 400, 300, parent, nullptr, hInstance, nullptr);
+
+            ShowWindow(items_window, nCmdShow);
+            UpdateWindow(items_window);
+
+            return items_window;
+        }
+
+        ATOM register_items_class(HINSTANCE hInstance)
+        {
+            WNDCLASSEXW wcex;
+            wcex.cbSize = sizeof(WNDCLASSEX);
+            wcex.style = CS_HREDRAW | CS_VREDRAW;
+            wcex.lpfnWndProc = items_window_procedure;
+            wcex.cbClsExtra = 0;
+            wcex.cbWndExtra = 0;
+            wcex.hInstance = hInstance;
+            wcex.hIcon = LoadIcon(hInstance, MAKEINTRESOURCE(IDI_TRVIEW));
+            wcex.hCursor = LoadCursor(nullptr, IDC_ARROW);
+            wcex.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+            wcex.lpszMenuName = nullptr;
+            wcex.lpszClassName = L"trview.items";
+            wcex.hIconSm = LoadIcon(wcex.hInstance, MAKEINTRESOURCE(IDI_SMALL));
+
+            return RegisterClassExW(&wcex);
+        }
+
+        HWND create_items_window(HWND parent)
+        {
+            HINSTANCE hInstance = GetModuleHandle(nullptr);
+            register_items_class(hInstance);
+            return init_items_instance(parent, hInstance, SW_NORMAL);
+        }
+    }
+
+    ItemsWindow::ItemsWindow(const Device& device, HWND parent)
+        : MessageHandler(create_items_window(parent)), _window_resizer(window()), _device_window(device.create_for_window(window()))
+    {
+        _window_resizer.on_resize += [=]() { _device_window->resize(); };
+    }
+
+    void ItemsWindow::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    {
+    }
+
+    void ItemsWindow::render(bool vsync)
+    {
+        _device_window->begin();
+        _device_window->clear(DirectX::SimpleMath::Color(0.0f, 0.2f, 0.4f, 1.0f));
+        _device_window->present(vsync);
+    }
+}

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -1,0 +1,37 @@
+/// @file ItemsWindow.h
+/// @brief Used to show and filter the items in the level.
+
+#pragma once
+
+#include <trview.common/MessageHandler.h>
+#include <trview.graphics/Device.h>
+#include "WindowResizer.h"
+
+namespace trview
+{
+    /// Used to show and filter the items in the level.
+    class ItemsWindow final : public MessageHandler
+    {
+    public:
+        /// Create an items window as a child of the specified window.
+        /// @param parent The parent window.
+        explicit ItemsWindow(const graphics::Device& device, HWND parent);
+
+        /// Destructor for items window
+        virtual ~ItemsWindow() = default;
+
+        /// Handles a window message.
+        /// @param window The window that received the message.
+        /// @param message The message that was received.
+        /// @param wParam The WPARAM for the message.
+        /// @param lParam The LPARAM for the message.
+        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+
+        /// Render the window and contents.
+        /// @param vsync Whether to use vsync when rendering.
+        void render(bool vsync);
+    private:
+        WindowResizer _window_resizer;
+        std::unique_ptr<graphics::DeviceWindow> _device_window;
+    };
+}

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -20,11 +20,13 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FileDropper.cpp" />
+    <ClCompile Include="ItemsWindow.cpp" />
     <ClCompile Include="RecentFiles.cpp" />
     <ClCompile Include="WindowResizer.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="FileDropper.h" />
+    <ClInclude Include="ItemsWindow.h" />
     <ClInclude Include="RecentFiles.h" />
     <ClInclude Include="WindowIDs.h" />
     <ClInclude Include="WindowResizer.h" />
@@ -108,7 +110,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir);</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile />
     </ClCompile>
     <Link>
@@ -130,7 +132,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir);</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile />
     </ClCompile>
     <Link>
@@ -150,7 +152,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir);</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile />
     </ClCompile>
     <Link>
@@ -172,7 +174,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir);</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile />
     </ClCompile>
     <Link>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -4,11 +4,13 @@
     <ClCompile Include="WindowResizer.cpp" />
     <ClCompile Include="RecentFiles.cpp" />
     <ClCompile Include="FileDropper.cpp" />
+    <ClCompile Include="ItemsWindow.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="WindowResizer.h" />
     <ClInclude Include="RecentFiles.h" />
     <ClInclude Include="WindowIDs.h" />
     <ClInclude Include="FileDropper.h" />
+    <ClInclude Include="ItemsWindow.h" />
   </ItemGroup>
 </Project>

--- a/trview.graphics/DeviceWindow.cpp
+++ b/trview.graphics/DeviceWindow.cpp
@@ -1,5 +1,4 @@
 #include "DeviceWindow.h"
-#include "RenderTarget.h"
 #include "Device.h"
 
 using namespace Microsoft::WRL;

--- a/trview.graphics/DeviceWindow.h
+++ b/trview.graphics/DeviceWindow.h
@@ -8,12 +8,12 @@
 #include <d3d11.h>
 #include <trview.common/Window.h>
 #include <trview.common/Colour.h>
+#include "RenderTarget.h"
 
 namespace trview
 {
     namespace graphics
     {
-        class RenderTarget;
         class Device;
 
         /// Wraps the D3D resources for rendering to a window.

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -36,6 +36,7 @@ namespace trview
         _window_resizer(window), _recent_files(window), _file_dropper(window)
     {
         _main_window = _device.create_for_window(window);
+        _items_window = std::make_unique<ItemsWindow>(_device, window);
 
         _settings = load_user_settings();
 
@@ -416,6 +417,8 @@ namespace trview
         render_map();
 
         _main_window->present(_settings.vsync);
+
+        _items_window->render(_settings.vsync);
     }
 
     // Determines whether the cursor is over a UI element that would take any input.

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -27,6 +27,7 @@
 #include <trview.app/WindowResizer.h>
 #include <trview.app/RecentFiles.h>
 #include <trview.app/FileDropper.h>
+#include <trview.app/ItemsWindow.h>
 
 namespace trview
 {
@@ -114,6 +115,7 @@ namespace trview
 
         graphics::Device _device;
         std::unique_ptr<graphics::DeviceWindow> _main_window;
+        std::unique_ptr<ItemsWindow> _items_window;
 
         std::unique_ptr<TextureWindow> _texture_window;
         std::unique_ptr<trlevel::ILevel> _current_level;


### PR DESCRIPTION
The items window is inside the new items window class.
This has the logic for creating an items window, so there could be more of them.
The new items window has a resizer and the device window, so everything is contained inside.
UI is the next step.
Issue: #251