### PR TITLE
Add flyby and cutscene commands

### DIFF
--- a/trview.app/Trigger.cpp
+++ b/trview.app/Trigger.cpp
@@ -43,7 +43,9 @@ namespace trview
             { TriggerCommandType::PlaySoundtrack, L"Music" },
             { TriggerCommandType::Flipeffect, L"Flipeffect" },
             { TriggerCommandType::SecretFound, L"Secret" },
-            { TriggerCommandType::ClearBodies, L"Clear Bodies" }
+            { TriggerCommandType::ClearBodies, L"Clear Bodies" },
+            { TriggerCommandType::Flyby, L"Flyby" },
+            { TriggerCommandType::Cutscene, L"Cutscene" }
         };
     }
 

--- a/trview.app/Trigger.h
+++ b/trview.app/Trigger.h
@@ -19,7 +19,7 @@ namespace trview
     enum class TriggerCommandType
     {
         Object, Camera, UnderwaterCurrent, FlipMap, FlipOn, FlipOff, LookAtItem,
-        EndLevel, PlaySoundtrack, Flipeffect, SecretFound, ClearBodies
+        EndLevel, PlaySoundtrack, Flipeffect, SecretFound, ClearBodies, Flyby, Cutscene
     };
 
     class Command final


### PR DESCRIPTION
These two commands were missing from the command type enumeration and the string map.
Issue: #357