### PR TITLE
Select the Lara item when 'Go to Lara' option is enabled

### DIFF
--- a/trview.app/Item.h
+++ b/trview.app/Item.h
@@ -10,6 +10,9 @@ namespace trview
     class Item final
     {
     public:
+        /// Default constructor for item.
+        Item() = default;
+
         /// Create an item.
         /// @param number The item number in the level.
         /// @param room The room number the item is in.
@@ -57,11 +60,11 @@ namespace trview
         const std::vector<Trigger*>& triggers() const;
     private:
         std::vector<Trigger*> _triggers;
-        uint32_t _number;
-        uint32_t _room;
-        uint32_t _type_id;
+        uint32_t _number{ 0u };
+        uint32_t _room{ 0u };
+        uint32_t _type_id{ 0u };
         std::wstring _type;
-        uint32_t _ocb;
-        uint16_t _flags;
+        uint32_t _ocb{ 0u };
+        uint16_t _flags{ 0u };
     };
 }

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -520,4 +520,16 @@ namespace trview
     {
         return *_texture_storage;
     }
+
+    bool find_item_by_type_id(const Level& level, uint32_t type_id, Item& output_item)
+    {
+        const auto& items = level.items();
+        auto found_item = std::find_if(items.begin(), items.end(), [=](const auto& item) { return item.type_id() == type_id; });
+        if (found_item == items.end())
+        {
+            return false;
+        }
+        output_item = *found_item;
+        return true;
+    }
 }

--- a/trview/Level.h
+++ b/trview/Level.h
@@ -183,4 +183,11 @@ namespace trview
 
         std::unique_ptr<SelectionRenderer> _selection_renderer;
     };
+
+    /// Find the first item with the type id specified.
+    /// @param level The level to search.
+    /// @param type_id The type id to search for.
+    /// @param output_item The item to output the result into.
+    /// @returns True if the item was found.
+    bool find_item_by_type_id(const Level& level, uint32_t type_id, Item& output_item);
 }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -481,10 +481,10 @@ namespace trview
         _room_navigator->set_flip(false);
         _room_navigator->set_flip_enabled(_level->any_alternates());
 
-        trlevel::tr2_entity lara_entity;
-        if (_settings.go_to_lara && _current_level->find_first_entity_by_type(0, lara_entity))
+        Item lara;
+        if (_settings.go_to_lara && find_item_by_type_id(*_level, 0u, lara))
         {
-            select_room(lara_entity.Room);
+            select_item(lara);
         }
         else
         {


### PR DESCRIPTION
Instead of just selecting the room that contains Lara, actually select the Lara item.
Issue: #368