### PR TITLE
Add a setting to control whether an items window is created at startup

### DIFF
--- a/trview/SettingsWindow.cpp
+++ b/trview/SettingsWindow.cpp
@@ -47,6 +47,11 @@ namespace trview
         _invert_map_controls = invert_map_controls.get();
         panel->add_child(std::move(invert_map_controls));
 
+        auto items_startup = std::make_unique<Checkbox>(Point(), Size(16, 16), L"Open Items Window at startup");
+        items_startup->on_state_changed += on_items_startup;
+        _items_startup = items_startup.get();
+        panel->add_child(std::move(items_startup));
+
         auto ok = std::make_unique<Button>(Point(), Size(60, 20), L"Close");
         ok->set_horizontal_alignment(Align::Centre);
         _token_store.add(ok->on_click += [&]() { _window->set_visible(!_window->visible()); });
@@ -81,6 +86,11 @@ namespace trview
     void SettingsWindow::set_invert_map_controls(bool value)
     {
         _invert_map_controls->set_state(value);
+    }
+
+    void SettingsWindow::set_items_startup(bool value)
+    {
+        _items_startup->set_state(value);
     }
 
     void SettingsWindow::toggle_visibility()

--- a/trview/SettingsWindow.h
+++ b/trview/SettingsWindow.h
@@ -32,6 +32,9 @@ namespace trview
         /// Event raised when the inverted map controls setting has been changed. The new setting is passed as the parameter.
         Event<bool> on_invert_map_controls;
 
+        /// Event raised when the 'items window at startup' setting has been changed. The new setting is passed as the parameter.
+        Event<bool> on_items_startup;
+
         /// Set the new value of the vsync setting. This will not raise the on_vsync event.
         /// @param value The new vsync setting.
         void set_vsync(bool value);
@@ -44,12 +47,17 @@ namespace trview
         /// @param value The new inverted map controls setting.
         void set_invert_map_controls(bool value);
 
+        /// Set the new value of the 'items window at startup' setting. This will not raise the on_items_startup event.
+        /// @param value The new 'items window at startup' setting.
+        void set_items_startup(bool value);
+
         /// Toggle the visibility of the settings window.
         void toggle_visibility();
     private:
         ui::Checkbox* _vsync;
         ui::Checkbox* _go_to_lara;
         ui::Checkbox* _invert_map_controls;
+        ui::Checkbox* _items_startup;
         ui::Control* _window;
         TokenStore _token_store;
     };

--- a/trview/UserSettings.cpp
+++ b/trview/UserSettings.cpp
@@ -88,6 +88,10 @@ namespace trview
                 {
                     file >> settings.invert_map_controls;
                 }
+                else if (setting == L"itemsstartup")
+                {
+                    file >> settings.items_startup;
+                }
                 else if (setting == L"recent")
                 {
                     uint32_t recent_count = 0;
@@ -141,6 +145,7 @@ namespace trview
         file << L"vsync " << settings.vsync << '\n';
         file << L"gotolara " << settings.go_to_lara << '\n';
         file << L"invertmapcontrols " << settings.invert_map_controls << '\n';
+        file << L"itemsstartup " << settings.items_startup << '\n';
         file << L"recent "  << settings.recent_files.size()     << '\n';
         for (const auto& file_name : settings.recent_files)
         {

--- a/trview/UserSettings.h
+++ b/trview/UserSettings.h
@@ -15,6 +15,7 @@ namespace trview
         bool                    vsync{ true };
         bool                    go_to_lara{ true };
         bool                    invert_map_controls{ false };
+        bool                    items_startup{ true };
     };
 
     // Load the user settings from the settings file.


### PR DESCRIPTION
By default, open an Items window on startup.
This can be disabled in the settings window.
#276