### PR TITLE
Add prefix and colour to picking label

### DIFF
--- a/trview.common/Colour.cpp
+++ b/trview.common/Colour.cpp
@@ -2,6 +2,11 @@
 
 namespace trview
 {
+    Colour::Colour(float r, float g, float b)
+        : Colour(1.0f, r, g, b)
+    {
+    }
+
     Colour::Colour(float a, float r, float g, float b)
         : a(a), r(r), g(g), b(b)
     {

--- a/trview.common/Colour.h
+++ b/trview.common/Colour.h
@@ -4,8 +4,14 @@
 
 namespace trview
 {
-    struct Colour
+    struct Colour final
     {
+        /// Create a colour with the specified rgb components and a fully opaque alpha value.
+        /// @param r The red value from 0 to 1.
+        /// @param g The green value from 0 to 1.
+        /// @param b The blue value from 0 to 1.
+        Colour(float r, float g, float b);
+
         Colour(float a, float r, float g, float b);
 
         operator DirectX::SimpleMath::Color() const;

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -113,7 +113,7 @@ namespace trview
             select_room(room);
         });
 
-        auto picking = std::make_unique<ui::Label>(Point(500, 0), Size(30, 30), Colour(1, 0.5f, 0.5f, 0.5f), L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
+        auto picking = std::make_unique<ui::Label>(Point(500, 0), Size(38, 30), Colour(0.2f, 0.2f, 0.2f), L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
         picking->set_visible(false);
         picking->set_handles_input(false);
         _picking = _control->add_child(std::move(picking));
@@ -506,7 +506,8 @@ namespace trview
         {
             Vector3 screen_pos = XMVector3Project(result.position, 0, 0, window_size.width, window_size.height, 0, 1.0f, projection, view, XMMatrixIdentity());
             _picking->set_position(Point(screen_pos.x - _picking->size().width, screen_pos.y - _picking->size().height));
-            _picking->set_text((result.type == PickResult::Type::Room ? L"R" : result.type == PickResult::Type::Trigger ? L"T" : L"I") + std::to_wstring(result.index));
+            _picking->set_text((result.type == PickResult::Type::Room ? L"R-" : result.type == PickResult::Type::Trigger ? L"T-" : L"I-") + std::to_wstring(result.index));
+            _picking->set_text_colour(result.type == PickResult::Type::Room ? Colour(1.0f, 1.0f, 1.0f) : result.type == PickResult::Type::Trigger ? Colour(1.0f, 0.0f, 1.0f) : Colour(0.0f, 1.0f, 0.0f));
         }
         _current_pick = result;
     }


### PR DESCRIPTION
Make the picking label background slightly darker.
Add I-/R-/T- prefix to the text.
Change the colour based on the type of pick (item, room, trigger).
Issue: #329