### PR TITLE
Reset the minimap force redraw flag after rendering

### DIFF
--- a/trview.ui.render/MapRenderer.cpp
+++ b/trview.ui.render/MapRenderer.cpp
@@ -59,6 +59,7 @@ namespace trview
 
                     _render_target->apply(context);
                     render_internal(context);
+                    _force_redraw = false;
                 }
 
                 // Now render the render target in the correct position.


### PR DESCRIPTION
This means it will actually draw the cached image instead of redrawing all the squares every frame.
Issue: #361