### PR TITLE
Don't pick if the cursor is not over the window

### DIFF
--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -78,6 +78,10 @@ namespace trview
 
         void Control::set_visible(bool value)
         {
+            if (_visible == value)
+            {
+                return;
+            }
             _visible = value;
             on_invalidate();
         }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -440,7 +440,7 @@ namespace trview
 
     void Viewer::pick()
     {
-        if (!_level || window_is_minimised(_window) || over_ui() || over_map() || cursor_outside_window(_window))
+        if (!_level || window_under_cursor() != _window || window_is_minimised(_window) || over_ui() || over_map() || cursor_outside_window(_window))
         {
             _picking->set_visible(false);
             return;


### PR DESCRIPTION
Add it to the long list of reasons why we wouldn't want to pick.
Also change control to only set the value of visible (and redraw) if it has changed.
Issue: #306 