### PR TITLE
Fix erratic scrolling on items list

### DIFF
--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -353,15 +353,18 @@ namespace trview
 
     void ItemsWindow::set_track_room(bool value)
     {
-        _track_room = value;
-        if (_track_room)
+        if (_track_room != value)
         {
-            set_current_room(_current_room);
-        }
-        else
-        {
-            set_items(_all_items);
-            _filter_applied = false;
+            _track_room = value;
+            if (_track_room)
+            {
+                set_current_room(_current_room);
+            }
+            else
+            {
+                set_items(_all_items);
+                _filter_applied = false;
+            }
         }
 
         if (_track_room_checkbox->state() != _track_room)

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -330,12 +330,15 @@ namespace trview
             bool handled = false;
             for (auto& child : _child_elements)
             {
-                handled |= child->inner_process_key_down(key);
+                if (child->inner_process_key_down(key))
+                {
+                    return handled;
+                }
             }
 
             // If none of the child elements have handled this event themselves, call the key_down
             // event of the control.
-            return handled | key_down(key);
+            return key_down(key);
         }
 
         bool Control::is_mouse_over(const Point& position) const

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -264,22 +264,15 @@ namespace trview
             }
             else
             {
-                // Go up if possible (not already at the start of the list)
-                if (key == VK_UP)
+                if (key == VK_UP && item != _items.begin())
                 {
-                    if (item == _items.begin())
-                    {
-                        return false;
-                    }
+                    // Go up if possible (not already at the start of the list)
                     select_item(*--item);
-                    return true;
                 }
-
-                // Go down if possible (not at the end of the list).
-                if (key == VK_DOWN && ++item != _items.end())
+                else if (key == VK_DOWN && ++item != _items.end())
                 {
+                    // Go down if possible (not at the end of the list).
                     select_item(*item);
-                    return true;
                 }
             }
             return true;

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -406,9 +406,16 @@ namespace trview
                 return;
             }
 
+            auto index = iter - _items.begin();
+
             // Scroll the list so that the selected item is visible. If it is already on the 
             // same page, then no need to scroll.
-            auto index = iter - _items.begin();
+            if (index >= _current_top && index < _current_top + _fully_visible_rows)
+            {
+                highlight_item();
+                return;
+            }
+
             if (index < _current_top)
             {
                 _current_top = index;

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -373,12 +373,15 @@ namespace trview
 
         void Listbox::scroll_to(uint32_t item)
         {
+            // If the item is a partially visible row, move the top of the list down by one (move it into view at 
+            // the bottom).
             if (item == _current_top + _fully_visible_rows)
             {
                 _current_top = std::clamp<int32_t>(_current_top + 1, 0, _items.size() - _fully_visible_rows);
             }
             else
             {
+                // Otherwise, just set the new item to be at the top of the list.
                 _current_top = std::clamp<int32_t>(item, 0, _items.size() - _fully_visible_rows);
             }
             populate_rows();


### PR DESCRIPTION
The main problem was that the triggers list was also getting the key up/down messages, firing the event which was setting track room to false (this was resetting the item list).
Made it stop resetting the item list if the new setting for track room is the same as the current one.
Also simplified some of the listbox scrolling code.
Made list boxes always say they handled the key down message (if it was up or down).
Isssue: #313 