### PR TITLE
If floordata parsing the end of the floordata list, stop processing

### DIFF
--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -66,6 +66,10 @@ namespace trlevel
         // Returns: The object texture.
         virtual tr_object_texture get_object_texture(uint32_t index) const = 0;
 
+        /// Get the number of floordata values in the level.
+        /// @returns The number of floordata values.
+        virtual uint32_t num_floor_data() const = 0;
+
         // Get the floor data at the specified index.
         // index: The index of the floor data to get.
         // Returns: The floor data.

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -292,6 +292,11 @@ namespace trlevel
         return _object_textures[index];
     }
 
+    uint32_t Level::num_floor_data() const
+    {
+        return _floor_data.size();
+    }
+
     uint16_t Level::get_floor_data(uint32_t index) const
     {
         return _floor_data[index];

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -72,6 +72,10 @@ namespace trlevel
         // Returns: The object texture.
         virtual tr_object_texture get_object_texture(uint32_t index) const override;
 
+        /// Get the number of floordata values in the level.
+        /// @returns The number of floordata values.
+        virtual uint32_t num_floor_data() const override;
+
         // Get the floor data at the specified index.
         // index: The index of the floor data to get.
         // Returns: The floor data.

--- a/trview/Sector.cpp
+++ b/trview/Sector.cpp
@@ -57,6 +57,8 @@ namespace trview
         if (cur_index == 0x0)
             return true; 
 
+        const auto max_floordata = _level.num_floor_data();
+
         for (;;)
         {
             std::uint16_t floor = _level.get_floor_data(cur_index);
@@ -93,12 +95,14 @@ namespace trview
                 _trigger.type = (TriggerType) subfunction;
 
                 // Parse actions 
-                while ((command = _level.get_floor_data(++cur_index)) & 0x8000)
+                ++cur_index;
+                while (cur_index < max_floordata && ((command = _level.get_floor_data(cur_index)) & 0x8000))
                 {
                     _trigger.commands.emplace_back (
                         (TriggerCommandType) ((command & 0x7C00) >> 10),
                         command & 0x3FF
                     ); 
+                    ++cur_index;
                 }
 
                 flags |= SectorFlag::Trigger; 


### PR DESCRIPTION
The continue bit was set, but it was reaching the end of the floordata array.
When this happens, just stop processing.
Issue: #281