### PR TITLE
Click on an item in the viewer to select it

### DIFF
--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -77,12 +77,10 @@ namespace trview
 
         ui::Listbox::Item create_listbox_item(const Item& item)
         {
-            return {{
-                    { L"#", std::to_wstring(item.number()) },
-                    { L"ID", std::to_wstring(item.type_id()) },
-                    { L"Room", std::to_wstring(item.room()) },
-                    { L"Type", item.type() }
-                    }};
+            return {{{ L"#", std::to_wstring(item.number()) },
+                     { L"ID", std::to_wstring(item.type_id()) },
+                     { L"Room", std::to_wstring(item.room()) },
+                     { L"Type", item.type() }}};
         }
     }
 
@@ -163,10 +161,7 @@ namespace trview
     {
         using namespace ui;
         std::vector<Listbox::Item> list_items;
-        for (const auto& item : items)
-        {
-            list_items.push_back(create_listbox_item(item));
-        }
+        std::transform(items.begin(), items.end(), std::back_inserter(list_items), create_listbox_item);
         _items_list->set_items(list_items);
     }
 
@@ -220,14 +215,7 @@ namespace trview
 
         auto sync_item = std::make_unique<Checkbox>(Point(), Size(16, 16), Colours::LeftPanel, L"Sync Item");
         sync_item->set_state(_sync_item);
-        _token_store.add(sync_item->on_state_changed += [this](bool value)
-        {
-            set_sync_item(value);
-            if (_selected_item.has_value())
-            {
-                set_selected_item(_selected_item.value());
-            }
-        });
+        _token_store.add(sync_item->on_state_changed += [this](bool value) { set_sync_item(value); });
         controls->add_child(std::move(sync_item));
 
         // Space out the button
@@ -409,7 +397,14 @@ namespace trview
 
     void ItemsWindow::set_sync_item(bool value)
     {
-        _sync_item = value;
+        if (_sync_item != value)
+        {
+            _sync_item = value;
+            if (_selected_item.has_value())
+            {
+                set_selected_item(_selected_item.value());
+            }
+        }
     }
 
     void ItemsWindow::toggle_expand()

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -94,7 +94,7 @@ namespace trview
         std::unique_ptr<ui::StackPanel> create_details_panel();
         void load_item_details(const Item& item);
         void set_track_room(bool value);
-        void set_track_item(bool value);
+        void set_sync_item(bool value);
         void toggle_expand();
 
         WindowResizer _window_resizer;
@@ -123,6 +123,7 @@ namespace trview
         /// Whether the room tracking filter has been applied.
         bool _filter_applied{ false };
         bool _expanded{ true };
-        bool _track_item{ false };
+        bool _sync_item{ true };
+        std::optional<Item> _selected_item;
     };
 }

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -80,6 +80,10 @@ namespace trview
         /// Set the current room. This will be used when the track room setting is on.
         /// @param room The current room number.
         void set_current_room(uint32_t room);
+
+        /// Set the selected item.
+        /// @param item The selected item.
+        void set_selected_item(const Item& item);
     private:
         void generate_ui();
         void populate_items(const std::vector<Item>& items);
@@ -90,6 +94,7 @@ namespace trview
         std::unique_ptr<ui::StackPanel> create_details_panel();
         void load_item_details(const Item& item);
         void set_track_room(bool value);
+        void set_track_item(bool value);
         void toggle_expand();
 
         WindowResizer _window_resizer;
@@ -117,7 +122,7 @@ namespace trview
         uint32_t _current_room{ 0u };
         /// Whether the room tracking filter has been applied.
         bool _filter_applied{ false };
-
         bool _expanded{ true };
+        bool _track_item{ false };
     };
 }

--- a/trview.app/ItemsWindowManager.cpp
+++ b/trview.app/ItemsWindowManager.cpp
@@ -80,4 +80,12 @@ namespace trview
             window->set_current_room(room);
         }
     }
+
+    void ItemsWindowManager::set_selected_item(const Item& item)
+    {
+        for (auto& window : _windows)
+        {
+            window->set_selected_item(item);
+        }
+    }
 }

--- a/trview.app/ItemsWindowManager.h
+++ b/trview.app/ItemsWindowManager.h
@@ -59,6 +59,10 @@ namespace trview
         /// @param room The current room.
         void set_room(uint32_t room);
 
+        /// Set the currently selected item.
+        /// @param item The selected item.
+        void set_selected_item(const Item& item);
+
         /// Create a new items window.
         void create_window();
     private:

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -338,9 +338,14 @@ namespace trview
             scroll_to(index);
         }
 
-        void Listbox::set_selected_item(const Item& item)
+        bool Listbox::set_selected_item(const Item& item)
         {
+            if (std::find(_items.begin(), _items.end(), item) == _items.end())
+            {
+                return false;
+            }
             select_item(item, false);
+            return true;
         }
     }
 }

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -281,11 +281,14 @@ namespace trview
             _headers_element = add_child(std::move(headers_element));
         }
 
-        void Listbox::select_item(const Item& item)
+        void Listbox::select_item(const Item& item, bool raise_event)
         {
             _selected_item = item;
             scroll_to_show(item);
-            on_item_selected(_selected_item.value());
+            if (raise_event)
+            {
+                on_item_selected(_selected_item.value());
+            }
         }
 
         void Listbox::highlight_item()
@@ -333,6 +336,11 @@ namespace trview
             }
 
             scroll_to(index);
+        }
+
+        void Listbox::set_selected_item(const Item& item)
+        {
+            select_item(item, false);
         }
     }
 }

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -145,7 +145,8 @@ namespace trview
 
             /// Set the selected item. This will not raise the on_item_selected event.
             /// @param item The selected item.
-            void set_selected_item(const Item& item);
+            /// @returns Whether the item was selected.
+            bool set_selected_item(const Item& item);
 
             /// Event raised when an item is selected
             Event<Item> on_item_selected;

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -143,6 +143,10 @@ namespace trview
             /// @param value Whether to highlight rows.
             void set_show_highlight(bool value);
 
+            /// Set the selected item. This will not raise the on_item_selected event.
+            /// @param item The selected item.
+            void set_selected_item(const Item& item);
+
             /// Event raised when an item is selected
             Event<Item> on_item_selected;
         protected:
@@ -160,7 +164,7 @@ namespace trview
             /// Sort the items according to the current sort method.
             void sort_items();
             /// Select the given item and scroll to make it visible.
-            void select_item(const Item& item);
+            void select_item(const Item& item, bool raise_event = true);
             /// Scroll the listbox so that the specified item index is visible.
             void scroll_to(uint32_t item);
             /// Scroll the listbox so that the specified item is visible.

--- a/trview/Entity.cpp
+++ b/trview/Entity.cpp
@@ -197,4 +197,14 @@ namespace trview
             }
         }
     }
+
+    PickResult Entity::pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const
+    {
+        // Check against some sort of bounding box (based on the mesh?)
+
+        // If it hit the bounding box
+
+        PickResult result;
+        return result;
+    }
 }

--- a/trview/Entity.cpp
+++ b/trview/Entity.cpp
@@ -315,6 +315,6 @@ namespace trview
         }
 
         // Create an axis-aligned BB from the points of the oriented ones.
-        BoundingBox::CreateFromPoints(_bounding_box, corners.size(), &corners[0], sizeof(XMFLOAT3));
+        BoundingBox::CreateFromPoints(_bounding_box, corners.size(), &corners[0], sizeof(Vector3));
     }
 }

--- a/trview/Entity.cpp
+++ b/trview/Entity.cpp
@@ -16,8 +16,8 @@ using namespace Microsoft::WRL;
 
 namespace trview
 {
-    Entity::Entity(const ComPtr<ID3D11Device>& device, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const ILevelTextureStorage& texture_storage, const IMeshStorage& mesh_storage)
-        : _room(entity.Room)
+    Entity::Entity(const ComPtr<ID3D11Device>& device, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const ILevelTextureStorage& texture_storage, const IMeshStorage& mesh_storage, uint32_t index)
+        : _room(entity.Room), _index(index)
     {
         using namespace DirectX;
         using namespace DirectX::SimpleMath;
@@ -179,6 +179,11 @@ namespace trview
         return _room;
     }
 
+    uint32_t Entity::index() const
+    {
+        return _index;
+    }
+
     void Entity::get_transparent_triangles(TransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour)
     {
         for (uint32_t i = 0; i < _meshes.size(); ++i)
@@ -214,6 +219,7 @@ namespace trview
 
         PickResult result;
         result.type = PickResult::Type::Entity;
+        result.index = _index;
         result.hit = true;
         result.distance = box_distance;
         result.position = position + direction * result.distance;
@@ -242,6 +248,7 @@ namespace trview
 
             // Transform the box by the model transform.
             BoundingOrientedBox oriented_box;
+            BoundingOrientedBox::CreateFromBoundingBox(oriented_box, box);
             oriented_box.Transform(oriented_box, _world_transforms[i] * _world);
             oriented_box.GetCorners(&corners[i * 8]);
         }

--- a/trview/Entity.cpp
+++ b/trview/Entity.cpp
@@ -217,6 +217,17 @@ namespace trview
             return PickResult();
         }
 
+        if (_sprite_mesh)
+        {
+            PickResult result;
+            result.hit = true;
+            result.type = PickResult::Type::Entity;
+            result.index = _index;
+            result.distance = box_distance;
+            result.position = position + direction * box_distance;
+            return result;
+        }
+
         using namespace DirectX;
         using namespace DirectX::SimpleMath;
 
@@ -273,13 +284,23 @@ namespace trview
 
     void Entity::generate_bounding_box()
     {
+        using namespace DirectX;
+
         // Sprite meshes not yet handled.
         if (_meshes.empty())
         {
+            if (_sprite_mesh)
+            {
+                float width = _scale._11;
+                float height = _scale._22;
+                BoundingSphere sphere(_position, sqrt(width * width + height * height) * 0.5f);
+                sphere.Transform(sphere, _offset);
+                BoundingBox::CreateFromSphere(_bounding_box, sphere);
+            }
+
             return;
         }
 
-        using namespace DirectX;
         using namespace DirectX::SimpleMath;
 
         // The entity bounding box is based on the bounding boxes of the meshes it contains.

--- a/trview/Entity.cpp
+++ b/trview/Entity.cpp
@@ -297,7 +297,6 @@ namespace trview
                 sphere.Transform(sphere, _offset);
                 BoundingBox::CreateFromSphere(_bounding_box, sphere);
             }
-
             return;
         }
 
@@ -319,7 +318,7 @@ namespace trview
             oriented_box.GetCorners(&corners[i * 8]);
         }
 
-        // Or a sprite mesh...
+        // Create an axis-aligned BB from the points of the oriented ones.
         BoundingBox::CreateFromPoints(_bounding_box, corners.size(), &corners[0], sizeof(XMFLOAT3));
     }
 }

--- a/trview/Entity.cpp
+++ b/trview/Entity.cpp
@@ -236,17 +236,9 @@ namespace trview
         // Check each of the meshes in the object.
         for (uint32_t i = 0; i < _meshes.size(); ++i)
         {
-            // Get the box for the mesh.
-            auto box = _meshes[i]->bounding_box();
-
-            // Transform the box by the model transform.
-            BoundingOrientedBox oriented_box;
-            BoundingOrientedBox::CreateFromBoundingBox(oriented_box, box);
-            oriented_box.Transform(oriented_box, _world_transforms[i] * _world);
-
             // Try and pick against the bounding box.
             float box_distance = 0;
-            if (oriented_box.Intersects(position, direction, box_distance))
+            if (_oriented_boxes[i].Intersects(position, direction, box_distance))
             {
                 // Pick against the triangles in this mesh.
                 pick_meshes.push_back(i);
@@ -302,6 +294,9 @@ namespace trview
 
         using namespace DirectX::SimpleMath;
 
+        // Remove any stored boxes so they can be created.
+        _oriented_boxes.clear();
+
         // The entity bounding box is based on the bounding boxes of the meshes it contains.
         // Allocate space for all of the corners.
         std::vector<Vector3> corners(_meshes.size() * 8);
@@ -311,11 +306,12 @@ namespace trview
             // Get the box for the mesh.
             auto box = _meshes[i]->bounding_box();
 
-            // Transform the box by the model transform.
+            // Transform the box by the model transform. Store this box for later picking.
             BoundingOrientedBox oriented_box;
             BoundingOrientedBox::CreateFromBoundingBox(oriented_box, box);
             oriented_box.Transform(oriented_box, _world_transforms[i] * _world);
             oriented_box.GetCorners(&corners[i * 8]);
+            _oriented_boxes.push_back(oriented_box);
         }
 
         // Create an axis-aligned BB from the points of the oriented ones.

--- a/trview/Entity.h
+++ b/trview/Entity.h
@@ -40,6 +40,7 @@ namespace trview
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);
         void load_sprite(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::tr_sprite_sequence& sprite_sequence, const trlevel::ILevel& level, const ILevelTextureStorage& texture_storage);
+        void generate_bounding_box();
 
         DirectX::SimpleMath::Matrix               _world;
         std::vector<Mesh*>                        _meshes;
@@ -51,5 +52,7 @@ namespace trview
         DirectX::SimpleMath::Matrix               _scale;
         DirectX::SimpleMath::Matrix               _offset;
         DirectX::SimpleMath::Vector3              _position;
+
+        DirectX::BoundingBox _bounding_box;
     };
 }

--- a/trview/Entity.h
+++ b/trview/Entity.h
@@ -29,9 +29,10 @@ namespace trview
     class Entity
     {
     public:
-        explicit Entity(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::ILevel& level, const trlevel::tr2_entity& room, const ILevelTextureStorage& texture_storage, const IMeshStorage& mesh_storage);
+        explicit Entity(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::ILevel& level, const trlevel::tr2_entity& room, const ILevelTextureStorage& texture_storage, const IMeshStorage& mesh_storage, uint32_t index);
         void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour);
         uint16_t room() const;
+        uint32_t index() const;
 
         void get_transparent_triangles(TransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour);
 
@@ -47,6 +48,7 @@ namespace trview
         std::unique_ptr<Mesh>                     _sprite_mesh;
         std::vector<DirectX::SimpleMath::Matrix>  _world_transforms;
         uint16_t                                  _room;
+        uint32_t                                  _index;
 
         // Bits for sprites.
         DirectX::SimpleMath::Matrix               _scale;

--- a/trview/Entity.h
+++ b/trview/Entity.h
@@ -55,6 +55,7 @@ namespace trview
         DirectX::SimpleMath::Matrix               _offset;
         DirectX::SimpleMath::Vector3              _position;
 
-        DirectX::BoundingBox _bounding_box;
+        DirectX::BoundingBox                      _bounding_box;
+        std::vector<DirectX::BoundingOrientedBox> _oriented_boxes;
     };
 }

--- a/trview/Entity.h
+++ b/trview/Entity.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 
+#include "PickResult.h"
 
 namespace trlevel
 {
@@ -33,6 +34,8 @@ namespace trview
         uint16_t room() const;
 
         void get_transparent_triangles(TransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour);
+
+        PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const;
     private:
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -374,7 +374,7 @@ namespace trview
     // Returns: The result of the operation. If 'hit' is true, distance and position contain
     // how far along the ray the hit was and the position in world space. The room that was hit
     // is also specified.
-    Level::PickResult Level::pick(const ICamera& camera, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const
+    PickResult Level::pick(const ICamera& camera, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const
     {
         PickResult final_result;
         auto rooms = get_rooms_to_render(camera);
@@ -386,7 +386,8 @@ namespace trview
                 final_result.hit = true;
                 final_result.distance = result.distance;
                 final_result.position = result.position;
-                final_result.room = room.number;
+                final_result.index = room.number;
+                final_result.type = PickResult::Type::Room;
             }
         }
         return final_result;

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -280,7 +280,7 @@ namespace trview
         for (uint16_t i = 0; i < num_rooms; ++i)
         {
             auto room = _level->get_room(i);
-            _rooms.push_back(std::make_unique<Room>(device, *_level, room, *_texture_storage.get(), *_mesh_storage.get()));
+            _rooms.push_back(std::make_unique<Room>(device, *_level, room, *_texture_storage.get(), *_mesh_storage.get(), i));
         }
 
         // Fix up the IsAlternate status of the rooms that are referenced by HasAlternate rooms.
@@ -321,7 +321,7 @@ namespace trview
         {
             // Entity for rendering.
             auto level_entity = _level->get_entity(i);
-            auto entity = std::make_unique<Entity>(device, *_level, level_entity, *_texture_storage.get(), *_mesh_storage.get());
+            auto entity = std::make_unique<Entity>(device, *_level, level_entity, *_texture_storage.get(), *_mesh_storage.get(), i);
             _rooms[entity->room()]->add_entity(entity.get());
             _entities.push_back(std::move(entity));
 
@@ -386,8 +386,8 @@ namespace trview
                 final_result.hit = true;
                 final_result.distance = result.distance;
                 final_result.position = result.position;
-                final_result.index = room.number;
-                final_result.type = PickResult::Type::Room;
+                final_result.index = result.index;
+                final_result.type = result.type;
             }
         }
         return final_result;

--- a/trview/Level.h
+++ b/trview/Level.h
@@ -47,16 +47,7 @@ namespace trview
             Neighbours
         };
 
-        struct PickResult
-        {
-            bool                         hit{ false };
-            uint32_t                     room;
-            DirectX::SimpleMath::Vector3 position;
-            float                        distance{ FLT_MAX };
-        };
-
         // Temporary, for the room info and texture window.
-
         std::vector<RoomInfo> room_info() const;
         RoomInfo room_info(uint32_t room) const;
         std::vector<graphics::Texture> level_textures() const;

--- a/trview/Mesh.cpp
+++ b/trview/Mesh.cpp
@@ -108,7 +108,7 @@ namespace trview
 
         const Vector3 half_size = (maximum - minimum) * 0.5f;
         _bounding_box.Extents = half_size;
-        _bounding_box.Center = Vector3::Zero;
+        _bounding_box.Center = minimum + half_size;
     }
 
     void Mesh::render(const ComPtr<ID3D11DeviceContext>& context, const Matrix& world_view_projection, const ILevelTextureStorage& texture_storage, const Color& colour)

--- a/trview/Mesh.cpp
+++ b/trview/Mesh.cpp
@@ -175,7 +175,6 @@ namespace trview
         using namespace DirectX::TriangleTests;
 
         PickResult result;
-        result.distance = FLT_MAX;
         result.type = PickResult::Type::Mesh;
         for (const auto& tri : _collision_triangles)
         {

--- a/trview/Mesh.cpp
+++ b/trview/Mesh.cpp
@@ -246,10 +246,14 @@ namespace trview
             {
                 transparent_triangles.emplace_back(verts[0], verts[1], verts[2], uvs[0], uvs[1], uvs[2], texture_storage.tile(texture), transparency_mode);
                 transparent_triangles.emplace_back(verts[2], verts[3], verts[0], uvs[2], uvs[3], uvs[0], texture_storage.tile(texture), transparency_mode);
+                collision_triangles.emplace_back(verts[0], verts[1], verts[2]);
+                collision_triangles.emplace_back(verts[2], verts[3], verts[0]);
                 if (double_sided)
                 {
                     transparent_triangles.emplace_back(verts[2], verts[1], verts[0], uvs[2], uvs[1], uvs[0], texture_storage.tile(texture), transparency_mode);
                     transparent_triangles.emplace_back(verts[0], verts[3], verts[2], uvs[0], uvs[3], uvs[2], texture_storage.tile(texture), transparency_mode);
+                    collision_triangles.emplace_back(verts[2], verts[1], verts[0]);
+                    collision_triangles.emplace_back(verts[0], verts[3], verts[2]);
                 }
                 continue;
             }
@@ -319,9 +323,11 @@ namespace trview
             if (determine_transparency(texture_storage.attribute(texture), tri.effects, transparency_mode))
             {
                 transparent_triangles.emplace_back(verts[0], verts[1], verts[2], uvs[0], uvs[1], uvs[2], texture_storage.tile(texture), transparency_mode);
+                collision_triangles.emplace_back(verts[0], verts[1], verts[2]);
                 if (double_sided)
                 {
                     transparent_triangles.emplace_back(verts[2], verts[1], verts[0], uvs[2], uvs[1], uvs[0], texture_storage.tile(texture), transparency_mode);
+                    collision_triangles.emplace_back(verts[2], verts[1], verts[0]);
                 }
                 continue;
             }

--- a/trview/Mesh.h
+++ b/trview/Mesh.h
@@ -9,6 +9,7 @@
 #include "MeshVertex.h"
 #include "TransparencyBuffer.h"
 #include "Triangle.h"
+#include "PickResult.h"
 
 namespace trview
 {
@@ -35,6 +36,8 @@ namespace trview
         const std::vector<TransparentTriangle>& transparent_triangles() const;
 
         const DirectX::BoundingBox& bounding_box() const;
+
+        PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const;
     private:
         Microsoft::WRL::ComPtr<ID3D11Buffer>              _vertex_buffer;
         std::vector<uint32_t>                             _index_counts;

--- a/trview/Mesh.h
+++ b/trview/Mesh.h
@@ -50,21 +50,23 @@ namespace trview
         DirectX::BoundingBox                              _bounding_box;
     };
 
-    // Create a new mesh based on the contents of the mesh specified.
-    // mesh: The level mesh to generate.
-    // device: The D3D device to use to create the mesh.
-    // texture_storage: The textures for the level.
-    // Returns: The new mesh.
-    std::unique_ptr<Mesh> create_mesh(const trlevel::tr_mesh& mesh, const Microsoft::WRL::ComPtr<ID3D11Device>& device, const ILevelTextureStorage& texture_storage);
+    /// Create a new mesh based on the contents of the mesh specified.
+    /// @param mesh The level mesh to generate.
+    /// @param device The D3D device to use to create the mesh.
+    /// @param texture_storage The textures for the level.
+    /// @param transparent_collision Whether to include transparent triangles in collision triangles.
+    /// @returns The new mesh.
+    std::unique_ptr<Mesh> create_mesh(const trlevel::tr_mesh& mesh, const Microsoft::WRL::ComPtr<ID3D11Device>& device, const ILevelTextureStorage& texture_storage, bool transparent_collision = true);
 
-    // Convert the textured rectangles into collections required to create a mesh.
-    // rectangles: The rectangles from the mesh or room geometry.
-    // input_vertices: The vertices that the rectangle indices refer to.
-    // texture_storage: The texture storage for the level.
-    // output_vertices: The collection to add the new vertices to.
-    // output_indices: The collection to add new indices to.
-    // transparent_triangles: The collection to add transparent triangles to.
-    // collision_triangles: The collection to add collision triangles to.
+    /// Convert the textured rectangles into collections required to create a mesh.
+    /// @param rectangles The rectangles from the mesh or room geometry.
+    /// @param input_vertices The vertices that the rectangle indices refer to.
+    /// @param texture_storage The texture storage for the level.
+    /// @param output_vertices The collection to add the new vertices to.
+    /// @param output_indices The collection to add new indices to.
+    /// @param transparent_triangles The collection to add transparent triangles to.
+    /// @param collision_triangles The collection to add collision triangles to.
+    /// @param transparent_collision Whether to add transparent rectangles as collision triangles.
     void process_textured_rectangles(
         const std::vector<trlevel::tr4_mesh_face4>& rectangles, 
         const std::vector<trlevel::tr_vertex>& input_vertices, 
@@ -72,16 +74,18 @@ namespace trview
         std::vector<MeshVertex>& output_vertices,
         std::vector<std::vector<uint32_t>>& output_indices,
         std::vector<TransparentTriangle>& transparent_triangles,
-        std::vector<Triangle>& collision_triangles);
+        std::vector<Triangle>& collision_triangles,
+        bool transparent_collision = true);
 
-    // Convert the textured triangles into collections required to create a mesh.
-    // triangles: The triangles from the mesh or room geometry.
-    // input_vertices: The vertices that the triangle indices refer to.
-    // texture_storage: The texture storage for the level.
-    // output_vertices: The collection to add the new vertices to.
-    // output_indices: The collection to add new indices to.
-    // transparent_triangles: The collection to add transparent triangles to.
-    // collision_triangles: The collection to add collision triangles to.
+    /// Convert the textured triangles into collections required to create a mesh.
+    /// @param triangles The triangles from the mesh or room geometry.
+    /// @param input_vertices The vertices that the triangle indices refer to.
+    /// @param texture_storage The texture storage for the level.
+    /// @param output_vertices The collection to add the new vertices to.
+    /// @param output_indices The collection to add new indices to.
+    /// @param transparent_triangles The collection to add transparent triangles to.
+    /// @param collision_triangles The collection to add collision triangles to.
+    /// @param transparent_collision Whether to add transparent rectangles as collision triangles.
     void process_textured_triangles(
         const std::vector<trlevel::tr4_mesh_face3>& triangles,
         const std::vector<trlevel::tr_vertex>& input_vertices,
@@ -89,7 +93,8 @@ namespace trview
         std::vector<MeshVertex>& output_vertices,
         std::vector<std::vector<uint32_t>>& output_indices,
         std::vector<TransparentTriangle>& transparent_triangles,
-        std::vector<Triangle>& collision_triangles);
+        std::vector<Triangle>& collision_triangles,
+        bool transparent_collision = true);
 
     // Convert the coloured rectangles into collections required to create a mesh.
     // triangles: The rectangles from the mesh or room geometry.

--- a/trview/Mesh.h
+++ b/trview/Mesh.h
@@ -8,6 +8,7 @@
 
 #include "MeshVertex.h"
 #include "TransparencyBuffer.h"
+#include "Triangle.h"
 
 namespace trview
 {
@@ -16,20 +17,24 @@ namespace trview
     class Mesh
     {
     public:
-        // Create a mesh using the specified vertices and indices.
-        // device: The D3D device to create the mesh.
-        // vertices: The vertices that make up the mesh.
-        // indices: The indices for triangles that use level textures.
-        // untextured_indices: The indices for triangles that do not use level textures.
+        /// Create a mesh using the specified vertices and indices.
+        /// @param device The D3D device to create the mesh.
+        /// @param vertices The vertices that make up the mesh.
+        /// @param indices The indices for triangles that use level textures.
+        /// @param untextured_indices The indices for triangles that do not use level textures.
+        /// @param collision_triangles The triangles for picking.
         Mesh(const Microsoft::WRL::ComPtr<ID3D11Device>& device,
              const std::vector<MeshVertex>& vertices, 
              const std::vector<std::vector<uint32_t>>& indices, 
              const std::vector<uint32_t>& untextured_indices,
-             const std::vector<TransparentTriangle>& transparent_triangles);
+             const std::vector<TransparentTriangle>& transparent_triangles,
+             const std::vector<Triangle>& collision_triangles);
 
         void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, const DirectX::SimpleMath::Matrix& world_view_projection, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour);
 
         const std::vector<TransparentTriangle>& transparent_triangles() const;
+
+        const DirectX::BoundingBox& bounding_box() const;
     private:
         Microsoft::WRL::ComPtr<ID3D11Buffer>              _vertex_buffer;
         std::vector<uint32_t>                             _index_counts;
@@ -38,19 +43,8 @@ namespace trview
         Microsoft::WRL::ComPtr<ID3D11Buffer>              _untextured_index_buffer;
         uint32_t                                          _untextured_index_count;
         std::vector<TransparentTriangle>                  _transparent_triangles;
-    };
-
-    struct Triangle
-    {
-        Triangle(const DirectX::SimpleMath::Vector3& v0, const DirectX::SimpleMath::Vector3& v1, const DirectX::SimpleMath::Vector3& v2)
-            : v0(v0), v1(v1), v2(v2), normal((v1 - v0).Cross(v2 - v0))
-        {
-        }
-
-        DirectX::SimpleMath::Vector3 v0;
-        DirectX::SimpleMath::Vector3 v1;
-        DirectX::SimpleMath::Vector3 v2;
-        DirectX::SimpleMath::Vector3 normal;
+        std::vector<Triangle>                             _collision_triangles;
+        DirectX::BoundingBox                              _bounding_box;
     };
 
     // Create a new mesh based on the contents of the mesh specified.

--- a/trview/PickResult.h
+++ b/trview/PickResult.h
@@ -13,7 +13,7 @@ namespace trview
         };
 
         bool                         hit{ false };
-        float                        distance;
+        float                        distance{ FLT_MAX };
         DirectX::SimpleMath::Vector3 position;
         Type                         type{ Type::Room };
         uint32_t                     index{ 0u };

--- a/trview/PickResult.h
+++ b/trview/PickResult.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <SimpleMath.h>
+
+namespace trview
+{
+    struct PickResult
+    {
+        enum class Type
+        {
+            Room,
+            Entity
+        };
+
+        bool                         hit{ false };
+        float                        distance;
+        DirectX::SimpleMath::Vector3 position;
+        Type                         type{ Type::Room };
+        uint32_t                     index{ 0u };
+    };
+}

--- a/trview/PickResult.h
+++ b/trview/PickResult.h
@@ -9,7 +9,8 @@ namespace trview
         enum class Type
         {
             Room,
-            Entity
+            Entity,
+            Mesh
         };
 
         bool                         hit{ false };

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -56,22 +56,31 @@ namespace trview
     // direction: The direction of the ray.
     // Returns: The result of the operation. If 'hit' is true, distance and position contain
     // how far along the ray the hit was and the position in world space.
-    Room::PickResult Room::pick(const Vector3& position, const Vector3& direction) const
+    PickResult Room::pick(const Vector3& position, const Vector3& direction) const
     {
         using namespace DirectX::TriangleTests;
-
-        PickResult result;
 
         // Test against bounding box for the room first, to avoid more expensive mesh-ray intersection
         float box_distance = 0;
         if (!_bounding_box.Intersects(position, direction, box_distance))
         {
-            return result;
+            return PickResult();
         }
 
+        std::vector<PickResult> pick_results;
+
+        // Pick against the entity geometry:
+        for (const auto& entity : _entities)
+        {
+            // Add to some sort of list...
+            pick_results.push_back(entity->pick(position, direction));
+        }
+
+        // Pick against the room geometry:
         auto room_offset = Matrix::CreateTranslation(-_info.x / 1024.f, 0, -_info.z / 1024.f);
         auto transformed_position = Vector3::Transform(position, room_offset);
 
+        PickResult result;
         result.distance = FLT_MAX;
         for (const auto& tri : _collision_triangles)
         {

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -23,11 +23,13 @@ namespace trview
         const trlevel::ILevel& level, 
         const trlevel::tr3_room& room,
         const ILevelTextureStorage& texture_storage,
-        const IMeshStorage& mesh_storage)
+        const IMeshStorage& mesh_storage,
+        uint32_t index)
         : _info { room.info.x, 0, room.info.z, room.info.yBottom, room.info.yTop }, 
         _alternate_room(room.alternate_room),
         _num_x_sectors(room.num_x_sectors),
-        _num_z_sectors(room.num_z_sectors)
+        _num_z_sectors(room.num_z_sectors),
+        _index(index)
     {
         // Can only determine HasAlternate or normal at this point. After all rooms have been loaded,
         // the level can fix up the rooms so that they know if they are alternates of another room
@@ -74,7 +76,7 @@ namespace trview
         {
             // Add to some sort of list...
             auto entity_result = entity->pick(position, direction);
-            if (entity_result.hit)
+            if (entity_result.hit && entity_result.distance > 0)
             {
                 pick_results.push_back(entity_result);
             }
@@ -86,6 +88,7 @@ namespace trview
 
         PickResult result;
         result.distance = FLT_MAX;
+        result.index = _index;
         for (const auto& tri : _collision_triangles)
         {
             float distance = 0;

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -74,9 +74,8 @@ namespace trview
         // Pick against the entity geometry:
         for (const auto& entity : _entities)
         {
-            // Add to some sort of list...
             auto entity_result = entity->pick(position, direction);
-            if (entity_result.hit && entity_result.distance > 0)
+            if (entity_result.hit)
             {
                 pick_results.push_back(entity_result);
             }
@@ -84,27 +83,14 @@ namespace trview
 
         // Pick against the room geometry:
         auto room_offset = Matrix::CreateTranslation(-_info.x / 1024.f, 0, -_info.z / 1024.f);
-        auto transformed_position = Vector3::Transform(position, room_offset);
-
-        PickResult result;
-        result.distance = FLT_MAX;
-        result.index = _index;
-        for (const auto& tri : _collision_triangles)
+        PickResult geometry_result = _mesh->pick(Vector3::Transform(position, room_offset), direction);
+        if (geometry_result.hit)
         {
-            float distance = 0;
-            if (direction.Dot(tri.normal) < 0 &&
-                Intersects(transformed_position, direction, tri.v0, tri.v1, tri.v2, distance))
-            {
-                result.hit = true;
-                result.distance = std::min(distance, result.distance);
-            }
-        }
-
-        // Calculate the world space hit position, if there was a hit.
-        if (result.hit)
-        {
-            result.position = position + direction * result.distance;
-            pick_results.push_back(result);
+            // Transform the position back in to world space. Also mark it as a room pick result.
+            geometry_result.type = PickResult::Type::Room;
+            geometry_result.index = _index;
+            geometry_result.position = Vector3::Transform(geometry_result.position, _room_offset);
+            pick_results.push_back(geometry_result);
         }
 
         if (pick_results.empty())
@@ -112,9 +98,9 @@ namespace trview
             return PickResult();
         }
 
+        // Choose the closest pick out of all results.
         std::sort(pick_results.begin(), pick_results.end(),
             [](const auto& l, const auto& r) { return l.distance < r.distance; });
-
         return pick_results.front();
     }
 
@@ -176,23 +162,13 @@ namespace trview
 
         // The indices are grouped by the number of textiles so that it can be drawn as the selected texture.
         std::vector<std::vector<uint32_t>> indices(texture_storage.num_tiles());
+        std::vector<Triangle> collision_triangles;
 
-        process_textured_rectangles(room.data.rectangles, room_vertices, texture_storage, vertices, indices, transparent_triangles, _collision_triangles);
-        process_textured_triangles(room.data.triangles, room_vertices, texture_storage, vertices, indices, transparent_triangles, _collision_triangles);
+        process_textured_rectangles(room.data.rectangles, room_vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles);
+        process_textured_triangles(room.data.triangles, room_vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles);
 
-        _mesh = std::make_unique<Mesh>(device, vertices, indices, std::vector<uint32_t>(), transparent_triangles, _collision_triangles);
-
-        // Generate the bounding box for use in picking.
-        Vector3 minimum(FLT_MAX, FLT_MAX, FLT_MAX);
-        Vector3 maximum(-FLT_MAX, -FLT_MAX, -FLT_MAX);
-        for (const auto& v : vertices)
-        {
-            minimum = Vector3::Min(minimum, v.pos);
-            maximum = Vector3::Max(maximum, v.pos);
-        }
-
-        const Vector3 half_size = (maximum - minimum) * 0.5f;
-        _bounding_box.Extents = half_size;
+        _mesh = std::make_unique<Mesh>(device, vertices, indices, std::vector<uint32_t>(), transparent_triangles, collision_triangles);
+        _bounding_box = _mesh->bounding_box();
         _bounding_box.Center = centre();
     }
 

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -164,8 +164,8 @@ namespace trview
         std::vector<std::vector<uint32_t>> indices(texture_storage.num_tiles());
         std::vector<Triangle> collision_triangles;
 
-        process_textured_rectangles(room.data.rectangles, room_vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles);
-        process_textured_triangles(room.data.triangles, room_vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles);
+        process_textured_rectangles(room.data.rectangles, room_vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
+        process_textured_triangles(room.data.triangles, room_vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
 
         _mesh = std::make_unique<Mesh>(device, vertices, indices, std::vector<uint32_t>(), transparent_triangles, collision_triangles);
         _bounding_box = _mesh->bounding_box();

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -143,8 +143,6 @@ namespace trview
         std::unique_ptr<Mesh>       _mesh;
         DirectX::SimpleMath::Matrix _room_offset;
 
-        // Triangle copy for ray intersection.
-        std::vector<Triangle> _collision_triangles;
         DirectX::BoundingBox  _bounding_box;
 
         std::vector<Entity*> _entities;

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -55,7 +55,8 @@ namespace trview
             const trlevel::ILevel& level, 
             const trlevel::tr3_room& room,
             const ILevelTextureStorage& texture_storage,
-            const IMeshStorage& mesh_storage);
+            const IMeshStorage& mesh_storage,
+            uint32_t index);
 
         Room(const Room&) = delete;
         Room& operator=(const Room&) = delete;
@@ -135,6 +136,7 @@ namespace trview
 
         RoomInfo                           _info;
         std::set<uint16_t>                 _neighbours;
+        uint32_t _index;
 
         std::vector<std::unique_ptr<StaticMesh>> _static_meshes;
 

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -20,6 +20,7 @@
 #include "TransparencyBuffer.h"
 #include "Mesh.h"
 #include <trview\Sector.h>
+#include "PickResult.h"
 
 namespace trview
 {
@@ -48,13 +49,6 @@ namespace trview
             HasAlternate,
             // This room is an alternate room to another room.
             IsAlternate
-        };
-
-        struct PickResult
-        {
-            bool                         hit{ false };
-            float                        distance;
-            DirectX::SimpleMath::Vector3 position;
         };
 
         explicit Room(const Microsoft::WRL::ComPtr<ID3D11Device>& device, 

--- a/trview/Triangle.h
+++ b/trview/Triangle.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace trview
+{
+    struct Triangle
+    {
+        Triangle(const DirectX::SimpleMath::Vector3& v0, const DirectX::SimpleMath::Vector3& v1, const DirectX::SimpleMath::Vector3& v2)
+            : v0(v0), v1(v1), v2(v2), normal((v1 - v0).Cross(v2 - v0))
+        {
+        }
+
+        DirectX::SimpleMath::Vector3 v0;
+        DirectX::SimpleMath::Vector3 v1;
+        DirectX::SimpleMath::Vector3 v2;
+        DirectX::SimpleMath::Vector3 normal;
+    };
+}

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -237,7 +237,7 @@ namespace trview
             {
                 if (!over_ui() && !over_map() && _picking->visible() && _current_pick.hit)
                 {
-                    select_room(_current_pick.room);
+                    select_room(_current_pick.index);
                     set_camera_mode(CameraMode::Orbit);
                 }
                 else if (over_map())
@@ -472,7 +472,7 @@ namespace trview
         {
             Vector3 screen_pos = XMVector3Project(result.position, 0, 0, window_size.width, window_size.height, 0, 1.0f, projection, view, XMMatrixIdentity());
             _picking->set_position(Point(screen_pos.x - _picking->size().width, screen_pos.y - _picking->size().height));
-            _picking->set_text(std::to_wstring(result.room));
+            _picking->set_text(std::to_wstring(result.index));
         }
         _current_pick = result;
     }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -237,7 +237,14 @@ namespace trview
             {
                 if (!over_ui() && !over_map() && _picking->visible() && _current_pick.hit)
                 {
-                    select_room(_current_pick.index);
+                    if (_current_pick.type == PickResult::Type::Room)
+                    {
+                        select_room(_current_pick.index);
+                    }
+                    else if (_current_pick.type == PickResult::Type::Entity)
+                    {
+                        select_item(_level->items()[_current_pick.index]);
+                    }
                     set_camera_mode(CameraMode::Orbit);
                 }
                 else if (over_map())

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -590,6 +590,7 @@ namespace trview
             auto entity = _current_level->get_entity(item.number());
             _target = DirectX::SimpleMath::Vector3(entity.x / 1024.0f, entity.y / -1024.0f, entity.z / 1024.0f);
             _level->set_selected_item(item.number());
+            _items_windows->set_selected_item(item);
         }
     }
 

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -472,7 +472,7 @@ namespace trview
         {
             Vector3 screen_pos = XMVector3Project(result.position, 0, 0, window_size.width, window_size.height, 0, 1.0f, projection, view, XMMatrixIdentity());
             _picking->set_position(Point(screen_pos.x - _picking->size().width, screen_pos.y - _picking->size().height));
-            _picking->set_text(std::to_wstring(result.index));
+            _picking->set_text((result.type == PickResult::Type::Room ? L"R" : L"I") + std::to_wstring(result.index));
         }
         _current_pick = result;
     }

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -142,7 +142,7 @@ namespace trview
         std::unique_ptr<SettingsWindow> _settings_window;
         UserSettings _settings;
         ui::Label* _picking;
-        Level::PickResult _current_pick;
+        PickResult _current_pick;
         LevelSwitcher _level_switcher;
         WindowResizer _window_resizer;
         RecentFiles _recent_files;

--- a/trview/trview.vcxproj
+++ b/trview/trview.vcxproj
@@ -201,6 +201,7 @@
     <ClInclude Include="MeshStorage.h" />
     <ClInclude Include="MeshVertex.h" />
     <ClInclude Include="Neighbours.h" />
+    <ClInclude Include="PickResult.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="ResourceHelper.h" />
     <ClInclude Include="Room.h" />

--- a/trview/trview.vcxproj
+++ b/trview/trview.vcxproj
@@ -217,6 +217,7 @@
     <ClInclude Include="TextureStorage.h" />
     <ClInclude Include="TransparencyBuffer.h" />
     <ClInclude Include="TransparentTriangle.h" />
+    <ClInclude Include="Triangle.h" />
     <ClInclude Include="trview.h" />
     <ClInclude Include="Types.h" />
     <ClInclude Include="UserSettings.h" />

--- a/trview/trview.vcxproj.filters
+++ b/trview/trview.vcxproj.filters
@@ -172,6 +172,9 @@
     <ClInclude Include="PickResult.h">
       <Filter>View</Filter>
     </ClInclude>
+    <ClInclude Include="Triangle.h">
+      <Filter>View</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Viewer.cpp">

--- a/trview/trview.vcxproj.filters
+++ b/trview/trview.vcxproj.filters
@@ -169,6 +169,9 @@
     <ClInclude Include="SelectionRenderer.h">
       <Filter>View\Selection</Filter>
     </ClInclude>
+    <ClInclude Include="PickResult.h">
+      <Filter>View</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Viewer.cpp">


### PR DESCRIPTION
Adds the ability to click on items in the 3D view to select them. This requires picking against the meshes and bounding boxes for the entities.
Code is moved from room into mesh so this can be shared. Mesh bounding boxes are generated when the mesh is loaded and transformed by the entity to quickly eliminate a pick, saving picking against the triangles of the mesh.
Now that the user can select an item outside of the item window I have added the 'Sync Item' checkbox in each item window. If this is checked, two way communication with the 3d view is enabled:

- If a user clicks an item in the 3d view, every item window with 'Sync Item' checked will have that item selected and details loaded.
- If the user clicks an item in an item window and 'Sync Item' is checked, the 3D view will be updated to focus on that item. All other item windows with 'Sync Item' will also focus on that item.

Sync item is on by default, but if you turn it off you can have a window just to look at item details without actually changing the focus. This seems like a good model so I'll use it for the trigger windows.

Sprites currently pick against a bounding sphere, so if they are stacked on top of each other it may be difficult. I will make an issue to improve this (potentially by sampling the texture to look for transparency). In any case, you can select the item via the item list (track room will make it easier).

Issue: #309 