### PR TITLE
Use room bottom for corners if trigger is in on wall sector

### DIFF
--- a/trview/Sector.cpp
+++ b/trview/Sector.cpp
@@ -55,12 +55,15 @@ namespace trview
         if (_room_below != 0xFF)
             flags |= SectorFlag::RoomBelow; 
 
+        // Start off the heights at the height of the floor (or in the case of a 
+        // wall, at the bottom of the room).
+        _corners.fill(flags & SectorFlag::Wall ?
+            _level.get_room(_room).info.yBottom / -1024.0f :
+            _sector.floor * -0.25f);
+
         std::uint16_t cur_index = _sector.floordata_index;
         if (cur_index == 0x0)
             return true; 
-
-        // Start off the heights at the height of the floor.
-        _corners.fill(_sector.floor * -0.25f);
 
         const auto max_floordata = _level.num_floor_data();
 


### PR DESCRIPTION
If a trigger is on a wall sector, use the room bottom instead of the sector floor as the sector floor is -127.
Also move the filling of the corners array above the check for no floordata - this is not required now, but when sector rendering is added it will need to happen.
Issue: #350