### PR TITLE
Add option for auto-orbit on selection

### DIFF
--- a/trview/SettingsWindow.cpp
+++ b/trview/SettingsWindow.cpp
@@ -51,6 +51,10 @@ namespace trview
         triggers_startup->on_state_changed += on_triggers_startup;
         _triggers_startup = panel->add_child(std::move(triggers_startup));
 
+        auto auto_orbit = std::make_unique<Checkbox>(Point(), Size(16, 16), L"Switch to orbit on selection");
+        auto_orbit->on_state_changed += on_auto_orbit;
+        _auto_orbit = panel->add_child(std::move(auto_orbit));
+
         auto ok = std::make_unique<Button>(Point(), Size(60, 20), L"Close");
         ok->set_horizontal_alignment(Align::Centre);
         _token_store.add(ok->on_click += [&]() { _window->set_visible(!_window->visible()); });
@@ -95,6 +99,11 @@ namespace trview
     void SettingsWindow::set_triggers_startup(bool value)
     {
         _triggers_startup->set_state(value);
+    }
+
+    void SettingsWindow::set_auto_orbit(bool value)
+    {
+        _auto_orbit->set_state(value);
     }
 
     void SettingsWindow::toggle_visibility()

--- a/trview/SettingsWindow.h
+++ b/trview/SettingsWindow.h
@@ -38,6 +38,9 @@ namespace trview
         /// Event raised when the 'triggers window at startup' setting has been changed. The new setting is passed as the parameter.
         Event<bool> on_triggers_startup;
 
+        /// Event raised when the 'Switch to orbit on selection' setting has been changed. The new setting is passed as the parameter.
+        Event<bool> on_auto_orbit;
+
         /// Set the new value of the vsync setting. This will not raise the on_vsync event.
         /// @param value The new vsync setting.
         void set_vsync(bool value);
@@ -58,6 +61,10 @@ namespace trview
         /// @param value The new 'triggers window at startup' setting.
         void set_triggers_startup(bool value);
 
+        /// Set the new value of the 'Switch to orbit on selection' setting. This will not raise the on_auto_orbit event.
+        /// @param value The new 'Switch to orbit on selection' setting.
+        void set_auto_orbit(bool value);
+
         /// Toggle the visibility of the settings window.
         void toggle_visibility();
     private:
@@ -66,6 +73,7 @@ namespace trview
         ui::Checkbox* _invert_map_controls;
         ui::Checkbox* _items_startup;
         ui::Checkbox* _triggers_startup;
+        ui::Checkbox* _auto_orbit;
         ui::Control* _window;
         TokenStore _token_store;
     };

--- a/trview/UserSettings.cpp
+++ b/trview/UserSettings.cpp
@@ -96,6 +96,10 @@ namespace trview
                 {
                     file >> settings.triggers_startup;
                 }
+                else if (setting == L"autoorbit")
+                {
+                    file >> settings.auto_orbit;
+                }
                 else if (setting == L"recent")
                 {
                     uint32_t recent_count = 0;
@@ -151,6 +155,7 @@ namespace trview
         file << L"invertmapcontrols " << settings.invert_map_controls << '\n';
         file << L"itemsstartup " << settings.items_startup << '\n';
         file << L"triggersstartup " << settings.triggers_startup << '\n';
+        file << L"autoorbit " << settings.auto_orbit << '\n';
         file << L"recent "  << settings.recent_files.size()     << '\n';
         for (const auto& file_name : settings.recent_files)
         {

--- a/trview/UserSettings.h
+++ b/trview/UserSettings.h
@@ -17,6 +17,7 @@ namespace trview
         bool                    invert_map_controls{ false };
         bool                    items_startup{ true };
         bool                    triggers_startup{ true };
+        bool                    auto_orbit{ true };
     };
 
     // Load the user settings from the settings file.

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -163,11 +163,17 @@ namespace trview
             _settings.triggers_startup = value;
             save_user_settings(_settings);
         });
+        _token_store.add(_settings_window->on_auto_orbit += [&](bool value)
+        {
+            _settings.auto_orbit = value;
+            save_user_settings(_settings);
+        });
         _settings_window->set_vsync(_settings.vsync);
         _settings_window->set_go_to_lara(_settings.go_to_lara);
         _settings_window->set_invert_map_controls(_settings.invert_map_controls);
         _settings_window->set_items_startup(_settings.items_startup);
         _settings_window->set_triggers_startup(_settings.triggers_startup);
+        _settings_window->set_auto_orbit(_settings.auto_orbit);
 
         // Create the renderer for the UI based on the controls created.
         _ui_renderer = std::make_unique<ui::render::Renderer>(_device.device(), *_shader_storage.get(), *_font_factory.get(), _window.size());
@@ -308,7 +314,11 @@ namespace trview
                             {
                                 select_trigger(_level->triggers()[_current_pick.index]);
                             }
-                            set_camera_mode(CameraMode::Orbit);
+
+                            if (_settings.auto_orbit)
+                            {
+                                set_camera_mode(CameraMode::Orbit);
+                            }
                         }
                     }
                 }
@@ -693,7 +703,10 @@ namespace trview
 
             _map_renderer->load(_level->room(_level->selected_room()));
 
-            set_camera_mode(CameraMode::Orbit);
+            if (_settings.auto_orbit)
+            {
+                set_camera_mode(CameraMode::Orbit);
+            }
 
             _target = _level->room(_level->selected_room())->centre();
 


### PR DESCRIPTION
This is enabled by default.
When disabled the camera will not automatically go into orbit mode when a room, item or trigger is selected.
Issue: #369