### PR TITLE
Add dragging of the scrollbar for the items list

### DIFF
--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -87,11 +87,11 @@ namespace trview
         });
         generate_ui();
 
-        _token_store.add(_mouse.mouse_up += [&](auto) { _ui->mouse_up(client_cursor_position(window())); });
-        _token_store.add(_mouse.mouse_move += [&](auto, auto) { _ui->mouse_move(client_cursor_position(window())); });
-        _token_store.add(_mouse.mouse_down += [&](input::Mouse::Button) { _ui->mouse_down(client_cursor_position(window())); });
+        _token_store.add(_mouse.mouse_up += [&](auto) { _ui->process_mouse_up(client_cursor_position(window())); });
+        _token_store.add(_mouse.mouse_move += [&](auto, auto) { _ui->process_mouse_move(client_cursor_position(window())); });
+        _token_store.add(_mouse.mouse_down += [&](input::Mouse::Button) { _ui->process_mouse_down(client_cursor_position(window())); });
         _token_store.add(_mouse.mouse_wheel += [&](int16_t delta) { _ui->mouse_scroll(client_cursor_position(window()), delta); });
-        _token_store.add(_keyboard.on_key_down += [&](auto key) { _ui->keyboard_down(key); });
+        _token_store.add(_keyboard.on_key_down += [&](auto key) { _ui->process_key_down(key); });
     }
 
     void ItemsWindow::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
@@ -185,7 +185,7 @@ namespace trview
         _left_panel->set_size(Size(_left_panel->size().width, new_height));
         _divider->set_size(Size(_divider->size().width, new_height));
         _right_panel->set_size(Size(_right_panel->size().width, new_height));
-        _items_list->set_size(Size(_items_list->size().width, new_height - _items_list->position().y));
+        _items_list->set_size(Size(_items_list->size().width, _left_panel->size().height - _items_list->position().y));
     }
 
     std::unique_ptr<ui::StackPanel> ItemsWindow::create_items_panel()
@@ -232,6 +232,9 @@ namespace trview
 
         _items_list = items_list.get();
         left_panel->add_child(std::move(items_list));
+
+        // Fix items list size now that it has been added to the panel.
+        _items_list->set_size(Size(200, left_panel->size().height - _items_list->position().y));
 
         _left_panel = left_panel.get();
         return left_panel;

--- a/trview.ui.tests/ButtonTests.cpp
+++ b/trview.ui.tests/ButtonTests.cpp
@@ -19,7 +19,7 @@ namespace trview
                     Button button(Point(), Size(20, 20), graphics::Texture(), graphics::Texture());
                     bool raised = false;
                     auto token = button.on_click += [&raised]() { raised = true; };
-                    button.mouse_down(Point());
+                    button.process_mouse_down(Point());
                     Assert::IsTrue(raised);
                 }
             };

--- a/trview.ui.tests/CheckboxTests.cpp
+++ b/trview.ui.tests/CheckboxTests.cpp
@@ -45,7 +45,7 @@ namespace trview
                         ++times;
                     };
 
-                    checkbox.mouse_down(Point());
+                    checkbox.process_mouse_down(Point());
                     Assert::IsTrue(raised);
                     Assert::AreEqual(1u, times);
                     Assert::AreEqual(true, raised_state);
@@ -64,8 +64,8 @@ namespace trview
                         states.push_back(state);
                     };
 
-                    checkbox.mouse_down(Point());
-                    checkbox.mouse_down(Point());
+                    checkbox.process_mouse_down(Point());
+                    checkbox.process_mouse_down(Point());
                     Assert::AreEqual((std::size_t)2u, states.size());
                     Assert::AreEqual(true, static_cast<bool>(states[0]));
                     Assert::AreEqual(false, static_cast<bool>(states[1]));

--- a/trview.ui/Button.cpp
+++ b/trview.ui/Button.cpp
@@ -27,6 +27,16 @@ namespace trview
         {
         }
 
+        bool Button::mouse_down(const Point&)
+        {
+            return true;
+        }
+
+        bool Button::mouse_up(const Point&)
+        {
+            return true;
+        }
+
         bool Button::clicked(Point)
         {
             on_click();

--- a/trview.ui/Button.h
+++ b/trview.ui/Button.h
@@ -60,6 +60,8 @@ namespace trview
             /// @param colour The background colour.
             void set_text_background_colour(const Colour& colour);
         protected:
+            virtual bool mouse_down(const Point& position) override;
+            virtual bool mouse_up(const Point& position) override;
             virtual bool clicked(Point position) override;
         private:
             graphics::Texture _up_image;

--- a/trview.ui/Checkbox.cpp
+++ b/trview.ui/Checkbox.cpp
@@ -50,6 +50,16 @@ namespace trview
             add_child(std::move(outer));
         }
 
+        bool Checkbox::mouse_down(const Point&)
+        {
+            return true;
+        }
+
+        bool Checkbox::mouse_up(const Point&)
+        {
+            return true;
+        }
+
         bool Checkbox::clicked(Point)
         {
             set_state(!_state);

--- a/trview.ui/Checkbox.h
+++ b/trview.ui/Checkbox.h
@@ -52,6 +52,8 @@ namespace trview
             /// @param enabled Whether the checkbox is enabled.
             void set_enabled(bool enabled);
         protected:
+            virtual bool mouse_down(const Point& position) override;
+            virtual bool mouse_up(const Point& position) override;
             virtual bool clicked(Point position) override;
         private:
             void create_image(const Size& size, const Colour& colour);

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -47,6 +47,10 @@ namespace trview
             /// @returns The position of the control relative to the parent.
             Point position() const;
 
+            /// Get the absolute position of the control relative the to most distant parent.
+            /// @returns The absolute position of the control.
+            Point absolute_position() const;
+
             /// Set the X and Y position of the control relative to the parent window.
             /// To get the position of the control, call position.
             /// @param position The position of the control in the parent window.
@@ -89,17 +93,17 @@ namespace trview
             /// Process a mouse_down event at the position specified.
             /// @param position The position of the mouse relative to the control.
             /// @returns Whether the mouse down event was handled by the control.
-            bool mouse_down(const Point& position);
+            bool process_mouse_down(const Point& position);
 
             /// Process a mouse_up event a tthe position specified.
             /// @param position The position of the mouse relative to the control.
             /// @returns Whether the mouse up event was handled by the control.
-            bool mouse_up(const Point& position);
+            bool process_mouse_up(const Point& position);
 
             /// Process a mouse_move event at the position specified.
             /// @param position The position of the mouse relative to the control.
             /// @returns Whether the mouse move was handled by the control.
-            bool mouse_move(const Point& position);
+            bool process_mouse_move(const Point& position);
 
             /// Process a mouse_scroll event.
             /// @param position The position of the mouse relative to the control.
@@ -120,7 +124,7 @@ namespace trview
             /// Process a key down event.
             /// @param key The key that was pressed down.
             /// @returns True if the event was processed by the control.
-            bool keyboard_down(uint16_t key);
+            bool process_key_down(uint16_t key);
 
             /// Set the size of the control.
             /// @param size The new size of the control.
@@ -150,6 +154,16 @@ namespace trview
             /// Event raised when there has been a change to the children of this control.
             Event<> on_hierarchy_changed;
         protected:
+            /// To be called when the mouse has been pressed down over the element.
+            /// @param position The position of the mouse down relative to the control.
+            /// @return True if the event was handled by the element.
+            virtual bool mouse_down(const Point& position);
+
+            /// To be called when the mouse has been reelase over the element.
+            /// @param position The position of the mouse up relative to the control.
+            /// @return True if the event was handled by the element.
+            virtual bool mouse_up(const Point& position);
+
             /// To be called when the user interface element has been clicked.
             /// This should be overriden by child elements to handle a click.
             /// @param position The position of the click relative to the control.
@@ -179,6 +193,22 @@ namespace trview
             /// @returns The currently focused control.
             Control* focus_control() const;
         private:
+            /// Set the focus control and recurse to child controls.
+            /// @param control The new focus control.
+            void inner_set_focus_control(Control* control);
+
+            /// Process a mouse move and recurse to child controls.
+            /// @param position The position of the mouse relative to the control.
+            bool inner_process_mouse_move(const Point& position);
+
+            /// Process a mouse up and recurse to child controls.
+            /// @param position The position of the mouse relative to the control.
+            bool inner_process_mouse_up(const Point& position);
+
+            /// Process a key down and recurse to child controls.
+            /// @param key The key that was pressed.
+            bool inner_process_key_down(uint16_t key);
+
             std::vector<std::unique_ptr<Control>> _child_elements;
 
             Control* _parent{ nullptr };

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -121,7 +121,7 @@ namespace trview
                     auto rows_scrollbar = std::make_unique<Scrollbar>(Point(), Size(scrollbar_width, remaining_height), background_colour());
                     _token_store.add(rows_scrollbar->on_scroll += [&](float value)
                     {
-                        _current_top = value * _items.size();
+                        _current_top = std::clamp<int32_t>(value * _items.size(), 0, _items.size() - _fully_visible_rows);
                         populate_rows();
                     });
                     _rows_scrollbar = rows_scrollbar.get();

--- a/trview.ui/Scrollbar.cpp
+++ b/trview.ui/Scrollbar.cpp
@@ -25,9 +25,28 @@ namespace trview
             _blob->set_position(Point(0, range_start_percentage * current_size.height));
         }
 
+        bool Scrollbar::mouse_down(const Point&)
+        {
+            return true;
+        }
+
+        bool Scrollbar::mouse_up(const Point&)
+        {
+            return true;
+        }
+
+        bool Scrollbar::move(Point position)
+        {
+            if (focus_control() == this)
+            {
+                return clicked(position);
+            }
+            return false;
+        }
+
         bool Scrollbar::clicked(Point position)
         {
-            on_scroll(position.y / size().height);
+            on_scroll(std::clamp(position.y / size().height, 0.0f, 1.0f));
             return true;
         }
     }

--- a/trview.ui/Scrollbar.h
+++ b/trview.ui/Scrollbar.h
@@ -32,6 +32,9 @@ namespace trview
             /// Event raised when the user has moved the blob in the scrollbar.
             Event<float> on_scroll;
         protected:
+            virtual bool mouse_down(const Point& position) override;
+            virtual bool mouse_up(const Point& position) override;
+            virtual bool move(Point position) override;
             virtual bool clicked(Point position) override;
         private:
             Window* _blob;

--- a/trview.ui/Slider.cpp
+++ b/trview.ui/Slider.cpp
@@ -39,6 +39,16 @@ namespace trview
             set_blob_position(value);
         }
 
+        bool Slider::mouse_down(const Point&)
+        {
+            return true;
+        }
+
+        bool Slider::mouse_up(const Point&)
+        {
+            return true;
+        }
+
         bool Slider::clicked(Point position)
         {
             set_blob_position(position);

--- a/trview.ui/Slider.h
+++ b/trview.ui/Slider.h
@@ -17,6 +17,8 @@ namespace trview
 
             void set_value(float value);
         protected:
+            virtual bool mouse_down(const Point& position) override;
+            virtual bool mouse_up(const Point& position) override;
             virtual bool clicked(Point position) override;
             virtual bool move(Point position) override;
         private:

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -276,15 +276,15 @@ namespace trview
             }
         });
 
-        _token_store.add(_mouse.mouse_up += [&](auto) { _control->mouse_up(client_cursor_position(_window)); });
-        _token_store.add(_mouse.mouse_move += [&](auto, auto) { _control->mouse_move(client_cursor_position(_window)); });
+        _token_store.add(_mouse.mouse_up += [&](auto) { _control->process_mouse_up(client_cursor_position(_window)); });
+        _token_store.add(_mouse.mouse_move += [&](auto, auto) { _control->process_mouse_move(client_cursor_position(_window)); });
 
         // Add some extra handlers for the user interface. These will be merged in
         // to one at some point so that the UI can take priority where appropriate.
         _token_store.add(_mouse.mouse_down += [&](Mouse::Button)
         {
             // The client mouse coordinate is already relative to the root window (at present).
-            _control->mouse_down(client_cursor_position(_window));
+            _control->process_mouse_down(client_cursor_position(_window));
         });
     }
 


### PR DESCRIPTION
Allow user to scroll the items list by clicking and dragging on the scrollbar.
Updated the control logic to have separate mouse down/up/click events. This could have been done in the same way that slider does it (in fact it is done in the same way), but it will be good to have these events as we can do fancier looking buttons at some point with them.
Issue: #288 