### PR TITLE
Fix 'Lara is a stack of thighs' problem

### DIFF
--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -145,5 +145,10 @@ namespace trlevel
         /// @param entity The output entity.
         /// @returns Whether the entity was found.
         virtual bool find_first_entity_by_type(int16_t type, tr2_entity& entity) const = 0;
+
+        /// Get the true mesh from a type id. For example Lara's skin.
+        /// @param type The type id to check.
+        /// @returns The mesh index for the type.
+        virtual int16_t get_mesh_from_type_id(int16_t type) const = 0;
     };
 }

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -12,6 +12,9 @@ namespace trlevel
     namespace
     {
         const float PiMul2 = 6.283185307179586476925286766559f;
+        const int16_t Lara = 0;
+        const int16_t LaraSkinTR3 = 315;
+        const int16_t LaraSkinPostTR3 = 8;
     }
 
     namespace
@@ -729,5 +732,19 @@ namespace trlevel
         }
         entity = *found;
         return true;
+    }
+
+    int16_t Level::get_mesh_from_type_id(int16_t type) const
+    {
+        if (type != 0 || _version < LevelVersion::Tomb3)
+        {
+            return type;
+        }
+
+        if (_version > trlevel::LevelVersion::Tomb3)
+        {
+            return LaraSkinPostTR3;
+        }
+        return LaraSkinTR3;
     }
 }

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -151,6 +151,11 @@ namespace trlevel
         /// @param entity The output entity.
         /// @returns Whether the entity was found.
         virtual bool find_first_entity_by_type(int16_t type, tr2_entity& entity) const override;
+
+        /// Get the true mesh from a type id. For example Lara's skin.
+        /// @param type The type id to check.
+        /// @returns The mesh index for the type.
+        virtual int16_t get_mesh_from_type_id(int16_t type) const override;
     private:
         void generate_meshes(const std::vector<uint16_t>& mesh_data);
 

--- a/trview/Entity.cpp
+++ b/trview/Entity.cpp
@@ -23,6 +23,8 @@ namespace trview
         using namespace DirectX::SimpleMath;
 
         // Extract the meshes required from the model.
+        load_meshes(level, entity.TypeID, mesh_storage);
+
         trlevel::tr_model model;
         trlevel::tr_sprite_sequence sprite;
 
@@ -31,7 +33,7 @@ namespace trview
             // Set up world matrix.
             _world = Matrix::CreateRotationY((entity.Angle / 16384.0f) * XM_PIDIV2) * 
                      Matrix::CreateTranslation(entity.x / 1024.0f, entity.y / -1024.0f, entity.z / 1024.0f);
-            load_model(model, level, mesh_storage);
+            load_model(model, level);
         }
         else if (level.get_sprite_sequence_by_id(entity.TypeID, sprite))
         {
@@ -41,16 +43,23 @@ namespace trview
         }
     }
 
-    void Entity::load_model(const trlevel::tr_model& model, const trlevel::ILevel& level, const IMeshStorage& mesh_storage)
+    void Entity::load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage)
+    {
+        trlevel::tr_model model;
+        if (level.get_model_by_id(level.get_mesh_from_type_id(type_id), model))
+        {
+            const uint32_t end_pointer = static_cast<uint32_t>(model.StartingMesh + model.NumMeshes);
+            for (uint32_t mesh_pointer = model.StartingMesh; mesh_pointer < end_pointer; ++mesh_pointer)
+            {
+                _meshes.push_back(mesh_storage.mesh(mesh_pointer));
+            }
+        }
+    }
+
+    void Entity::load_model(const trlevel::tr_model& model, const trlevel::ILevel& level)
     {
         using namespace DirectX;
         using namespace DirectX::SimpleMath;
-
-        const uint32_t end_pointer = static_cast<uint32_t>(model.StartingMesh + model.NumMeshes);
-        for (uint32_t mesh_pointer = model.StartingMesh; mesh_pointer < end_pointer; ++mesh_pointer)
-        {
-            _meshes.push_back(mesh_storage.mesh(mesh_pointer));
-        }
 
         if (model.NumMeshes > 0)
         {

--- a/trview/Entity.h
+++ b/trview/Entity.h
@@ -34,7 +34,8 @@ namespace trview
 
         void get_transparent_triangles(TransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour);
     private:
-        void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level, const IMeshStorage& mesh_storage);
+        void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
+        void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);
         void load_sprite(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::tr_sprite_sequence& sprite_sequence, const trlevel::ILevel& level, const ILevelTextureStorage& texture_storage);
 
         DirectX::SimpleMath::Matrix               _world;


### PR DESCRIPTION
Fixes bug #78

Post TR2, Lara's actual skin is in a different mesh ID. Now based on the game, replace entity 0 with the appropriate number.

Works in TR3, but note that this does not fully fix #158, but at least Lara has the right body parts now.