### PR TITLE
Display the triggers that trigger an item in the items window

### DIFF
--- a/trview.app/Item.cpp
+++ b/trview.app/Item.cpp
@@ -2,8 +2,8 @@
 
 namespace trview
 {
-    Item::Item(uint32_t number, uint32_t room, uint32_t type_id, const std::wstring& type, uint32_t ocb, uint16_t flags)
-        : _number(number), _room(room), _type_id(type_id), _type(type), _ocb(ocb), _flags(flags)
+    Item::Item(uint32_t number, uint32_t room, uint32_t type_id, const std::wstring& type, uint32_t ocb, uint16_t flags, const std::vector<Trigger>& triggers)
+        : _number(number), _room(room), _type_id(type_id), _type(type), _ocb(ocb), _flags(flags), _triggers(triggers)
     {
     }
 

--- a/trview.app/Item.cpp
+++ b/trview.app/Item.cpp
@@ -46,4 +46,9 @@ namespace trview
     {
         return (_flags & 0x100) != 0;
     }
+
+    const std::vector<Trigger>& Item::triggers() const
+    {
+        return _triggers;
+    }
 }

--- a/trview.app/Item.h
+++ b/trview.app/Item.h
@@ -51,6 +51,10 @@ namespace trview
         /// Get whether the invisible_flag is set.
         /// @returns Whether invisible flag is set.
         bool invisible_flag() const;
+
+        /// Get the triggers that affect this object.
+        /// @returns The triggers.
+        const std::vector<Trigger>& triggers() const;
     private:
         std::vector<Trigger> _triggers;
         uint32_t _number;

--- a/trview.app/Item.h
+++ b/trview.app/Item.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include "Trigger.h"
 
 namespace trview
 {
@@ -16,7 +17,8 @@ namespace trview
         /// @param type The type name of the item.
         /// @param ocb The OCB value of the item.
         /// @param flags The flags for the entity.
-        explicit Item(uint32_t number, uint32_t room, const uint32_t type_id, const std::wstring& type, uint32_t ocb, uint16_t flags);
+        /// @param triggers The triggers that affect this entity.
+        explicit Item(uint32_t number, uint32_t room, const uint32_t type_id, const std::wstring& type, uint32_t ocb, uint16_t flags, const std::vector<Trigger>& triggers);
 
         /// Get the item number.
         /// @returns The item number.
@@ -50,6 +52,7 @@ namespace trview
         /// @returns Whether invisible flag is set.
         bool invisible_flag() const;
     private:
+        std::vector<Trigger> _triggers;
         uint32_t _number;
         uint32_t _room;
         uint32_t _type_id;

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -289,8 +289,7 @@ namespace trview
         trigger_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"Room", 40 },
-                { Listbox::Column::Type::Number, L"X", 70 },
-                { Listbox::Column::Type::Number, L"Z", 70 },
+                { Listbox::Column::Type::Number, L"Type", 140 },
             }
         );
         trigger_list->set_show_headers(true);
@@ -352,8 +351,7 @@ namespace trview
                     {
                         { L"#", std::to_wstring(trigger.number()) },
                         { L"Room", std::to_wstring(trigger.room()) },
-                        { L"X", std::to_wstring(trigger.x()) },
-                        { L"Z", std::to_wstring(trigger.z()) }
+                        { L"Type", trigger_type_name(trigger.type()) },
                     }
                 });
         }

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -287,7 +287,7 @@ namespace trview
             }
         );
         trigger_list->set_show_headers(false);
-        trigger_list->set_show_scrollbar(false);
+        trigger_list->set_show_scrollbar(true);
         trigger_list->set_show_highlight(false);
 
         _trigger_list = trigger_group_box->add_child(std::move(trigger_list));
@@ -330,5 +330,12 @@ namespace trview
         stats.push_back(make_item(L"Flags", format_binary(item.activation_flags())));
         stats.push_back(make_item(L"OCB", std::to_wstring(item.ocb())));
         _stats_list->set_items(stats);
+
+        std::vector<Listbox::Item> triggers;
+        for (auto& trigger : item.triggers())
+        {
+            triggers.push_back(make_item(std::wstring(L"Type"), std::wstring(L"Trigger")));
+        }
+        _trigger_list->set_items(triggers);
     }
 }

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -285,15 +285,16 @@ namespace trview
         // Add the trigger details group box.
         auto trigger_group_box = std::make_unique<GroupBox>(Point(), Size(200, 200), Colours::Triggers, Colours::DetailsBorder, L"Triggered By");
 
-        auto trigger_list = std::make_unique<Listbox>(Point(10, 21), Size(180, 160), Colours::Triggers);
+        auto trigger_list = std::make_unique<Listbox>(Point(10, 21), Size(190, 160), Colours::Triggers);
         trigger_list->set_columns(
             {
+                { Listbox::Column::Type::Number, L"#", 20 },
                 { Listbox::Column::Type::Number, L"Room", 40 },
-                { Listbox::Column::Type::Number, L"Type", 140 },
+                { Listbox::Column::Type::String, L"Type", 120 },
             }
         );
         trigger_list->set_show_headers(true);
-        trigger_list->set_show_scrollbar(false);
+        trigger_list->set_show_scrollbar(true);
         trigger_list->set_show_highlight(false);
 
         _token_store.add(trigger_list->on_item_selected += [&](const auto& item)
@@ -343,13 +344,14 @@ namespace trview
         stats.push_back(make_item(L"OCB", std::to_wstring(item.ocb())));
         _stats_list->set_items(stats);
 
+        uint32_t i = 0u;
         std::vector<Listbox::Item> triggers;
         for (auto& trigger : item.triggers())
         {
             triggers.push_back(
                 {
                     {
-                        { L"#", std::to_wstring(trigger.number()) },
+                        { L"#", std::to_wstring(i++) },
                         { L"Room", std::to_wstring(trigger.room()) },
                         { L"Type", trigger_type_name(trigger.type()) },
                     }

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -140,6 +140,7 @@ namespace trview
     void ItemsWindow::set_triggers(const std::vector<Trigger>& triggers)
     {
         _all_triggers = triggers;
+        _trigger_list->set_items({});
     }
 
     void ItemsWindow::clear_selected_item()
@@ -287,9 +288,9 @@ namespace trview
         auto trigger_list = std::make_unique<Listbox>(Point(10, 21), Size(180, 160), Colours::Triggers);
         trigger_list->set_columns(
             {
-                { Listbox::Column::Type::Number, L"Room", 30 },
-                { Listbox::Column::Type::Number, L"X", 75 },
-                { Listbox::Column::Type::Number, L"Z", 75 },
+                { Listbox::Column::Type::Number, L"Room", 40 },
+                { Listbox::Column::Type::Number, L"X", 70 },
+                { Listbox::Column::Type::Number, L"Z", 70 },
             }
         );
         trigger_list->set_show_headers(true);

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -282,12 +282,13 @@ namespace trview
         auto trigger_list = std::make_unique<Listbox>(Point(10, 21), Size(180, 160), Colours::Triggers);
         trigger_list->set_columns(
             {
-                { Listbox::Column::Type::Number, L"Name", 60 },
-                { Listbox::Column::Type::Number, L"Value", 120 },
+                { Listbox::Column::Type::Number, L"Room", 30 },
+                { Listbox::Column::Type::Number, L"X", 75 },
+                { Listbox::Column::Type::Number, L"Z", 75 },
             }
         );
-        trigger_list->set_show_headers(false);
-        trigger_list->set_show_scrollbar(true);
+        trigger_list->set_show_headers(true);
+        trigger_list->set_show_scrollbar(false);
         trigger_list->set_show_highlight(false);
 
         _trigger_list = trigger_group_box->add_child(std::move(trigger_list));
@@ -334,7 +335,14 @@ namespace trview
         std::vector<Listbox::Item> triggers;
         for (auto& trigger : item.triggers())
         {
-            triggers.push_back(make_item(std::wstring(L"Type"), std::wstring(L"Trigger")));
+            triggers.push_back(
+                {
+                    {
+                        { L"Room", std::to_wstring(trigger.room()) },
+                        { L"X", std::to_wstring(trigger.x()) },
+                        { L"Z", std::to_wstring(trigger.z()) }
+                    }
+                });
         }
         _trigger_list->set_items(triggers);
     }

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -25,7 +25,7 @@ namespace trview
             const Colour Divider { 1.0f, 0.0f, 0.0f, 0.0f };
             const Colour LeftPanel { 1.0f, 0.4f, 0.4f, 0.4f };
             const Colour ItemDetails { 1.0f, 0.35f, 0.35f, 0.35f };
-            const Colour Triggers { 1.0f, 0.375f, 0.375f, 0.375f };
+            const Colour Triggers { 1.0f, 0.3f, 0.3f, 0.3f };
             const Colour DetailsBorder { 0.0f, 0.0f, 0.0f, 0.0f };
         }
 
@@ -253,8 +253,8 @@ namespace trview
 
         const float height = window().size().height;
 
-        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colours::ItemDetails, Size(0, 4), StackPanel::Direction::Vertical, SizeMode::Manual);
-        auto group_box = std::make_unique<GroupBox>(Point(), Size(200, height), Colours::ItemDetails, Colours::DetailsBorder, L"Item Details");
+        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colours::ItemDetails, Size(0, 0), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto group_box = std::make_unique<GroupBox>(Point(), Size(200, 190), Colours::ItemDetails, Colours::DetailsBorder, L"Item Details");
 
         // Add some information about the selected item.
         auto stats_list = std::make_unique<Listbox>(Point(10,21), Size(180, 160), Colours::ItemDetails);
@@ -269,7 +269,17 @@ namespace trview
         stats_list->set_show_highlight(false);
 
         _stats_list = group_box->add_child(std::move(stats_list));
+
+        right_panel->add_child(std::make_unique<ui::Window>(Point(), Size(200, 8), Colours::ItemDetails));
         right_panel->add_child(std::move(group_box));
+
+        // Spacer element.
+        right_panel->add_child(std::make_unique<ui::Window>(Point(), Size(200, 5), Colours::Triggers));
+
+        // Add the trigger details group box.
+        auto trigger_group_box = std::make_unique<GroupBox>(Point(), Size(200, 200), Colours::Triggers, Colours::DetailsBorder, L"Trigger Details");
+
+        right_panel->add_child(std::move(trigger_group_box));
 
         // Store the right panel for later use.
         _right_panel = right_panel.get();

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -253,7 +253,7 @@ namespace trview
 
         const float height = window().size().height;
 
-        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colours::ItemDetails, Size(0, 0), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
         auto group_box = std::make_unique<GroupBox>(Point(), Size(200, 190), Colours::ItemDetails, Colours::DetailsBorder, L"Item Details");
 
         // Add some information about the selected item.
@@ -277,8 +277,20 @@ namespace trview
         right_panel->add_child(std::make_unique<ui::Window>(Point(), Size(200, 5), Colours::Triggers));
 
         // Add the trigger details group box.
-        auto trigger_group_box = std::make_unique<GroupBox>(Point(), Size(200, 200), Colours::Triggers, Colours::DetailsBorder, L"Trigger Details");
+        auto trigger_group_box = std::make_unique<GroupBox>(Point(), Size(200, 200), Colours::Triggers, Colours::DetailsBorder, L"Triggered By");
 
+        auto trigger_list = std::make_unique<Listbox>(Point(10, 21), Size(180, 160), Colours::Triggers);
+        trigger_list->set_columns(
+            {
+                { Listbox::Column::Type::Number, L"Name", 60 },
+                { Listbox::Column::Type::Number, L"Value", 120 },
+            }
+        );
+        trigger_list->set_show_headers(false);
+        trigger_list->set_show_scrollbar(false);
+        trigger_list->set_show_highlight(false);
+
+        _trigger_list = trigger_group_box->add_child(std::move(trigger_list));
         right_panel->add_child(std::move(trigger_group_box));
 
         // Store the right panel for later use.

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -24,7 +24,8 @@ namespace trview
         {
             const Colour Divider { 1.0f, 0.0f, 0.0f, 0.0f };
             const Colour LeftPanel { 1.0f, 0.4f, 0.4f, 0.4f };
-            const Colour RightPanel { 1.0f, 0.35f, 0.35f, 0.35f };
+            const Colour ItemDetails { 1.0f, 0.35f, 0.35f, 0.35f };
+            const Colour Triggers { 1.0f, 0.375f, 0.375f, 0.375f };
             const Colour DetailsBorder { 0.0f, 0.0f, 0.0f, 0.0f };
         }
 
@@ -35,11 +36,11 @@ namespace trview
 
         HWND init_items_instance(HWND parent, HINSTANCE hInstance, int nCmdShow)
         {
-            RECT rect{ 0, 0, 400, 200 };
+            RECT rect{ 0, 0, 400, 400 };
             AdjustWindowRect(&rect, window_style, FALSE);
 
             HWND items_window = CreateWindowW(L"trview.items", L"Items", window_style,
-                CW_USEDEFAULT, 0, rect.right - rect.left, 310, parent, nullptr, hInstance, nullptr);
+                CW_USEDEFAULT, 0, rect.right - rect.left, rect.bottom - rect.top, parent, nullptr, hInstance, nullptr);
 
             ShowWindow(items_window, nCmdShow);
             UpdateWindow(items_window);
@@ -102,13 +103,13 @@ namespace trview
         }
         else if (message == WM_GETMINMAXINFO)
         {
-            RECT rect{ 0, 0, _ui->size().width, 200 };
+            RECT rect{ 0, 0, _ui->size().width, 400 };
             AdjustWindowRect(&rect, window_style, FALSE);
 
             MINMAXINFO* info = reinterpret_cast<MINMAXINFO*>(lParam);
             info->ptMinTrackSize.x = rect.right - rect.left;
             info->ptMaxTrackSize.x = rect.right - rect.left;
-            info->ptMinTrackSize.y = 200;
+            info->ptMinTrackSize.y = rect.bottom - rect.top;
         }
     }
 
@@ -252,12 +253,11 @@ namespace trview
 
         const float height = window().size().height;
 
-        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colours::RightPanel, Size(0, 4), StackPanel::Direction::Vertical, SizeMode::Manual);
-        auto group_box = std::make_unique<GroupBox>(Point(), Size(200, height), Colours::RightPanel, Colours::DetailsBorder, L"Item Details");
-        auto controls = std::make_unique<StackPanel>(Point(10, 11), group_box->size(), Colours::RightPanel, Size(0, 5), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colours::ItemDetails, Size(0, 4), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto group_box = std::make_unique<GroupBox>(Point(), Size(200, height), Colours::ItemDetails, Colours::DetailsBorder, L"Item Details");
 
         // Add some information about the selected item.
-        auto stats_list = std::make_unique<Listbox>(Point(), Size(180, 160), Colours::RightPanel);
+        auto stats_list = std::make_unique<Listbox>(Point(10,21), Size(180, 160), Colours::ItemDetails);
         stats_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"Name", 60 },
@@ -268,8 +268,7 @@ namespace trview
         stats_list->set_show_scrollbar(false);
         stats_list->set_show_highlight(false);
 
-        _stats_list = controls->add_child(std::move(stats_list));
-        group_box->add_child(std::move(controls));
+        _stats_list = group_box->add_child(std::move(stats_list));
         right_panel->add_child(std::move(group_box));
 
         // Store the right panel for later use.

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -137,6 +137,11 @@ namespace trview
         populate_items(items);
     }
 
+    void ItemsWindow::set_triggers(const std::vector<Trigger>& triggers)
+    {
+        _all_triggers = triggers;
+    }
+
     void ItemsWindow::clear_selected_item()
     {
         _stats_list->set_items({});
@@ -291,6 +296,12 @@ namespace trview
         trigger_list->set_show_scrollbar(false);
         trigger_list->set_show_highlight(false);
 
+        _token_store.add(trigger_list->on_item_selected += [&](const auto& item)
+        {
+            auto index = std::stoi(item.value(L"#"));
+            on_trigger_selected(_all_triggers[index]);
+        });
+
         _trigger_list = trigger_group_box->add_child(std::move(trigger_list));
         right_panel->add_child(std::move(trigger_group_box));
 
@@ -338,6 +349,7 @@ namespace trview
             triggers.push_back(
                 {
                     {
+                        { L"#", std::to_wstring(trigger.number()) },
                         { L"Room", std::to_wstring(trigger.room()) },
                         { L"X", std::to_wstring(trigger.x()) },
                         { L"Z", std::to_wstring(trigger.z()) }

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -89,6 +89,7 @@ namespace trview
         ui::Window*  _controls;
         ui::Listbox* _items_list;
         ui::Listbox* _stats_list;
+        ui::Listbox* _trigger_list;
         std::unique_ptr<ui::render::Renderer> _ui_renderer;
         input::Mouse _mouse;
         input::Keyboard _keyboard;

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -58,11 +58,18 @@ namespace trview
         /// @param items The items to show.
         void set_items(const std::vector<Item>& items);
 
+        /// Set the triggers to display in the window.
+        /// @param triggers The triggers.
+        void set_triggers(const std::vector<Trigger>& triggers);
+
         /// Clear the currently selected item from the details panel.
         void clear_selected_item();
 
         /// Event raised when an item is selected in the list.
         Event<Item> on_item_selected;
+
+        /// Event raised when a trigger is selected in the list.
+        Event<Trigger> on_trigger_selected;
 
         /// Event raised when the items window is closed.
         Event<> on_window_closed;
@@ -96,6 +103,7 @@ namespace trview
         TokenStore _token_store;
 
         std::vector<Item> _all_items;
+        std::vector<Trigger> _all_triggers;
         /// Whether the item window is tracking the current room.
         bool _track_room{ false };
         /// The current room number selected for tracking.

--- a/trview.app/ItemsWindowManager.cpp
+++ b/trview.app/ItemsWindowManager.cpp
@@ -59,6 +59,15 @@ namespace trview
         }
     }
 
+    void ItemsWindowManager::set_triggers(const std::vector<Trigger>& triggers)
+    {
+        _triggers = triggers;
+        for (auto& window : _windows)
+        {
+            window->set_triggers(triggers);
+        }
+    }
+
     void ItemsWindowManager::set_room(uint32_t room)
     {
         _current_room = room;

--- a/trview.app/ItemsWindowManager.h
+++ b/trview.app/ItemsWindowManager.h
@@ -48,6 +48,10 @@ namespace trview
         /// @param items The items in the level.
         void set_items(const std::vector<Item>& items);
 
+        /// Set the triggers to use in the windows.
+        /// @param triggers The triggers in the level.
+        void set_triggers(const std::vector<Trigger>& triggers);
+
         /// Set the current room to filter item windows.
         /// @param room The current room.
         void set_room(uint32_t room);
@@ -58,6 +62,7 @@ namespace trview
         std::vector<std::unique_ptr<ItemsWindow>> _windows;
         std::vector<ItemsWindow*> _closing_windows;
         std::vector<Item> _items;
+        std::vector<Trigger> _triggers;
         graphics::Device& _device;
         graphics::IShaderStorage& _shader_storage;
         graphics::FontFactory& _font_factory;

--- a/trview.app/Trigger.cpp
+++ b/trview.app/Trigger.cpp
@@ -3,7 +3,8 @@
 
 namespace trview
 {
-    Trigger::Trigger(const TriggerInfo& trigger_info)
+    Trigger::Trigger(uint16_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info)
+        : _room(room), _x(x), _z(z)
     {
         for (auto action : trigger_info.commands)
         {
@@ -12,6 +13,21 @@ namespace trview
                 _objects.push_back(action.second);
             }
         }
+    }
+
+    uint16_t Trigger::room() const
+    {
+        return _room;
+    }
+
+    uint16_t Trigger::x() const
+    {
+        return _x;
+    }
+
+    uint16_t Trigger::z() const
+    {
+        return _z;
     }
 
     bool Trigger::triggers_item(uint16_t index) const

--- a/trview.app/Trigger.cpp
+++ b/trview.app/Trigger.cpp
@@ -1,10 +1,36 @@
 #include "Trigger.h"
 #include <trview/Types.h>
+#include <unordered_map>
 
 namespace trview
 {
+    namespace
+    {
+        const std::unordered_map<TriggerType, std::wstring> trigger_type_names
+        {
+            { TriggerType::Trigger, L"Trigger" },
+            { TriggerType::Pad, L"Pad" },
+            { TriggerType::Switch, L"Switch" },
+            { TriggerType::Key, L"Key" },
+            { TriggerType::Pickup, L"Pickup" },
+            { TriggerType::HeavyTrigger, L"Heavy Trigger" },
+            { TriggerType::Antipad, L"Antipad" },
+            { TriggerType::Combat, L"Combat" },
+            { TriggerType::Dummy, L"Dummy" },
+            { TriggerType::AntiTrigger, L"Antitrigger" },
+            { TriggerType::HeavySwitch, L"Heavy Switch" },
+            { TriggerType::HeavyAntiTrigger, L"Heavy Antitrigger" },
+            { TriggerType::Monkey, L"Monkey" },
+            { TriggerType::Skeleton, L"Skeleton" },
+            { TriggerType::Tightrope, L"Tightrope" },
+            { TriggerType::Crawl, L"Crawl" },
+            { TriggerType::Climb, L"Climb"}
+        };
+    }
+
+
     Trigger::Trigger(uint32_t number, uint16_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info)
-        : _number(number), _room(room), _x(x), _z(z)
+        : _number(number), _room(room), _x(x), _z(z), _type(trigger_info.type)
     {
         for (auto action : trigger_info.commands)
         {
@@ -38,5 +64,20 @@ namespace trview
     bool Trigger::triggers_item(uint16_t index) const
     {
         return std::find(_objects.begin(), _objects.end(), index) != _objects.end();
+    }
+
+    TriggerType Trigger::type() const
+    {
+        return _type;
+    }
+
+    std::wstring trigger_type_name(TriggerType type)
+    {
+        auto name = trigger_type_names.find(type);
+        if (name == trigger_type_names.end())
+        {
+            return L"Unknown";
+        } 
+        return name->second;
     }
 }

--- a/trview.app/Trigger.cpp
+++ b/trview.app/Trigger.cpp
@@ -3,8 +3,8 @@
 
 namespace trview
 {
-    Trigger::Trigger(uint16_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info)
-        : _room(room), _x(x), _z(z)
+    Trigger::Trigger(uint32_t number, uint16_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info)
+        : _number(number), _room(room), _x(x), _z(z)
     {
         for (auto action : trigger_info.commands)
         {
@@ -13,6 +13,11 @@ namespace trview
                 _objects.push_back(action.second);
             }
         }
+    }
+
+    uint32_t Trigger::number() const
+    {
+        return _number;
     }
 
     uint16_t Trigger::room() const

--- a/trview.app/Trigger.cpp
+++ b/trview.app/Trigger.cpp
@@ -1,0 +1,21 @@
+#include "Trigger.h"
+#include <trview/Types.h>
+
+namespace trview
+{
+    Trigger::Trigger(const TriggerInfo& trigger_info)
+    {
+        for (auto action : trigger_info.commands)
+        {
+            if (action.first == TriggerCommandType::Object)
+            {
+                _objects.push_back(action.second);
+            }
+        }
+    }
+
+    bool Trigger::triggers_item(uint16_t index) const
+    {
+        return std::find(_objects.begin(), _objects.end(), index) != _objects.end();
+    }
+}

--- a/trview.app/Trigger.h
+++ b/trview.app/Trigger.h
@@ -10,14 +10,16 @@ namespace trview
     class Trigger final 
     {
     public:
-        explicit Trigger(uint16_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info);
+        explicit Trigger(uint32_t number, uint16_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info);
 
+        uint32_t number() const;
         uint16_t room() const;
         uint16_t x() const;
         uint16_t z() const;
         bool triggers_item(uint16_t index) const;
     private:
         std::vector<uint16_t> _objects;
+        uint32_t _number;
         uint16_t _room;
         uint16_t _x;
         uint16_t _z;

--- a/trview.app/Trigger.h
+++ b/trview.app/Trigger.h
@@ -10,10 +10,16 @@ namespace trview
     class Trigger final 
     {
     public:
-        Trigger(const TriggerInfo& trigger_info);
+        explicit Trigger(uint16_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info);
 
+        uint16_t room() const;
+        uint16_t x() const;
+        uint16_t z() const;
         bool triggers_item(uint16_t index) const;
     private:
         std::vector<uint16_t> _objects;
+        uint16_t _room;
+        uint16_t _x;
+        uint16_t _z;
     };
 }

--- a/trview.app/Trigger.h
+++ b/trview.app/Trigger.h
@@ -7,6 +7,12 @@ namespace trview
 {
     struct TriggerInfo;
 
+    enum class TriggerType
+    {
+        Trigger, Pad, Switch, Key, Pickup, HeavyTrigger, Antipad, Combat, Dummy,
+        AntiTrigger, HeavySwitch, HeavyAntiTrigger, Monkey, Skeleton, Tightrope, Crawl, Climb
+    };
+
     class Trigger final 
     {
     public:
@@ -17,11 +23,18 @@ namespace trview
         uint16_t x() const;
         uint16_t z() const;
         bool triggers_item(uint16_t index) const;
+        TriggerType type() const;
     private:
         std::vector<uint16_t> _objects;
+        TriggerType _type;
         uint32_t _number;
         uint16_t _room;
         uint16_t _x;
         uint16_t _z;
     };
+
+    /// Get the string representation of the trigger type specified.
+    /// @param type The type to test.
+    /// @returns The string version of the enum.
+    std::wstring trigger_type_name(TriggerType type);
 }

--- a/trview.app/Trigger.h
+++ b/trview.app/Trigger.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace trview
+{
+    struct TriggerInfo;
+
+    class Trigger final 
+    {
+    public:
+        Trigger(const TriggerInfo& trigger_info);
+
+        bool triggers_item(uint16_t index) const;
+    private:
+        std::vector<uint16_t> _objects;
+    };
+}

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="ItemsWindow.cpp" />
     <ClCompile Include="ItemsWindowManager.cpp" />
     <ClCompile Include="RecentFiles.cpp" />
+    <ClCompile Include="Trigger.cpp" />
     <ClCompile Include="WindowResizer.cpp" />
   </ItemGroup>
   <ItemGroup>
@@ -32,6 +33,7 @@
     <ClInclude Include="ItemsWindow.h" />
     <ClInclude Include="ItemsWindowManager.h" />
     <ClInclude Include="RecentFiles.h" />
+    <ClInclude Include="Trigger.h" />
     <ClInclude Include="WindowIDs.h" />
     <ClInclude Include="WindowResizer.h" />
   </ItemGroup>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -7,6 +7,7 @@
     <ClCompile Include="ItemsWindow.cpp" />
     <ClCompile Include="Item.cpp" />
     <ClCompile Include="ItemsWindowManager.cpp" />
+    <ClCompile Include="Trigger.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="WindowResizer.h" />
@@ -16,5 +17,6 @@
     <ClInclude Include="ItemsWindow.h" />
     <ClInclude Include="Item.h" />
     <ClInclude Include="ItemsWindowManager.h" />
+    <ClInclude Include="Trigger.h" />
   </ItemGroup>
 </Project>

--- a/trview.ui.render/MapRenderer.cpp
+++ b/trview.ui.render/MapRenderer.cpp
@@ -10,6 +10,23 @@ namespace trview
 {
     namespace ui
     {
+        namespace
+        {
+            std::map<uint16_t, DirectX::SimpleMath::Color> default_colours = {
+                { SectorFlag::Portal, { 0.0f, 0.0f, 0.0f } },
+                { SectorFlag::Wall, { 0.4f, 0.4f, 0.4f } },
+                { SectorFlag::Trigger, { 1.0f, 0.3f, 0.7f } },
+                { SectorFlag::Death, { 0.9f, 0.1f, 0.1f } },
+                { SectorFlag::MinecartLeft, { 0.0f, 0.9f, 0.9f } },
+                { SectorFlag::MinecartRight, { 0.0f, 0.9f, 0.9f } },
+                { SectorFlag::MonkeySwing, { 0.9f, 0.9f, 0.4f } },
+                { SectorFlag::ClimbableUp, { 0.0f, 0.9f, 0.0f, 0.6f } },
+                { SectorFlag::ClimbableDown, { 0.0f, 0.9f, 0.0f, 0.6f } },
+                { SectorFlag::ClimbableRight, { 0.0f, 0.9f, 0.0f, 0.6f } },
+                { SectorFlag::ClimbableLeft, { 0.0f, 0.9f, 0.0f, 0.6f } },
+            };
+        }
+
         namespace render
         {
             MapRenderer::MapRenderer(const ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const Size& window_size)

--- a/trview.ui.render/MapRenderer.cpp
+++ b/trview.ui.render/MapRenderer.cpp
@@ -149,8 +149,8 @@ namespace trview
             Point MapRenderer::get_position(const Sector& sector)
             {
                 return Point {
-                    /* X */ _DRAW_SCALE * (sector.id() / _rows),
-                    /* Y */ _DRAW_SCALE * (_rows - (sector.id() % _rows) - 1)
+                    /* X */ _DRAW_SCALE * sector.x(),
+                    /* Y */ _DRAW_SCALE * sector.z()
                 } + Point(1,1); 
             }
 

--- a/trview.ui.render/MapRenderer.h
+++ b/trview.ui.render/MapRenderer.h
@@ -41,20 +41,6 @@ namespace trview
                     Point position; 
                     Size size; 
                 };
-
-                std::map<SectorFlag, DirectX::SimpleMath::Color> default_colours = {
-                    { Portal, { 0.0f, 0.0f, 0.0f } }, 
-                    { Wall, { 0.4f, 0.4f, 0.4f } }, 
-                    { Trigger, { 1.0f, 0.3f, 0.7f } },
-                    { Death, { 0.9f, 0.1f, 0.1f } },
-                    { MinecartLeft, { 0.0f, 0.9f, 0.9f } },
-                    { MinecartRight, { 0.0f, 0.9f, 0.9f } },
-                    { MonkeySwing, { 0.9f, 0.9f, 0.4f } },
-                    { ClimbableUp, { 0.0f, 0.9f, 0.0f, 0.6f } },
-                    { ClimbableDown, { 0.0f, 0.9f, 0.0f, 0.6f } },
-                    { ClimbableRight, { 0.0f, 0.9f, 0.0f, 0.6f } },
-                    { ClimbableLeft, { 0.0f, 0.9f, 0.0f, 0.6f } },
-                };
             }
 
             class MapRenderer

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -241,8 +241,7 @@ namespace trview
                 // If the bottom of the list is already visible, then don't scroll down any more.
                 if (!rows.empty())
                 {
-                    const auto& last = rows.back();
-                    if (last->position().y + last->size().height <= _rows_element->size().height)
+                    if (_current_top + _fully_visible_rows >= _items.size())
                     {
                         return true;
                     }

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -291,9 +291,14 @@ namespace trview
             _entities.push_back(std::move(entity));
 
             // Relevant triggers.
-            std::vector<Trigger> relevant_triggers(
-                std::find_if(_triggers.begin(), _triggers.end(), [=](const auto& t) { return t.triggers_item(i); }),
-                _triggers.end());
+            std::vector<Trigger> relevant_triggers;
+            for (const auto& trigger : _triggers)
+            {
+                if (trigger.triggers_item(i))
+                {
+                    relevant_triggers.push_back(trigger);
+                }
+            }
 
             // Item for item information.
             _items.emplace_back(i, level_entity.Room, level_entity.TypeID, lookup_type_name(level_entity.TypeID), _level->get_version() >= trlevel::LevelVersion::Tomb4 ? level_entity.Intensity2 : 0, level_entity.Flags, relevant_triggers);

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -273,7 +273,7 @@ namespace trview
             {
                 if (sector.second->flags & SectorFlag::Trigger)
                 {
-                    _triggers.emplace_back(sector.second->trigger());
+                    _triggers.emplace_back(i, sector.second->x(), sector.second->z(), sector.second->trigger());
                 }
             }
         }

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -90,6 +90,11 @@ namespace trview
         return _items;
     }
 
+    const std::vector<Trigger>& Level::triggers() const
+    {
+        return _triggers;
+    }
+
     Level::RoomHighlightMode Level::highlight_mode() const
     {
         return _room_highlight_mode;
@@ -273,7 +278,7 @@ namespace trview
             {
                 if (sector.second->flags & SectorFlag::Trigger)
                 {
-                    _triggers.emplace_back(i, sector.second->x(), sector.second->z(), sector.second->trigger());
+                    _triggers.emplace_back(_triggers.size(), i, sector.second->x(), sector.second->z(), sector.second->trigger());
                 }
             }
         }

--- a/trview/Level.h
+++ b/trview/Level.h
@@ -64,6 +64,10 @@ namespace trview
         /// @returns All items in the level.
         const std::vector<Item>& items() const;
 
+        /// Get the triggers in this level.
+        /// @returns All triggers in the level.
+        const std::vector<Trigger>& triggers() const;
+
         // Determine whether the specified ray hits any of the triangles in any of the room geometry.
         // position: The world space position of the source of the ray.
         // direction: The direction of the ray.

--- a/trview/Level.h
+++ b/trview/Level.h
@@ -16,6 +16,7 @@
 #include "Mesh.h"
 #include "StaticMesh.h"
 #include <trview.app/Item.h>
+#include <trview.app/Trigger.h>
 
 #include "IMeshStorage.h"
 
@@ -100,6 +101,7 @@ namespace trview
         bool any_alternates() const;
     private:
         void generate_rooms(const Microsoft::WRL::ComPtr<ID3D11Device>& device);
+        void generate_triggers();
         void generate_entities(const Microsoft::WRL::ComPtr<ID3D11Device>& device);
         void regenerate_neighbours();
         void generate_neighbours(std::set<uint16_t>& all_rooms, uint16_t previous_room, uint16_t selected_room, int32_t current_depth, int32_t max_depth);
@@ -145,6 +147,7 @@ namespace trview
 
         const trlevel::ILevel*               _level;
         std::vector<std::unique_ptr<Room>>   _rooms;
+        std::vector<Trigger>                 _triggers;
         std::vector<std::unique_ptr<Entity>> _entities;
         std::vector<Item> _items;
 

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -192,7 +192,7 @@ namespace trview
         {
             const trlevel::tr_room_sector &sector = room.sector_list.at(i);
             _sectors.emplace(std::make_pair(
-                i, std::make_shared<Sector>(level, sector, i)
+                i, std::make_shared<Sector>(level, room, sector, i)
             ));
         }
     }

--- a/trview/Sector.cpp
+++ b/trview/Sector.cpp
@@ -150,5 +150,10 @@ namespace trview
 
         return true; 
     }
+
+    const TriggerInfo& Sector::trigger() const
+    {
+        return _trigger;
+    }
 }
 

--- a/trview/Sector.cpp
+++ b/trview/Sector.cpp
@@ -3,9 +3,11 @@
 
 namespace trview
 {
-    Sector::Sector(const trlevel::ILevel &level, const trlevel::tr_room_sector &sector, int sector_id)
+    Sector::Sector(const trlevel::ILevel &level, const trlevel::tr3_room& room, const trlevel::tr_room_sector &sector, int sector_id)
         : _level(level), _sector(sector), _sector_id(sector_id), _room_above(sector.room_above), _room_below(sector.room_below)
     {
+        _x = sector_id / room.num_z_sectors;
+        _z = room.num_z_sectors - (sector_id % room.num_z_sectors) - 1;
         parse();
     }
 
@@ -166,6 +168,16 @@ namespace trview
     const TriggerInfo& Sector::trigger() const
     {
         return _trigger;
+    }
+
+    uint16_t Sector::x() const
+    {
+        return _x;
+    }
+
+    uint16_t Sector::z() const
+    {
+        return _z;
     }
 }
 

--- a/trview/Sector.cpp
+++ b/trview/Sector.cpp
@@ -83,7 +83,7 @@ namespace trview
 
             case 0x4:
             {
-                std::uint16_t command; 
+                std::uint16_t command = 0; 
                 std::uint16_t setup = _level.get_floor_data(++cur_index);
 
                 // Basic trigger setup 

--- a/trview/Sector.h
+++ b/trview/Sector.h
@@ -17,7 +17,7 @@ namespace trview
     {
     public:
         // Constructs sector object and parses floor data automatically 
-        Sector(const trlevel::ILevel &level, const trlevel::tr_room_sector &sector, int sector_id);
+        Sector(const trlevel::ILevel &level, const trlevel::tr3_room& room, const trlevel::tr_room_sector &sector, int sector_id);
 
         // Returns the id of the room that this floor data points to 
         std::uint16_t portal() const; 
@@ -39,6 +39,10 @@ namespace trview
 
         /// Get trigger information for the sector.
         const TriggerInfo& trigger() const;
+
+        uint16_t x() const;
+
+        uint16_t z() const;
     private:
         bool parse(); 
 
@@ -59,5 +63,11 @@ namespace trview
 
         // Reference to the base sector structure 
         const trlevel::tr_room_sector &_sector;
+
+        // X position of the sector in the room.
+        uint16_t _x;
+
+        // Z position of the sector in the room.
+        uint16_t _z;
     };
 }

--- a/trview/Sector.h
+++ b/trview/Sector.h
@@ -37,6 +37,8 @@ namespace trview
         // Holds "Function" enum bitwise values 
         std::uint16_t flags = 0;
 
+        /// Get trigger information for the sector.
+        const TriggerInfo& trigger() const;
     private:
         bool parse(); 
 
@@ -47,7 +49,7 @@ namespace trview
         std::uint16_t _floor_slant, _ceiling_slant; 
 
         // Holds trigger data 
-        struct Trigger _trigger; 
+        TriggerInfo _trigger;
 
         // ID of the sector 
         int _sector_id; 

--- a/trview/Types.h
+++ b/trview/Types.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <list>
+#include <vector>
 
 namespace trview
 {

--- a/trview/Types.h
+++ b/trview/Types.h
@@ -5,24 +5,27 @@
 namespace trview
 {
     // Flags stored on sector to determine behaviour 
-    enum SectorFlag
+    namespace SectorFlag
     {
-        Portal = 0x1,
-        Wall = 0x2, 
-        Trigger = 0x4, 
-        Death = 0x8,
-        FloorSlant = 0x10,
-        CeilingSlant = 0x20, 
-        ClimbableUp = 0x40, // Top edge is climbable 
-        ClimbableRight = 0x80, // Right edge is climbable 
-        ClimbableDown = 0x100, // Bottom edge is climbable 
-        ClimbableLeft = 0x200, // Left edge is climbable
-        MonkeySwing = 0x400, 
-        RoomAbove = 0x800, // There is a ceiling portal above
-        RoomBelow = 0x1000, // There is a floor portal 
-        MinecartLeft = 0x2000, // Minecart turns left, Trigger Triggerer in TR4+
-        MinecartRight = 0x4000, // Minecart turns right
-    };
+        enum
+        {
+            Portal = 0x1,
+            Wall = 0x2,
+            Trigger = 0x4,
+            Death = 0x8,
+            FloorSlant = 0x10,
+            CeilingSlant = 0x20,
+            ClimbableUp = 0x40, // Top edge is climbable 
+            ClimbableRight = 0x80, // Right edge is climbable 
+            ClimbableDown = 0x100, // Bottom edge is climbable 
+            ClimbableLeft = 0x200, // Left edge is climbable
+            MonkeySwing = 0x400,
+            RoomAbove = 0x800, // There is a ceiling portal above
+            RoomBelow = 0x1000, // There is a floor portal 
+            MinecartLeft = 0x2000, // Minecart turns left, Trigger Triggerer in TR4+
+            MinecartRight = 0x4000, // Minecart turns right
+        };
+    }
 
     enum ClimbableWalls
     {
@@ -44,7 +47,7 @@ namespace trview
         AntiTrigger, HeavySwitch, HeavyAntiTrigger, Monkey, Skeleton, Tightrope, Crawl, Climb
     };
 
-    struct Trigger
+    struct TriggerInfo
     {
         std::uint8_t timer, oneshot, mask;
         TriggerType type; 

--- a/trview/Types.h
+++ b/trview/Types.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <trview.app/Trigger.h>
 
 namespace trview
 {
@@ -39,12 +40,6 @@ namespace trview
     {
         Object, Camera, UnderwaterCurrent, FlipMap, FlipOn, FlipOff, LookAtItem,
         EndLevel, PlaySoundtrack, Flipeffect, SecretFound, ClearBodies
-    };
-
-    enum class TriggerType
-    {
-        Trigger, Pad, Switch, Key, Pickup, HeavyTrigger, Antipad, Combat, Dummy, 
-        AntiTrigger, HeavySwitch, HeavyAntiTrigger, Monkey, Skeleton, Tightrope, Crawl, Climb
     };
 
     struct TriggerInfo

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -374,6 +374,7 @@ namespace trview
         _token_store.add(_level->on_alternate_mode_selected += [&](bool enabled) { set_alternate_mode(enabled); });
 
         _items_windows->set_items(_level->items());
+        _items_windows->set_triggers(_level->triggers());
 
         // Set up the views.
         auto rooms = _level->room_info();


### PR DESCRIPTION
Show a list of triggers that trigger an item in the details panel of the items window.
This just shows the room number and the type of trigger. The trigger click event exists and is raised, but nothing is listening to it yet.

Trigger is a new class to be used in the application, a less raw version of TriggerInfo. 
Moved a few types around to help with this. Moved SectorFlag into a namespace as it was clashing with the word Trigger.
Triggers are parsed by Level on load and stored - when items are generated they take note of which triggers reference them which goes through to the item window.

Part of issue: #284 
