### PR TITLE
Check state of control key before doing non-control shortcuts

### DIFF
--- a/trview/CameraInput.cpp
+++ b/trview/CameraInput.cpp
@@ -17,6 +17,11 @@ namespace trview
     // key: The key that was pressed.
     void CameraInput::key_down(uint16_t key)
     {
+        if (GetAsyncKeyState(VK_CONTROL))
+        {
+            return;
+        }
+
         switch (key)
         {
             case 'F':

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -223,6 +223,11 @@ namespace trview
 
         _token_store.add(_keyboard.on_key_down += [&](uint16_t key)
         {
+            if (GetAsyncKeyState(VK_CONTROL))
+            {
+                return;
+            }
+
             switch (key)
             {
                 case 'P':


### PR DESCRIPTION
Check that control is not currently pressed before executing shortcuts such as toggling triggers or changing camera mode.
These are all spread out a little bit, at some point they should probably all come in to one place.
Issue: #338 