### PR TITLE
Add button to expand or collapse the item details panel

### DIFF
--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -10,6 +10,7 @@
 #include <SimpleMath.h>
 #include <trview.ui/Checkbox.h>
 #include <trview.ui/GroupBox.h>
+#include <trview.ui/Button.h>
 
 using namespace trview::graphics;
 
@@ -209,6 +210,15 @@ namespace trview
         });
 
         _track_room_checkbox = controls->add_child(std::move(track_room));
+
+        auto expander = std::make_unique<Button>(Point(), Size(16, 16), L"<<");
+        _token_store.add(expander->on_click += [this]()
+        {
+            _expanded = !_expanded;
+            _expander->set_text(_expanded ? L"<<" : L">>");
+        });
+        _expander = controls->add_child(std::move(expander));
+
         _controls = left_panel->add_child(std::move(controls));
 
         auto items_list = std::make_unique<Listbox>(Point(), Size(200, window().size().height - _controls->size().height), Colours::LeftPanel);

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -211,11 +211,13 @@ namespace trview
 
         _track_room_checkbox = controls->add_child(std::move(track_room));
 
+        // Space out the button
+        controls->add_child(std::make_unique<ui::Window>(Point(), Size(90, 20), Colours::LeftPanel));
+
         auto expander = std::make_unique<Button>(Point(), Size(16, 16), L"<<");
         _token_store.add(expander->on_click += [this]()
         {
-            _expanded = !_expanded;
-            _expander->set_text(_expanded ? L"<<" : L">>");
+            toggle_expand();
         });
         _expander = controls->add_child(std::move(expander));
 
@@ -378,5 +380,17 @@ namespace trview
         {
             _track_room_checkbox->set_state(_track_room);
         }
+    }
+
+    void ItemsWindow::toggle_expand()
+    {
+        _expanded = !_expanded;
+        _expander->set_text(_expanded ? L"<<" : L">>");
+        _ui->set_size(Size(_expanded ? 400 : 200, _ui->size().height));
+
+        // Force resize the window.
+        RECT rect{ 0, 0, _ui->size().width, _ui->size().height };
+        AdjustWindowRect(&rect, window_style, FALSE);
+        SetWindowPos(window(), 0, 0, 0, rect.right - rect.left, rect.bottom - rect.top, SWP_NOMOVE);
     }
 }

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -90,6 +90,7 @@ namespace trview
         std::unique_ptr<ui::StackPanel> create_details_panel();
         void load_item_details(const Item& item);
         void set_track_room(bool value);
+        void toggle_expand();
 
         WindowResizer _window_resizer;
         std::unique_ptr<graphics::DeviceWindow> _device_window;

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -27,6 +27,7 @@ namespace trview
             class Renderer;
         }
 
+        class Button;
         class Checkbox;
     }
 
@@ -101,6 +102,7 @@ namespace trview
         ui::Listbox* _stats_list;
         ui::Listbox* _trigger_list;
         ui::Checkbox* _track_room_checkbox;
+        ui::Button* _expander;
         std::unique_ptr<ui::render::Renderer> _ui_renderer;
         input::Mouse _mouse;
         input::Keyboard _keyboard;
@@ -114,5 +116,7 @@ namespace trview
         uint32_t _current_room{ 0u };
         /// Whether the room tracking filter has been applied.
         bool _filter_applied{ false };
+
+        bool _expanded{ true };
     };
 }


### PR DESCRIPTION
Clicking will toggle whether or not the panel is expanded.
Issue: #303 