### PR TITLE
Make the trigger window slightly less wide

### DIFF
--- a/trview.app/Trigger.cpp
+++ b/trview.app/Trigger.cpp
@@ -34,15 +34,15 @@ namespace trview
         {
             { TriggerCommandType::Object, L"Object" },
             { TriggerCommandType::Camera, L"Camera" },
-            { TriggerCommandType::UnderwaterCurrent, L"Underwater Current" },
+            { TriggerCommandType::UnderwaterCurrent, L"Current" },
             { TriggerCommandType::FlipMap, L"Flip Map" },
             { TriggerCommandType::FlipOn, L"Flip On" },
             { TriggerCommandType::FlipOff, L"Flip Off" },
             { TriggerCommandType::LookAtItem, L"Look at Item" },
             { TriggerCommandType::EndLevel, L"End Level" },
-            { TriggerCommandType::PlaySoundtrack, L"Play Soundtrack" },
+            { TriggerCommandType::PlaySoundtrack, L"Music" },
             { TriggerCommandType::Flipeffect, L"Flipeffect" },
-            { TriggerCommandType::SecretFound, L"Secret Found" },
+            { TriggerCommandType::SecretFound, L"Secret" },
             { TriggerCommandType::ClearBodies, L"Clear Bodies" }
         };
     }

--- a/trview.app/TriggersWindow.cpp
+++ b/trview.app/TriggersWindow.cpp
@@ -38,7 +38,7 @@ namespace trview
     using namespace graphics;
 
     TriggersWindow::TriggersWindow(const Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent)
-        : CollapsiblePanel(device, shader_storage, font_factory, parent, L"trview.triggers", L"Triggers", Size(500, 400))
+        : CollapsiblePanel(device, shader_storage, font_factory, parent, L"trview.triggers", L"Triggers", Size(470, 400))
     {
         set_panels(create_left_panel(), create_right_panel());
     }
@@ -105,7 +105,7 @@ namespace trview
     std::unique_ptr<ui::Control> TriggersWindow::create_right_panel()
     {
         using namespace ui;
-        const float panel_width = 300;
+        const float panel_width = 270;
         auto right_panel = std::make_unique<StackPanel>(Point(), Size(panel_width, window().size().height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
         auto group_box = std::make_unique<GroupBox>(Point(), Size(panel_width, 190), Colours::ItemDetails, Colours::DetailsBorder, L"Trigger Details");
 
@@ -114,7 +114,7 @@ namespace trview
         stats_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"Name", 100 },
-                { Listbox::Column::Type::Number, L"Value", 180 },
+                { Listbox::Column::Type::Number, L"Value", 150 },
             }
         );
         stats_list->set_show_headers(false);
@@ -134,7 +134,7 @@ namespace trview
         auto command_list = std::make_unique<Listbox>(Point(10, 21), Size(panel_width - 20, 160), Colours::Triggers);
         command_list->set_columns(
             {
-                { Listbox::Column::Type::String, L"Type", 110 },
+                { Listbox::Column::Type::String, L"Type", 80 },
                 { Listbox::Column::Type::String, L"Index", 35 },
                 { Listbox::Column::Type::String, L"Entity", 125 },
             }


### PR DESCRIPTION
Make some of the trigger type names shorter.
The window can be made a bit less wide.
Issue: #352