### PR TITLE
Calculate room bounding box from room info

### DIFF
--- a/trview.app/Mesh.cpp
+++ b/trview.app/Mesh.cpp
@@ -107,7 +107,7 @@ namespace trview
             maximum = Vector3::Max(maximum, v.pos);
         }
 
-        const Vector3 half_size = (maximum - minimum) * 0.5f;
+        const Vector3 half_size = vertices.empty() ? Vector3::Zero : (maximum - minimum) * 0.5f;
         _bounding_box.Extents = half_size;
         _bounding_box.Center = minimum + half_size;
     }

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -188,8 +188,10 @@ namespace trview
         process_textured_triangles(room.data.triangles, room_vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
 
         _mesh = std::make_unique<Mesh>(device, vertices, indices, std::vector<uint32_t>(), transparent_triangles, collision_triangles);
-        _bounding_box = _mesh->bounding_box();
-        _bounding_box.Center = centre();
+        
+        // Generate the bounding box based on the room dimensions.
+        const auto extents = Vector3(_num_x_sectors, (_info.yBottom - _info.yTop) / trlevel::Scale_Y, _num_z_sectors) * 0.5f;
+        _bounding_box = DirectX::BoundingBox(centre(), extents);
     }
 
     void Room::generate_adjacency()


### PR DESCRIPTION
Use the room info instead of the room mesh data to generate the bounding box as some rooms don't have any geometry. This was the case for the room under the exit in Jungle.
Also change mesh bounding box to have 0 size instead of infinite if there are no vertices. This doesn't affect the room problem but would probably be a problem in the future.
Issue: #365