### PR TITLE
Add hover highlighting on list box elements

### DIFF
--- a/trview.common/Colour.cpp
+++ b/trview.common/Colour.cpp
@@ -11,4 +11,13 @@ namespace trview
     {
         return DirectX::SimpleMath::Color(r, g, b, a);
     }
+
+    Colour& Colour::operator += (const Colour& other)
+    {
+        a += other.a;
+        r += other.r;
+        g += other.g;
+        b += other.b;
+        return *this;
+    }
 }

--- a/trview.common/Colour.h
+++ b/trview.common/Colour.h
@@ -10,6 +10,8 @@ namespace trview
 
         operator DirectX::SimpleMath::Color() const;
 
+        Colour& operator += (const Colour& other);
+
         float a, r, g, b;
     };
 }

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -144,15 +144,6 @@ namespace trview
 
         bool Control::process_mouse_move(const Point& position)
         {
-            if (_focus_control && _focus_control != this)
-            {
-                bool focus_handled = _focus_control->move(position - _focus_control->absolute_position());
-                if (focus_handled)
-                {
-                    return true;
-                }
-            }
-
             // Get the control at the current mouse position.
             Control* control = hover_control_at_position(position);
             if (control != _hover_control)
@@ -161,8 +152,20 @@ namespace trview
                 {
                     _hover_control->mouse_leave();
                 }
-                _hover_control = control;
-                _hover_control->mouse_enter();
+                set_hover_control(control);
+                if (_hover_control)
+                {
+                    _hover_control->mouse_enter();
+                }
+            }
+
+            if (_focus_control && _focus_control != this)
+            {
+                bool focus_handled = _focus_control->move(position - _focus_control->absolute_position());
+                if (focus_handled)
+                {
+                    return true;
+                }
             }
 
             return inner_process_mouse_move(position);
@@ -418,14 +421,12 @@ namespace trview
             return nullptr;
         }
 
-        bool Control::mouse_enter()
+        void Control::mouse_enter()
         {
-            return false;
         }
 
-        bool Control::mouse_leave()
+        void Control::mouse_leave()
         {
-            return false;
         }
 
         void Control::set_hover_control(Control* control)

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -152,6 +152,19 @@ namespace trview
                     return true;
                 }
             }
+
+            // Get the control at the current mouse position.
+            Control* control = hover_control_at_position(position);
+            if (control != _hover_control)
+            {
+                if (_hover_control)
+                {
+                    _hover_control->mouse_leave();
+                }
+                _hover_control = control;
+                _hover_control->mouse_enter();
+            }
+
             return inner_process_mouse_move(position);
         }
 
@@ -379,6 +392,66 @@ namespace trview
 
         void Control::inner_add_child(Control*)
         {
+        }
+
+        Control* Control::hover_control_at_position(const Point& position)
+        {
+            if (!in_bounds(position, size()))
+            {
+                return nullptr;
+            }
+
+            for (const auto& control : _child_elements)
+            {
+                auto result = control->hover_control_at_position(position - control->position());
+                if (result && result->_handles_hover)
+                {
+                    return result;
+                }
+            }
+
+            if (_handles_hover)
+            {
+                return this;
+            }
+
+            return nullptr;
+        }
+
+        bool Control::mouse_enter()
+        {
+            return false;
+        }
+
+        bool Control::mouse_leave()
+        {
+            return false;
+        }
+
+        void Control::set_hover_control(Control* control)
+        {
+            if (_parent)
+            {
+                _parent->set_hover_control(control);
+            }
+            else
+            {
+                inner_set_hover_control(control);
+            }
+        }
+
+        void Control::inner_set_hover_control(Control* control)
+        {
+            _hover_control = control;
+            for (const auto& child : _child_elements)
+            {
+                child->inner_set_hover_control(control);
+            }
+        }
+
+        void Control::set_handles_hover(bool value)
+        {
+            _handles_hover = value;
         }
     }
 }

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -175,12 +175,10 @@ namespace trview
             virtual bool mouse_up(const Point& position);
 
             /// To be called when the mouse has hovered over the element.
-            /// @return True if the control handles this event.
-            virtual bool mouse_enter();
+            virtual void mouse_enter();
 
             /// To be called when the mouse has stopped hovering over the element.
-            /// @return True if the control handles this event.
-            virtual bool mouse_leave();
+            virtual void mouse_leave();
 
             /// To be called when the user interface element has been clicked.
             /// This should be overriden by child elements to handle a click.

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -123,6 +123,10 @@ namespace trview
             /// @param value Whether the control handles input.
             void set_handles_input(bool value);
 
+            /// Set whether this control handles mouse hover events. Defaults to false.
+            /// @param value Whether the control handles mouse hover events.
+            void set_handles_hover(bool value);
+
             /// Process a key down event.
             /// @param key The key that was pressed down.
             /// @returns True if the event was processed by the control.
@@ -170,6 +174,14 @@ namespace trview
             /// @return True if the event was handled by the element.
             virtual bool mouse_up(const Point& position);
 
+            /// To be called when the mouse has hovered over the element.
+            /// @return True if the control handles this event.
+            virtual bool mouse_enter();
+
+            /// To be called when the mouse has stopped hovering over the element.
+            /// @return True if the control handles this event.
+            virtual bool mouse_leave();
+
             /// To be called when the user interface element has been clicked.
             /// This should be overriden by child elements to handle a click.
             /// @param position The position of the click relative to the control.
@@ -195,6 +207,10 @@ namespace trview
             /// @param control The current focus control
             void set_focus_control(Control* control);
 
+            /// Set the control in the tree that is the hover element.
+            /// @param control The hovered over control.
+            void set_hover_control(Control* control);
+
             /// Get the currently focused control.
             /// @returns The currently focused control.
             Control* focus_control() const;
@@ -204,6 +220,10 @@ namespace trview
             /// Set the focus control and recurse to child controls.
             /// @param control The new focus control.
             void inner_set_focus_control(Control* control);
+
+            /// Set the hover control and recurse to child controls.
+            /// @param control The new hover control.
+            void inner_set_hover_control(Control* control);
 
             /// Process a mouse move and recurse to child controls.
             /// @param position The position of the mouse relative to the control.
@@ -217,14 +237,19 @@ namespace trview
             /// @param key The key that was pressed.
             bool inner_process_key_down(uint16_t key);
 
+            /// Get the control at the specified mouse position.
+            Control* hover_control_at_position(const Point& position);
+
             std::vector<std::unique_ptr<Control>> _child_elements;
 
             Control* _parent{ nullptr };
             Control* _focus_control{ nullptr };
+            Control* _hover_control{ nullptr };
             Point    _position;
             Size     _size;
             bool     _visible;
             bool     _handles_input{ true };
+            bool     _handles_hover{ false };
             Align    _horizontal_alignment{ Align::Near };
             Align    _vertical_alignment{ Align::Near };
             std::string _name;

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -8,51 +8,6 @@ namespace trview
 {
     namespace ui
     {
-        Listbox::Column::Column()
-            : _type(Type::String)
-        {
-        }
-
-        Listbox::Column::Column(Type type, const std::wstring& name, uint32_t width)
-            : _type(type), _name(name), _width(width)
-        {
-        }
-
-        Listbox::Column::Type Listbox::Column::type() const
-        {
-            return _type;
-        }
-
-        const std::wstring& Listbox::Column::name() const
-        {
-            return _name;
-        }
-
-        uint32_t Listbox::Column::width() const
-        {
-            return _width;
-        }
-
-        Listbox::Item::Item(const std::unordered_map<std::wstring, std::wstring>& values)
-            : _values(values)
-        {
-        }
-
-        std::wstring Listbox::Item::value(const std::wstring& key) const
-        {
-            auto item = _values.find(key);
-            if (item == _values.end())
-            {
-                return std::wstring();
-            }
-            return item->second;
-        }
-
-        bool Listbox::Item::operator == (const Item& other) const
-        {
-            return _values == other._values;
-        }
-
         Listbox::Listbox(const Point& position, const Size& size, const Colour& background_colour)
             : StackPanel(position, size, background_colour, Size(), Direction::Vertical, SizeMode::Manual)
         {
@@ -142,18 +97,8 @@ namespace trview
 
             for (auto i = 0; i < remaining_rows; ++i)
             {
-                auto index = i + existing_rows;
-
-                auto row = std::make_unique<StackPanel>(Point(), Size(), background_colour(), Size(), Direction::Horizontal);
-                for (const auto& column : _columns)
-                {
-                    auto button = std::make_unique<Button>(Point(), Size(column.width(), 20), L"Test");
-                    _token_store.add(button->on_click += [this, index]()
-                    {
-                        select_item(_items[index + _current_top]);
-                    });
-                    row->add_child(std::move(button));
-                }
+                auto row = std::make_unique<Row>(background_colour(), _columns);
+                _token_store.add(row->on_click += [this](const auto& item) { select_item(item); });
                 _rows_element->add_child(std::move(row));
             }
         }
@@ -169,28 +114,22 @@ namespace trview
             const auto rows = _rows_element->child_elements();
             for (auto r = 0; r < rows.size(); ++r)
             {
-                if (r + _current_top < _items.size())
+                auto index = r + _current_top;
+                auto row = static_cast<Row*>(rows[r]);
+                if (index < _items.size())
                 {
-                    if (!rows[r]->visible())
-                    {
-                        rows[r]->set_visible(true);
-                    }
-
-                    if (rows[r]->position().y + rows[r]->size().height <= _rows_element->size().height)
+                    if (row->position().y + row->size().height <= _rows_element->size().height)
                     {
                         ++_fully_visible_rows;
                     }
 
-                    const auto& item = _items[r + _current_top];
-                    const auto columns = rows[r]->child_elements();
-                    for (auto c = 0; c < _columns.size(); ++c)
-                    {
-                        static_cast<Button*>(columns[c])->set_text(item.value(_columns[c].name()));
-                    }
+                    row->set_item(_items[index]);
+                    row->set_visible(true);
                 }
                 else
                 {
-                    rows[r]->set_visible(false);
+                    row->set_visible(false);
+                    row->clear_item();
                 }
             }
 
@@ -353,21 +292,14 @@ namespace trview
             const auto rows = _rows_element->child_elements();
             for (auto i = 0; i < rows.size(); ++i)
             {
-                // Default colour - not highlighted.
-                Colour colour{ 1.0f, 0.4f, 0.4f, 0.4f };
+                auto row = static_cast<Row*>(rows[i]);
 
-                const auto index = i + _current_top;
-                if (_show_highlight && index < _items.size() && _selected_item == _items[index])
+                Colour colour{ 1.0f, 0.4f, 0.4f, 0.4f };
+                if (_show_highlight && row->item() == _selected_item)
                 {
                     colour = Colour(1.0f, 0.5f, 0.5f, 0.5f);
                 }
-
-                const auto columns = rows[i]->child_elements();
-                for (auto& cell : columns)
-                {
-                    Button* button_cell = static_cast<Button*>(cell);
-                    button_cell->set_text_background_colour(colour);
-                }
+                row->set_row_colour(colour);
             }
         }
 

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -293,13 +293,7 @@ namespace trview
             for (auto i = 0; i < rows.size(); ++i)
             {
                 auto row = static_cast<Row*>(rows[i]);
-
-                Colour colour{ 1.0f, 0.4f, 0.4f, 0.4f };
-                if (_show_highlight && row->item() == _selected_item)
-                {
-                    colour = Colour(1.0f, 0.5f, 0.5f, 0.5f);
-                }
-                row->set_row_colour(colour);
+                row->set_highlighted(_show_highlight && row->item() == _selected_item);
             }
         }
 

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -114,7 +114,7 @@ namespace trview
             const auto rows = _rows_element->child_elements();
             for (auto r = 0; r < rows.size(); ++r)
             {
-                auto index = r + _current_top;
+                const auto index = r + _current_top;
                 auto row = static_cast<Row*>(rows[r]);
                 if (index < _items.size())
                 {

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -259,6 +259,7 @@ namespace trview
             for (const auto column : _columns)
             {
                 auto header_element = std::make_unique<Button>(Point(), Size(column.width(), 20), column.name());
+                header_element->set_text_background_colour(background_colour());
                 _token_store.add(header_element->on_click += [this, column]()
                 {
                     if (_current_sort.name() == column.name())

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -80,6 +80,32 @@ namespace trview
                 std::unordered_map<std::wstring, std::wstring> _values;
             };
 
+            /// A row in the list box.
+            class Row final : public StackPanel
+            {
+            public:
+                explicit Row(const Colour& colour, const std::vector<Column>& columns);
+
+                /// Set the current item for the row.
+                /// @param item The item for the row.
+                void set_item(const Item& item);
+
+                /// Set the row to have no associated item.
+                void clear_item();
+
+                /// Get the item for this row.
+                const std::optional<Item>& item() const;
+
+                /// Event raised when a row is clicked.
+                Event<Item> on_click;
+
+                /// Set the background colour of the row.
+                void set_row_colour(const Colour& colour);
+            private:
+                std::optional<Item> _item;
+                std::vector<Column> _columns;
+            };
+
             /// Create a new Listbox.
             /// @param position The position of the listbox.
             /// @param size The size of the listbox.

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -86,6 +86,8 @@ namespace trview
             public:
                 explicit Row(const Colour& colour, const std::vector<Column>& columns);
 
+                virtual ~Row() = default;
+
                 /// Set the current item for the row.
                 /// @param item The item for the row.
                 void set_item(const Item& item);
@@ -99,11 +101,17 @@ namespace trview
                 /// Event raised when a row is clicked.
                 Event<Item> on_click;
 
-                /// Set the background colour of the row.
-                void set_row_colour(const Colour& colour);
+                void set_highlighted(bool value);
+            protected:
+                virtual void mouse_enter() override;
+                virtual void mouse_leave() override;
             private:
+                void update_row_colour();
+
                 std::optional<Item> _item;
                 std::vector<Column> _columns;
+                bool _highlighted{ false };
+                bool _hovered{ false };
             };
 
             /// Create a new Listbox.

--- a/trview.ui/ListboxColumn.cpp
+++ b/trview.ui/ListboxColumn.cpp
@@ -1,0 +1,32 @@
+#include "Listbox.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        Listbox::Column::Column()
+            : _type(Type::String)
+        {
+        }
+
+        Listbox::Column::Column(Type type, const std::wstring& name, uint32_t width)
+            : _type(type), _name(name), _width(width)
+        {
+        }
+
+        Listbox::Column::Type Listbox::Column::type() const
+        {
+            return _type;
+        }
+
+        const std::wstring& Listbox::Column::name() const
+        {
+            return _name;
+        }
+
+        uint32_t Listbox::Column::width() const
+        {
+            return _width;
+        }
+    }
+}

--- a/trview.ui/ListboxItem.cpp
+++ b/trview.ui/ListboxItem.cpp
@@ -1,0 +1,27 @@
+#include "Listbox.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        Listbox::Item::Item(const std::unordered_map<std::wstring, std::wstring>& values)
+            : _values(values)
+        {
+        }
+
+        std::wstring Listbox::Item::value(const std::wstring& key) const
+        {
+            auto item = _values.find(key);
+            if (item == _values.end())
+            {
+                return std::wstring();
+            }
+            return item->second;
+        }
+
+        bool Listbox::Item::operator == (const Item& other) const
+        {
+            return _values == other._values;
+        }
+    }
+}

--- a/trview.ui/ListboxRow.cpp
+++ b/trview.ui/ListboxRow.cpp
@@ -8,6 +8,8 @@ namespace trview
         Listbox::Row::Row(const Colour& colour, const std::vector<Listbox::Column>& columns)
             : StackPanel(Point(), Size(), colour, Size(), Direction::Horizontal), _columns(columns)
         {
+            set_handles_hover(true);
+
             for (const auto& column : columns)
             {
                 auto button = std::make_unique<Button>(Point(), Size(column.width(), 20), L" ");
@@ -38,8 +40,14 @@ namespace trview
             _item.reset();
         }
 
-        void Listbox::Row::set_row_colour(const Colour& colour)
+        void Listbox::Row::update_row_colour()
         {
+            Colour colour = background_colour();
+            if (_highlighted || _hovered)
+            {
+                colour += Colour(0.0f, 0.1f, 0.1f, 0.1f);
+            }
+
             const auto columns = child_elements();
             for (auto& cell : columns)
             {
@@ -51,6 +59,24 @@ namespace trview
         const std::optional<Listbox::Item>& Listbox::Row::item() const
         {
             return _item;
+        }
+
+        void Listbox::Row::mouse_enter()
+        {
+            _hovered = true;
+            update_row_colour();
+        }
+
+        void Listbox::Row::mouse_leave()
+        {
+            _hovered = false;
+            update_row_colour();
+        }
+
+        void Listbox::Row::set_highlighted(bool value)
+        {
+            _highlighted = value;
+            update_row_colour();
         }
     }
 }

--- a/trview.ui/ListboxRow.cpp
+++ b/trview.ui/ListboxRow.cpp
@@ -1,0 +1,56 @@
+#include "Listbox.h"
+#include "Button.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        Listbox::Row::Row(const Colour& colour, const std::vector<Listbox::Column>& columns)
+            : StackPanel(Point(), Size(), colour, Size(), Direction::Horizontal), _columns(columns)
+        {
+            for (const auto& column : columns)
+            {
+                auto button = std::make_unique<Button>(Point(), Size(column.width(), 20), L" ");
+                _token_store.add(button->on_click += [this]
+                {
+                    if (_item.has_value())
+                    {
+                        on_click(_item.value());
+                    }
+                });
+                add_child(std::move(button));
+            }
+        }
+
+        void Listbox::Row::set_item(const Item& item)
+        {
+            _item = item;
+
+            const auto columns = child_elements();
+            for (auto c = 0; c < _columns.size(); ++c)
+            {
+                static_cast<Button*>(columns[c])->set_text(item.value(_columns[c].name()));
+            }
+        }
+
+        void Listbox::Row::clear_item()
+        {
+            _item.reset();
+        }
+
+        void Listbox::Row::set_row_colour(const Colour& colour)
+        {
+            const auto columns = child_elements();
+            for (auto& cell : columns)
+            {
+                Button* button_cell = static_cast<Button*>(cell);
+                button_cell->set_text_background_colour(colour);
+            }
+        }
+
+        const std::optional<Listbox::Item>& Listbox::Row::item() const
+        {
+            return _item;
+        }
+    }
+}

--- a/trview.ui/trview.ui.vcxproj
+++ b/trview.ui/trview.ui.vcxproj
@@ -42,6 +42,9 @@
     <ClCompile Include="Image.cpp" />
     <ClCompile Include="Label.cpp" />
     <ClCompile Include="Listbox.cpp" />
+    <ClCompile Include="ListboxColumn.cpp" />
+    <ClCompile Include="ListboxItem.cpp" />
+    <ClCompile Include="ListboxRow.cpp" />
     <ClCompile Include="NumericUpDown.cpp" />
     <ClCompile Include="Scrollbar.cpp" />
     <ClCompile Include="Slider.cpp" />

--- a/trview.ui/trview.ui.vcxproj.filters
+++ b/trview.ui/trview.ui.vcxproj.filters
@@ -84,6 +84,15 @@
     <ClCompile Include="Scrollbar.cpp">
       <Filter>Controls\Scrollbar</Filter>
     </ClCompile>
+    <ClCompile Include="ListboxRow.cpp">
+      <Filter>Controls\Listbox</Filter>
+    </ClCompile>
+    <ClCompile Include="ListboxItem.cpp">
+      <Filter>Controls\Listbox</Filter>
+    </ClCompile>
+    <ClCompile Include="ListboxColumn.cpp">
+      <Filter>Controls\Listbox</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Types">


### PR DESCRIPTION
Adds hovering to controls - this is done by keeping track of the 'hover control' - this is the lowest level control that the mouse is over that handles hover events. The hover events are mouse_enter and mouse_leave.
Hover control is implemented a bit like focus control - to be honest these things need to be moved into some sort of controller, as currently it requires traversing the whole tree to update references.
Also split the implementation of the classes defined in Listbox.h into separate cpp files to keep things clearer.
Issue: #315 