### PR TITLE
Add a compass/axis display to the viewer

### DIFF
--- a/trview.app/Camera.cpp
+++ b/trview.app/Camera.cpp
@@ -1,4 +1,3 @@
-#include "stdafx.h"
 #include "Camera.h"
 
 #include <algorithm>

--- a/trview.app/Camera.h
+++ b/trview.app/Camera.h
@@ -2,7 +2,7 @@
 
 #include <trview.common/Size.h>
 
-#include <trview.app/ICamera.h>
+#include "ICamera.h"
 
 namespace trview
 {

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -153,7 +153,7 @@ namespace trview
             pitch = 0;
             break;
         case Compass::Axis::Neg_X:
-            yaw = Pi;
+            yaw = -Pi;
             pitch = 0;
             break;
         case Compass::Axis::Neg_Y:

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -42,7 +42,8 @@ namespace trview
             _mesh_camera.set_rotation_yaw(camera.rotation_yaw());
 
             const auto view_projection = _mesh_camera.view_projection();
-            const auto scale = Matrix::CreateScale(0.015f, 1.0f, 0.015f);
+            const float thickness = 0.015f;
+            const auto scale = Matrix::CreateScale(thickness, 1.0f, thickness);
 
             // Y
             _mesh->render(context, scale * view_projection, texture_storage, Color(1.0f, 0.0f, 0.0f));

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -59,7 +59,7 @@ namespace trview
 
             // Have a camera that looks at the compass and match rotation to the real camera
             _mesh_camera.set_target(Vector3::Zero);
-            _mesh_camera.set_zoom(2.5f);
+            _mesh_camera.set_zoom(2.0f);
             _mesh_camera.set_rotation_pitch(camera.rotation_pitch());
             _mesh_camera.set_rotation_yaw(camera.rotation_yaw());
 

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -1,13 +1,27 @@
 #include "Compass.h"
 #include "ICamera.h"
 #include "MeshVertex.h"
+#include <trview.graphics/Sprite.h>
+#include <trview.graphics/IShaderStorage.h>
+#include <trview.graphics/RenderTargetStore.h>
+#include <trview.graphics/ViewportStore.h>
 
 namespace trview
 {
     using namespace graphics;
     using namespace DirectX::SimpleMath;
 
-    void Compass::render(const Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage)
+    namespace
+    {
+        const float Pi = 1.5707963267948966192313216916398f;
+    }
+
+    Compass::Compass()
+        : _mesh_camera(Size(100, 100))
+    {
+    }
+
+    void Compass::render(const Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage, const IShaderStorage& shader_storage)
     {
         auto context = device.context();
 
@@ -19,37 +33,46 @@ namespace trview
             _render_target = std::make_unique<RenderTarget>(device.device(), 100, 100, RenderTarget::DepthStencilMode::Enabled);
         }
 
-        // _render_target->apply(context);
-
-        // Have a camera that looks at the compass
-        // Match rotation to the real camera
-
-        // Render the mesh 
-        // Render the axes mesh 
-        if (!_mesh)
         {
-            const std::vector<MeshVertex> vertices
-            {
-                { { 0.5f, 0.5f, 0.5f },  { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-                { { 0.5f, 0.5f, -0.5f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-                { { -0.5f, 0.5f, -0.5f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-                { { -0.5f, 0.5f, 0.5f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-                { { 0.0f, -0.5f, 0.0f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-            };
+            RenderTargetStore rs_store(context);
+            ViewportStore vp_store(context);
+            _render_target->apply(context);
+            _render_target->clear(context, Color(0.0f, 0.0f, 0.0f, 0.0f));
 
-            const std::vector<uint32_t> indices
-            {
-                0, 4, 1, // + x
-                2, 4, 3, // - x
-                0, 3, 4, // + z
-                1, 4, 2, // - z
-                0, 1, 2, 2, 3, 0  // - y
-            };
+            // Have a camera that looks at the compass
+            // Match rotation to the real camera
+            _mesh_camera.set_target(Vector3::Zero);
+            _mesh_camera.set_zoom(2.5f);
+            _mesh_camera.set_rotation_pitch(camera.rotation_pitch());
+            _mesh_camera.set_rotation_yaw(camera.rotation_yaw());
 
-            _mesh = std::make_unique<Mesh>(device.device(), vertices, std::vector<std::vector<uint32_t>>(), indices, std::vector<TransparentTriangle>(), std::vector<Triangle>());
+            // Render the mesh 
+            // Render the axes mesh 
+            if (!_mesh)
+            {
+                const std::vector<MeshVertex> vertices
+                {
+                    { { 0.0f, 0.5f, 0.0f },  { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+                    { { 0.0f, -0.5f, 0.0f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } }
+                };
+                const std::vector<uint32_t> indices { 0, 1 };
+
+                _mesh = std::make_unique<Mesh>(device.device(), vertices, std::vector<std::vector<uint32_t>>(), indices, std::vector<TransparentTriangle>(), std::vector<Triangle>(), Mesh::Primitive::Line);
+            }
+
+            auto view_projection = _mesh_camera.view_projection();
+
+            // Y
+            _mesh->render(context, view_projection, texture_storage, Color(1.0f, 0.0f, 0.0f));
+            // X
+            _mesh->render(context, Matrix::CreateRotationZ(Pi) * view_projection, texture_storage, Color(0.0f, 1.0f, 0.0f));
+            // Z
+            _mesh->render(context, Matrix::CreateRotationX(Pi) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
         }
 
-        auto wvp = camera.view_projection();
-        _mesh->render(context, wvp, texture_storage, Color(1.0f, 0.0f, 0.0f));
+        // Render the image to the screen somewhere.
+        auto sprite = std::make_unique<Sprite>(device.device(), shader_storage, camera.view_size());
+        auto screen_size = camera.view_size();
+        sprite->render(context, _render_target->texture(), screen_size.width - 100, screen_size.height - 100, 100, 100);
     }
 }

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -48,6 +48,18 @@ namespace trview
             _mesh->render(context, scale * view_projection, texture_storage, Color(1.0f, 0.0f, 0.0f));
             _mesh->render(context, scale * Matrix::CreateRotationZ(Pi) * view_projection, texture_storage, Color(0.0f, 1.0f, 0.0f));
             _mesh->render(context, scale * Matrix::CreateRotationX(Pi) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
+
+            // Nodules for each direction - they can be clicked.
+            const auto nodule_scale = Matrix::CreateScale(0.05f);
+            // Y
+            _mesh->render(context, nodule_scale * Matrix::CreateTranslation(0, 0.5f, 0) * view_projection, texture_storage, Color(1.0f, 0.0f, 0.0f));
+            _mesh->render(context, nodule_scale * Matrix::CreateTranslation(0, -0.5f, 0) * view_projection, texture_storage, Color(1.0f, 0.0f, 0.0f));
+            // X
+            _mesh->render(context, nodule_scale * Matrix::CreateTranslation(0.5f, 0, 0) * view_projection, texture_storage, Color(0.0f, 1.0f, 0.0f));
+            _mesh->render(context, nodule_scale * Matrix::CreateTranslation(-0.5f, 0, 0) * view_projection, texture_storage, Color(0.0f, 1.0f, 0.0f));
+            // Z
+            _mesh->render(context, nodule_scale * Matrix::CreateTranslation(0, 0, 0.5f) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
+            _mesh->render(context, nodule_scale * Matrix::CreateTranslation(0, 0, -0.5f) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
         }
 
         auto screen_size = camera.view_size();

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -45,11 +45,8 @@ namespace trview
             const float thickness = 0.015f;
             const auto scale = Matrix::CreateScale(thickness, 1.0f, thickness);
 
-            // Y
             _mesh->render(context, scale * view_projection, texture_storage, Color(1.0f, 0.0f, 0.0f));
-            // X
             _mesh->render(context, scale * Matrix::CreateRotationZ(Pi) * view_projection, texture_storage, Color(0.0f, 1.0f, 0.0f));
-            // Z
             _mesh->render(context, scale * Matrix::CreateRotationX(Pi) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
         }
 

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -51,41 +51,18 @@ namespace trview
             // Render the axes mesh 
             if (!_mesh)
             {
-                const float Thick = 0.015f;
-
-                const std::vector<MeshVertex> vertices
-                {
-                    { { Thick, 0.5f, Thick },  { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-                    { { Thick, 0.5f, -Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-                    { { -Thick, 0.5f, -Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-                    { { -Thick, 0.5f, Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-                    { { Thick, -0.5f, Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-                    { { Thick, -0.5f, -Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-                    { { -Thick, -0.5f, -Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-                    { { -Thick, -0.5f, Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } }
-                };
-
-                const std::vector<uint32_t> indices
-                {
-                    2, 1, 0, 0, 3, 2, // + y
-                    5, 4, 0, 0, 1, 5, // + x
-                    2, 3, 7, 7, 6, 2, // - x
-                    0, 4, 3, 3, 4, 7, // + z
-                    5, 1, 2, 2, 6, 5, // - z
-                    4, 5, 6, 6, 7, 4  // - y
-                };
-
-                _mesh = std::make_unique<Mesh>(device.device(), vertices, std::vector<std::vector<uint32_t>>(), indices, std::vector<TransparentTriangle>(), std::vector<Triangle>());
+                _mesh = create_cube_mesh(device.device());
             }
 
-            auto view_projection = _mesh_camera.view_projection();
+            const auto view_projection = _mesh_camera.view_projection();
+            const auto scale = Matrix::CreateScale(0.015f, 1.0f, 0.015f);
 
             // Y
-            _mesh->render(context, view_projection, texture_storage, Color(1.0f, 0.0f, 0.0f));
+            _mesh->render(context, scale * view_projection, texture_storage, Color(1.0f, 0.0f, 0.0f));
             // X
-            _mesh->render(context, Matrix::CreateRotationZ(Pi) * view_projection, texture_storage, Color(0.0f, 1.0f, 0.0f));
+            _mesh->render(context, scale * Matrix::CreateRotationZ(Pi) * view_projection, texture_storage, Color(0.0f, 1.0f, 0.0f));
             // Z
-            _mesh->render(context, Matrix::CreateRotationX(Pi) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
+            _mesh->render(context, scale * Matrix::CreateRotationX(Pi) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
         }
 
         // Render the image to the screen somewhere.

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -14,10 +14,11 @@ namespace trview
     namespace
     {
         const float Pi = 1.5707963267948966192313216916398f;
+        const float View_Size = 200;
     }
 
     Compass::Compass()
-        : _mesh_camera(Size(100, 100))
+        : _mesh_camera(Size(View_Size, View_Size))
     {
     }
 
@@ -30,7 +31,7 @@ namespace trview
         // Create a render target
         if (!_render_target)
         {
-            _render_target = std::make_unique<RenderTarget>(device.device(), 100, 100, RenderTarget::DepthStencilMode::Enabled);
+            _render_target = std::make_unique<RenderTarget>(device.device(), View_Size, View_Size, RenderTarget::DepthStencilMode::Enabled);
         }
 
         {
@@ -50,14 +51,31 @@ namespace trview
             // Render the axes mesh 
             if (!_mesh)
             {
+                const float Thick = 0.015f;
+
                 const std::vector<MeshVertex> vertices
                 {
-                    { { 0.0f, 0.5f, 0.0f },  { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-                    { { 0.0f, -0.5f, 0.0f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } }
+                    { { Thick, 0.5f, Thick },  { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+                    { { Thick, 0.5f, -Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+                    { { -Thick, 0.5f, -Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+                    { { -Thick, 0.5f, Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+                    { { Thick, -0.5f, Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+                    { { Thick, -0.5f, -Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+                    { { -Thick, -0.5f, -Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+                    { { -Thick, -0.5f, Thick }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } }
                 };
-                const std::vector<uint32_t> indices { 0, 1 };
 
-                _mesh = std::make_unique<Mesh>(device.device(), vertices, std::vector<std::vector<uint32_t>>(), indices, std::vector<TransparentTriangle>(), std::vector<Triangle>(), Mesh::Primitive::Line);
+                const std::vector<uint32_t> indices
+                {
+                    2, 1, 0, 0, 3, 2, // + y
+                    5, 4, 0, 0, 1, 5, // + x
+                    2, 3, 7, 7, 6, 2, // - x
+                    0, 4, 3, 3, 4, 7, // + z
+                    5, 1, 2, 2, 6, 5, // - z
+                    4, 5, 6, 6, 7, 4  // - y
+                };
+
+                _mesh = std::make_unique<Mesh>(device.device(), vertices, std::vector<std::vector<uint32_t>>(), indices, std::vector<TransparentTriangle>(), std::vector<Triangle>());
             }
 
             auto view_projection = _mesh_camera.view_projection();
@@ -73,6 +91,6 @@ namespace trview
         // Render the image to the screen somewhere.
         auto sprite = std::make_unique<Sprite>(device.device(), shader_storage, camera.view_size());
         auto screen_size = camera.view_size();
-        sprite->render(context, _render_target->texture(), screen_size.width - 100, screen_size.height - 100, 100, 100);
+        sprite->render(context, _render_target->texture(), screen_size.width - View_Size, screen_size.height - View_Size, View_Size, View_Size);
     }
 }

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -1,0 +1,55 @@
+#include "Compass.h"
+#include "ICamera.h"
+#include "MeshVertex.h"
+
+namespace trview
+{
+    using namespace graphics;
+    using namespace DirectX::SimpleMath;
+
+    void Compass::render(const Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage)
+    {
+        auto context = device.context();
+
+        // The process for rendering the compass:
+        // Select an area to render the mesh to - let's say a 100x100 square in the bottom right
+        // Create a render target
+        if (!_render_target)
+        {
+            _render_target = std::make_unique<RenderTarget>(device.device(), 100, 100, RenderTarget::DepthStencilMode::Enabled);
+        }
+
+        // _render_target->apply(context);
+
+        // Have a camera that looks at the compass
+        // Match rotation to the real camera
+
+        // Render the mesh 
+        // Render the axes mesh 
+        if (!_mesh)
+        {
+            const std::vector<MeshVertex> vertices
+            {
+                { { 0.5f, 0.5f, 0.5f },  { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+                { { 0.5f, 0.5f, -0.5f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+                { { -0.5f, 0.5f, -0.5f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+                { { -0.5f, 0.5f, 0.5f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+                { { 0.0f, -0.5f, 0.0f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+            };
+
+            const std::vector<uint32_t> indices
+            {
+                0, 4, 1, // + x
+                2, 4, 3, // - x
+                0, 3, 4, // + z
+                1, 4, 2, // - z
+                0, 1, 2, 2, 3, 0  // - y
+            };
+
+            _mesh = std::make_unique<Mesh>(device.device(), vertices, std::vector<std::vector<uint32_t>>(), indices, std::vector<TransparentTriangle>(), std::vector<Triangle>());
+        }
+
+        auto wvp = camera.view_projection();
+        _mesh->render(context, wvp, texture_storage, Color(1.0f, 0.0f, 0.0f));
+    }
+}

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -26,8 +26,6 @@ namespace trview
     {
         auto context = device.context();
 
-        // The process for rendering the compass:
-        // Select an area to render the mesh to - let's say a 100x100 square in the bottom right
         // Create a render target
         if (!_render_target)
         {
@@ -40,15 +38,13 @@ namespace trview
             _render_target->apply(context);
             _render_target->clear(context, Color(0.0f, 0.0f, 0.0f, 0.0f));
 
-            // Have a camera that looks at the compass
-            // Match rotation to the real camera
+            // Have a camera that looks at the compass and match rotation to the real camera
             _mesh_camera.set_target(Vector3::Zero);
             _mesh_camera.set_zoom(2.5f);
             _mesh_camera.set_rotation_pitch(camera.rotation_pitch());
             _mesh_camera.set_rotation_yaw(camera.rotation_yaw());
 
             // Render the mesh 
-            // Render the axes mesh 
             if (!_mesh)
             {
                 _mesh = create_cube_mesh(device.device());
@@ -65,9 +61,13 @@ namespace trview
             _mesh->render(context, scale * Matrix::CreateRotationX(Pi) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
         }
 
-        // Render the image to the screen somewhere.
-        auto sprite = std::make_unique<Sprite>(device.device(), shader_storage, camera.view_size());
+        if (!_sprite)
+        {
+            _sprite = std::make_unique<Sprite>(device.device(), shader_storage, camera.view_size());
+        }
+
         auto screen_size = camera.view_size();
-        sprite->render(context, _render_target->texture(), screen_size.width - View_Size, screen_size.height - View_Size, View_Size, View_Size);
+        _sprite->set_host_size(screen_size);
+        _sprite->render(context, _render_target->texture(), screen_size.width - View_Size, screen_size.height - View_Size, View_Size, View_Size);
     }
 }

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -18,11 +18,11 @@ namespace trview
     }
 
     Compass::Compass(const graphics::Device& device, const IShaderStorage& shader_storage)
-        : _mesh_camera(Size(View_Size, View_Size))
+        : _mesh_camera(Size(View_Size, View_Size)),
+          _mesh(create_cube_mesh(device.device())),
+          _sprite(std::make_unique<Sprite>(device.device(), shader_storage, Size(View_Size, View_Size))),
+          _render_target(std::make_unique<RenderTarget>(device.device(), View_Size, View_Size, RenderTarget::DepthStencilMode::Enabled))
     {
-        _mesh = create_cube_mesh(device.device());
-        _sprite = std::make_unique<Sprite>(device.device(), shader_storage, Size(View_Size, View_Size));
-        _render_target = std::make_unique<RenderTarget>(device.device(), View_Size, View_Size, RenderTarget::DepthStencilMode::Enabled);
     }
 
     void Compass::render(const Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage)

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -17,20 +17,17 @@ namespace trview
         const float View_Size = 200;
     }
 
-    Compass::Compass()
+    Compass::Compass(const graphics::Device& device, const IShaderStorage& shader_storage)
         : _mesh_camera(Size(View_Size, View_Size))
     {
+        _mesh = create_cube_mesh(device.device());
+        _sprite = std::make_unique<Sprite>(device.device(), shader_storage, Size(View_Size, View_Size));
+        _render_target = std::make_unique<RenderTarget>(device.device(), View_Size, View_Size, RenderTarget::DepthStencilMode::Enabled);
     }
 
-    void Compass::render(const Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage, const IShaderStorage& shader_storage)
+    void Compass::render(const Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage)
     {
         auto context = device.context();
-
-        // Create a render target
-        if (!_render_target)
-        {
-            _render_target = std::make_unique<RenderTarget>(device.device(), View_Size, View_Size, RenderTarget::DepthStencilMode::Enabled);
-        }
 
         {
             RenderTargetStore rs_store(context);
@@ -44,12 +41,6 @@ namespace trview
             _mesh_camera.set_rotation_pitch(camera.rotation_pitch());
             _mesh_camera.set_rotation_yaw(camera.rotation_yaw());
 
-            // Render the mesh 
-            if (!_mesh)
-            {
-                _mesh = create_cube_mesh(device.device());
-            }
-
             const auto view_projection = _mesh_camera.view_projection();
             const auto scale = Matrix::CreateScale(0.015f, 1.0f, 0.015f);
 
@@ -59,11 +50,6 @@ namespace trview
             _mesh->render(context, scale * Matrix::CreateRotationZ(Pi) * view_projection, texture_storage, Color(0.0f, 1.0f, 0.0f));
             // Z
             _mesh->render(context, scale * Matrix::CreateRotationX(Pi) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
-        }
-
-        if (!_sprite)
-        {
-            _sprite = std::make_unique<Sprite>(device.device(), shader_storage, camera.view_size());
         }
 
         auto screen_size = camera.view_size();

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -9,12 +9,34 @@
 namespace trview
 {
     using namespace graphics;
+    using namespace DirectX;
     using namespace DirectX::SimpleMath;
 
     namespace
     {
         const float Pi = 1.5707963267948966192313216916398f;
         const float View_Size = 200;
+        const float Nodule_Size = 0.05f;
+
+        const std::unordered_map<Compass::Axis, std::wstring> axis_type_names
+        {
+            { Compass::Axis::Pos_X, L"+X" },
+            { Compass::Axis::Pos_Y, L"+Y" },
+            { Compass::Axis::Pos_Z, L"+Z" },
+            { Compass::Axis::Neg_X, L"-X" },
+            { Compass::Axis::Neg_Y, L"-Y" },
+            { Compass::Axis::Neg_Z, L"-Z" },
+        };
+
+        const std::unordered_map<Compass::Axis, BoundingBox> nodule_boxes
+        {
+            { Compass::Axis::Pos_X, BoundingBox(Vector3(0.5f, 0, 0), Vector3(Nodule_Size)) },
+            { Compass::Axis::Pos_Y, BoundingBox(Vector3(0, 0.5f, 0), Vector3(Nodule_Size)) },
+            { Compass::Axis::Pos_Z, BoundingBox(Vector3(0, 0, 0.5f), Vector3(Nodule_Size)) },
+            { Compass::Axis::Neg_X, BoundingBox(Vector3(-0.5f, 0, 0), Vector3(Nodule_Size)) },
+            { Compass::Axis::Neg_Y, BoundingBox(Vector3(0, -0.5f, 0), Vector3(Nodule_Size)) },
+            { Compass::Axis::Neg_Z, BoundingBox(Vector3(0, 0, -0.5f), Vector3(Nodule_Size)) },
+        };
     }
 
     Compass::Compass(const graphics::Device& device, const IShaderStorage& shader_storage)
@@ -65,5 +87,85 @@ namespace trview
         auto screen_size = camera.view_size();
         _sprite->set_host_size(screen_size);
         _sprite->render(context, _render_target->texture(), screen_size.width - View_Size, screen_size.height - View_Size, View_Size, View_Size);
+    }
+
+    bool Compass::pick(const Point& mouse_position, const ICamera& camera, Axis& axis)
+    {
+        // Convert the mouse position into coordinates of the compass window.
+        const auto screen_size = camera.view_size();
+        const auto view_top_left = Point(screen_size.width - View_Size, screen_size.height - View_Size);
+        const auto view_pos = mouse_position - view_top_left;
+        const auto view_size = Size(View_Size, View_Size);
+
+        if (!view_pos.is_between(Point(), Point(View_Size, View_Size)))
+        {
+            return false;
+        }
+
+        const Vector3 position = _mesh_camera.position();
+        auto world = Matrix::CreateTranslation(position);
+
+        Vector3 direction = XMVector3Unproject(Vector3(view_pos.x, view_pos.y, 1), 0, 0, view_size.width, view_size.height, 0, 1.0f, _mesh_camera.projection(), _mesh_camera.view(), world);
+        direction.Normalize();
+
+        bool hit = false;
+        float nearest = 0;
+        for (const auto& box : nodule_boxes)
+        {
+            float box_distance = 0;
+            if (box.second.Intersects(position, direction, box_distance) && (!hit || box_distance < nearest))
+            {
+                nearest = box_distance;
+                axis = box.first;
+                hit = true;
+            }
+        }
+
+        return hit;
+    }
+
+    std::wstring axis_name(Compass::Axis axis)
+    {
+        auto name = axis_type_names.find(axis);
+        if (name == axis_type_names.end())
+        {
+            return L"Unknown";
+        }
+        return name->second;
+    }
+
+    void align_camera_to_axis(ICamera& camera, Compass::Axis axis)
+    {
+        float yaw = camera.rotation_yaw();
+        float pitch = camera.rotation_pitch();
+
+        switch (axis)
+        {
+        case Compass::Axis::Pos_X:
+            yaw = Pi;
+            pitch = 0;
+            break;
+        case Compass::Axis::Pos_Y:
+            pitch = -Pi;
+            break;
+        case Compass::Axis::Pos_Z:
+            yaw = 0;
+            pitch = 0;
+            break;
+        case Compass::Axis::Neg_X:
+            yaw = Pi;
+            pitch = 0;
+            break;
+        case Compass::Axis::Neg_Y:
+            pitch = Pi;
+            break;
+        case Compass::Axis::Neg_Z:
+            yaw = Pi * 2;
+            pitch = 0;
+            break;
+        }
+
+        camera.set_rotation_yaw(yaw);
+        camera.set_rotation_pitch(pitch);
     }
 }

--- a/trview.app/Compass.h
+++ b/trview.app/Compass.h
@@ -2,6 +2,7 @@
 
 #include <trview.graphics/Device.h>
 #include <trview.graphics/RenderTarget.h>
+#include <trview.graphics/Sprite.h>
 #include "Mesh.h"
 #include "Camera.h"
 
@@ -22,6 +23,7 @@ namespace trview
     private:
         std::unique_ptr<graphics::RenderTarget> _render_target;
         std::unique_ptr<Mesh> _mesh;
+        std::unique_ptr<graphics::Sprite> _sprite;
         Camera _mesh_camera;
     };
 }

--- a/trview.app/Compass.h
+++ b/trview.app/Compass.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <trview.graphics/Device.h>
+#include <trview.graphics/RenderTarget.h>
+#include "Mesh.h"
+
+namespace trview
+{
+    struct ICamera;
+    struct ILevelTextureStorage;
+
+    class Compass final
+    {
+    public:
+        void render(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage);
+    private:
+        std::unique_ptr<graphics::RenderTarget> _render_target;
+        std::unique_ptr<Mesh> _mesh;
+    };
+}

--- a/trview.app/Compass.h
+++ b/trview.app/Compass.h
@@ -19,6 +19,17 @@ namespace trview
     class Compass final
     {
     public:
+        /// The axis on the compass.
+        enum class Axis
+        {
+            Pos_X,
+            Pos_Y,
+            Pos_Z,
+            Neg_X,
+            Neg_Y,
+            Neg_Z
+        };
+
         /// Create a compass.
         /// @param device The device to use to render the compass.
         /// @param shader_storage The shader storage instance.
@@ -29,10 +40,26 @@ namespace trview
         /// @param camera The current camera being used to view the level.
         /// @param texture_storage The texture storage instance to use.
         void render(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage);
+
+        /// Pick against the compass points.
+        /// @param mouse_position The mouse position in screen space.
+        /// @param camera The screen camera.
+        /// @param axis The axis that was hovered over.
+        bool pick(const Point& mouse_position, const ICamera& camera, Axis& axis);
     private:
         std::unique_ptr<graphics::RenderTarget> _render_target;
         std::unique_ptr<Mesh> _mesh;
         std::unique_ptr<graphics::Sprite> _sprite;
         Camera _mesh_camera;
     };
+
+    /// Get a string representation of a compass axis.
+    /// @param axis The axis.
+    /// @returns The name of the axis.
+    std::wstring axis_name(Compass::Axis axis);
+
+    /// Align a camera to a particular axis.
+    /// @param camera The camera to adjust.
+    /// @param axis The axis.
+    void align_camera_to_axis(ICamera& camera, Compass::Axis axis);
 }

--- a/trview.app/Compass.h
+++ b/trview.app/Compass.h
@@ -15,10 +15,19 @@ namespace trview
         struct IShaderStorage;
     }
 
+    /// The compass shows the X, Y and Z axes.
     class Compass final
     {
     public:
+        /// Create a compass.
+        /// @param device The device to use to render the compass.
+        /// @param shader_storage The shader storage instance.
         Compass(const graphics::Device& device, const graphics::IShaderStorage& shader_storage);
+
+        /// Render the compass.
+        /// @param device The device to use to render the compass.
+        /// @param camera The current camera being used to view the level.
+        /// @param texture_storage The texture storage instance to use.
         void render(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage);
     private:
         std::unique_ptr<graphics::RenderTarget> _render_target;

--- a/trview.app/Compass.h
+++ b/trview.app/Compass.h
@@ -3,18 +3,25 @@
 #include <trview.graphics/Device.h>
 #include <trview.graphics/RenderTarget.h>
 #include "Mesh.h"
+#include "Camera.h"
 
 namespace trview
 {
-    struct ICamera;
     struct ILevelTextureStorage;
+
+    namespace graphics 
+    {
+        struct IShaderStorage;
+    }
 
     class Compass final
     {
     public:
-        void render(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage);
+        Compass();
+        void render(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage, const graphics::IShaderStorage& shader_storage);
     private:
         std::unique_ptr<graphics::RenderTarget> _render_target;
         std::unique_ptr<Mesh> _mesh;
+        Camera _mesh_camera;
     };
 }

--- a/trview.app/Compass.h
+++ b/trview.app/Compass.h
@@ -18,8 +18,8 @@ namespace trview
     class Compass final
     {
     public:
-        Compass();
-        void render(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage, const graphics::IShaderStorage& shader_storage);
+        Compass(const graphics::Device& device, const graphics::IShaderStorage& shader_storage);
+        void render(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage);
     private:
         std::unique_ptr<graphics::RenderTarget> _render_target;
         std::unique_ptr<Mesh> _mesh;

--- a/trview.app/Measure.cpp
+++ b/trview.app/Measure.cpp
@@ -27,12 +27,12 @@ namespace trview
 
         const std::vector<uint32_t> indices
         {
-            0, 1, 2, 2, 3, 0, // + y
-            0, 4, 5, 5, 1, 0, // + x
-            7, 3, 2, 2, 6, 7, // - x
-            3, 4, 0, 7, 4, 3, // + z
-            2, 1, 5, 5, 6, 2, // - z
-            6, 5, 4, 4, 7, 6  // - y
+            2, 1, 0, 0, 3, 2, // + y
+            5, 4, 0, 0, 1, 5, // + x
+            2, 3, 7, 7, 6, 2, // - x
+            0, 4, 3, 3, 4, 7, // + z
+            5, 1, 2, 2, 6, 5, // - z
+            4, 5, 6, 6, 7, 4  // - y
         };
 
         _mesh = std::make_unique<Mesh>(device.device(), vertices, std::vector<std::vector<uint32_t>>(), indices, std::vector<TransparentTriangle>(), std::vector<Triangle>());

--- a/trview.app/Measure.cpp
+++ b/trview.app/Measure.cpp
@@ -12,31 +12,8 @@ using namespace DirectX::SimpleMath;
 namespace trview
 {
     Measure::Measure(const Device& device, ui::Control& ui)
+        : _mesh(create_cube_mesh(device.device()))
     {
-        const std::vector<MeshVertex> vertices
-        {
-            { { 0.5f, 0.5f, 0.5f },  { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-            { { 0.5f, 0.5f, -0.5f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-            { { -0.5f, 0.5f, -0.5f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-            { { -0.5f, 0.5f, 0.5f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-            { { 0.5f, -0.5f, 0.5f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-            { { 0.5f, -0.5f, -0.5f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-            { { -0.5f, -0.5f, -0.5f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
-            { { -0.5f, -0.5f, 0.5f }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } }
-        };
-
-        const std::vector<uint32_t> indices
-        {
-            2, 1, 0, 0, 3, 2, // + y
-            5, 4, 0, 0, 1, 5, // + x
-            2, 3, 7, 7, 6, 2, // - x
-            0, 4, 3, 3, 4, 7, // + z
-            5, 1, 2, 2, 6, 5, // - z
-            4, 5, 6, 6, 7, 4  // - y
-        };
-
-        _mesh = std::make_unique<Mesh>(device.device(), vertices, std::vector<std::vector<uint32_t>>(), indices, std::vector<TransparentTriangle>(), std::vector<Triangle>());
-
         auto label = std::make_unique<ui::Label>(Point(300, 100), Size(50, 30), Colour(1.0f, 0.2f, 0.2f, 0.2f), L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
         label->set_visible(false);
         _label = ui.add_child(std::move(label));

--- a/trview.app/Mesh.cpp
+++ b/trview.app/Mesh.cpp
@@ -28,8 +28,9 @@ namespace trview
         const std::vector<std::vector<uint32_t>>& indices, 
         const std::vector<uint32_t>& untextured_indices, 
         const std::vector<TransparentTriangle>& transparent_triangles,
-        const std::vector<Triangle>& collision_triangles)
-        : _transparent_triangles(transparent_triangles), _collision_triangles(collision_triangles)
+        const std::vector<Triangle>& collision_triangles,
+        Primitive primitive)
+        : _transparent_triangles(transparent_triangles), _collision_triangles(collision_triangles), _primitive(primitive)
     {
         if (!vertices.empty())
         {
@@ -139,6 +140,7 @@ namespace trview
         UINT offset = 0;
         context->IASetVertexBuffers(0, 1, _vertex_buffer.GetAddressOf(), &stride, &offset);
         context->VSSetConstantBuffers(0, 1, _matrix_buffer.GetAddressOf());
+        context->IASetPrimitiveTopology(_primitive == Primitive::Triangle ? D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST : D3D11_PRIMITIVE_TOPOLOGY_LINELIST);
 
         for (uint32_t i = 0; i < _index_buffers.size(); ++i)
         {

--- a/trview.app/Mesh.cpp
+++ b/trview.app/Mesh.cpp
@@ -28,9 +28,8 @@ namespace trview
         const std::vector<std::vector<uint32_t>>& indices, 
         const std::vector<uint32_t>& untextured_indices, 
         const std::vector<TransparentTriangle>& transparent_triangles,
-        const std::vector<Triangle>& collision_triangles,
-        Primitive primitive)
-        : _transparent_triangles(transparent_triangles), _collision_triangles(collision_triangles), _primitive(primitive)
+        const std::vector<Triangle>& collision_triangles)
+        : _transparent_triangles(transparent_triangles), _collision_triangles(collision_triangles)
     {
         if (!vertices.empty())
         {
@@ -140,7 +139,6 @@ namespace trview
         UINT offset = 0;
         context->IASetVertexBuffers(0, 1, _vertex_buffer.GetAddressOf(), &stride, &offset);
         context->VSSetConstantBuffers(0, 1, _matrix_buffer.GetAddressOf());
-        context->IASetPrimitiveTopology(_primitive == Primitive::Triangle ? D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST : D3D11_PRIMITIVE_TOPOLOGY_LINELIST);
 
         for (uint32_t i = 0; i < _index_buffers.size(); ++i)
         {

--- a/trview.app/Mesh.cpp
+++ b/trview.app/Mesh.cpp
@@ -213,6 +213,33 @@ namespace trview
         return std::make_unique<Mesh>(device, vertices, indices, untextured_indices, transparent_triangles, collision_triangles);
     }
 
+    std::unique_ptr<Mesh> create_cube_mesh(const Microsoft::WRL::ComPtr<ID3D11Device>& device)
+    {
+        const std::vector<MeshVertex> vertices
+        {
+            { { 0.5, 0.5f, 0.5 },  { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+            { { 0.5, 0.5f, -0.5 }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+            { { -0.5, 0.5f, -0.5 }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+            { { -0.5, 0.5f, 0.5 }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+            { { 0.5, -0.5f, 0.5 }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+            { { 0.5, -0.5f, -0.5 }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+            { { -0.5, -0.5f, -0.5 }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },
+            { { -0.5, -0.5f, 0.5 }, { 0, 0 }, { 1.0f, 1.0f, 1.0f } }
+        };
+
+        const std::vector<uint32_t> indices
+        {
+            2, 1, 0, 0, 3, 2, // + y
+            5, 4, 0, 0, 1, 5, // + x
+            2, 3, 7, 7, 6, 2, // - x
+            0, 4, 3, 3, 4, 7, // + z
+            5, 1, 2, 2, 6, 5, // - z
+            4, 5, 6, 6, 7, 4  // - y
+        };
+
+        return std::make_unique<Mesh>(device, vertices, std::vector<std::vector<uint32_t>>(), indices, std::vector<TransparentTriangle>(), std::vector<Triangle>());
+    }
+
     void process_textured_rectangles(
         const std::vector<trlevel::tr4_mesh_face4>& rectangles, 
         const std::vector<trlevel::tr_vertex>& input_vertices,

--- a/trview.app/Mesh.h
+++ b/trview.app/Mesh.h
@@ -24,7 +24,6 @@ namespace trview
         /// @param indices The indices for triangles that use level textures.
         /// @param untextured_indices The indices for triangles that do not use level textures.
         /// @param collision_triangles The triangles for picking.
-        /// @param primitive The primitive type.
         Mesh(const Microsoft::WRL::ComPtr<ID3D11Device>& device,
              const std::vector<MeshVertex>& vertices, 
              const std::vector<std::vector<uint32_t>>& indices, 

--- a/trview.app/Mesh.h
+++ b/trview.app/Mesh.h
@@ -18,18 +18,26 @@ namespace trview
     class Mesh
     {
     public:
+        enum class Primitive
+        {
+            Triangle,
+            Line
+        };
+
         /// Create a mesh using the specified vertices and indices.
         /// @param device The D3D device to create the mesh.
         /// @param vertices The vertices that make up the mesh.
         /// @param indices The indices for triangles that use level textures.
         /// @param untextured_indices The indices for triangles that do not use level textures.
         /// @param collision_triangles The triangles for picking.
+        /// @param primitive The primitive type.
         Mesh(const Microsoft::WRL::ComPtr<ID3D11Device>& device,
              const std::vector<MeshVertex>& vertices, 
              const std::vector<std::vector<uint32_t>>& indices, 
              const std::vector<uint32_t>& untextured_indices,
              const std::vector<TransparentTriangle>& transparent_triangles,
-             const std::vector<Triangle>& collision_triangles);
+             const std::vector<Triangle>& collision_triangles,
+             Primitive primitive = Primitive::Triangle);
 
         void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, const DirectX::SimpleMath::Matrix& world_view_projection, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour);
 
@@ -48,6 +56,7 @@ namespace trview
         std::vector<TransparentTriangle>                  _transparent_triangles;
         std::vector<Triangle>                             _collision_triangles;
         DirectX::BoundingBox                              _bounding_box;
+        Primitive                                         _primitive;
     };
 
     /// Create a new mesh based on the contents of the mesh specified.

--- a/trview.app/Mesh.h
+++ b/trview.app/Mesh.h
@@ -59,6 +59,9 @@ namespace trview
     /// @returns The new mesh.
     std::unique_ptr<Mesh> create_mesh(const trlevel::tr_mesh& mesh, const Microsoft::WRL::ComPtr<ID3D11Device>& device, const ILevelTextureStorage& texture_storage, bool transparent_collision = true);
 
+    /// Create a new cube mesh.
+    std::unique_ptr<Mesh> create_cube_mesh(const Microsoft::WRL::ComPtr<ID3D11Device>& device);
+
     /// Convert the textured rectangles into collections required to create a mesh.
     /// @param rectangles The rectangles from the mesh or room geometry.
     /// @param input_vertices The vertices that the rectangle indices refer to.

--- a/trview.app/Mesh.h
+++ b/trview.app/Mesh.h
@@ -18,12 +18,6 @@ namespace trview
     class Mesh
     {
     public:
-        enum class Primitive
-        {
-            Triangle,
-            Line
-        };
-
         /// Create a mesh using the specified vertices and indices.
         /// @param device The D3D device to create the mesh.
         /// @param vertices The vertices that make up the mesh.
@@ -36,8 +30,7 @@ namespace trview
              const std::vector<std::vector<uint32_t>>& indices, 
              const std::vector<uint32_t>& untextured_indices,
              const std::vector<TransparentTriangle>& transparent_triangles,
-             const std::vector<Triangle>& collision_triangles,
-             Primitive primitive = Primitive::Triangle);
+             const std::vector<Triangle>& collision_triangles);
 
         void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, const DirectX::SimpleMath::Matrix& world_view_projection, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour);
 
@@ -56,7 +49,6 @@ namespace trview
         std::vector<TransparentTriangle>                  _transparent_triangles;
         std::vector<Triangle>                             _collision_triangles;
         DirectX::BoundingBox                              _bounding_box;
-        Primitive                                         _primitive;
     };
 
     /// Create a new mesh based on the contents of the mesh specified.

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Camera.cpp" />
     <ClCompile Include="CollapsiblePanel.cpp" />
     <ClCompile Include="Compass.cpp" />
     <ClCompile Include="FileDropper.cpp" />
@@ -39,6 +40,7 @@
     <ClCompile Include="WindowResizer.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Camera.h" />
     <ClInclude Include="CollapsiblePanel.h" />
     <ClInclude Include="Compass.h" />
     <ClInclude Include="FileDropper.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CollapsiblePanel.cpp" />
+    <ClCompile Include="Compass.cpp" />
     <ClCompile Include="FileDropper.cpp" />
     <ClCompile Include="ICamera.cpp" />
     <ClCompile Include="ILevelTextureStorage.cpp" />
@@ -39,6 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CollapsiblePanel.h" />
+    <ClInclude Include="Compass.h" />
     <ClInclude Include="FileDropper.h" />
     <ClInclude Include="ICamera.h" />
     <ClInclude Include="ILevelTextureStorage.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -46,6 +46,7 @@
     <ClCompile Include="ICamera.cpp">
       <Filter>Camera</Filter>
     </ClCompile>
+    <ClCompile Include="Compass.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="WindowResizer.h" />
@@ -101,6 +102,7 @@
     <ClInclude Include="ICamera.h">
       <Filter>Camera</Filter>
     </ClInclude>
+    <ClInclude Include="Compass.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Items">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -47,6 +47,9 @@
       <Filter>Camera</Filter>
     </ClCompile>
     <ClCompile Include="Compass.cpp" />
+    <ClCompile Include="Camera.cpp">
+      <Filter>Camera</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="WindowResizer.h" />
@@ -103,6 +106,9 @@
       <Filter>Camera</Filter>
     </ClInclude>
     <ClInclude Include="Compass.h" />
+    <ClInclude Include="Camera.h">
+      <Filter>Camera</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Items">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -46,10 +46,10 @@
     <ClCompile Include="ICamera.cpp">
       <Filter>Camera</Filter>
     </ClCompile>
-    <ClCompile Include="Compass.cpp" />
     <ClCompile Include="Camera.cpp">
       <Filter>Camera</Filter>
     </ClCompile>
+    <ClCompile Include="Compass.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="WindowResizer.h" />
@@ -105,10 +105,10 @@
     <ClInclude Include="ICamera.h">
       <Filter>Camera</Filter>
     </ClInclude>
-    <ClInclude Include="Compass.h" />
     <ClInclude Include="Camera.h">
       <Filter>Camera</Filter>
     </ClInclude>
+    <ClInclude Include="Compass.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Items">

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -90,6 +90,7 @@ namespace trview
         generate_ui();
 
         _measure = std::make_unique<Measure>(_device, *_control);
+        _compass = std::make_unique<Compass>(_device, *_shader_storage);
     }
 
     Viewer::~Viewer()
@@ -589,7 +590,7 @@ namespace trview
             _level->render(_device.context(), current_camera());
 
             _measure->render(_device.context(), current_camera(), _level->texture_storage());
-            _compass.render(_device, current_camera(), _level->texture_storage(), *_shader_storage);
+            _compass->render(_device, current_camera(), _level->texture_storage());
         }
     }
 

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -558,6 +558,7 @@ namespace trview
             _compass_axis = axis;
             _picking->set_visible(true);
             _picking->set_text(axis_name(axis));
+            _picking->set_text_colour(Colour(1.0f, 1.0f, 1.0f));
             _picking->set_position(Point(mouse_pos.x - _picking->size().width, mouse_pos.y - _picking->size().height));
             return;
         }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -589,6 +589,7 @@ namespace trview
             _level->render(_device.context(), current_camera());
 
             _measure->render(_device.context(), current_camera(), _level->texture_storage());
+            _compass.render(_device, current_camera(), _level->texture_storage());
         }
     }
 

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -589,7 +589,7 @@ namespace trview
             _level->render(_device.context(), current_camera());
 
             _measure->render(_device.context(), current_camera(), _level->texture_storage());
-            _compass.render(_device, current_camera(), _level->texture_storage());
+            _compass.render(_device, current_camera(), _level->texture_storage(), *_shader_storage);
         }
     }
 

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -168,6 +168,7 @@ namespace trview
         Tool _active_tool{ Tool::None };
         std::unique_ptr<Measure> _measure;
         std::unique_ptr<Compass> _compass;
+        std::optional<Compass::Axis> _compass_axis;
     };
 }
 

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -167,7 +167,7 @@ namespace trview
 
         Tool _active_tool{ Tool::None };
         std::unique_ptr<Measure> _measure;
-        Compass _compass;
+        std::unique_ptr<Compass> _compass;
     };
 }
 

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -18,7 +18,7 @@
 #include <trview.input/Mouse.h>
 #include <trview.common/TokenStore.h>
 
-#include "Camera.h"
+#include <trview.app/Camera.h>
 #include "CameraInput.h"
 #include "CameraMode.h"
 #include "FreeCamera.h"

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -32,6 +32,7 @@
 #include <trview.app/TriggersWindowManager.h>
 #include <trview.app/Toolbar.h>
 #include <trview.app/Measure.h>
+#include <trview.app/Compass.h>
 
 namespace trview
 {
@@ -166,6 +167,7 @@ namespace trview
 
         Tool _active_tool{ Tool::None };
         std::unique_ptr<Measure> _measure;
+        Compass _compass;
     };
 }
 

--- a/trview/trview.vcxproj
+++ b/trview/trview.vcxproj
@@ -179,7 +179,6 @@
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="Camera.h" />
     <ClInclude Include="CameraControls.h" />
     <ClInclude Include="CameraInput.h" />
     <ClInclude Include="CameraMode.h" />
@@ -216,7 +215,6 @@
     <ClInclude Include="Viewer.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="Camera.cpp" />
     <ClCompile Include="CameraControls.cpp" />
     <ClCompile Include="CameraInput.cpp" />
     <ClCompile Include="DefaultFonts.cpp" />

--- a/trview/trview.vcxproj.filters
+++ b/trview/trview.vcxproj.filters
@@ -121,9 +121,6 @@
     <ClInclude Include="DefaultShaders.h">
       <Filter>Graphics</Filter>
     </ClInclude>
-    <ClInclude Include="Camera.h">
-      <Filter>Camera</Filter>
-    </ClInclude>
     <ClInclude Include="FreeCamera.h">
       <Filter>Camera</Filter>
     </ClInclude>
@@ -215,9 +212,6 @@
     </ClCompile>
     <ClCompile Include="DefaultShaders.cpp">
       <Filter>Graphics</Filter>
-    </ClCompile>
-    <ClCompile Include="Camera.cpp">
-      <Filter>Camera</Filter>
     </ClCompile>
     <ClCompile Include="FreeCamera.cpp">
       <Filter>Camera</Filter>


### PR DESCRIPTION
Adds an axis display to the viewer. This shows the direction of the X, Y and Z axis relative to the current camera.
The axis display itself is rendered to a render target with its own camera that matches the main viewer camera. The user can click on the little cubes at the end of each axis to align the viewer camera to that axis.
Camera class was moved to trview.app as the axis display needed it.
Creating a cube mesh was moved to a function as it was also used in the measure tool. The windings were reversed as they were wrong after the change to stop inverting y.
Issue: #92 