### PR TITLE
Focus the viewer on the trigger position

### DIFF
--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -288,8 +288,8 @@ namespace trview
         auto trigger_list = std::make_unique<Listbox>(Point(10, 21), Size(190, 160), Colours::Triggers);
         trigger_list->set_columns(
             {
-                { Listbox::Column::Type::Number, L"#", 20 },
-                { Listbox::Column::Type::Number, L"Room", 40 },
+                { Listbox::Column::Type::Number, L"#", 25 },
+                { Listbox::Column::Type::Number, L"Room", 35 },
                 { Listbox::Column::Type::String, L"Type", 120 },
             }
         );
@@ -344,14 +344,13 @@ namespace trview
         stats.push_back(make_item(L"OCB", std::to_wstring(item.ocb())));
         _stats_list->set_items(stats);
 
-        uint32_t i = 0u;
         std::vector<Listbox::Item> triggers;
         for (auto& trigger : item.triggers())
         {
             triggers.push_back(
                 {
                     {
-                        { L"#", std::to_wstring(i++) },
+                        { L"#", std::to_wstring(trigger.number()) },
                         { L"Room", std::to_wstring(trigger.room()) },
                         { L"Type", trigger_type_name(trigger.type()) },
                     }

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -208,7 +208,7 @@ namespace trview
             set_track_room(value);
         });
 
-        controls->add_child(std::move(track_room));
+        _track_room_checkbox = controls->add_child(std::move(track_room));
         _controls = left_panel->add_child(std::move(controls));
 
         auto items_list = std::make_unique<Listbox>(Point(), Size(200, window().size().height - _controls->size().height), Colours::LeftPanel);
@@ -362,6 +362,11 @@ namespace trview
         {
             set_items(_all_items);
             _filter_applied = false;
+        }
+
+        if (_track_room_checkbox->state() != _track_room)
+        {
+            _track_room_checkbox->set_state(_track_room);
         }
     }
 }

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -205,16 +205,7 @@ namespace trview
         auto track_room = std::make_unique<Checkbox>(Point(), Size(16, 16), Colours::LeftPanel, L"Track Room");
         _token_store.add(track_room->on_state_changed += [this](bool value)
         {
-            _track_room = value;
-            if (_track_room)
-            {
-                set_current_room(_current_room);
-            }
-            else
-            {
-                set_items(_all_items);
-                _filter_applied = false;
-            }
+            set_track_room(value);
         });
 
         controls->add_child(std::move(track_room));
@@ -300,6 +291,7 @@ namespace trview
         _token_store.add(trigger_list->on_item_selected += [&](const auto& item)
         {
             auto index = std::stoi(item.value(L"#"));
+            set_track_room(false);
             on_trigger_selected(_all_triggers[index]);
         });
 
@@ -357,5 +349,19 @@ namespace trview
                 });
         }
         _trigger_list->set_items(triggers);
+    }
+
+    void ItemsWindow::set_track_room(bool value)
+    {
+        _track_room = value;
+        if (_track_room)
+        {
+            set_current_room(_current_room);
+        }
+        else
+        {
+            set_items(_all_items);
+            _filter_applied = false;
+        }
     }
 }

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -86,6 +86,7 @@ namespace trview
         std::unique_ptr<ui::Control> create_divider();
         std::unique_ptr<ui::StackPanel> create_details_panel();
         void load_item_details(const Item& item);
+        void set_track_room(bool value);
 
         WindowResizer _window_resizer;
         std::unique_ptr<graphics::DeviceWindow> _device_window;

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -26,6 +26,8 @@ namespace trview
         {
             class Renderer;
         }
+
+        class Checkbox;
     }
 
     /// Used to show and filter the items in the level.
@@ -98,6 +100,7 @@ namespace trview
         ui::Listbox* _items_list;
         ui::Listbox* _stats_list;
         ui::Listbox* _trigger_list;
+        ui::Checkbox* _track_room_checkbox;
         std::unique_ptr<ui::render::Renderer> _ui_renderer;
         input::Mouse _mouse;
         input::Keyboard _keyboard;

--- a/trview.app/ItemsWindowManager.cpp
+++ b/trview.app/ItemsWindowManager.cpp
@@ -37,6 +37,7 @@ namespace trview
     {
         auto items_window = std::make_unique<ItemsWindow>(_device, _shader_storage, _font_factory, window());
         items_window->on_item_selected += on_item_selected;
+        items_window->on_trigger_selected += on_trigger_selected;
         items_window->set_items(_items);
         items_window->set_current_room(_current_room);
 

--- a/trview.app/ItemsWindowManager.cpp
+++ b/trview.app/ItemsWindowManager.cpp
@@ -39,6 +39,7 @@ namespace trview
         items_window->on_item_selected += on_item_selected;
         items_window->on_trigger_selected += on_trigger_selected;
         items_window->set_items(_items);
+        items_window->set_triggers(_triggers);
         items_window->set_current_room(_current_room);
 
         const auto window = items_window.get();

--- a/trview.app/ItemsWindowManager.h
+++ b/trview.app/ItemsWindowManager.h
@@ -39,6 +39,9 @@ namespace trview
         /// Event raised when an item is selected in one of the item windows.
         Event<Item> on_item_selected;
 
+        /// Event raised when a trigger is selected in one of the item windows.
+        Event<Trigger> on_trigger_selected;
+
         /// Render all of the item windows.
         /// @param device The device to use to render.
         /// @param vsync Whether to use vsync.

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -127,6 +127,10 @@ namespace trview
             void sort_items();
             /// Select the given item and scroll to make it visible.
             void select_item(const Item& item);
+            /// Scroll the listbox so that the specified item index is visible.
+            void scroll_to(uint32_t item);
+            /// Scroll the listbox so that the specified item is visible.
+            void scroll_to_show(const Item& item);
 
             void highlight_item();
 

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -58,6 +58,10 @@ namespace trview
         {
             select_item(item);
         });
+        _token_store.add(_items_windows->on_trigger_selected += [this](const auto& trigger)
+        {
+            select_trigger(trigger);
+        });
 
         _token_store.add(_level_switcher.on_switch_level += [=](const auto& file) { open(file); });
         _token_store.add(on_file_loaded += [&](const auto& file) { _level_switcher.open_file(file); });
@@ -579,6 +583,10 @@ namespace trview
             auto entity = _current_level->get_entity(item.number());
             _target = DirectX::SimpleMath::Vector3(entity.x / 1024.0f, entity.y / -1024.0f, entity.z / 1024.0f);
         }
+    }
+
+    void Viewer::select_trigger(const Trigger& trigger)
+    {
     }
 
     void Viewer::set_alternate_mode(bool enabled)

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -587,6 +587,20 @@ namespace trview
 
     void Viewer::select_trigger(const Trigger& trigger)
     {
+        if (_level)
+        {
+            select_room(trigger.room());
+            const auto room = _level->room(trigger.room());
+            const auto room_info = room->info();
+
+            // Calculate the X/Z position - the Y must be determined by casting
+            // a ray from above directly down, to see what it hits.
+
+            const float x = (room_info.x + trigger.x() * 1024.0f) / 1024.0f + 0.5f;
+            const float z = (room_info.z + (room->num_z_sectors() - 1 - trigger.z()) * 1024.0f) / 1024.0f + 0.5f;
+
+            _target = DirectX::SimpleMath::Vector3(x, room_info.yBottom / 1024.0f, z);
+        }
     }
 
     void Viewer::set_alternate_mode(bool enabled)

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -590,16 +590,20 @@ namespace trview
         if (_level)
         {
             select_room(trigger.room());
+
             const auto room = _level->room(trigger.room());
             const auto room_info = room->info();
 
-            // Calculate the X/Z position - the Y must be determined by casting
-            // a ray from above directly down, to see what it hits.
+            // Calculate the X/Z position - the Y must be determined by casting a ray from above 
+            // directly down, to see what it hits. If it hits nothing, use the centre of the room.
+            const float x = room_info.x / 1024.0f + trigger.x() + 0.5f;
+            const float z = room_info.z / 1024.0f + (room->num_z_sectors() - 1 - trigger.z()) + 0.5f;
 
-            const float x = (room_info.x + trigger.x() * 1024.0f) / 1024.0f + 0.5f;
-            const float z = (room_info.z + (room->num_z_sectors() - 1 - trigger.z()) * 1024.0f) / 1024.0f + 0.5f;
+            using namespace DirectX::SimpleMath;
+            const auto pick = room->pick(Vector3(x, 500.0f, z), Vector3(0, -1, 0));
+            const float y = pick.hit ? pick.position.y : room->centre().y;
 
-            _target = DirectX::SimpleMath::Vector3(x, room_info.yBottom / 1024.0f, z);
+            _target = DirectX::SimpleMath::Vector3(x, y, z);
         }
     }
 

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -28,7 +28,6 @@
 #include <trview.app/WindowResizer.h>
 #include <trview.app/RecentFiles.h>
 #include <trview.app/FileDropper.h>
-#include <trview.app/ItemsWindow.h>
 #include <trview.app/ItemsWindowManager.h>
 
 namespace trview
@@ -101,6 +100,7 @@ namespace trview
         void render_map(); 
         void select_room(uint32_t room);
         void select_item(const Item& item);
+        void select_trigger(const Trigger& trigger);
         // Determines whether the cursor is over a UI element that would take any input.
         // Returns: True if there is any UI under the cursor that would take input.
         bool over_ui() const;


### PR DESCRIPTION
When a trigger is clicked in the item details panel, focus the viewer on the location of the trigger.
Y position is calculated by picking - if there is nothing for the ray to hit, it will use the centre height of the room.
If 'Track Room' is on in the Items Window, it will be disabled. The currently selected item will be scrolled into view on the main item list. If you want to get back to the room with the item in you will need to click on the item in the items list again. This is OK for now but may need reworking, depending on how we feel about it after trying it out for a while.
Issue: #284 