### PR TITLE
Cull rooms if they aren't visible to the camera

### DIFF
--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -226,10 +226,10 @@ namespace trview
 
         auto in_view = [&](const Room& room)
         {
+            using namespace DirectX;
             using namespace DirectX::SimpleMath;
-
-            // Check the corners (or the box).
-            return frustum.Contains(room.centre()) != DirectX::DISJOINT;
+            BoundingOrientedBox box(room.centre(), room.extents(), Vector4(0, 0, 0, 1));
+            return frustum.Contains(box) != DirectX::DISJOINT;
         };
 
         switch (_room_highlight_mode)

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -163,7 +163,7 @@ namespace trview
     void Level::render_rooms(const ComPtr<ID3D11DeviceContext>& context, const ICamera& camera)
     {
         // Only render the rooms that the current view mode includes.
-        auto rooms = get_rooms_to_render();
+        auto rooms = get_rooms_to_render(camera);
 
         if (_regenerate_transparency)
         {
@@ -217,9 +217,21 @@ namespace trview
 
     // Get the collection of rooms that need to be renderered depending on the current view mode.
     // Returns: The rooms to render and their selection mode.
-    std::vector<Level::RoomToRender> Level::get_rooms_to_render() const
+    std::vector<Level::RoomToRender> Level::get_rooms_to_render(const ICamera& camera) const
     {
         std::vector<RoomToRender> rooms;
+
+        DirectX::BoundingFrustum frustum(camera.projection());
+        frustum.Transform(frustum, camera.view().Invert());
+
+        auto in_view = [&](const Room& room)
+        {
+            using namespace DirectX::SimpleMath;
+
+            // Check the corners (or the box).
+            return frustum.Contains(room.centre()) != DirectX::DISJOINT;
+        };
+
         switch (_room_highlight_mode)
         {
             case RoomHighlightMode::None:
@@ -227,7 +239,7 @@ namespace trview
                 for (std::size_t i = 0; i < _rooms.size(); ++i)
                 {
                     const auto& room = _rooms[i].get();
-                    if (is_alternate_mismatch(room->alternate_mode()))
+                    if (is_alternate_mismatch(room->alternate_mode()) || !in_view(*room))
                     {
                         continue;
                     }
@@ -240,7 +252,7 @@ namespace trview
                 for (std::size_t i = 0; i < _rooms.size(); ++i)
                 {
                     const auto& room = _rooms[i];
-                    if (is_alternate_mismatch(room->alternate_mode()))
+                    if (is_alternate_mismatch(room->alternate_mode()) || !in_view(*room))
                     {
                         continue;
                     }
@@ -253,7 +265,7 @@ namespace trview
                 for (uint16_t i : _neighbours)
                 {
                     const auto& room = _rooms[i];
-                    if (is_alternate_mismatch(room->alternate_mode()))
+                    if (is_alternate_mismatch(room->alternate_mode()) || !in_view(*room))
                     {
                         continue;
                     }
@@ -365,10 +377,10 @@ namespace trview
     // Returns: The result of the operation. If 'hit' is true, distance and position contain
     // how far along the ray the hit was and the position in world space. The room that was hit
     // is also specified.
-    Level::PickResult Level::pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const
+    Level::PickResult Level::pick(const ICamera& camera, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const
     {
         PickResult final_result;
-        auto rooms = get_rooms_to_render();
+        auto rooms = get_rooms_to_render(camera);
         for (auto& room : rooms)
         {
             auto result = room.room.pick(position, direction);

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -228,8 +228,7 @@ namespace trview
         {
             using namespace DirectX;
             using namespace DirectX::SimpleMath;
-            BoundingOrientedBox box(room.centre(), room.extents(), Vector4(0, 0, 0, 1));
-            return frustum.Contains(box) != DirectX::DISJOINT;
+            return frustum.Contains(room.bounding_box()) != DISJOINT;
         };
 
         switch (_room_highlight_mode)

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -226,9 +226,7 @@ namespace trview
 
         auto in_view = [&](const Room& room)
         {
-            using namespace DirectX;
-            using namespace DirectX::SimpleMath;
-            return frustum.Contains(room.bounding_box()) != DISJOINT;
+            return frustum.Contains(room.bounding_box()) != DirectX::DISJOINT;
         };
 
         switch (_room_highlight_mode)

--- a/trview/Level.h
+++ b/trview/Level.h
@@ -77,7 +77,7 @@ namespace trview
         // Returns: The result of the operation. If 'hit' is true, distance and position contain
         // how far along the ray the hit was and the position in world space. The room that was hit
         // is also specified.
-        PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const;
+        PickResult pick(const ICamera& camera, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const;
 
         void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, const ICamera& camera);
 
@@ -135,7 +135,7 @@ namespace trview
 
         // Get the collection of rooms that need to be renderered depending on the current view mode.
         // Returns: The rooms to render and their selection mode.
-        std::vector<RoomToRender> get_rooms_to_render() const;
+        std::vector<RoomToRender> get_rooms_to_render(const ICamera& camera) const;
 
         // Determines whether the room is currently being rendered.
         // room: The room index.

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -259,4 +259,11 @@ namespace trview
                  _info.yBottom / -1024.f + (_info.yTop - _info.yBottom) / -1024.f / 2.0f,
                  (_info.z / 1024.f) + _num_z_sectors / 2.f);
     }
+
+    Vector3 Room::extents() const
+    {
+        return Vector3(static_cast<float>(_num_x_sectors) * 0.5f,
+            (_info.yTop - _info.yBottom) / -1024.0f * 0.5f,
+            static_cast<float>(_num_z_sectors) * 0.5f);
+    }
 }

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -62,15 +62,15 @@ namespace trview
 
         PickResult result;
 
-        auto room_offset = Matrix::CreateTranslation(-_info.x / 1024.f, 0, -_info.z / 1024.f);
-        auto transformed_position = Vector3::Transform(position, room_offset);
-
         // Test against bounding box for the room first, to avoid more expensive mesh-ray intersection
         float box_distance = 0;
-        if (!_bounding_box.Intersects(transformed_position, direction, box_distance))
+        if (!_bounding_box.Intersects(position, direction, box_distance))
         {
             return result;
         }
+
+        auto room_offset = Matrix::CreateTranslation(-_info.x / 1024.f, 0, -_info.z / 1024.f);
+        auto transformed_position = Vector3::Transform(position, room_offset);
 
         result.distance = FLT_MAX;
         for (const auto& tri : _collision_triangles)
@@ -167,7 +167,7 @@ namespace trview
 
         const Vector3 half_size = (maximum - minimum) * 0.5f;
         _bounding_box.Extents = half_size;
-        _bounding_box.Center = minimum + half_size;
+        _bounding_box.Center = centre();
     }
 
     void Room::generate_adjacency()
@@ -260,10 +260,8 @@ namespace trview
                  (_info.z / 1024.f) + _num_z_sectors / 2.f);
     }
 
-    Vector3 Room::extents() const
+    const DirectX::BoundingBox& Room::bounding_box() const
     {
-        return Vector3(static_cast<float>(_num_x_sectors) * 0.5f,
-            (_info.yTop - _info.yBottom) / -1024.0f * 0.5f,
-            static_cast<float>(_num_z_sectors) * 0.5f);
+        return _bounding_box;
     }
 }

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -124,10 +124,13 @@ namespace trview
         // Returns the number of z sectors in the room 
         inline std::uint16_t num_z_sectors() const { return _num_z_sectors; }
 
-        /// Get the centre point of the room.#
+        /// Get the centre point of the room.
         /// @returns The centre position of the room.
         DirectX::SimpleMath::Vector3 centre() const;
 
+        /// Get the extents of the room.
+        /// @retusn The extents of the room.
+        DirectX::SimpleMath::Vector3 extents() const;
     private:
         void generate_geometry(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage);
         void generate_adjacency();

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -128,9 +128,9 @@ namespace trview
         /// @returns The centre position of the room.
         DirectX::SimpleMath::Vector3 centre() const;
 
-        /// Get the extents of the room.
-        /// @retusn The extents of the room.
-        DirectX::SimpleMath::Vector3 extents() const;
+        /// Get the bounding box of the room. The bounding box is pre-transformed to the coordinates of the room.
+        /// @returns The bounding box for the room.
+        const DirectX::BoundingBox& bounding_box() const;
     private:
         void generate_geometry(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage);
         void generate_adjacency();

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -465,7 +465,7 @@ namespace trview
         Vector3 direction = XMVector3Unproject(Vector3(mouse_pos.x, mouse_pos.y, 1), 0, 0, window_size.width, window_size.height, 0, 1.0f, projection, view, world);
         direction.Normalize();
 
-        auto result = _level->pick(position, direction);
+        auto result = _level->pick(camera, position, direction);
 
         _picking->set_visible(result.hit);
         if (result.hit)


### PR DESCRIPTION
If a room's bounding box isn't contained or intersecting the camera view frustum, don't draw it (or any items inside it).
This saves on draw calls and so should make things more efficient.
Issue: #211 