### PR TITLE
Set the UI to have neighbour depth of 1 on level load

### DIFF
--- a/trview/Neighbours.cpp
+++ b/trview/Neighbours.cpp
@@ -24,7 +24,7 @@ namespace trview
         depth->on_value_changed += on_depth_changed;
 
         _enabled = group->add_child(std::move(enabled));
-        group->add_child(std::move(depth));
+        _depth = group->add_child(std::move(depth));
         parent.add_child(std::move(group));
     }
 
@@ -33,5 +33,10 @@ namespace trview
     void Neighbours::set_enabled(bool value)
     {
         _enabled->set_state(value);
+    }
+
+    void Neighbours::set_depth(int32_t value)
+    {
+        _depth->set_value(value);
     }
 }

--- a/trview/Neighbours.h
+++ b/trview/Neighbours.h
@@ -15,6 +15,7 @@ namespace trview
     {
         class Control;
         class Checkbox;
+        class NumericUpDown;
     }
 
     struct ITextureStorage;
@@ -41,7 +42,12 @@ namespace trview
         /// Set whether neighbours are enabled. This will not raise the on_enabled_changed event.
         /// @param value Whether neighbours are enabled.
         void set_enabled(bool value);
+
+        /// Set the value of the depth control. This will not raise the on_depth_changed event.
+        /// @param value The neighbour depth to use.
+        void set_depth(int32_t value);
     private:
-        ui::Checkbox* _enabled;
+        ui::Checkbox*      _enabled;
+        ui::NumericUpDown* _depth;
     };
 }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -418,6 +418,7 @@ namespace trview
         }
 
         _neighbours->set_enabled(false);
+        _neighbours->set_depth(1);
 
         // Strip the last part of the path away.
         auto last_index = std::min(filename.find_last_of('\\'), filename.find_last_of('/'));


### PR DESCRIPTION
This makes it match up with reality.
Issue: #326