### PR TITLE
Create command filter for triggers

### DIFF
--- a/trview.app/CollapsiblePanel.cpp
+++ b/trview.app/CollapsiblePanel.cpp
@@ -85,6 +85,8 @@ namespace trview
         _token_store.add(_mouse.mouse_down += [&](input::Mouse::Button) { _ui->process_mouse_down(client_cursor_position(window())); });
         _token_store.add(_mouse.mouse_wheel += [&](int16_t delta) { _ui->mouse_scroll(client_cursor_position(window()), delta); });
         _token_store.add(_keyboard.on_key_down += [&](auto key) { _ui->process_key_down(key); });
+
+        _ui = std::make_unique<ui::Window>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f));
     }
 
     void CollapsiblePanel::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
@@ -115,10 +117,11 @@ namespace trview
 
     void CollapsiblePanel::set_panels(std::unique_ptr<ui::Control> left_panel, std::unique_ptr<ui::Control> right_panel)
     {
-        _ui = std::make_unique<StackPanel>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(0, 0), StackPanel::Direction::Horizontal, SizeMode::Manual);
-        _left_panel = _ui->add_child(std::move(left_panel));
-        _divider = _ui->add_child(create_divider());
-        _right_panel = _ui->add_child(std::move(right_panel));
+        auto panel = std::make_unique<StackPanel>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(0, 0), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        _left_panel = panel->add_child(std::move(left_panel));
+        _divider = panel->add_child(create_divider());
+        _right_panel = panel->add_child(std::move(right_panel));
+        _panels = _ui->add_child(std::move(panel));
         _ui_renderer->load(_ui.get());
     }
 
@@ -130,6 +133,7 @@ namespace trview
     void CollapsiblePanel::update_layout()
     {
         _ui->set_size(window().size());
+        _panels->set_size(window().size());
         const auto new_height = window().size().height;
         _left_panel->set_size(Size(_left_panel->size().width, new_height));
         _divider->set_size(Size(_divider->size().width, new_height));

--- a/trview.app/CollapsiblePanel.h
+++ b/trview.app/CollapsiblePanel.h
@@ -28,6 +28,7 @@ namespace trview
         class Control;
         class Window;
         class Button;
+        class StackPanel;
         namespace render
         {
             class Renderer;
@@ -83,13 +84,14 @@ namespace trview
         TokenStore   _token_store;
         ui::Control* _left_panel;
         ui::Control* _right_panel;
+        std::unique_ptr<ui::Window> _ui;
     private:
         void toggle_expand();
         std::unique_ptr<ui::Control> create_divider();
 
         std::unique_ptr<graphics::DeviceWindow> _device_window;
         std::unique_ptr<ui::render::Renderer>   _ui_renderer;
-        std::unique_ptr<ui::Window> _ui;
+        ui::StackPanel* _panels;
         WindowResizer   _window_resizer;
         input::Mouse    _mouse;
         input::Keyboard _keyboard;

--- a/trview.app/Trigger.cpp
+++ b/trview.app/Trigger.cpp
@@ -188,10 +188,7 @@ namespace trview
 
     bool Trigger::has_command(TriggerCommandType type) const
     {
-        return std::find_if(_commands.begin(), _commands.end(), [&](const auto& c)
-        {
-            return c.type() == type;
-        }) != _commands.end();
+        return std::any_of(_commands.begin(), _commands.end(), [&](const auto& c) { return c.type() == type; });
     }
 
     std::wstring trigger_type_name(TriggerType type)

--- a/trview.app/Trigger.cpp
+++ b/trview.app/Trigger.cpp
@@ -47,6 +47,24 @@ namespace trview
             { TriggerCommandType::Flyby, L"Flyby" },
             { TriggerCommandType::Cutscene, L"Cutscene" }
         };
+
+        const std::unordered_map<std::wstring, TriggerCommandType> command_type_lookup
+        {
+            { L"Object", TriggerCommandType::Object },
+            { L"Camera", TriggerCommandType::Camera },
+            { L"Current", TriggerCommandType::UnderwaterCurrent },
+            { L"Flip Map", TriggerCommandType::FlipMap },
+            { L"Flip On", TriggerCommandType::FlipOn },
+            { L"Flip Off", TriggerCommandType::FlipOff },
+            { L"Look at Item", TriggerCommandType::LookAtItem },
+            { L"End Level", TriggerCommandType::EndLevel },
+            { L"Music", TriggerCommandType::PlaySoundtrack },
+            { L"Flipeffect", TriggerCommandType::Flipeffect },
+            { L"Secret", TriggerCommandType::SecretFound },
+            { L"Clear Bodies", TriggerCommandType::ClearBodies },
+            { L"Flyby", TriggerCommandType::Flyby },
+            { L"Cutscene", TriggerCommandType::Cutscene }
+        };
     }
 
     Command::Command(uint32_t number, TriggerCommandType type, uint16_t index)
@@ -168,6 +186,14 @@ namespace trview
         return PickResult();
     }
 
+    bool Trigger::has_command(TriggerCommandType type) const
+    {
+        return std::find_if(_commands.begin(), _commands.end(), [&](const auto& c)
+        {
+            return c.type() == type;
+        }) != _commands.end();
+    }
+
     std::wstring trigger_type_name(TriggerType type)
     {
         auto name = trigger_type_names.find(type);
@@ -186,5 +212,15 @@ namespace trview
             return L"Unknown";
         }
         return name->second;
+    }
+
+    TriggerCommandType command_from_name(const std::wstring& name)
+    {
+        auto type = command_type_lookup.find(name);
+        if (type == command_type_lookup.end())
+        {
+            return TriggerCommandType::Object;
+        }
+        return type->second;
     }
 }

--- a/trview.app/Trigger.h
+++ b/trview.app/Trigger.h
@@ -57,6 +57,7 @@ namespace trview
         const std::vector<TransparentTriangle>& triangles() const;
         void set_triangles(const std::vector<TransparentTriangle>& transparent_triangles);
         PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const;
+        bool has_command(TriggerCommandType type) const;
     private:
         std::vector<uint16_t> _objects;
         std::vector<Command> _commands;
@@ -82,4 +83,9 @@ namespace trview
     /// @param type The type to test.
     /// @returns The string version of the enum.
     std::wstring command_type_name(TriggerCommandType type);
+
+    /// Get the trigger command type from a string.
+    /// @param name The string to convert.
+    /// @returns The trigger command type.
+    TriggerCommandType command_from_name(const std::wstring& name);
 }

--- a/trview.app/TriggersWindow.cpp
+++ b/trview.app/TriggersWindow.cpp
@@ -79,9 +79,8 @@ namespace trview
 
         // Command filter:
         auto controls_row2 = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 0), StackPanel::Direction::Horizontal, SizeMode::Manual);
-        controls_row2->add_child(std::make_unique<Label>(Point(), Size(60, 20), Colours::LeftPanel, L"Command: ", 8, TextAlignment::Centre, ParagraphAlignment::Centre));
 
-        auto command_filter = std::make_unique<Dropdown>(Point(), Size(110, 20));
+        auto command_filter = std::make_unique<Dropdown>(Point(), Size(183, 20));
         command_filter->set_values({L"All"});
         command_filter->set_dropdown_scope(_ui.get());
         command_filter->set_selected_value(L"All");

--- a/trview.app/TriggersWindow.cpp
+++ b/trview.app/TriggersWindow.cpp
@@ -50,6 +50,7 @@ namespace trview
         auto left_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colours::LeftPanel, Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Control modes:.
+        auto controls_box = std::make_unique<StackPanel>(Point(), Size(200, 50), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Vertical, SizeMode::Manual);
         auto controls = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
         auto track_room = std::make_unique<Checkbox>(Point(), Size(16, 16), Colours::LeftPanel, L"Track Room");
         _token_store.add(track_room->on_state_changed += [this](bool value)
@@ -73,9 +74,13 @@ namespace trview
         // Add the expander button at this point.
         add_expander(*controls);
 
-        _controls = left_panel->add_child(std::move(controls));
+        auto controls_row2 = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
 
-        auto triggers_list = std::make_unique<Listbox>(Point(), Size(200, window().size().height - _controls->size().height), Colours::LeftPanel);
+        _controls = controls_box->add_child(std::move(controls));
+        controls_box->add_child(std::move(controls_row2));
+        auto _controls_box = left_panel->add_child(std::move(controls_box));
+
+        auto triggers_list = std::make_unique<Listbox>(Point(), Size(200, window().size().height - _controls_box->size().height), Colours::LeftPanel);
         triggers_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 30 },

--- a/trview.app/TriggersWindow.cpp
+++ b/trview.app/TriggersWindow.cpp
@@ -101,10 +101,11 @@ namespace trview
         _command_filter = controls_row2->add_child(std::move(command_filter));
 
         _controls = controls_box->add_child(std::move(controls));
+        auto controls_box_bottom = controls_box->size().height;
         controls_box->add_child(std::move(controls_row2));
-        auto _controls_box = left_panel->add_child(std::move(controls_box));
+        left_panel->add_child(std::move(controls_box));
 
-        auto triggers_list = std::make_unique<Listbox>(Point(), Size(200, window().size().height - _controls_box->size().height), Colours::LeftPanel);
+        auto triggers_list = std::make_unique<Listbox>(Point(), Size(200, window().size().height - controls_box_bottom), Colours::LeftPanel);
         triggers_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 30 },

--- a/trview.app/TriggersWindow.cpp
+++ b/trview.app/TriggersWindow.cpp
@@ -7,6 +7,7 @@
 #include <trview.ui/Checkbox.h>
 #include <trview.ui/Button.h>
 #include <trview.ui/GroupBox.h>
+#include <trview.ui/Dropdown.h>
 
 namespace trview
 {
@@ -74,7 +75,15 @@ namespace trview
         // Add the expander button at this point.
         add_expander(*controls);
 
+        // Command filter:
         auto controls_row2 = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        controls_row2->add_child(std::make_unique<Label>(Point(), Size(60, 20), Colours::LeftPanel, L"Command: ", 8, TextAlignment::Centre, ParagraphAlignment::Centre));
+
+        auto command_filter = std::make_unique<Dropdown>(Point(), Size(100, 20));
+        command_filter->set_values({L"All", L"Object", L"End Level"});
+        command_filter->set_dropdown_scope(_ui.get());
+
+        controls_row2->add_child(std::move(command_filter));
 
         _controls = controls_box->add_child(std::move(controls));
         controls_box->add_child(std::move(controls_row2));

--- a/trview.app/TriggersWindow.h
+++ b/trview.app/TriggersWindow.h
@@ -13,6 +13,7 @@ namespace trview
     namespace ui
     {
         class Checkbox;
+        class Dropdown;
     }
 
     class TriggersWindow final : public CollapsiblePanel
@@ -59,12 +60,14 @@ namespace trview
         void set_track_room(bool value);
         void set_sync_trigger(bool value);
         void load_trigger_details(const Trigger& trigger);
+        void apply_filters();
 
         ui::Window*   _controls;
         ui::Checkbox* _track_room_checkbox;
         ui::Listbox*  _triggers_list;
         ui::Listbox*  _stats_list;
         ui::Listbox*  _command_list;
+        ui::Dropdown* _command_filter;
 
         std::vector<Item> _all_items;
         std::vector<Trigger*> _all_triggers;
@@ -77,5 +80,6 @@ namespace trview
         bool _filter_applied{ false };
         bool _sync_trigger{ true };
         std::optional<const Trigger*> _selected_trigger;
+        std::optional<TriggerCommandType> _selected_command;
     };
 }

--- a/trview.ui.render/RenderNode.cpp
+++ b/trview.ui.render/RenderNode.cpp
@@ -59,7 +59,12 @@ namespace trview
 
                 render_self(context, sprite);
 
-                for (auto& child : _child_nodes)
+                std::vector<RenderNode*> children;
+                std::transform(_child_nodes.begin(), _child_nodes.end(), std::back_inserter(children),
+                    [](auto& child) { return child.get(); });
+                std::sort(children.begin(), children.end(), [](const auto& l, const auto& r) { return l->z() > r->z(); });
+
+                for (auto& child : children)
                 {
                     if (!child->visible())
                     {
@@ -120,6 +125,11 @@ namespace trview
             {
                 return std::any_of(_child_nodes.begin(), _child_nodes.end(),
                     [](const auto& n) { return n->needs_redraw() || n->needs_recompositing(); });
+            }
+
+            int RenderNode::z() const
+            {
+                return _control->z();
             }
         }
     }

--- a/trview.ui.render/RenderNode.h
+++ b/trview.ui.render/RenderNode.h
@@ -49,6 +49,8 @@ namespace trview
                 Size size() const;
 
                 bool visible() const;
+
+                int z() const;
             protected:
                 virtual void render_self(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, graphics::Sprite& sprite) = 0;
 

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -470,5 +470,11 @@ namespace trview
         {
             return _z;
         }
+
+        void Control::set_z(int value)
+        {
+            _z = value;
+            on_invalidate();
+        }
     }
 }

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -151,7 +151,13 @@ namespace trview
             template <typename T>
             T* find(const std::string& name) const;
 
+            /// Get the z order of the control.
+            /// @returns The z order.
             int z() const;
+
+            /// Set the z order of the control.
+            /// @param value The new z order.
+            void set_z(int value);
 
             /// Event raised when the size of the control has changed.
             Event<Size> on_size_changed;
@@ -257,7 +263,6 @@ namespace trview
             Align    _horizontal_alignment{ Align::Near };
             Align    _vertical_alignment{ Align::Near };
             std::string _name;
-        public:
             int      _z{ 0 };
         };
     }

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -151,6 +151,8 @@ namespace trview
             template <typename T>
             T* find(const std::string& name) const;
 
+            int z() const;
+
             /// Event raised when the size of the control has changed.
             Event<Size> on_size_changed;
 
@@ -255,6 +257,8 @@ namespace trview
             Align    _horizontal_alignment{ Align::Near };
             Align    _vertical_alignment{ Align::Near };
             std::string _name;
+        public:
+            int      _z{ 0 };
         };
     }
 }

--- a/trview.ui/Dropdown.cpp
+++ b/trview.ui/Dropdown.cpp
@@ -21,7 +21,7 @@ namespace trview
         void Dropdown::set_dropdown_scope(ui::Control* scope)
         {
             auto dropdown = std::make_unique<StackPanel>(Point(), Size(size().width, size().height * _values.size()), Colour(0.4f, 0.0f, 0.4f), Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
-            dropdown->_z = -1;
+            dropdown->set_z(-1);
             dropdown->set_visible(false);
             _dropdown = scope->add_child(std::move(dropdown));
             update_dropdown();

--- a/trview.ui/Dropdown.cpp
+++ b/trview.ui/Dropdown.cpp
@@ -1,0 +1,80 @@
+#include "Dropdown.h"
+#include "Label.h"
+#include "StackPanel.h"
+#include "Button.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        Dropdown::Dropdown(const Point& position, const Size& size)
+            : Window(position, size, Colour(1.0f, 0.0f, 0.0f))
+        {
+            _label = add_child(
+                std::make_unique<Label>(
+                    position, 
+                    size, 
+                    Colour(1.0f, 0.0f, 0.0f), 
+                    L"", 
+                    8,
+                    graphics::TextAlignment::Centre,
+                    graphics::ParagraphAlignment::Centre));
+            set_handles_input(true);
+            set_handles_hover(true);
+        }
+
+        void Dropdown::set_dropdown_scope(ui::Control* scope)
+        {
+            auto dropdown = std::make_unique<StackPanel>(Point(), Size(size().width, size().height * _values.size()), Colour(0.4f, 0.0f, 0.4f), Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
+            dropdown->_z = -1;
+            dropdown->set_visible(false);
+            _dropdown = scope->add_child(std::move(dropdown));
+            update_dropdown();
+        }
+
+        void Dropdown::set_values(const std::vector<std::wstring>& values)
+        {
+            _values = values;
+            update_dropdown();
+        }
+
+        void Dropdown::update_dropdown()
+        {
+            if (!_dropdown || !_dropdown->visible())
+            {
+                return;
+            }
+
+            // Set the position of the dropdown to be just below us.
+            _dropdown->set_position(absolute_position() + Point(0, size().height));
+            _dropdown->clear_child_elements();
+            for (const auto& value : _values)
+            {
+                auto button = std::make_unique<Button>(Point(), size(), value);
+                _token_store.add(button->on_click += [&]()
+                {
+                    _label->set_text(value);
+                    _dropdown->set_visible(false);
+                });
+                _dropdown->add_child(std::move(button));
+            }
+        }
+
+        bool Dropdown::mouse_down(const Point&)
+        {
+            return true;
+        }
+
+        bool Dropdown::mouse_up(const Point&)
+        {
+            return true;
+        }
+
+        bool Dropdown::clicked(Point)
+        {
+            _dropdown->set_visible(!_dropdown->visible());
+            update_dropdown();
+            return true;
+        }
+    }
+}

--- a/trview.ui/Dropdown.cpp
+++ b/trview.ui/Dropdown.cpp
@@ -10,17 +10,12 @@ namespace trview
         Dropdown::Dropdown(const Point& position, const Size& size)
             : Window(position, size, Colour(1.0f, 0.0f, 0.0f))
         {
-            _label = add_child(
-                std::make_unique<Label>(
-                    position, 
-                    size, 
-                    Colour(1.0f, 0.0f, 0.0f), 
-                    L"", 
-                    8,
-                    graphics::TextAlignment::Centre,
-                    graphics::ParagraphAlignment::Centre));
-            set_handles_input(true);
-            set_handles_hover(true);
+            _button = add_child(std::make_unique<Button>(position, size, L""));
+            _token_store.add(_button->on_click += [&]()
+            {
+                _dropdown->set_visible(!_dropdown->visible());
+                update_dropdown();
+            });
         }
 
         void Dropdown::set_dropdown_scope(ui::Control* scope)
@@ -38,6 +33,11 @@ namespace trview
             update_dropdown();
         }
 
+        void Dropdown::set_selected_value(const std::wstring& value)
+        {
+            _button->set_text(value);
+        }
+
         void Dropdown::update_dropdown()
         {
             if (!_dropdown || !_dropdown->visible())
@@ -48,33 +48,18 @@ namespace trview
             // Set the position of the dropdown to be just below us.
             _dropdown->set_position(absolute_position() + Point(0, size().height));
             _dropdown->clear_child_elements();
+            _dropdown->set_size(Size(size().width, size().height * _values.size()));
             for (const auto& value : _values)
             {
                 auto button = std::make_unique<Button>(Point(), size(), value);
                 _token_store.add(button->on_click += [&]()
                 {
-                    _label->set_text(value);
+                    _button->set_text(value);
                     _dropdown->set_visible(false);
+                    on_value_selected(value);
                 });
                 _dropdown->add_child(std::move(button));
             }
-        }
-
-        bool Dropdown::mouse_down(const Point&)
-        {
-            return true;
-        }
-
-        bool Dropdown::mouse_up(const Point&)
-        {
-            return true;
-        }
-
-        bool Dropdown::clicked(Point)
-        {
-            _dropdown->set_visible(!_dropdown->visible());
-            update_dropdown();
-            return true;
         }
     }
 }

--- a/trview.ui/Dropdown.h
+++ b/trview.ui/Dropdown.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+#include "Window.h"
+#include "Label.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        class StackPanel;
+
+        class Dropdown final : public Window
+        {
+        public:
+            /// Create a new dropdown box.
+            /// @param position The position of the control.
+            /// @param size The size of the control.
+            explicit Dropdown(const Point& position, const Size& size);
+
+            /// Destructor for Dropdown.
+            virtual ~Dropdown() = default;
+
+            /// Set the scope that the dropdown will appear in. This may be required if the parent control
+            /// does not have space for the entire dropdown to be rendered.
+            /// @param scope The scope to create the dropdown control in.
+            void set_dropdown_scope(ui::Control* scope);
+
+            /// Set the values to show in the dropdown.
+            /// @param values The values to show.
+            void set_values(const std::vector<std::wstring>& values);
+
+            /// Event raised when a value is selected. The selected value is passed as a parameter.
+            Event<std::wstring> on_value_selected;
+        protected:
+            virtual bool mouse_down(const Point&) override;
+            virtual bool mouse_up(const Point&) override;
+            virtual bool clicked(Point position) override;
+        private:
+            void update_dropdown();
+
+            std::vector<std::wstring> _values;
+            ui::Label*                _label;
+            ui::StackPanel*           _dropdown;
+        };
+    }
+}

--- a/trview.ui/Dropdown.h
+++ b/trview.ui/Dropdown.h
@@ -4,7 +4,7 @@
 #include <string>
 
 #include "Window.h"
-#include "Label.h"
+#include "Button.h"
 
 namespace trview
 {
@@ -32,17 +32,17 @@ namespace trview
             /// @param values The values to show.
             void set_values(const std::vector<std::wstring>& values);
 
+            /// Set the selected value. This will not raise the on_value_selected event.
+            /// @param value The new value.
+            void set_selected_value(const std::wstring& value);
+
             /// Event raised when a value is selected. The selected value is passed as a parameter.
             Event<std::wstring> on_value_selected;
-        protected:
-            virtual bool mouse_down(const Point&) override;
-            virtual bool mouse_up(const Point&) override;
-            virtual bool clicked(Point position) override;
         private:
             void update_dropdown();
 
             std::vector<std::wstring> _values;
-            ui::Label*                _label;
+            ui::Button*               _button;
             ui::StackPanel*           _dropdown;
         };
     }

--- a/trview.ui/trview.ui.vcxproj
+++ b/trview.ui/trview.ui.vcxproj
@@ -22,6 +22,7 @@
     <ClInclude Include="Align.h" />
     <ClInclude Include="Button.h" />
     <ClInclude Include="Control.h" />
+    <ClInclude Include="Dropdown.h" />
     <ClInclude Include="GroupBox.h" />
     <ClInclude Include="Image.h" />
     <ClInclude Include="Label.h" />
@@ -38,6 +39,7 @@
   <ItemGroup>
     <ClCompile Include="Button.cpp" />
     <ClCompile Include="Control.cpp" />
+    <ClCompile Include="Dropdown.cpp" />
     <ClCompile Include="GroupBox.cpp" />
     <ClCompile Include="Image.cpp" />
     <ClCompile Include="Label.cpp" />

--- a/trview.ui/trview.ui.vcxproj.filters
+++ b/trview.ui/trview.ui.vcxproj.filters
@@ -46,6 +46,9 @@
     <ClInclude Include="Scrollbar.h">
       <Filter>Controls\Scrollbar</Filter>
     </ClInclude>
+    <ClInclude Include="Dropdown.h">
+      <Filter>Controls\Dropdown</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Control.cpp">
@@ -93,6 +96,9 @@
     <ClCompile Include="ListboxColumn.cpp">
       <Filter>Controls\Listbox</Filter>
     </ClCompile>
+    <ClCompile Include="Dropdown.cpp">
+      <Filter>Controls\Dropdown</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Types">
@@ -106,6 +112,9 @@
     </Filter>
     <Filter Include="Controls\Scrollbar">
       <UniqueIdentifier>{148c0414-eb8e-4d27-8c1c-8b53340436dd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Controls\Dropdown">
+      <UniqueIdentifier>{07f12ab6-b126-4ef8-b58d-9a1ef6abb44b}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Add a filter drop-down box to the triggers window. This filters the list of triggers to only those that contain the selected command.
The command filter is populated with 'All' and any commands that are present in the triggers in the level.
Had to add z sorting for the UI to support the new dropdown control.
Issue: #120 