### PR TITLE
Move token store to Control class

### DIFF
--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -8,6 +8,7 @@
 #include <trview.common/Event.h>
 #include <trview.common/Size.h>
 #include <trview.common/Point.h>
+#include <trview.common/TokenStore.h>
 #include "Align.h"
 
 namespace trview
@@ -192,6 +193,8 @@ namespace trview
             /// Get the currently focused control.
             /// @returns The currently focused control.
             Control* focus_control() const;
+
+            TokenStore _token_store;
         private:
             /// Set the focus control and recurse to child controls.
             /// @param control The new focus control.

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -8,8 +8,6 @@
 #include <unordered_map>
 #include <optional>
 
-#include <trview.common/TokenStore.h>
-
 #include "StackPanel.h"
 
 namespace trview
@@ -144,7 +142,6 @@ namespace trview
             bool _show_scrollbar{ true };
             bool _show_headers{ true };
             bool _show_highlight{ true };
-            TokenStore _token_store;
             std::optional<Item> _selected_item;
             uint32_t _fully_visible_rows{ 0u };
         };

--- a/trview.ui/NumericUpDown.h
+++ b/trview.ui/NumericUpDown.h
@@ -3,7 +3,6 @@
 #include "Window.h"
 #include <trview.graphics/Texture.h>
 #include <trview.common/Event.h>
-#include <trview.common/TokenStore.h>
 
 namespace trview
 {
@@ -33,7 +32,6 @@ namespace trview
             int32_t _value{ 0 };
 
             ui::Label* _label;
-            TokenStore _token_store;
         };
     }
 }

--- a/trview.ui/StackPanel.h
+++ b/trview.ui/StackPanel.h
@@ -6,7 +6,6 @@
 #include "Window.h"
 #include "SizeMode.h"
 #include "SizeDimension.h"
-#include <trview.common/TokenStore.h>
 
 namespace trview
 {
@@ -53,7 +52,6 @@ namespace trview
             const Direction _direction;
             SizeMode _size_mode;
             SizeDimension _size_dimension{ SizeDimension::All };
-            TokenStore _token_store;
         };
     }
 }


### PR DESCRIPTION
A few controls were getting their own token store, so just move it to the base class so they all have one, whether they use it or not.
Issue: #300