### PR TITLE
Show item details in a panel in the Items window

### DIFF
--- a/trview.app/Item.cpp
+++ b/trview.app/Item.cpp
@@ -2,8 +2,8 @@
 
 namespace trview
 {
-    Item::Item(uint32_t number, uint32_t room, uint32_t type_id, const std::wstring& type)
-        : _number(number), _room(room), _type_id(type_id), _type(type)
+    Item::Item(uint32_t number, uint32_t room, uint32_t type_id, const std::wstring& type, uint32_t ocb, uint16_t flags)
+        : _number(number), _room(room), _type_id(type_id), _type(type), _ocb(ocb), _flags(flags)
     {
     }
 
@@ -27,4 +27,23 @@ namespace trview
         return _type;
     }
 
+    uint32_t Item::ocb() const
+    {
+        return _ocb;
+    }
+
+    uint16_t Item::activation_flags() const
+    {
+        return (_flags & 0x3E00) >> 9;
+    }
+
+    bool Item::clear_body_flag() const
+    {
+        return (_flags & 0x8000) != 0;
+    }
+
+    bool Item::invisible_flag() const
+    {
+        return (_flags & 0x100) != 0;
+    }
 }

--- a/trview.app/Item.h
+++ b/trview.app/Item.h
@@ -14,7 +14,9 @@ namespace trview
         /// @param room The room number the item is in.
         /// @param type_id The type number of the item.
         /// @param type The type name of the item.
-        explicit Item(uint32_t number, uint32_t room, const uint32_t type_id, const std::wstring& type);
+        /// @param ocb The OCB value of the item.
+        /// @param flags The flags for the entity.
+        explicit Item(uint32_t number, uint32_t room, const uint32_t type_id, const std::wstring& type, uint32_t ocb, uint16_t flags);
 
         /// Get the item number.
         /// @returns The item number.
@@ -31,10 +33,28 @@ namespace trview
         /// Get the type name of the item.
         /// @returns The type name of the item.
         const std::wstring& type() const;
+
+        /// Get the OCB value of the item.
+        /// @returns The OCB value of the item.
+        uint32_t ocb() const;
+
+        /// Get the activation flags for the entity.
+        /// @returns The activation flags.
+        uint16_t activation_flags() const;
+
+        /// Get whether the clear_body flag is set.
+        /// @returns Whether clear_body is set.
+        bool clear_body_flag() const;
+
+        /// Get whether the invisible_flag is set.
+        /// @returns Whether invisible flag is set.
+        bool invisible_flag() const;
     private:
         uint32_t _number;
         uint32_t _room;
         uint32_t _type_id;
         std::wstring _type;
+        uint32_t _ocb;
+        uint16_t _flags;
     };
 }

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -110,53 +110,12 @@ namespace trview
     void ItemsWindow::generate_ui()
     {
         using namespace ui;
-
-        _ui = std::make_unique<ui::StackPanel>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(0, 3), StackPanel::Direction::Horizontal, SizeMode::Manual);
-
-        auto left_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(0,3), StackPanel::Direction::Vertical, SizeMode::Manual);
-
-        // Control modes:.
-        auto controls = std::make_unique<StackPanel>(Point(), Size(window().size().width, 20), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(2,2), StackPanel::Direction::Horizontal, SizeMode::Manual);
-        auto track_room = std::make_unique<Checkbox>(Point(), Size(16, 16), L"Track Room");
-        _token_store.add(track_room->on_state_changed += [this](bool value)
-        {
-            _track_room = value;
-            if (_track_room)
-            {
-                set_current_room(_current_room);
-            }
-            else
-            {
-                set_items(_all_items);
-            }
-        });
-
-        controls->add_child(std::move(track_room));
-        _controls = controls.get();
-        left_panel->add_child(std::move(controls));
-
-        auto items_list = std::make_unique<Listbox>(Point(), window().size() - Size(0, _controls->size().height));
-        items_list->set_columns(
-            { 
-                { Listbox::Column::Type::Number, L"#", 30 }, 
-                { Listbox::Column::Type::Number, L"Room", 30 },
-                { Listbox::Column::Type::Number, L"ID", 30 },
-                { Listbox::Column::Type::String, L"Type", 100 } }
-            );
-        _token_store.add(items_list->on_item_selected += [&](const auto& item)
-        {
-            auto index = std::stoi(item.value(L"#"));
-            on_item_selected(_all_items[index]);
-        });
-
-        _items_list = items_list.get();
-        left_panel->add_child(std::move(items_list));
-
-        _left_panel = left_panel.get();
-        _ui->add_child(std::move(left_panel));
-
+        _ui = std::make_unique<StackPanel>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(0, 0), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        _ui->add_child(create_items_panel());
+        auto divider = std::make_unique<ui::Window>(Point(), Size(1, window().size().height), Colour(1.0f, 0.0f, 0.0f, 0.0f));
+        _divider = divider.get();
+        _ui->add_child(std::move(divider));
         _ui->add_child(create_details_panel());
-
         _ui_renderer->load(_ui.get());
     }
 
@@ -204,8 +163,56 @@ namespace trview
     {
         _ui->set_size(window().size());
         _left_panel->set_size(Size(200, window().size().height));
+        _divider->set_size(Size(1, window().size().height));
         _right_panel->set_size(Size(200, window().size().height));
         _items_list->set_size(Size(200, window().size().height - _controls->size().height));
+    }
+
+    std::unique_ptr<ui::StackPanel> ItemsWindow::create_items_panel()
+    {
+        using namespace ui;
+        auto left_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
+
+        // Control modes:.
+        auto controls = std::make_unique<StackPanel>(Point(), Size(window().size().width, 20), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        auto track_room = std::make_unique<Checkbox>(Point(), Size(16, 16), L"Track Room");
+        _token_store.add(track_room->on_state_changed += [this](bool value)
+        {
+            _track_room = value;
+            if (_track_room)
+            {
+                set_current_room(_current_room);
+            }
+            else
+            {
+                set_items(_all_items);
+            }
+        });
+
+        controls->add_child(std::move(track_room));
+        _controls = controls.get();
+        left_panel->add_child(std::move(controls));
+
+        auto items_list = std::make_unique<Listbox>(Point(), Size(200, window().size().height - _controls->size().height));
+        items_list->set_columns(
+            {
+                { Listbox::Column::Type::Number, L"#", 30 },
+                { Listbox::Column::Type::Number, L"Room", 30 },
+                { Listbox::Column::Type::Number, L"ID", 30 },
+                { Listbox::Column::Type::String, L"Type", 100 } 
+            }
+        );
+        _token_store.add(items_list->on_item_selected += [&](const auto& item)
+        {
+            auto index = std::stoi(item.value(L"#"));
+            on_item_selected(_all_items[index]);
+        });
+
+        _items_list = items_list.get();
+        left_panel->add_child(std::move(items_list));
+
+        _left_panel = left_panel.get();
+        return left_panel;
     }
 
     std::unique_ptr<ui::StackPanel> ItemsWindow::create_details_panel()
@@ -214,9 +221,9 @@ namespace trview
 
         const float height = window().size().height;
 
-        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colour(1.0f, 0.5f, 0.3f, 0.5f), Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colour(1.0f, 0.35f, 0.35f, 0.35f), Size(0, 5), StackPanel::Direction::Vertical, SizeMode::Manual);
 
-        auto group_box = std::make_unique<GroupBox>(Point(), Size(200, height), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Item Details");
+        auto group_box = std::make_unique<GroupBox>(Point(), Size(200, height), Colour(1.0f, 0.35f, 0.35f, 0.35f), Colour(0.0f, 0.0f, 0.0f, 0.0f), L"Item Details");
         right_panel->add_child(std::move(group_box));
 
         // Store the right panel for later use.

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -21,25 +21,16 @@ namespace trview
 
         LRESULT CALLBACK items_window_procedure(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         {
-            if (message == WM_GETMINMAXINFO)
-            {
-                RECT rect{ 0, 0, 400, 200 };
-                AdjustWindowRect(&rect, window_style, FALSE);
-
-                MINMAXINFO* info = reinterpret_cast<MINMAXINFO*>(lParam);
-                info->ptMinTrackSize.x = rect.right - rect.left;
-                info->ptMaxTrackSize.x = rect.right - rect.left;
-                info->ptMinTrackSize.y = 200;
-                return 0;
-            }
-
             return DefWindowProc(hWnd, message, wParam, lParam);
         }
 
         HWND init_items_instance(HWND parent, HINSTANCE hInstance, int nCmdShow)
         {
+            RECT rect{ 0, 0, 400, 200 };
+            AdjustWindowRect(&rect, window_style, FALSE);
+
             HWND items_window = CreateWindowW(L"trview.items", L"Items", window_style,
-                CW_USEDEFAULT, 0, 400, 310, parent, nullptr, hInstance, nullptr);
+                CW_USEDEFAULT, 0, rect.right - rect.left, 310, parent, nullptr, hInstance, nullptr);
 
             ShowWindow(items_window, nCmdShow);
             UpdateWindow(items_window);
@@ -99,6 +90,16 @@ namespace trview
         {
             on_window_closed();
         }
+        else if (message == WM_GETMINMAXINFO)
+        {
+            RECT rect{ 0, 0, _ui->size().width, 200 };
+            AdjustWindowRect(&rect, window_style, FALSE);
+
+            MINMAXINFO* info = reinterpret_cast<MINMAXINFO*>(lParam);
+            info->ptMinTrackSize.x = rect.right - rect.left;
+            info->ptMaxTrackSize.x = rect.right - rect.left;
+            info->ptMinTrackSize.y = 200;
+        }
     }
 
     void ItemsWindow::render(const Device& device, bool vsync)
@@ -148,7 +149,6 @@ namespace trview
     {
         if (_track_room && (!_filter_applied || _current_room != room))
         {
-            _current_room = room;
             _filter_applied = true;
 
             std::vector<Item> filtered_items;
@@ -161,6 +161,8 @@ namespace trview
             }
             populate_items(filtered_items);
         }
+
+        _current_room = room;
     }
 
     void ItemsWindow::update_layout()

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -171,11 +171,11 @@ namespace trview
     std::unique_ptr<ui::StackPanel> ItemsWindow::create_items_panel()
     {
         using namespace ui;
-        auto left_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto left_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colour(1.0f, 0.4f, 0.4f, 0.4f), Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Control modes:.
-        auto controls = std::make_unique<StackPanel>(Point(), Size(window().size().width, 20), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
-        auto track_room = std::make_unique<Checkbox>(Point(), Size(16, 16), L"Track Room");
+        auto controls = std::make_unique<StackPanel>(Point(), Size(window().size().width, 20), Colour(1.0f, 0.4f, 0.4f, 0.4f), Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        auto track_room = std::make_unique<Checkbox>(Point(), Size(16, 16), Colour(1.0f, 0.4f, 0.4f, 0.4f), L"Track Room");
         _token_store.add(track_room->on_state_changed += [this](bool value)
         {
             _track_room = value;
@@ -193,7 +193,7 @@ namespace trview
         _controls = controls.get();
         left_panel->add_child(std::move(controls));
 
-        auto items_list = std::make_unique<Listbox>(Point(), Size(200, window().size().height - _controls->size().height));
+        auto items_list = std::make_unique<Listbox>(Point(), Size(200, window().size().height - _controls->size().height), Colour(1.0f, 0.4f, 0.4f, 0.4f));
         items_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 30 },
@@ -222,8 +222,28 @@ namespace trview
         const float height = window().size().height;
 
         auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colour(1.0f, 0.35f, 0.35f, 0.35f), Size(0, 5), StackPanel::Direction::Vertical, SizeMode::Manual);
-
         auto group_box = std::make_unique<GroupBox>(Point(), Size(200, height), Colour(1.0f, 0.35f, 0.35f, 0.35f), Colour(0.0f, 0.0f, 0.0f, 0.0f), L"Item Details");
+        auto controls = std::make_unique<StackPanel>(Point(10, 12), group_box->size(), Colour(1.0f, 0.35f, 0.35f, 0.35f), Size(0, 5), StackPanel::Direction::Vertical, SizeMode::Manual);
+
+        // Add some information about the selected item.
+        auto stats_list = std::make_unique<Listbox>(Point(), Size(180, 100), Colour(1.0f, 0.35f, 0.35f, 0.35f));
+        stats_list->set_columns(
+            {
+                { Listbox::Column::Type::Number, L"Name", 50 },
+                { Listbox::Column::Type::Number, L"Value", 130 },
+            }
+        );
+        stats_list->set_show_headers(false);
+        stats_list->set_show_scrollbar(false);
+
+        std::vector<Listbox::Item> stats;
+        stats.push_back({ { { L"Name", L"Room" }, { L"Value", L"100" } } });
+        stats.push_back({ { { L"Name", L"Flags" }, { L"Value", L"111111-11" } } });
+        stats.push_back({ { { L"Name", L"OCB" },{ L"Value", L"0" } } });
+        stats_list->set_items(stats);
+
+        controls->add_child(std::move(stats_list));
+        group_box->add_child(std::move(controls));
         right_panel->add_child(std::move(group_box));
 
         // Store the right panel for later use.

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -243,6 +243,7 @@ namespace trview
         );
         stats_list->set_show_headers(false);
         stats_list->set_show_scrollbar(false);
+        stats_list->set_show_highlight(false);
 
         _stats_list = stats_list.get();
 

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -128,6 +128,11 @@ namespace trview
         populate_items(items);
     }
 
+    void ItemsWindow::clear_selected_item()
+    {
+        _stats_list->set_items({});
+    }
+
     void ItemsWindow::populate_items(const std::vector<Item>& items)
     {
         using namespace ui;

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -19,6 +19,15 @@ namespace trview
     {
         const DWORD window_style = WS_OVERLAPPEDWINDOW & ~(WS_MINIMIZEBOX | WS_MAXIMIZEBOX);
 
+        /// Colours commonly used in this class.
+        namespace Colours
+        {
+            const Colour Divider { 1.0f, 0.0f, 0.0f, 0.0f };
+            const Colour LeftPanel { 1.0f, 0.4f, 0.4f, 0.4f };
+            const Colour RightPanel { 1.0f, 0.35f, 0.35f, 0.35f };
+            const Colour DetailsBorder { 0.0f, 0.0f, 0.0f, 0.0f };
+        }
+
         LRESULT CALLBACK items_window_procedure(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         {
             return DefWindowProc(hWnd, message, wParam, lParam);
@@ -180,11 +189,11 @@ namespace trview
     std::unique_ptr<ui::StackPanel> ItemsWindow::create_items_panel()
     {
         using namespace ui;
-        auto left_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colour(1.0f, 0.4f, 0.4f, 0.4f), Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto left_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colours::LeftPanel, Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Control modes:.
-        auto controls = std::make_unique<StackPanel>(Point(), Size(window().size().width, 20), Colour(1.0f, 0.4f, 0.4f, 0.4f), Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
-        auto track_room = std::make_unique<Checkbox>(Point(), Size(16, 16), Colour(1.0f, 0.4f, 0.4f, 0.4f), L"Track Room");
+        auto controls = std::make_unique<StackPanel>(Point(), Size(window().size().width, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        auto track_room = std::make_unique<Checkbox>(Point(), Size(16, 16), Colours::LeftPanel, L"Track Room");
         _token_store.add(track_room->on_state_changed += [this](bool value)
         {
             _track_room = value;
@@ -203,7 +212,7 @@ namespace trview
         _controls = controls.get();
         left_panel->add_child(std::move(controls));
 
-        auto items_list = std::make_unique<Listbox>(Point(), Size(200, window().size().height - _controls->size().height), Colour(1.0f, 0.4f, 0.4f, 0.4f));
+        auto items_list = std::make_unique<Listbox>(Point(), Size(200, window().size().height - _controls->size().height), Colours::LeftPanel);
         items_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 30 },
@@ -228,7 +237,7 @@ namespace trview
 
     std::unique_ptr<ui::Control> ItemsWindow::create_divider()
     {
-        auto divider = std::make_unique<ui::Window>(Point(), Size(1, window().size().height), Colour(1.0f, 0.0f, 0.0f, 0.0f));
+        auto divider = std::make_unique<ui::Window>(Point(), Size(1, window().size().height), Colours::Divider);
         _divider = divider.get();
         return divider;
     }
@@ -239,12 +248,12 @@ namespace trview
 
         const float height = window().size().height;
 
-        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colour(1.0f, 0.35f, 0.35f, 0.35f), Size(0, 4), StackPanel::Direction::Vertical, SizeMode::Manual);
-        auto group_box = std::make_unique<GroupBox>(Point(), Size(200, height), Colour(1.0f, 0.35f, 0.35f, 0.35f), Colour(0.0f, 0.0f, 0.0f, 0.0f), L"Item Details");
-        auto controls = std::make_unique<StackPanel>(Point(10, 11), group_box->size(), Colour(1.0f, 0.35f, 0.35f, 0.35f), Size(0, 5), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colours::RightPanel, Size(0, 4), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto group_box = std::make_unique<GroupBox>(Point(), Size(200, height), Colours::RightPanel, Colours::DetailsBorder, L"Item Details");
+        auto controls = std::make_unique<StackPanel>(Point(10, 11), group_box->size(), Colours::RightPanel, Size(0, 5), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Add some information about the selected item.
-        auto stats_list = std::make_unique<Listbox>(Point(), Size(180, 160), Colour(1.0f, 0.35f, 0.35f, 0.35f));
+        auto stats_list = std::make_unique<Listbox>(Point(), Size(180, 160), Colours::RightPanel);
         stats_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"Name", 60 },

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -20,7 +20,7 @@ namespace trview
         {
             if (message == WM_GETMINMAXINFO)
             {
-                RECT rect{ 0, 0, 200, 200 };
+                RECT rect{ 0, 0, 400, 200 };
                 AdjustWindowRect(&rect, window_style, FALSE);
 
                 MINMAXINFO* info = reinterpret_cast<MINMAXINFO*>(lParam);
@@ -36,7 +36,7 @@ namespace trview
         HWND init_items_instance(HWND parent, HINSTANCE hInstance, int nCmdShow)
         {
             HWND items_window = CreateWindowW(L"trview.items", L"Items", window_style,
-                CW_USEDEFAULT, 0, 200, 310, parent, nullptr, hInstance, nullptr);
+                CW_USEDEFAULT, 0, 400, 310, parent, nullptr, hInstance, nullptr);
 
             ShowWindow(items_window, nCmdShow);
             UpdateWindow(items_window);
@@ -110,7 +110,9 @@ namespace trview
     {
         using namespace ui;
 
-        _ui = std::make_unique<ui::StackPanel>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(0,3), StackPanel::Direction::Vertical, SizeMode::Manual);
+        _ui = std::make_unique<ui::StackPanel>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(0, 3), StackPanel::Direction::Horizontal, SizeMode::Manual);
+
+        auto left_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(0,3), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Control modes:.
         auto controls = std::make_unique<StackPanel>(Point(), Size(window().size().width, 20), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(2,2), StackPanel::Direction::Horizontal, SizeMode::Manual);
@@ -130,7 +132,7 @@ namespace trview
 
         controls->add_child(std::move(track_room));
         _controls = controls.get();
-        _ui->add_child(std::move(controls));
+        left_panel->add_child(std::move(controls));
 
         auto items_list = std::make_unique<Listbox>(Point(), window().size() - Size(0, _controls->size().height));
         items_list->set_columns(
@@ -146,8 +148,16 @@ namespace trview
             on_item_selected(_all_items[index]);
         });
 
+        auto right_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colour(1.0f, 0.5f, 0.3f, 0.5f), Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
+
         _items_list = items_list.get();
-        _ui->add_child(std::move(items_list));
+        left_panel->add_child(std::move(items_list));
+
+        _left_panel = left_panel.get();
+        _ui->add_child(std::move(left_panel));
+
+        _right_panel = right_panel.get();
+        _ui->add_child(std::move(right_panel));
         _ui_renderer->load(_ui.get());
     }
 
@@ -194,6 +204,8 @@ namespace trview
     void ItemsWindow::update_layout()
     {
         _ui->set_size(window().size());
-        _items_list->set_size(window().size() - Size(0, _controls->size().height));
+        _left_panel->set_size(Size(200, window().size().height));
+        _right_panel->set_size(Size(200, window().size().height));
+        _items_list->set_size(Size(200, window().size().height - _controls->size().height));
     }
 }

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -7,6 +7,7 @@
 #include <trview.ui.render/Renderer.h>
 #include <SimpleMath.h>
 #include <trview.ui/Checkbox.h>
+#include <trview.ui/GroupBox.h>
 
 using namespace trview::graphics;
 
@@ -148,16 +149,14 @@ namespace trview
             on_item_selected(_all_items[index]);
         });
 
-        auto right_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colour(1.0f, 0.5f, 0.3f, 0.5f), Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
-
         _items_list = items_list.get();
         left_panel->add_child(std::move(items_list));
 
         _left_panel = left_panel.get();
         _ui->add_child(std::move(left_panel));
 
-        _right_panel = right_panel.get();
-        _ui->add_child(std::move(right_panel));
+        _ui->add_child(create_details_panel());
+
         _ui_renderer->load(_ui.get());
     }
 
@@ -207,5 +206,21 @@ namespace trview
         _left_panel->set_size(Size(200, window().size().height));
         _right_panel->set_size(Size(200, window().size().height));
         _items_list->set_size(Size(200, window().size().height - _controls->size().height));
+    }
+
+    std::unique_ptr<ui::StackPanel> ItemsWindow::create_details_panel()
+    {
+        using namespace ui;
+
+        const float height = window().size().height;
+
+        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colour(1.0f, 0.5f, 0.3f, 0.5f), Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
+
+        auto group_box = std::make_unique<GroupBox>(Point(), Size(200, height), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Item Details");
+        right_panel->add_child(std::move(group_box));
+
+        // Store the right panel for later use.
+        _right_panel = right_panel.get();
+        return right_panel;
     }
 }

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -180,10 +180,11 @@ namespace trview
     void ItemsWindow::update_layout()
     {
         _ui->set_size(window().size());
-        _left_panel->set_size(Size(_left_panel->size().width, window().size().height));
-        _divider->set_size(Size(_divider->size().width, window().size().height));
-        _right_panel->set_size(Size(_right_panel->size().width, window().size().height));
-        _items_list->set_size(Size(_items_list->size().width, window().size().height - _items_list->position().y));
+        const auto new_height = window().size().height;
+        _left_panel->set_size(Size(_left_panel->size().width, new_height));
+        _divider->set_size(Size(_divider->size().width, new_height));
+        _right_panel->set_size(Size(_right_panel->size().width, new_height));
+        _items_list->set_size(Size(_items_list->size().width, new_height - _items_list->position().y));
     }
 
     std::unique_ptr<ui::StackPanel> ItemsWindow::create_items_panel()
@@ -192,7 +193,7 @@ namespace trview
         auto left_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colours::LeftPanel, Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Control modes:.
-        auto controls = std::make_unique<StackPanel>(Point(), Size(window().size().width, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        auto controls = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
         auto track_room = std::make_unique<Checkbox>(Point(), Size(16, 16), Colours::LeftPanel, L"Track Room");
         _token_store.add(track_room->on_state_changed += [this](bool value)
         {

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -1,4 +1,6 @@
 #include "ItemsWindow.h"
+#include <sstream>
+#include <bitset>
 #include <Windows.h>
 #include <trview/resource.h>
 #include <trview.graphics/DeviceWindow.h>
@@ -250,14 +252,28 @@ namespace trview
 
     void ItemsWindow::load_item_details(const Item& item)
     {
+        auto format_bool = [](bool value)
+        {
+            std::wstringstream stream;
+            stream << std::boolalpha << value;
+            return stream.str();
+        };
+
+        auto format_binary = [](uint16_t value)
+        {
+            std::wstringstream stream;
+            stream << std::bitset<5>(value);
+            return stream.str();
+        };
+
         using namespace ui;
         std::vector<Listbox::Item> stats;
         stats.push_back({ { { L"Name", L"Type" },{ L"Value", item.type() } } });
         stats.push_back({ { { L"Name", L"Type ID" },{ L"Value", std::to_wstring(item.type_id()) } } });
         stats.push_back({ { { L"Name", L"Room" },{ L"Value", std::to_wstring(item.room()) } } });
-        stats.push_back({ { { L"Name", L"Clear Body" },{ L"Value", std::to_wstring(item.clear_body_flag()) } } });
-        stats.push_back({ { { L"Name", L"Invisible" },{ L"Value", std::to_wstring(item.invisible_flag()) } } });
-        stats.push_back({ { { L"Name", L"Flags" },{ L"Value", std::to_wstring(item.activation_flags()) } } });
+        stats.push_back({ { { L"Name", L"Clear Body" },{ L"Value", format_bool(item.clear_body_flag()) } } });
+        stats.push_back({ { { L"Name", L"Invisible" },{ L"Value", format_bool(item.invisible_flag()) } } });
+        stats.push_back({ { { L"Name", L"Flags" },{ L"Value", format_binary(item.activation_flags()) } } });
         stats.push_back({ { { L"Name", L"OCB" },{ L"Value", std::to_wstring(item.ocb()) } } });
         _stats_list->set_items(stats);
     }

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -227,11 +227,11 @@ namespace trview
         auto controls = std::make_unique<StackPanel>(Point(10, 11), group_box->size(), Colour(1.0f, 0.35f, 0.35f, 0.35f), Size(0, 5), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Add some information about the selected item.
-        auto stats_list = std::make_unique<Listbox>(Point(), Size(180, 100), Colour(1.0f, 0.35f, 0.35f, 0.35f));
+        auto stats_list = std::make_unique<Listbox>(Point(), Size(180, 160), Colour(1.0f, 0.35f, 0.35f, 0.35f));
         stats_list->set_columns(
             {
-                { Listbox::Column::Type::Number, L"Name", 50 },
-                { Listbox::Column::Type::Number, L"Value", 130 },
+                { Listbox::Column::Type::Number, L"Name", 60 },
+                { Listbox::Column::Type::Number, L"Value", 120 },
             }
         );
         stats_list->set_show_headers(false);
@@ -255,8 +255,10 @@ namespace trview
         stats.push_back({ { { L"Name", L"Type" },{ L"Value", item.type() } } });
         stats.push_back({ { { L"Name", L"Type ID" },{ L"Value", std::to_wstring(item.type_id()) } } });
         stats.push_back({ { { L"Name", L"Room" },{ L"Value", std::to_wstring(item.room()) } } });
-        stats.push_back({ { { L"Name", L"Flags" },{ L"Value", L"111111-11" } } });
-        stats.push_back({ { { L"Name", L"OCB" },{ L"Value", L"0" } } });
+        stats.push_back({ { { L"Name", L"Clear Body" },{ L"Value", std::to_wstring(item.clear_body_flag()) } } });
+        stats.push_back({ { { L"Name", L"Invisible" },{ L"Value", std::to_wstring(item.invisible_flag()) } } });
+        stats.push_back({ { { L"Name", L"Flags" },{ L"Value", std::to_wstring(item.activation_flags()) } } });
+        stats.push_back({ { { L"Name", L"OCB" },{ L"Value", std::to_wstring(item.ocb()) } } });
         _stats_list->set_items(stats);
     }
 }

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -115,9 +115,7 @@ namespace trview
         using namespace ui;
         _ui = std::make_unique<StackPanel>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(0, 0), StackPanel::Direction::Horizontal, SizeMode::Manual);
         _ui->add_child(create_items_panel());
-        auto divider = std::make_unique<ui::Window>(Point(), Size(1, window().size().height), Colour(1.0f, 0.0f, 0.0f, 0.0f));
-        _divider = divider.get();
-        _ui->add_child(std::move(divider));
+        _ui->add_child(create_divider());
         _ui->add_child(create_details_panel());
         _ui_renderer->load(_ui.get());
     }
@@ -173,10 +171,10 @@ namespace trview
     void ItemsWindow::update_layout()
     {
         _ui->set_size(window().size());
-        _left_panel->set_size(Size(200, window().size().height));
-        _divider->set_size(Size(1, window().size().height));
-        _right_panel->set_size(Size(200, window().size().height));
-        _items_list->set_size(Size(200, window().size().height - _controls->size().height));
+        _left_panel->set_size(Size(_left_panel->size().width, window().size().height));
+        _divider->set_size(Size(_divider->size().width, window().size().height));
+        _right_panel->set_size(Size(_right_panel->size().width, window().size().height));
+        _items_list->set_size(Size(_items_list->size().width, window().size().height - _items_list->position().y));
     }
 
     std::unique_ptr<ui::StackPanel> ItemsWindow::create_items_panel()
@@ -228,6 +226,13 @@ namespace trview
         return left_panel;
     }
 
+    std::unique_ptr<ui::Control> ItemsWindow::create_divider()
+    {
+        auto divider = std::make_unique<ui::Window>(Point(), Size(1, window().size().height), Colour(1.0f, 0.0f, 0.0f, 0.0f));
+        _divider = divider.get();
+        return divider;
+    }
+
     std::unique_ptr<ui::StackPanel> ItemsWindow::create_details_panel()
     {
         using namespace ui;
@@ -277,15 +282,21 @@ namespace trview
             return stream.str();
         };
 
+        auto make_item = [](const auto& name, const auto& value)
+        {
+            return Listbox::Item { { { L"Name", name }, { L"Value", value } } };
+        };
+
         using namespace ui;
         std::vector<Listbox::Item> stats;
-        stats.push_back({ { { L"Name", L"Type" },{ L"Value", item.type() } } });
-        stats.push_back({ { { L"Name", L"Type ID" },{ L"Value", std::to_wstring(item.type_id()) } } });
-        stats.push_back({ { { L"Name", L"Room" },{ L"Value", std::to_wstring(item.room()) } } });
-        stats.push_back({ { { L"Name", L"Clear Body" },{ L"Value", format_bool(item.clear_body_flag()) } } });
-        stats.push_back({ { { L"Name", L"Invisible" },{ L"Value", format_bool(item.invisible_flag()) } } });
-        stats.push_back({ { { L"Name", L"Flags" },{ L"Value", format_binary(item.activation_flags()) } } });
-        stats.push_back({ { { L"Name", L"OCB" },{ L"Value", std::to_wstring(item.ocb()) } } });
+        stats.push_back(make_item(L"Type", item.type()));
+        stats.push_back(make_item(L"#", std::to_wstring(item.number())));
+        stats.push_back(make_item(L"Type ID", std::to_wstring(item.type_id())));
+        stats.push_back(make_item(L"Room", std::to_wstring(item.room())));
+        stats.push_back(make_item(L"Clear Body", format_bool(item.clear_body_flag())));
+        stats.push_back(make_item(L"Invisible", format_bool(item.invisible_flag())));
+        stats.push_back(make_item(L"Flags", format_binary(item.activation_flags())));
+        stats.push_back(make_item(L"OCB", std::to_wstring(item.ocb())));
         _stats_list->set_items(stats);
     }
 }

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -146,9 +146,11 @@ namespace trview
 
     void ItemsWindow::set_current_room(uint32_t room)
     {
-        _current_room = room;
-        if (_track_room)
+        if (_track_room && (!_filter_applied || _current_room != room))
         {
+            _current_room = room;
+            _filter_applied = true;
+
             std::vector<Item> filtered_items;
             for (const auto& item : _all_items)
             {
@@ -188,6 +190,7 @@ namespace trview
             else
             {
                 set_items(_all_items);
+                _filter_applied = false;
             }
         });
 

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -205,6 +205,7 @@ namespace trview
         _token_store.add(items_list->on_item_selected += [&](const auto& item)
         {
             auto index = std::stoi(item.value(L"#"));
+            load_item_details(_all_items[index]);
             on_item_selected(_all_items[index]);
         });
 
@@ -221,9 +222,9 @@ namespace trview
 
         const float height = window().size().height;
 
-        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colour(1.0f, 0.35f, 0.35f, 0.35f), Size(0, 5), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colour(1.0f, 0.35f, 0.35f, 0.35f), Size(0, 4), StackPanel::Direction::Vertical, SizeMode::Manual);
         auto group_box = std::make_unique<GroupBox>(Point(), Size(200, height), Colour(1.0f, 0.35f, 0.35f, 0.35f), Colour(0.0f, 0.0f, 0.0f, 0.0f), L"Item Details");
-        auto controls = std::make_unique<StackPanel>(Point(10, 12), group_box->size(), Colour(1.0f, 0.35f, 0.35f, 0.35f), Size(0, 5), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto controls = std::make_unique<StackPanel>(Point(10, 11), group_box->size(), Colour(1.0f, 0.35f, 0.35f, 0.35f), Size(0, 5), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Add some information about the selected item.
         auto stats_list = std::make_unique<Listbox>(Point(), Size(180, 100), Colour(1.0f, 0.35f, 0.35f, 0.35f));
@@ -236,11 +237,7 @@ namespace trview
         stats_list->set_show_headers(false);
         stats_list->set_show_scrollbar(false);
 
-        std::vector<Listbox::Item> stats;
-        stats.push_back({ { { L"Name", L"Room" }, { L"Value", L"100" } } });
-        stats.push_back({ { { L"Name", L"Flags" }, { L"Value", L"111111-11" } } });
-        stats.push_back({ { { L"Name", L"OCB" },{ L"Value", L"0" } } });
-        stats_list->set_items(stats);
+        _stats_list = stats_list.get();
 
         controls->add_child(std::move(stats_list));
         group_box->add_child(std::move(controls));
@@ -249,5 +246,17 @@ namespace trview
         // Store the right panel for later use.
         _right_panel = right_panel.get();
         return right_panel;
+    }
+
+    void ItemsWindow::load_item_details(const Item& item)
+    {
+        using namespace ui;
+        std::vector<Listbox::Item> stats;
+        stats.push_back({ { { L"Name", L"Type" },{ L"Value", item.type() } } });
+        stats.push_back({ { { L"Name", L"Type ID" },{ L"Value", std::to_wstring(item.type_id()) } } });
+        stats.push_back({ { { L"Name", L"Room" },{ L"Value", std::to_wstring(item.room()) } } });
+        stats.push_back({ { { L"Name", L"Flags" },{ L"Value", L"111111-11" } } });
+        stats.push_back({ { { L"Name", L"OCB" },{ L"Value", L"0" } } });
+        _stats_list->set_items(stats);
     }
 }

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -71,12 +71,14 @@ namespace trview
         void populate_items(const std::vector<Item>& items);
         /// After the window has been resized, adjust the sizes of the child elements.
         void update_layout();
+        std::unique_ptr<ui::StackPanel> create_items_panel();
         std::unique_ptr<ui::StackPanel> create_details_panel();
 
         WindowResizer _window_resizer;
         std::unique_ptr<graphics::DeviceWindow> _device_window;
         std::unique_ptr<ui::Window> _ui;
         ui::Window* _left_panel;
+        ui::Window* _divider;
         ui::Window* _right_panel;
         ui::Window*  _controls;
         ui::Listbox* _items_list;

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -75,6 +75,8 @@ namespace trview
         WindowResizer _window_resizer;
         std::unique_ptr<graphics::DeviceWindow> _device_window;
         std::unique_ptr<ui::Window> _ui;
+        ui::Window* _left_panel;
+        ui::Window* _right_panel;
         ui::Window*  _controls;
         ui::Listbox* _items_list;
         std::unique_ptr<ui::render::Renderer> _ui_renderer;

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -89,7 +89,11 @@ namespace trview
         TokenStore _token_store;
 
         std::vector<Item> _all_items;
+        /// Whether the item window is tracking the current room.
         bool _track_room{ false };
+        /// The current room number selected for tracking.
         uint32_t _current_room{ 0u };
+        /// Whether the room tracking filter has been applied.
+        bool _filter_applied{ false };
     };
 }

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -71,6 +71,7 @@ namespace trview
         void populate_items(const std::vector<Item>& items);
         /// After the window has been resized, adjust the sizes of the child elements.
         void update_layout();
+        std::unique_ptr<ui::StackPanel> create_details_panel();
 
         WindowResizer _window_resizer;
         std::unique_ptr<graphics::DeviceWindow> _device_window;

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -57,6 +57,9 @@ namespace trview
         /// @param items The items to show.
         void set_items(const std::vector<Item>& items);
 
+        /// Clear the currently selected item from the details panel.
+        void clear_selected_item();
+
         /// Event raised when an item is selected in the list.
         Event<Item> on_item_selected;
 

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -75,6 +75,7 @@ namespace trview
         /// After the window has been resized, adjust the sizes of the child elements.
         void update_layout();
         std::unique_ptr<ui::StackPanel> create_items_panel();
+        std::unique_ptr<ui::Control> create_divider();
         std::unique_ptr<ui::StackPanel> create_details_panel();
         void load_item_details(const Item& item);
 

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -73,6 +73,7 @@ namespace trview
         void update_layout();
         std::unique_ptr<ui::StackPanel> create_items_panel();
         std::unique_ptr<ui::StackPanel> create_details_panel();
+        void load_item_details(const Item& item);
 
         WindowResizer _window_resizer;
         std::unique_ptr<graphics::DeviceWindow> _device_window;
@@ -82,6 +83,7 @@ namespace trview
         ui::Window* _right_panel;
         ui::Window*  _controls;
         ui::Listbox* _items_list;
+        ui::Listbox* _stats_list;
         std::unique_ptr<ui::render::Renderer> _ui_renderer;
         input::Mouse _mouse;
         TokenStore _token_store;

--- a/trview.app/ItemsWindowManager.cpp
+++ b/trview.app/ItemsWindowManager.cpp
@@ -54,6 +54,7 @@ namespace trview
         _items = items;
         for (auto& window : _windows)
         {
+            window->clear_selected_item();
             window->set_items(items);
         }
     }

--- a/trview.ui/Button.cpp
+++ b/trview.ui/Button.cpp
@@ -53,5 +53,13 @@ namespace trview
                 _text->set_text(text);
             }
         }
+
+        void Button::set_text_background_colour(const Colour& colour)
+        {
+            if (_text)
+            {
+                _text->set_background_colour(colour);
+            }
+        }
     }
 }

--- a/trview.ui/Button.h
+++ b/trview.ui/Button.h
@@ -10,6 +10,8 @@
 
 namespace trview
 {
+    struct Colour;
+
     namespace ui
     {
         class Label;
@@ -53,6 +55,10 @@ namespace trview
             /// Set the text of the button, if it has a label for text.
             /// @param text The new text for the button.
             void set_text(const std::wstring& text);
+
+            /// Set the background colour of the text, if present.
+            /// @param colour The background colour.
+            void set_text_background_colour(const Colour& colour);
         protected:
             virtual bool clicked(Point position) override;
         private:

--- a/trview.ui/Checkbox.cpp
+++ b/trview.ui/Checkbox.cpp
@@ -16,26 +16,31 @@ namespace trview
         Checkbox::Checkbox(const Point& position, const Size& size)
             : StackPanel(position, size, Colour(0.0f, 0.0f, 0.0f, 0.0f), Size(), Direction::Horizontal)
         {
-            create_image(size);
+            create_image(size, Colour(1.0f, 0.5f, 0.5f, 0.5f));
         }
 
         Checkbox::Checkbox(const Point& position, const Size& size, const std::wstring& label_text)
+            : Checkbox(position, size, Colour(1.0f, 0.5f, 0.5f, 0.5f), label_text)
+        {
+        }
+
+        Checkbox::Checkbox(const Point& position, const Size& size, const Colour& background_colour, const std::wstring& label_text)
             : StackPanel(position, size, Colour(0.0f, 0.0f, 0.0f, 0.0f), Size(), Direction::Horizontal)
         {
-            create_image(size);
+            create_image(size, background_colour);
 
-            add_child(std::make_unique<Window>(Point(), Size(3, size.height), Colour(1.0f, 0.5f, 0.5f, 0.5f)));
+            add_child(std::make_unique<Window>(Point(), Size(3, size.height), background_colour));
 
-            auto label = std::make_unique<Label>(Point(), Size(1, 1), Colour(1.0f, 0.5f, 0.5f, 0.5f), label_text, 8, TextAlignment::Left, ParagraphAlignment::Centre, SizeMode::Auto);
+            auto label = std::make_unique<Label>(Point(), Size(1, 1), background_colour, label_text, 8, TextAlignment::Left, ParagraphAlignment::Centre, SizeMode::Auto);
             label->set_vertical_alignment(Align::Centre);
             _label = label.get();
             add_child(std::move(label));
         }
 
-        void Checkbox::create_image(const Size& size)
+        void Checkbox::create_image(const Size& size, const Colour& colour)
         {
             auto outer = std::make_unique<Window>(Point(), size, Colour(1.0f, 0.0f, 0.0f, 0.0f));
-            auto inner = std::make_unique<Window>(Point(1, 1), size - Size(2, 2), Colour(1.0f, 0.5f, 0.5f, 0.5f));
+            auto inner = std::make_unique<Window>(Point(1, 1), size - Size(2, 2), colour);
             auto fill = std::make_unique<Window>(Point(1, 1), size - Size(4, 4), off_colour);
 
             _fill = fill.get();

--- a/trview.ui/Checkbox.h
+++ b/trview.ui/Checkbox.h
@@ -26,6 +26,13 @@ namespace trview
             /// @param label_text The text for the associated label.
             Checkbox(const Point& position, const Size& size, const std::wstring& label_text);
 
+            /// Creates a checkox with an associated label.
+            /// @param position The position of the checkbox.
+            /// @param size The size of the checkbox.
+            /// @param background_colour Background colour of the label.
+            /// @param label_text The text for the associated label.
+            Checkbox(const Point& position, const Size& size, const Colour& background_colour, const std::wstring& label_text);
+
             /// Destructor for the checkbox.
             virtual ~Checkbox() = default;
 
@@ -47,7 +54,7 @@ namespace trview
         protected:
             virtual bool clicked(Point position) override;
         private:
-            void create_image(const Size& size);
+            void create_image(const Size& size, const Colour& colour);
 
             ui::Label*  _label;
             ui::Window* _fill;

--- a/trview.ui/GroupBox.cpp
+++ b/trview.ui/GroupBox.cpp
@@ -5,7 +5,7 @@ namespace trview
 {
     namespace ui
     {
-        GroupBox::GroupBox(Point point, Size size, Colour background_colour, Colour border_colour, const std::wstring& text)
+        GroupBox::GroupBox(const Point& point, const Size& size, const Colour& background_colour, const Colour& border_colour, const std::wstring& text)
             : Window(point, size, background_colour), _border_colour(border_colour), _text(text)
         {
             auto top = std::make_unique<Window>(Point(0, 5), Size(size.width, 2), border_colour);

--- a/trview.ui/GroupBox.h
+++ b/trview.ui/GroupBox.h
@@ -9,7 +9,7 @@ namespace trview
         class GroupBox : public Window
         {
         public:
-            GroupBox(Point point, Size size, Colour background_colour, Colour border_colour, const std::wstring& text);
+            GroupBox(const Point& point, const Size& size, const Colour& background_colour, const Colour& border_colour, const std::wstring& text);
         private:
             Colour       _border_colour;
             std::wstring _text;

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -238,7 +238,7 @@ namespace trview
                 // of the list of items) then do not do any more scrolling down. Only elements that are
                 // invisible and fully in the client area count towards this.
                 const auto rows = _rows_element->child_elements();
-                if (std::any_of(rows.begin(), rows.end(), [](const auto& r) { return !r->visible() && r->position().y + r->size().height < r->parent()->size().height; }))
+                if (std::any_of(rows.begin(), rows.end(), [](const auto& r) { return !r->visible() && r->position().y + r->size().height <= r->parent()->size().height; }))
                 {
                     return true;
                 }
@@ -247,7 +247,7 @@ namespace trview
                 if (!rows.empty())
                 {
                     const auto& last = rows.back();
-                    if (last->position().y + last->size().height < _rows_element->size().height)
+                    if (last->position().y + last->size().height <= _rows_element->size().height)
                     {
                         return true;
                     }

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -17,7 +17,7 @@ namespace trview
             : _type(type), _name(name), _width(width)
         {
         }
-        
+
         Listbox::Column::Type Listbox::Column::type() const
         {
             return _type;
@@ -143,6 +143,8 @@ namespace trview
                     auto button = std::make_unique<Button>(Point(), Size(column.width(), 20), L"Test");
                     _token_store.add(button->on_click += [this, index]()
                     {
+                        _selected_item = index + _current_top;
+                        highlight_item();
                         on_item_selected(_items[index + _current_top]);
                     });
                     row->add_child(std::move(button));
@@ -191,6 +193,8 @@ namespace trview
             {
                 _rows_scrollbar->set_range(_current_top, _current_top + fully_visible_rows, _items.size());
             }
+
+            highlight_item();
         }
 
         void Listbox::sort_items()
@@ -307,6 +311,20 @@ namespace trview
 
             _headers_element = headers_element.get();
             add_child(std::move(headers_element));
+        }
+
+        void Listbox::highlight_item()
+        {
+            const auto rows = _rows_element->child_elements();
+            for (uint32_t i = 0; i < rows.size(); ++i)
+            {
+                const auto columns = rows[i]->child_elements();
+                for (auto& cell : columns)
+                {
+                    Button* button_cell = static_cast<Button*>(cell);
+                    button_cell->set_text_background_colour(i + _current_top == _selected_item ? Colour(1.0f, 0.5f, 0.5f, 0.5f) : Colour(1.0f, 0.4f, 0.4f, 0.4f));
+                }
+            }
         }
     }
 }

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -282,7 +282,7 @@ namespace trview
                 return;
             }
 
-            auto headers_element = std::make_unique<StackPanel>(Point(), size(), Colour(1.0f, 0.3f, 0.3f, 0.3f), Size(), Direction::Horizontal);
+            auto headers_element = std::make_unique<StackPanel>(Point(), size(), background_colour(), Size(), Direction::Horizontal);
             for (const auto column : _columns)
             {
                 auto header_element = std::make_unique<Button>(Point(), Size(column.width(), 20), column.name());
@@ -303,7 +303,7 @@ namespace trview
             }
 
             // Add the spacer to make the scrollbar look ok.
-            headers_element->add_child(std::make_unique<Window>(Point(), Size(10, 20), Colour(1.0f, 0.4f, 0.4f, 0.4f)));
+            headers_element->add_child(std::make_unique<Window>(Point(), Size(10, 20), background_colour()));
 
             _headers_element = headers_element.get();
             add_child(std::move(headers_element));

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -333,12 +333,9 @@ namespace trview
                 Colour colour{ 1.0f, 0.4f, 0.4f, 0.4f };
 
                 const auto index = i + _current_top;
-                if (_show_highlight && index < _items.size() && _selected_item.has_value())
+                if (_show_highlight && index < _items.size() && _selected_item == _items[index])
                 {
-                    if (_items[index] == _selected_item.value())
-                    {
-                        colour = Colour(1.0f, 0.5f, 0.5f, 0.5f);
-                    }
+                    colour = Colour(1.0f, 0.5f, 0.5f, 0.5f);
                 }
 
                 const auto columns = rows[i]->child_elements();

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -48,6 +48,11 @@ namespace trview
             return item->second;
         }
 
+        bool Listbox::Item::operator == (const Item& other) const
+        {
+            return _values == other._values;
+        }
+
         Listbox::Listbox(const Point& position, const Size& size, const Colour& background_colour)
             : StackPanel(position, size, background_colour, Size(), Direction::Vertical, SizeMode::Manual)
         {
@@ -72,9 +77,6 @@ namespace trview
         {
             // Reset the index for scrolling.
             _current_top = 0;
-
-            // Reset highlight
-            _selected_item = -1;
 
             // Store the items for later.
             _items = items;
@@ -146,9 +148,9 @@ namespace trview
                     auto button = std::make_unique<Button>(Point(), Size(column.width(), 20), L"Test");
                     _token_store.add(button->on_click += [this, index]()
                     {
-                        _selected_item = index + _current_top;
+                        _selected_item = _items[index + _current_top];
                         highlight_item();
-                        on_item_selected(_items[index + _current_top]);
+                        on_item_selected(_selected_item.value());
                     });
                     row->add_child(std::move(button));
                 }
@@ -321,11 +323,23 @@ namespace trview
             const auto rows = _rows_element->child_elements();
             for (uint32_t i = 0; i < rows.size(); ++i)
             {
+                // Default colour - not highlighted.
+                Colour colour{ 1.0f, 0.4f, 0.4f, 0.4f };
+
+                const auto index = i + _current_top;
+                if (index < _items.size() && _selected_item.has_value())
+                {
+                    if (_items[index] == _selected_item.value())
+                    {
+                        colour = Colour(1.0f, 0.5f, 0.5f, 0.5f);
+                    }
+                }
+
                 const auto columns = rows[i]->child_elements();
                 for (auto& cell : columns)
                 {
                     Button* button_cell = static_cast<Button*>(cell);
-                    button_cell->set_text_background_colour(i + _current_top == _selected_item ? Colour(1.0f, 0.5f, 0.5f, 0.5f) : Colour(1.0f, 0.4f, 0.4f, 0.4f));
+                    button_cell->set_text_background_colour(colour);
                 }
             }
         }

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -73,6 +73,9 @@ namespace trview
             // Reset the index for scrolling.
             _current_top = 0;
 
+            // Reset highlight
+            _selected_item = -1;
+
             // Store the items for later.
             _items = items;
 

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -327,7 +327,7 @@ namespace trview
         void Listbox::highlight_item()
         {
             const auto rows = _rows_element->child_elements();
-            for (uint32_t i = 0; i < rows.size(); ++i)
+            for (auto i = 0; i < rows.size(); ++i)
             {
                 // Default colour - not highlighted.
                 Colour colour{ 1.0f, 0.4f, 0.4f, 0.4f };

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -333,7 +333,7 @@ namespace trview
                 Colour colour{ 1.0f, 0.4f, 0.4f, 0.4f };
 
                 const auto index = i + _current_top;
-                if (index < _items.size() && _selected_item.has_value())
+                if (_show_highlight && index < _items.size() && _selected_item.has_value())
                 {
                     if (_items[index] == _selected_item.value())
                     {

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -271,6 +271,12 @@ namespace trview
             generate_ui();
         }
 
+        void Listbox::set_show_highlight(bool value)
+        {
+            _show_highlight = value;
+            generate_ui();
+        }
+
         void Listbox::generate_ui()
         {
             _headers_element = nullptr;

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -117,6 +117,8 @@ namespace trview
             /// Sort the items according to the current sort method.
             void sort_items();
 
+            void highlight_item();
+
             std::vector<Column> _columns;
             std::vector<Item> _items;
             StackPanel* _headers_element;
@@ -129,6 +131,7 @@ namespace trview
             bool _show_scrollbar{ true };
             bool _show_headers{ true };
             TokenStore _token_store;
+            int32_t _selected_item{ -1 };
         };
     }
 }

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -79,7 +79,8 @@ namespace trview
             /// Create a new Listbox.
             /// @param position The position of the listbox.
             /// @param size The size of the listbox.
-            Listbox(const Point& position, const Size& size);
+            /// @param background_colour The background colour for the list box.
+            Listbox(const Point& position, const Size& size, const Colour& background_colour);
 
             /// Destructor for Listbox.
             virtual ~Listbox();
@@ -92,11 +93,23 @@ namespace trview
             /// @param items The items to add to the list box.
             void set_items(const std::vector<Item>& items);
 
+            /// Set whether to show a scrollbar.
+            /// @param value Whether to show the scrollbar.
+            void set_show_scrollbar(bool value);
+
+            /// Set whether to show column headers.
+            /// @param value Whether to show column headers.
+            void set_show_headers(bool value);
+
             /// Event raised when an item is selected
             Event<Item> on_item_selected;
         protected:
             virtual bool scroll(int delta) override;
         private:
+            /// Generate all child UI elements.
+            void generate_ui();
+            /// Generate the header element.
+            void generate_headers();
             /// Create the row UI elements to be populated.
             void generate_rows();
             /// Populate the row UI elements with the values from the current listbox item sort.
@@ -113,6 +126,8 @@ namespace trview
             int32_t _current_top{ 0 };
             Column _current_sort;
             bool _current_sort_direction;
+            bool _show_scrollbar{ true };
+            bool _show_headers{ true };
             TokenStore _token_store;
         };
     }

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -107,6 +107,10 @@ namespace trview
             /// @param value Whether to show column headers.
             void set_show_headers(bool value);
 
+            /// Set whether to highlight rows.
+            /// @param value Whether to highlight rows.
+            void set_show_highlight(bool value);
+
             /// Event raised when an item is selected
             Event<Item> on_item_selected;
         protected:
@@ -136,6 +140,7 @@ namespace trview
             bool _current_sort_direction;
             bool _show_scrollbar{ true };
             bool _show_headers{ true };
+            bool _show_highlight{ true };
             TokenStore _token_store;
             std::optional<Item> _selected_item;
         };

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <string>
 #include <unordered_map>
+#include <optional>
 
 #include <trview.common/TokenStore.h>
 
@@ -72,6 +73,11 @@ namespace trview
                 /// @param key The key to search for.
                 /// @returns The value for the key.
                 std::wstring value(const std::wstring& key) const;
+
+                /// Determines whether two items are equal.
+                /// @param other The item to compare.
+                /// @returns Whether the items are equal.
+                bool operator == (const Item& other) const;
             private:
                 std::unordered_map<std::wstring, std::wstring> _values;
             };
@@ -131,7 +137,7 @@ namespace trview
             bool _show_scrollbar{ true };
             bool _show_headers{ true };
             TokenStore _token_store;
-            int32_t _selected_item{ -1 };
+            std::optional<Item> _selected_item;
         };
     }
 }

--- a/trview.ui/Scrollbar.cpp
+++ b/trview.ui/Scrollbar.cpp
@@ -4,8 +4,8 @@ namespace trview
 {
     namespace ui
     {
-        Scrollbar::Scrollbar(const Point& position, const Size& size)
-            : Window(position, size, Colour(1.0f, 0.4f, 0.4f, 0.4f))
+        Scrollbar::Scrollbar(const Point& position, const Size& size, const Colour& background_colour)
+            : Window(position, size, background_colour)
         {
             auto blob = std::make_unique<Window>(Point(), Size(size.width, 10), Colour(1.0f, 0.2f, 0.2f, 0.2f));
             _blob = blob.get();

--- a/trview.ui/Scrollbar.h
+++ b/trview.ui/Scrollbar.h
@@ -16,7 +16,8 @@ namespace trview
             /// Create a new scrollbar.
             /// @param position The position for the scrollbar.
             /// @param size The size of the new scrollbar.
-            Scrollbar(const Point& position, const Size& size);
+            /// @param background_colour The background colour of the scrollbar.
+            Scrollbar(const Point& position, const Size& size, const Colour& background_colour);
 
             /// Destructor for scrollbar.
             virtual ~Scrollbar() = default;

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -275,7 +275,7 @@ namespace trview
             _entities.push_back(std::move(entity));
 
             // Item for item information.
-            _items.emplace_back(i, level_entity.Room, level_entity.TypeID, lookup_type_name(level_entity.TypeID));
+            _items.emplace_back(i, level_entity.Room, level_entity.TypeID, lookup_type_name(level_entity.TypeID), _level->get_version() >= trlevel::LevelVersion::Tomb4 ? level_entity.Intensity2 : 0, level_entity.Flags);
         }
     }
 


### PR DESCRIPTION
Item details are show in a panel in the items window. The details of the currently selected item are shown.

The current stats are:
- Type
- Number
- Type ID
- Room
- Clear Body flag
- Invisible flag
- OCB value

Doesn't show where an item is triggered yet - that is in issue #284
Issue: #274 