### PR TITLE
Allow scrolling the items list with up/down arrows

### DIFF
--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -77,7 +77,7 @@ namespace trview
     ItemsWindow::ItemsWindow(const Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent)
         : MessageHandler(create_items_window(parent)), _window_resizer(window()), _device_window(device.create_for_window(window())),
         _ui_renderer(std::make_unique<ui::render::Renderer>(device.device(), shader_storage, font_factory, window().size())),
-        _mouse(window())
+        _mouse(window()), _keyboard(window())
     {
         _token_store.add(_window_resizer.on_resize += [=]()
         {
@@ -91,6 +91,7 @@ namespace trview
         _token_store.add(_mouse.mouse_move += [&](auto, auto) { _ui->mouse_move(client_cursor_position(window())); });
         _token_store.add(_mouse.mouse_down += [&](input::Mouse::Button) { _ui->mouse_down(client_cursor_position(window())); });
         _token_store.add(_mouse.mouse_wheel += [&](int16_t delta) { _ui->mouse_scroll(client_cursor_position(window()), delta); });
+        _token_store.add(_keyboard.on_key_down += [&](auto key) { _ui->keyboard_down(key); });
     }
 
     void ItemsWindow::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -6,6 +6,7 @@
 #include <trview.common/MessageHandler.h>
 #include <trview.graphics/Device.h>
 #include <trview.input/Mouse.h>
+#include <trview.input/Keyboard.h>
 #include <trview.common/TokenStore.h>
 #include <trview.ui/Listbox.h>
 #include "WindowResizer.h"
@@ -90,6 +91,7 @@ namespace trview
         ui::Listbox* _stats_list;
         std::unique_ptr<ui::render::Renderer> _ui_renderer;
         input::Mouse _mouse;
+        input::Keyboard _keyboard;
         TokenStore _token_store;
 
         std::vector<Item> _all_items;

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -208,6 +208,11 @@ namespace trview
             return false;
         }
 
+        bool Control::key_down(uint16_t key)
+        {
+            return false;
+        }
+
         void Control::set_focus_control(Control* control)
         {
             if (_parent)
@@ -234,6 +239,28 @@ namespace trview
         void Control::set_handles_input(bool value)
         {
             _handles_input = value;
+        }
+
+        bool Control::keyboard_down(uint16_t key)
+        {
+            if (_focus_control && _focus_control != this)
+            {
+                bool focus_handled = _focus_control->keyboard_down(key);
+                if (focus_handled)
+                {
+                    return true;
+                }
+            }
+
+            bool handled = false;
+            for (auto& child : _child_elements)
+            {
+                handled |= child->keyboard_down(key);
+            }
+
+            // If none of the child elements have handled this event themselves, call the key_down
+            // event of the control.
+            return handled | key_down(key);
         }
 
         bool Control::is_mouse_over(const Point& position) const

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -117,6 +117,11 @@ namespace trview
             /// @param value Whether the control handles input.
             void set_handles_input(bool value);
 
+            /// Process a key down event.
+            /// @param key The key that was pressed down.
+            /// @returns True if the event was processed by the control.
+            bool keyboard_down(uint16_t key);
+
             /// Set the size of the control.
             /// @param size The new size of the control.
             void set_size(Size size);
@@ -159,6 +164,12 @@ namespace trview
             /// This should be overiden by child elements to handle a scroll.
             /// @param delta The mouse scroll delta.
             virtual bool scroll(int delta);
+
+            /// To be called when a key was pressed.
+            /// This should be overidden by child elements to handle a key down event.
+            /// @param key The key that was pressed.
+            /// @returns True if the key event was handled.
+            virtual bool key_down(uint16_t key);
 
             /// Set the control in the tree that has focus.
             /// @param control The current focus control

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -163,7 +163,7 @@ namespace trview
                 return;
             }
 
-            int32_t fully_visible_rows = 0;
+            _fully_visible_rows = 0;
             const auto rows = _rows_element->child_elements();
             for (auto r = 0; r < rows.size(); ++r)
             {
@@ -176,7 +176,7 @@ namespace trview
 
                     if (rows[r]->position().y + rows[r]->size().height <= _rows_element->size().height)
                     {
-                        ++fully_visible_rows;
+                        ++_fully_visible_rows;
                     }
 
                     const auto& item = _items[r + _current_top];
@@ -194,7 +194,7 @@ namespace trview
 
             if (!_items.empty() && _rows_scrollbar)
             {
-                _rows_scrollbar->set_range(_current_top, _current_top + fully_visible_rows, _items.size());
+                _rows_scrollbar->set_range(_current_top, _current_top + _fully_visible_rows, _items.size());
             }
 
             highlight_item();
@@ -366,7 +366,20 @@ namespace trview
         void Listbox::select_item(const Item& item)
         {
             _selected_item = item;
-            highlight_item();
+
+            // Scroll the list so that the selected item is visible. If it is already on the 
+            // same page, then no need to scroll.
+            auto index = std::find(_items.begin(), _items.end(), item) - _items.begin();
+            if (index < _current_top)
+            {
+                _current_top = index;
+            }
+            else if (index >= _current_top + _fully_visible_rows)
+            {
+                _current_top = index - _fully_visible_rows + 1;
+            }
+
+            populate_rows();
             on_item_selected(_selected_item.value());
         }
 

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -148,9 +148,7 @@ namespace trview
                     auto button = std::make_unique<Button>(Point(), Size(column.width(), 20), L"Test");
                     _token_store.add(button->on_click += [this, index]()
                     {
-                        _selected_item = _items[index + _current_top];
-                        highlight_item();
-                        on_item_selected(_selected_item.value());
+                        select_item(_items[index + _current_top]);
                     });
                     row->add_child(std::move(button));
                 }
@@ -259,6 +257,47 @@ namespace trview
             return true;
         }
 
+        bool Listbox::key_down(uint16_t key)
+        {
+            if (key != VK_UP && key != VK_DOWN)
+            {
+                return false;
+            }
+
+            // Find the selected item in the list.
+            auto item = std::find(_items.begin(), _items.end(), _selected_item);
+
+            // If the item isn't in the list but there are items in the list, select the first item in the list.
+            if (item == _items.end())
+            {
+                if (!_items.empty())
+                {
+                    select_item(_items.front());
+                }
+            }
+            else 
+            {
+                // Go up if possible (not already at the start of the list)
+                if (key == VK_UP)
+                {
+                    if (item == _items.begin())
+                    {
+                        return false;
+                    }
+                    select_item(*--item);
+                    return true;
+                }
+
+                // Go down if possible (not at the end of the list).
+                if (key == VK_DOWN && ++item != _items.end())
+                {
+                    select_item(*item);
+                    return true;
+                }
+            }
+            return true;
+        }
+
         void Listbox::set_show_scrollbar(bool value)
         {
             _show_scrollbar = value;
@@ -322,6 +361,13 @@ namespace trview
 
             _headers_element = headers_element.get();
             add_child(std::move(headers_element));
+        }
+
+        void Listbox::select_item(const Item& item)
+        {
+            _selected_item = item;
+            highlight_item();
+            on_item_selected(_selected_item.value());
         }
 
         void Listbox::highlight_item()

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -146,6 +146,7 @@ namespace trview
             bool _show_highlight{ true };
             TokenStore _token_store;
             std::optional<Item> _selected_item;
+            uint32_t _fully_visible_rows;
         };
     }
 }

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -115,6 +115,7 @@ namespace trview
             Event<Item> on_item_selected;
         protected:
             virtual bool scroll(int delta) override;
+            virtual bool key_down(uint16_t key) override;
         private:
             /// Generate all child UI elements.
             void generate_ui();
@@ -126,6 +127,8 @@ namespace trview
             void populate_rows();
             /// Sort the items according to the current sort method.
             void sort_items();
+
+            void select_item(const Item& item);
 
             void highlight_item();
 

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -146,7 +146,7 @@ namespace trview
             bool _show_highlight{ true };
             TokenStore _token_store;
             std::optional<Item> _selected_item;
-            uint32_t _fully_visible_rows;
+            uint32_t _fully_visible_rows{ 0u };
         };
     }
 }

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -127,7 +127,7 @@ namespace trview
             void populate_rows();
             /// Sort the items according to the current sort method.
             void sort_items();
-
+            /// Select the given item and scroll to make it visible.
             void select_item(const Item& item);
 
             void highlight_item();


### PR DESCRIPTION
User can press up/down arrows when the Items window is the focus window.
The items list will go to the previous/next item.
The item is selected and scrolled into view if required.
Issue: #287 