### PR TITLE
Stop inverting the y coordinates

### DIFF
--- a/trlevel.tests/trlevel.tests.vcxproj
+++ b/trlevel.tests/trlevel.tests.vcxproj
@@ -92,7 +92,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);%(AdditionalIncludeDirectories);$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -107,7 +107,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);%(AdditionalIncludeDirectories);$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -124,7 +124,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);%(AdditionalIncludeDirectories);$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <LanguageStandard>stdcpp17</LanguageStandard>
@@ -143,7 +143,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);%(AdditionalIncludeDirectories);$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <LanguageStandard>stdcpp17</LanguageStandard>

--- a/trlevel/trlevel.vcxproj
+++ b/trlevel/trlevel.vcxproj
@@ -90,7 +90,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib;$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -106,7 +106,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib;$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -124,7 +124,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib;$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
@@ -144,7 +144,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib;$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -2,10 +2,16 @@
 
 #include <cstdint>
 #include <vector>
+#include <SimpleMath.h>
 
 namespace trlevel
 {
 #pragma pack(push, 1)
+
+    constexpr float Scale_X { 1024.0f };
+    constexpr float Scale_Y { -1024.0f };
+    constexpr float Scale_Z { 1024.0f };
+
     struct tr_colour
     {
         uint8_t Red;
@@ -172,6 +178,11 @@ namespace trlevel
         int32_t Offset_X;
         int32_t Offset_Y;
         int32_t Offset_Z;
+
+        DirectX::SimpleMath::Vector3 position() const
+        {
+            return DirectX::SimpleMath::Vector3(Offset_X / Scale_X, Offset_Y / Scale_Y, Offset_Z / Scale_Z);
+        }
     };
 
     struct tr_model  // 18 bytes
@@ -306,6 +317,11 @@ namespace trlevel
         int16_t Intensity1;
         int16_t Intensity2; // Like Intensity1, and almost always with the same value.
         uint16_t Flags;
+
+        DirectX::SimpleMath::Vector3 position() const
+        {
+            return DirectX::SimpleMath::Vector3(x / Scale_X, y / Scale_Y, z / Scale_Z);
+        }
     };
 
     struct tr_sound_details // 8 bytes
@@ -447,6 +463,11 @@ namespace trlevel
         uint16_t colour;     // 15-bit colour
         uint16_t unused;     // Not used!
         uint16_t mesh_id;     // Which StaticMesh item to draw
+
+        DirectX::SimpleMath::Vector3 position() const
+        {
+            return DirectX::SimpleMath::Vector3(x / Scale_X, y / Scale_Y, z / Scale_Z);
+        }
     };
 
     struct tr2_frame_rotation
@@ -509,6 +530,11 @@ namespace trlevel
         int16_t bb2x, bb2y, bb2z;
         int16_t offsetx, offsety, offsetz;
         std::vector<tr2_frame_rotation> values;
+
+        DirectX::SimpleMath::Vector3 position() const
+        {
+            return DirectX::SimpleMath::Vector3(offsetx / Scale_X, offsety / Scale_Y, offsetz / Scale_Z);
+        }
     };
 
     struct tr_mesh

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -9,7 +9,7 @@ namespace trlevel
 #pragma pack(push, 1)
 
     constexpr float Scale_X { 1024.0f };
-    constexpr float Scale_Y { -1024.0f };
+    constexpr float Scale_Y { 1024.0f };
     constexpr float Scale_Z { 1024.0f };
 
     struct tr_colour

--- a/trview.app/ICamera.h
+++ b/trview.app/ICamera.h
@@ -30,5 +30,7 @@ namespace trview
         virtual void set_rotation_yaw(float rotation) = 0;
 
         virtual void set_rotation_pitch(float rotation) = 0;
+
+        virtual DirectX::BoundingFrustum frustum() const = 0;
     };
 }

--- a/trview.app/Mesh.cpp
+++ b/trview.app/Mesh.cpp
@@ -19,7 +19,7 @@ namespace trview
         // Returns: The scaled vector.
         Vector3 convert_vertex(const trlevel::tr_vertex& vertex)
         {
-            return Vector3(vertex.x / 1024.f, -vertex.y / 1024.f, vertex.z / 1024.f);
+            return Vector3(vertex.x / trlevel::Scale_X, vertex.y / trlevel::Scale_Y, vertex.z / trlevel::Scale_Z);
         };
     }
 

--- a/trview.app/Triangle.h
+++ b/trview.app/Triangle.h
@@ -5,7 +5,7 @@ namespace trview
     struct Triangle
     {
         Triangle(const DirectX::SimpleMath::Vector3& v0, const DirectX::SimpleMath::Vector3& v1, const DirectX::SimpleMath::Vector3& v2)
-            : v0(v0), v1(v1), v2(v2), normal((v1 - v0).Cross(v2 - v0))
+            : v0(v0), v1(v1), v2(v2), normal((v2 - v0).Cross(v1 - v0))
         {
         }
 

--- a/trview/Camera.h
+++ b/trview/Camera.h
@@ -32,18 +32,22 @@ namespace trview
         // Set the dimensions of the render target for the camera.
         // size: The size in pixels of the render target.
         void set_view_size(const Size& size);
+
+        virtual DirectX::BoundingFrustum frustum() const override;
     private:
         void calculate_projection_matrix(const Size& size);
         void calculate_view_matrix();
 
-        const float default_pitch = 0.78539f;
+        const float default_pitch = -0.78539f;
         const float default_yaw = 0.0f;
         const float default_zoom = 8.0f;
 
         // This is the orbit target.
         DirectX::SimpleMath::Vector3 _target;
         DirectX::SimpleMath::Matrix _view;
+        DirectX::SimpleMath::Matrix _view_lh;
         DirectX::SimpleMath::Matrix _projection;
+        DirectX::SimpleMath::Matrix _projection_lh;
         DirectX::SimpleMath::Matrix _view_projection;
         float             _rotation_yaw{ default_yaw };
         float             _rotation_pitch{ default_pitch };

--- a/trview/CameraInput.cpp
+++ b/trview/CameraInput.cpp
@@ -9,7 +9,7 @@ namespace trview
     {
         return DirectX::SimpleMath::Vector3(
             _free_left ? -1.0f : 0.0f + _free_right ? 1.0f : 0.0f,
-            _free_up ? 1.0f : 0.0f + _free_down ? -1.0f : 0.0f,
+            _free_up ? -1.0f : 0.0f + _free_down ? 1.0f : 0.0f,
             _free_forward ? 1.0f : 0.0f + _free_backward ? -1.0f : 0.0f);
     }
 

--- a/trview/Entity.cpp
+++ b/trview/Entity.cpp
@@ -64,6 +64,11 @@ namespace trview
         using namespace DirectX;
         using namespace DirectX::SimpleMath;
 
+        auto get_rotate = [](const trlevel::tr2_frame_rotation& r)
+        {
+            return Matrix::CreateRotationZ(XM_2PI - r.y) * Matrix::CreateRotationX(XM_2PI - r.x) * Matrix::CreateRotationY(r.z);
+        };
+
         if (model.NumMeshes > 0)
         {
             // Load the frames.
@@ -73,12 +78,10 @@ namespace trview
 
             auto initial_frame = frame.values[frame_offset++];
 
-            Matrix initial_rotation = Matrix::CreateFromYawPitchRoll(initial_frame.y, XM_2PI - initial_frame.x, XM_2PI - initial_frame.z);
+            Matrix initial_rotation = get_rotate(initial_frame);
             Matrix initial_frame_offset = Matrix::CreateTranslation(frame.offsetx / 1024.0f, frame.offsety / -1024.0f, frame.offsetz / 1024.0f);
 
-            _world = initial_rotation * initial_frame_offset * _world;
-
-            Matrix previous_world = Matrix::Identity;
+            Matrix previous_world = initial_rotation * initial_frame_offset;
             _world_transforms.push_back(previous_world);
 
             std::stack<Matrix> world_stack;
@@ -104,7 +107,7 @@ namespace trview
                 // Get the rotation from the frames.
                 // Rotations are performed in Y, X, Z order.
                 auto rotation = frame.values[frame_offset++];
-                Matrix rotation_matrix = Matrix::CreateFromYawPitchRoll(rotation.y, XM_2PI - rotation.x, XM_2PI - rotation.z);
+                Matrix rotation_matrix = get_rotate(rotation);
                 Matrix translation_matrix = Matrix::CreateTranslation(node.Offset_X / 1024.0f, node.Offset_Y / -1024.0f, node.Offset_Z / 1024.0f);
                 Matrix node_transform = rotation_matrix * translation_matrix * parent_world;
 

--- a/trview/Entity.cpp
+++ b/trview/Entity.cpp
@@ -66,7 +66,7 @@ namespace trview
 
         auto get_rotate = [](const trlevel::tr2_frame_rotation& r)
         {
-            return Matrix::CreateFromYawPitchRoll(r.y, XM_2PI - r.x, XM_2PI - r.z);
+            return Matrix::CreateFromYawPitchRoll(r.y, r.x, r.z);
         };
 
         if (model.NumMeshes > 0)
@@ -133,10 +133,10 @@ namespace trview
         using namespace DirectX::SimpleMath;
         std::vector<MeshVertex> vertices
         {
-            { Vector3(-0.5f, 0.5f, 0), Vector2(u, v), Vector4(1,1,1,1) },
-            { Vector3(0.5f, 0.5f, 0), Vector2(u + width, v), Vector4(1,1,1,1) },
             { Vector3(-0.5f, -0.5f, 0), Vector2(u, v + height), Vector4(1,1,1,1) },
             { Vector3(0.5f, -0.5f, 0), Vector2(u + width, v + height), Vector4(1,1,1,1) },
+            { Vector3(-0.5f, 0.5f, 0), Vector2(u, v), Vector4(1,1,1,1) },
+            { Vector3(0.5f, 0.5f, 0), Vector2(u + width, v), Vector4(1,1,1,1) },
         };
 
         std::vector<TransparentTriangle> transparent_triangles
@@ -155,7 +155,7 @@ namespace trview
         _scale = Matrix::CreateScale(object_width, object_height, 1);
 
         // An offset to move the sprite up a bit.
-        _offset = Matrix::CreateTranslation(0, object_height / 2.0f, 0);
+        _offset = Matrix::CreateTranslation(0, object_height / -2.0f, 0);
     }
 
     void Entity::render(const ComPtr<ID3D11DeviceContext>& context, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour)

--- a/trview/FreeCamera.h
+++ b/trview/FreeCamera.h
@@ -43,12 +43,16 @@ namespace trview
         // Set the dimensions of the render target for the camera.
         // size: The size in pixels of the render target.
         void set_view_size(const Size& size);
+
+        virtual DirectX::BoundingFrustum frustum() const override;
     private:
         void calculate_projection_matrix(const Size& size);
         void calculate_view_matrix();
 
         DirectX::SimpleMath::Matrix _view;
+        DirectX::SimpleMath::Matrix _view_lh;
         DirectX::SimpleMath::Matrix _projection;
+        DirectX::SimpleMath::Matrix _projection_lh;
         DirectX::SimpleMath::Matrix _view_projection;
 
         DirectX::SimpleMath::Vector3 _position;

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -226,8 +226,7 @@ namespace trview
     {
         std::vector<RoomToRender> rooms;
 
-        DirectX::BoundingFrustum frustum(camera.projection());
-        frustum.Transform(frustum, camera.view().Invert());
+        DirectX::BoundingFrustum frustum = camera.frustum();
 
         auto in_view = [&](const Room& room)
         {

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -41,7 +41,7 @@ namespace trview
         // (IsAlternate).
         _alternate_mode = room.alternate_room != -1 ? AlternateMode::HasAlternate : AlternateMode::None;
 
-        _room_offset = Matrix::CreateTranslation(room.info.x / 1024.f, 0, room.info.z / 1024.f);
+        _room_offset = Matrix::CreateTranslation(room.info.x / trlevel::Scale_X, 0, room.info.z / trlevel::Scale_Z);
         generate_geometry(device, room, texture_storage);
         generate_sectors(level, room);
         generate_adjacency();
@@ -102,7 +102,7 @@ namespace trview
         }
 
         // Pick against the room geometry:
-        auto room_offset = Matrix::CreateTranslation(-_info.x / 1024.f, 0, -_info.z / 1024.f);
+        auto room_offset = Matrix::CreateTranslation(-_info.x / trlevel::Scale_X, 0, -_info.z / trlevel::Scale_Z);
         PickResult geometry_result = _mesh->pick(Vector3::Transform(position, room_offset), direction);
         if (geometry_result.hit)
         {
@@ -298,9 +298,9 @@ namespace trview
 
     Vector3 Room::centre() const
     {
-        return Vector3(_info.x / 1024.f + _num_x_sectors / 2.f,
-                 _info.yBottom / -1024.f + (_info.yTop - _info.yBottom) / -1024.f / 2.0f,
-                 (_info.z / 1024.f) + _num_z_sectors / 2.f);
+        return Vector3(_info.x / trlevel::Scale_X + _num_x_sectors / 2.f,
+                 _info.yBottom / trlevel::Scale_Y + (_info.yTop - _info.yBottom) / trlevel::Scale_Y / 2.0f,
+                 (_info.z / trlevel::Scale_Z) + _num_z_sectors / 2.f);
     }
 
     const DirectX::BoundingBox& Room::bounding_box() const
@@ -357,8 +357,8 @@ namespace trview
             }
 
             // Calculate the X/Z position.
-            const float x = _info.x / 1024.0f + trigger->x() + 0.5f;
-            const float z = _info.z / 1024.0f + (_num_z_sectors - 1 - trigger->z()) + 0.5f;
+            const float x = _info.x / trlevel::Scale_X + trigger->x() + 0.5f;
+            const float z = _info.z / trlevel::Scale_Z + (_num_z_sectors - 1 - trigger->z()) + 0.5f;
             const float height = 0.25f;
 
             std::array<float, 4> y_top = { 0,0,0,0 };

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -299,7 +299,7 @@ namespace trview
     Vector3 Room::centre() const
     {
         return Vector3(_info.x / trlevel::Scale_X + _num_x_sectors / 2.f,
-                 _info.yBottom / trlevel::Scale_Y + (_info.yTop - _info.yBottom) / trlevel::Scale_Y / 2.0f,
+                 _info.yTop / trlevel::Scale_Y + (_info.yBottom - _info.yTop) / trlevel::Scale_Y / 2.0f,
                  (_info.z / trlevel::Scale_Z) + _num_z_sectors / 2.f);
     }
 
@@ -364,7 +364,7 @@ namespace trview
             std::array<float, 4> y_top = { 0,0,0,0 };
             for (int i = 0; i < 4; ++i)
             {
-                y_top[i] = y_bottom[i] + height;
+                y_top[i] = y_bottom[i] - height;
             }
 
             std::vector<TransparentTriangle> triangles;

--- a/trview/RoomNavigator.cpp
+++ b/trview/RoomNavigator.cpp
@@ -3,6 +3,7 @@
 #include <trview.app/ITextureStorage.h>
 #include "RoomInfo.h"
 
+#include <trlevel/trtypes.h>
 #include <trview.ui/GroupBox.h>
 #include <trview.ui/Label.h>
 #include <trview.ui/NumericUpDown.h>
@@ -60,8 +61,8 @@ namespace trview
 
     void RoomNavigator::set_room_info(RoomInfo room_info)
     {
-        _x->set_text(L"X:" + std::to_wstring(room_info.x / 1024));
-        _z-> set_text(L"Z:" + std::to_wstring(room_info.z / 1024));
+        _x->set_text(L"X:" + std::to_wstring(room_info.x / trlevel::Scale_X));
+        _z-> set_text(L"Z:" + std::to_wstring(room_info.z / trlevel::Scale_Z));
     }
 
     void RoomNavigator::set_max_rooms(uint32_t max_rooms)

--- a/trview/RoomNavigator.cpp
+++ b/trview/RoomNavigator.cpp
@@ -61,8 +61,8 @@ namespace trview
 
     void RoomNavigator::set_room_info(RoomInfo room_info)
     {
-        _x->set_text(L"X:" + std::to_wstring(room_info.x / trlevel::Scale_X));
-        _z-> set_text(L"Z:" + std::to_wstring(room_info.z / trlevel::Scale_Z));
+        _x->set_text(L"X:" + std::to_wstring(static_cast<uint32_t>(room_info.x / trlevel::Scale_X)));
+        _z->set_text(L"Z:" + std::to_wstring(static_cast<uint32_t>(room_info.z / trlevel::Scale_Z)));
     }
 
     void RoomNavigator::set_max_rooms(uint32_t max_rooms)

--- a/trview/Sector.cpp
+++ b/trview/Sector.cpp
@@ -58,7 +58,7 @@ namespace trview
         // Start off the heights at the height of the floor (or in the case of a 
         // wall, at the bottom of the room).
         _corners.fill(flags & SectorFlag::Wall ?
-            _level.get_room(_room).info.yBottom / -1024.0f :
+            _level.get_room(_room).info.yBottom / trlevel::Scale_Y :
             _sector.floor * -0.25f);
 
         std::uint16_t cur_index = _sector.floordata_index;

--- a/trview/Sector.cpp
+++ b/trview/Sector.cpp
@@ -59,7 +59,7 @@ namespace trview
         // wall, at the bottom of the room).
         _corners.fill(flags & SectorFlag::Wall ?
             _level.get_room(_room).info.yBottom / trlevel::Scale_Y :
-            _sector.floor * -0.25f);
+            _sector.floor * 0.25f);
 
         std::uint16_t cur_index = _sector.floordata_index;
         if (cur_index == 0x0)
@@ -157,10 +157,10 @@ namespace trview
                 const uint16_t c11 = (corner_values & 0xF000) >> 12;
                 const auto max_corner = std::max({ c00, c01, c10, c11 });
 
-                _corners[0] -= (max_corner - c00) * 0.25f;
-                _corners[1] -= (max_corner - c01) * 0.25f;
-                _corners[2] -= (max_corner - c10) * 0.25f;
-                _corners[3] -= (max_corner - c11) * 0.25f;
+                _corners[0] += (max_corner - c00) * 0.25f;
+                _corners[1] += (max_corner - c01) * 0.25f;
+                _corners[2] += (max_corner - c10) * 0.25f;
+                _corners[3] += (max_corner - c11) * 0.25f;
                 break;
             }
             case 0x9:
@@ -214,24 +214,24 @@ namespace trview
 
         if (x_slope > 0)
         {
-            _corners[0] -= x_slope * 0.25f;
-            _corners[1] -= x_slope * 0.25f;
+            _corners[0] += x_slope * 0.25f;
+            _corners[1] += x_slope * 0.25f;
         }
         else if (x_slope < 0)
         {
-            _corners[2] += x_slope * 0.25f;
-            _corners[3] += x_slope * 0.25f;
+            _corners[2] -= x_slope * 0.25f;
+            _corners[3] -= x_slope * 0.25f;
         }
 
         if (z_slope > 0)
         {
-            _corners[0] -= z_slope * 0.25f;
-            _corners[2] -= z_slope * 0.25f;
+            _corners[0] += z_slope * 0.25f;
+            _corners[2] += z_slope * 0.25f;
         }
         else if (z_slope < 0)
         {
-            _corners[1] += z_slope * 0.25f;
-            _corners[3] += z_slope * 0.25f;
+            _corners[1] -= z_slope * 0.25f;
+            _corners[3] -= z_slope * 0.25f;
         }
     }
 

--- a/trview/StaticMesh.cpp
+++ b/trview/StaticMesh.cpp
@@ -11,7 +11,7 @@ namespace trview
         _visibility_max(level_static_mesh.VisibilityBox.MaxX, level_static_mesh.VisibilityBox.MaxY, level_static_mesh.VisibilityBox.MaxZ),
         _collision_min(level_static_mesh.CollisionBox.MinX, level_static_mesh.CollisionBox.MinY, level_static_mesh.CollisionBox.MinZ),
         _collision_max(level_static_mesh.CollisionBox.MaxX, level_static_mesh.CollisionBox.MaxY, level_static_mesh.CollisionBox.MaxZ),
-        _position(static_mesh.x / 1024.0f, static_mesh.y / -1024.0f, static_mesh.z / 1024.0f),
+        _position(static_mesh.x / trlevel::Scale_X, static_mesh.y / trlevel::Scale_Y, static_mesh.z / trlevel::Scale_Z),
         _rotation(static_mesh.rotation / 16384.0f * DirectX::XM_PIDIV2)
     {
         using namespace DirectX::SimpleMath;

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -405,7 +405,7 @@ namespace trview
                 {
                     // Reset the camera to defaults.
                     _camera.set_rotation_yaw(0.f);
-                    _camera.set_rotation_pitch(0.78539f);
+                    _camera.set_rotation_pitch(-0.78539f);
                     _camera.set_zoom(8.f);
                     break;
                 }
@@ -705,7 +705,7 @@ namespace trview
             const float z = room_info.z / trlevel::Scale_Z + (room->num_z_sectors() - 1 - trigger->z()) + 0.5f;
 
             using namespace DirectX::SimpleMath;
-            const auto pick = room->pick(Vector3(x, 500.0f, z), Vector3(0, -1, 0), false);
+            const auto pick = room->pick(Vector3(x, -500.0f, z), Vector3(0, +1, 0), false);
             const float y = pick.hit ? pick.position.y : room->centre().y;
 
             _target = DirectX::SimpleMath::Vector3(x, y, z);
@@ -758,7 +758,7 @@ namespace trview
             const float high_sensitivity = 25.0f;
             const float sensitivity = low_sensitivity + (high_sensitivity - low_sensitivity) * _settings.camera_sensitivity;
             camera.set_rotation_yaw(camera.rotation_yaw() + x / sensitivity);
-            camera.set_rotation_pitch(camera.rotation_pitch() + y / sensitivity);
+            camera.set_rotation_pitch(camera.rotation_pitch() - y / sensitivity);
             if (_level)
             {
                 _level->on_camera_moved();

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -684,7 +684,7 @@ namespace trview
         {
             select_room(item.room());
             auto entity = _current_level->get_entity(item.number());
-            _target = DirectX::SimpleMath::Vector3(entity.x / 1024.0f, entity.y / -1024.0f, entity.z / 1024.0f);
+            _target = entity.position();
             _level->set_selected_item(item.number());
             _items_windows->set_selected_item(item);
         }
@@ -701,8 +701,8 @@ namespace trview
 
             // Calculate the X/Z position - the Y must be determined by casting a ray from above 
             // directly down, to see what it hits. If it hits nothing, use the centre of the room.
-            const float x = room_info.x / 1024.0f + trigger->x() + 0.5f;
-            const float z = room_info.z / 1024.0f + (room->num_z_sectors() - 1 - trigger->z()) + 0.5f;
+            const float x = room_info.x / trlevel::Scale_X + trigger->x() + 0.5f;
+            const float z = room_info.z / trlevel::Scale_Z + (room->num_z_sectors() - 1 - trigger->z()) + 0.5f;
 
             using namespace DirectX::SimpleMath;
             const auto pick = room->pick(Vector3(x, 500.0f, z), Vector3(0, -1, 0), false);


### PR DESCRIPTION
Use the y coordinates as they are in the game, still with a scaling from 1024 -> 1.

- Add global scale values so there isn't `/ 1024` all over the place
- Add `position` functions to basic types so there isn't position scaling everywhere.
- Change vertices used in cross product for collision triangles as facing has changed.
- Change camera to use right handed perspective and view matrices
- Add bounding frustum calculation to camera - it needs to use a left handed matrix for frustum culling
- Trigger volumes height flipped as up is down now.
- Camera controls adjusted to work with new up (down) vector.

Issue: #11 