### PR TITLE
Add support for Tomb Raider 5 levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # trview
 
-trview is a level visualiser for Tomb Raider 1, 2, 3 and The Last Revelation 
-made with speedrunning in mind. This program is useful to quickly check how the 
-rooms are laid out, see the triggers present on them and analyse route
-possibilities.
+trview is a level visualiser for Tomb Raider 1 - 5 made with speedrunning 
+in mind. This program is useful to quickly check how the rooms are laid out,
+see the triggers present on them and analyse route possibilities.
 
 ![Screenshot](https://i.imgur.com/irC0Udm.png)
 
@@ -27,6 +26,6 @@ Build > Build Solution.
 
 ## Running
 
-Double click a level file (.TR2, .TR4 or .PHD) present in the game's data folder and
-choose to open it with trview.exe. You can also open trview by itself and choose
+Double click a level file (.TR2, .TR4, .TRC or .PHD) present in the game's data folder 
+and choose to open it with trview.exe. You can also open trview by itself and choose
 a level file using the File menu or drag and drop a level file onto the window.

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -537,13 +537,18 @@ namespace trlevel
             uint32_t leveldata_compressed = read<uint32_t>(file);
             load_level_data(file);
         }
-        /*
+
+        if (_version == LevelVersion::Tomb5)
+        {
+            skip(file, 6);
+        }
+
         uint32_t num_sound_samples = read<uint32_t>(file);
         std::vector<tr4_sample> sound_samples(num_sound_samples);
         for (uint32_t i = 0; i < num_sound_samples; ++i)
         {
             sound_samples[i].sound_data = read_compressed(file);
-        }*/
+        }
 
         generate_meshes(_mesh_data);
     }
@@ -690,11 +695,6 @@ namespace trlevel
 
                     vertex_offset += layer.num_vertices;
                 }
-
-                // file.seekg(room_start + vertices_offset, std::ios::beg);
-
-                // room.data.rectangles = convert_rectangles(read_vector<tr_face4>(file, num_room_rectangles));
-                // room.data.triangles = convert_triangles(read_vector<tr_face3>(file, num_room_triangles));
 
                 file.seekg(room_start + vertices_offset + 208, std::ios::beg);
 
@@ -891,9 +891,13 @@ namespace trlevel
         {
             _object_textures = read_vector<uint32_t, tr_object_texture>(file);
         }
-        if (get_version() >= LevelVersion::Tomb4)
+        if (get_version() == LevelVersion::Tomb4)
         {
             _object_textures = convert_object_textures(read_vector<uint32_t, tr4_object_texture>(file));
+        }
+        else if (get_version() == LevelVersion::Tomb5)
+        {
+            _object_textures = convert_object_textures(read_vector<uint32_t, tr5_object_texture>(file));
         }
 
         if (_version == LevelVersion::Tomb1)
@@ -941,7 +945,6 @@ namespace trlevel
             std::vector<int16_t> sound_map = read_vector<int16_t>(file, 450);
         }
 
-        return;
         std::vector<tr3_sound_details> sound_details = read_vector<uint32_t, tr3_sound_details>(file);
 
         if (_version == LevelVersion::Tomb1)

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -81,6 +81,18 @@ namespace trlevel
             data_stream.exceptions(std::ifstream::failbit | std::ifstream::badbit | std::ifstream::eofbit);
             return read_vector<DataType>(data_stream, elements);
         }
+
+        bool is_tr5(LevelVersion version, const std::wstring& filename)
+        {
+            if (version != LevelVersion::Tomb4)
+            {
+                return false;
+            }
+
+            std::wstring transformed;
+            std::transform(filename.begin(), filename.end(), std::back_inserter(transformed), toupper);
+            return transformed.find(L".TRC") != filename.npos;
+        }
     }
 
     Level::Level(const std::wstring& filename)
@@ -93,6 +105,10 @@ namespace trlevel
             file.open(filename.c_str(), std::ios::binary);
 
             _version = convert_level_version(read<uint32_t>(file));
+            if (is_tr5(_version, filename))
+            {
+                _version = LevelVersion::Tomb5;
+            }
 
             if (_version == LevelVersion::Tomb4)
             {

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -110,7 +110,7 @@ namespace trlevel
                 _version = LevelVersion::Tomb5;
             }
 
-            if (_version == LevelVersion::Tomb4)
+            if (_version >= LevelVersion::Tomb4)
             {
                 load_tr4(file);
                 return;
@@ -507,11 +507,26 @@ namespace trlevel
         _textile16 = read_vector_compressed<tr_textile16>(file, _num_textiles);
         auto textile32_misc = read_vector_compressed<tr_textile32>(file, 2);
 
-        std::vector<uint8_t> level_data = read_compressed(file);
-        std::string data(reinterpret_cast<char*>(&level_data[0]), level_data.size());
-        std::istringstream data_stream(data, std::ios::binary);
+        if (_version == LevelVersion::Tomb5)
+        {
+            uint16_t lara_type = read<uint16_t>(file);
+            uint16_t weather_type = read<uint16_t>(file);
+            file.seekg(28, std::ios::cur);
+        }
 
-        load_level_data(data_stream);
+        if (_version == LevelVersion::Tomb4)
+        {
+            std::vector<uint8_t> level_data = read_compressed(file);
+            std::string data(reinterpret_cast<char*>(&level_data[0]), level_data.size());
+            std::istringstream data_stream(data, std::ios::binary);
+            load_level_data(data_stream);
+        }
+        else
+        {
+            uint32_t leveldata_uncompressed = read<uint32_t>(file);
+            uint32_t leveldata_compressed = read<uint32_t>(file);
+            load_level_data(file);
+        }
 
         uint32_t num_sound_samples = read<uint32_t>(file);
         std::vector<tr4_sample> sound_samples(num_sound_samples);

--- a/trlevel/trtypes.cpp
+++ b/trlevel/trtypes.cpp
@@ -130,13 +130,7 @@ namespace trlevel
     {
         std::vector<tr_object_texture> new_object_textures;
         new_object_textures.reserve(object_textures.size());
-        std::transform(object_textures.begin(), object_textures.end(),
-            std::back_inserter(new_object_textures), [](const auto& texture)
-        {
-            tr_object_texture new_entity{ texture.Attribute, texture.TileAndFlag };
-            memcpy(new_entity.Vertices, texture.Vertices, sizeof(new_entity.Vertices));
-            return new_entity;
-        });
+        std::transform(object_textures.begin(), object_textures.end(), std::back_inserter(new_object_textures), convert_object_texture);
         return new_object_textures;
     }
 
@@ -145,12 +139,7 @@ namespace trlevel
         std::vector<tr_object_texture> new_object_textures;
         new_object_textures.reserve(object_textures.size());
         std::transform(object_textures.begin(), object_textures.end(),
-            std::back_inserter(new_object_textures), [](const auto& texture)
-        {
-            tr_object_texture new_entity{ texture.tr4_texture.Attribute, texture.tr4_texture.TileAndFlag };
-            memcpy(new_entity.Vertices, texture.tr4_texture.Vertices, sizeof(new_entity.Vertices));
-            return new_entity;
-        });
+            std::back_inserter(new_object_textures), [](const auto& texture) { return convert_object_texture(texture.tr4_texture); });
         return new_object_textures;
     }
 
@@ -193,7 +182,7 @@ namespace trlevel
         new_info.y = 0;
         new_info.z = room_info.z;
         new_info.yTop = room_info.yTop;
-        new_info.y = room_info.yBottom;
+        new_info.yBottom = room_info.yBottom;
         return new_info;
     }
 

--- a/trlevel/trtypes.cpp
+++ b/trlevel/trtypes.cpp
@@ -67,8 +67,7 @@ namespace trlevel
             std::back_inserter(new_vertices), [](const auto& vert)
         {
             tr_vertex vertex{ vert.vertex.x, vert.vertex.y, vert.vertex.z };
-            tr3_room_vertex new_vertex{ vertex, 0, 0, 0xffff };
-            return new_vertex;
+            return tr3_room_vertex { vertex, 0, 0, 0xffff };
         });
         return new_vertices;
     }
@@ -191,12 +190,7 @@ namespace trlevel
         std::vector<tr_model> new_models;
         new_models.reserve(models.size());
         std::transform(models.begin(), models.end(),
-            std::back_inserter(new_models), [](const auto& model)
-        {
-            tr_model new_model;
-            memcpy(&new_model, &model, sizeof(tr_model));
-            return new_model;
-        });
+            std::back_inserter(new_models), [](const auto& model) { return model.model; });
         return new_models;
     }
 }

--- a/trlevel/trtypes.cpp
+++ b/trlevel/trtypes.cpp
@@ -46,6 +46,20 @@ namespace trlevel
         return new_vertices;
     }
 
+    std::vector<tr3_room_vertex> convert_vertices(std::vector<tr5_room_vertex> vertices)
+    {
+        std::vector<tr3_room_vertex> new_vertices;
+        new_vertices.reserve(vertices.size());
+        std::transform(vertices.begin(), vertices.end(),
+            std::back_inserter(new_vertices), [](const auto& vert)
+        {
+            tr_vertex vertex{ vert.vertex.x, vert.vertex.y, vert.vertex.z };
+            tr3_room_vertex new_vertex{ vertex, 0, 0, 0xffff };
+            return new_vertex;
+        });
+        return new_vertices;
+    }
+
     // Convert a set of Tomb Raider I lights into a light format compatible
     // with Tomb Raider III (what the viewer is currently using).
     std::vector<tr3_room_light> convert_lights(std::vector<tr_room_light> lights)
@@ -143,5 +157,30 @@ namespace trlevel
             return new_face4;
         });
         return new_rectangles;
+    }
+
+    tr_room_info convert_room_info(const tr1_4_room_info& room_info)
+    {
+        tr_room_info new_info;
+        new_info.x = room_info.x;
+        new_info.y = 0;
+        new_info.z = room_info.z;
+        new_info.yTop = room_info.yTop;
+        new_info.y = room_info.yBottom;
+        return new_info;
+    }
+
+    std::vector<tr_model> convert_models(std::vector<tr5_model> models)
+    {
+        std::vector<tr_model> new_models;
+        new_models.reserve(models.size());
+        std::transform(models.begin(), models.end(),
+            std::back_inserter(new_models), [](const auto& model)
+        {
+            tr_model new_model;
+            memcpy(&new_model, &model, sizeof(tr_model));
+            return new_model;
+        });
+        return new_models;
     }
 }

--- a/trlevel/trtypes.cpp
+++ b/trlevel/trtypes.cpp
@@ -127,6 +127,20 @@ namespace trlevel
         return new_object_textures;
     }
 
+    std::vector<tr_object_texture> convert_object_textures(std::vector<tr5_object_texture> object_textures)
+    {
+        std::vector<tr_object_texture> new_object_textures;
+        new_object_textures.reserve(object_textures.size());
+        std::transform(object_textures.begin(), object_textures.end(),
+            std::back_inserter(new_object_textures), [](const auto& texture)
+        {
+            tr_object_texture new_entity{ texture.tr4_texture.Attribute, texture.tr4_texture.TileAndFlag };
+            memcpy(new_entity.Vertices, texture.tr4_texture.Vertices, sizeof(new_entity.Vertices));
+            return new_entity;
+        });
+        return new_object_textures;
+    }
+
     std::vector<tr4_mesh_face3> convert_triangles(std::vector<tr_face3> triangles)
     {
         std::vector<tr4_mesh_face3> new_triangles;

--- a/trlevel/trtypes.cpp
+++ b/trlevel/trtypes.cpp
@@ -4,6 +4,19 @@
 
 namespace trlevel
 {
+    namespace
+    {
+        /// Convert a tr4 object texture into a type that matches 1-3.
+        /// @param texture The texture to convert.
+        /// @returns The converted texture.
+        tr_object_texture convert_object_texture(const tr4_object_texture& texture)
+        {
+            tr_object_texture new_entity{ texture.Attribute, texture.TileAndFlag };
+            memcpy(new_entity.Vertices, texture.Vertices, sizeof(new_entity.Vertices));
+            return new_entity;
+        }
+    }
+
     uint32_t convert_textile32(uint32_t t)
     {
         uint32_t a = (t & 0xff000000) >> 24;

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -45,6 +45,15 @@ namespace trlevel
     struct tr_room_info
     {
         int32_t x;
+        int32_t y;
+        int32_t z;
+        int32_t yBottom;
+        int32_t yTop;
+    };
+
+    struct tr1_4_room_info
+    {
+        int32_t x;
         int32_t z;
         int32_t yBottom;
         int32_t yTop;
@@ -55,6 +64,13 @@ namespace trlevel
         int16_t x;
         int16_t y;
         int16_t z;
+    };
+
+    struct tr5_vertex
+    {
+        float x;
+        float y;
+        float z;
     };
 
     // Four vertices(the values are indices into the appropriate vertex list) and a texture(an index into 
@@ -194,6 +210,18 @@ namespace trlevel
         uint32_t FrameOffset;  // Byte offset into Frames[] (divide by 2 for Frames[i])
         uint16_t Animation;    // Offset into Animations[]
     };
+
+    struct tr5_model  // 18 bytes
+    {
+        uint32_t ID;           // Type Identifier (matched in Entities[])
+        uint16_t NumMeshes;    // Number of meshes in this object
+        uint16_t StartingMesh; // Starting mesh (offset into MeshPointers[])
+        uint32_t MeshTree;     // Offset into MeshTree[]
+        uint32_t FrameOffset;  // Byte offset into Frames[] (divide by 2 for Frames[i])
+        uint16_t Animation;    // Offset into Animations[]
+        uint16_t Filler;
+    };
+
 
     struct tr_bounding_box // 12 bytes
     {
@@ -388,6 +416,38 @@ namespace trlevel
         uint16_t    colour;
     };
 
+    struct tr5_room_vertex
+    {
+        tr5_vertex vertex;
+        tr5_vertex normal;
+        uint32_t   colour;
+    };
+
+    struct tr5_room_layer
+    {
+        uint16_t num_vertices;
+        uint16_t unknown1;
+        uint16_t unknown2;
+        uint16_t num_rectangles;
+        uint16_t num_triangles;
+        uint16_t unknown3;
+
+        uint16_t filler;
+        uint16_t filler2;
+
+        float    bb_x1;
+        float    bb_y1;
+        float    bb_z1;
+        float    bb_x2;
+        float    bb_y2;
+        float    bb_z2;
+
+        uint32_t filler3;
+        uint32_t unknown4;
+        uint32_t unknown5;
+        uint32_t unknown6;
+    };
+
     struct tr_room_portal
     {
         uint16_t  adjoining_room;
@@ -441,6 +501,23 @@ namespace trlevel
         float dx;
         float dy;
         float dz;
+    };
+
+    struct tr5_room_light
+    {
+        float x, y, z;
+        float r, g, b;
+        uint32_t separator;
+        float in;
+        float out;
+        float rad_in;
+        float rad_out;
+        float range;
+        float dx, dy, dz;
+        int32_t x2, y2, z2;
+        int32_t dx2, dy2, dz2;
+        uint8_t light_type;
+        uint8_t filler[3];
     };
 
     // Version of tr_room_staticmesh used in TR1/UB.
@@ -508,6 +585,7 @@ namespace trlevel
         uint16_t num_x_sectors;
         std::vector<tr_room_sector> sector_list;
 
+        uint32_t colour{ 0xffffffff };
         int16_t ambient_intensity_1;
         int16_t ambient_intensity_2;
         int16_t light_mode;
@@ -565,6 +643,12 @@ namespace trlevel
     // with Tomb Raider III (what the viewer is currently using).
     std::vector<tr3_room_vertex> convert_vertices(std::vector<tr_room_vertex> vertices);
 
+    /// Convert a set of Tomb Raider 5 vertices into a vertex format compatible
+    /// with Tomb Raider III (what the viewer is currently using).
+    /// @param vertices The vertices to convert.
+    /// @return The converted vertices.
+    std::vector<tr3_room_vertex> convert_vertices(std::vector<tr5_room_vertex> vertices);
+
     // Convert a set of Tomb Raider I lights into a light format compatible
     // with Tomb Raider III (what the viewer is currently using).
     std::vector<tr3_room_light> convert_lights(std::vector<tr_room_light> lights);
@@ -589,4 +673,11 @@ namespace trlevel
 
     // Convert a set of Tomb Raider I-III rectangles to TRIV rectangles.
     std::vector<tr4_mesh_face4> convert_rectangles(std::vector<tr_face4> rectangles);
+
+    /// Convert a pre TR5 room info into a TR5 room info.
+    /// @param room_info The room info to convert.
+    /// @returns The converted room info.
+    tr_room_info convert_room_info(const tr1_4_room_info& room_info);
+
+    std::vector<tr_model> convert_models(std::vector<tr5_model> models);
 }

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -401,6 +401,12 @@ namespace trlevel
         uint32_t               Height;    // Actually height-1
     };
 
+    struct tr5_object_texture
+    {
+        tr4_object_texture tr4_texture;
+        uint16_t           filler;
+    };
+
     // Room vertex for Tomb Raider 1/Unfinished Business.
     struct tr_room_vertex
     {
@@ -667,6 +673,11 @@ namespace trlevel
     // Convert a set of Tomb Raider IV object textures into a format compatible
     // with Tomb Raider III (what the viewer is currently using).
     std::vector<tr_object_texture> convert_object_textures(std::vector<tr4_object_texture> object_textures);
+
+    /// Convert a set of TR5 object textures into a format compatible with TR3 (what the viewer is currently using).
+    /// @param object_textures The textures to convert.
+    /// @returns The converted texture.
+    std::vector<tr_object_texture> convert_object_textures(std::vector<tr5_object_texture> object_textures);
 
     // Convert a set of Tomb Raider I-III triangles to TRIV triangles.
     std::vector<tr4_mesh_face3> convert_triangles(std::vector<tr_face3> triangles);

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -639,6 +639,47 @@ namespace trlevel
         std::vector<uint8_t> sound_data;
     };
 
+    struct tr5_room_header
+    {
+        uint8_t _1[4];
+        uint32_t end_sd_offset;
+        uint32_t start_sd_offset;
+        uint8_t _2[4];
+        uint32_t end_portal_offset;
+        tr_room_info info;
+        uint16_t num_z_sectors;
+        uint16_t num_x_sectors;
+        uint32_t colour;
+        uint16_t num_lights;
+        uint16_t num_static_meshes;
+        uint8_t reverb_info;
+        uint8_t alternate_group;
+        uint16_t water_scheme;
+        uint8_t _3[20];
+        uint16_t alternate_room;
+        uint16_t flags;
+        uint8_t _4[20];
+        float room_x;
+        float room_y;
+        float room_z;
+        uint8_t _5[24];
+        uint32_t num_room_triangles;
+        uint32_t num_room_rectangles;
+        uint8_t _6[4];
+        uint32_t light_data_size;
+        uint32_t num_lights2;
+        uint8_t _7[4];
+        float room_y_top;
+        float room_y_bottom;
+        uint32_t num_layers;
+        uint32_t layer_offset;
+        uint32_t vertices_offset;
+        uint32_t poly_offset;
+        uint32_t poly_offset2;
+        uint32_t vertices_size;
+        uint8_t _8[16];
+    };
+
     // Convert a 32 bit textile into a 32 bit argb value.
     uint32_t convert_textile32(uint32_t t);
 

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -211,15 +211,10 @@ namespace trlevel
         uint16_t Animation;    // Offset into Animations[]
     };
 
-    struct tr5_model  // 18 bytes
+    struct tr5_model
     {
-        uint32_t ID;           // Type Identifier (matched in Entities[])
-        uint16_t NumMeshes;    // Number of meshes in this object
-        uint16_t StartingMesh; // Starting mesh (offset into MeshPointers[])
-        uint32_t MeshTree;     // Offset into MeshTree[]
-        uint32_t FrameOffset;  // Byte offset into Frames[] (divide by 2 for Frames[i])
-        uint16_t Animation;    // Offset into Animations[]
-        uint16_t Filler;
+        tr_model model;
+        uint16_t filler;
     };
 
 
@@ -432,26 +427,13 @@ namespace trlevel
     struct tr5_room_layer
     {
         uint16_t num_vertices;
-        uint16_t unknown1;
-        uint16_t unknown2;
+        uint16_t _1[2];
         uint16_t num_rectangles;
         uint16_t num_triangles;
-        uint16_t unknown3;
-
-        uint16_t filler;
-        uint16_t filler2;
-
-        float    bb_x1;
-        float    bb_y1;
-        float    bb_z1;
-        float    bb_x2;
-        float    bb_y2;
-        float    bb_z2;
-
-        uint32_t filler3;
-        uint32_t unknown4;
-        uint32_t unknown5;
-        uint32_t unknown6;
+        uint16_t _2[3];
+        tr5_vertex bounding_box_min;
+        tr5_vertex bounding_box_max;
+        uint32_t _3[4];
     };
 
     struct tr_room_portal
@@ -511,7 +493,7 @@ namespace trlevel
 
     struct tr5_room_light
     {
-        float x, y, z;
+        tr5_vertex position;
         float r, g, b;
         uint32_t separator;
         float in;
@@ -519,7 +501,7 @@ namespace trlevel
         float rad_in;
         float rad_out;
         float range;
-        float dx, dy, dz;
+        tr5_vertex direction;
         int32_t x2, y2, z2;
         int32_t dx2, dy2, dz2;
         uint8_t light_type;

--- a/trview.app/Mesh.h
+++ b/trview.app/Mesh.h
@@ -58,7 +58,7 @@ namespace trview
     /// @param texture_storage The textures for the level.
     /// @param transparent_collision Whether to include transparent triangles in collision triangles.
     /// @returns The new mesh.
-    std::unique_ptr<Mesh> create_mesh(trlevel::LevelVersion level_version, trlevel::tr_mesh& mesh, const Microsoft::WRL::ComPtr<ID3D11Device>& device, const ILevelTextureStorage& texture_storage, bool transparent_collision = true);
+    std::unique_ptr<Mesh> create_mesh(trlevel::LevelVersion level_version, const trlevel::tr_mesh& mesh, const Microsoft::WRL::ComPtr<ID3D11Device>& device, const ILevelTextureStorage& texture_storage, bool transparent_collision = true);
 
     /// Create a new cube mesh.
     std::unique_ptr<Mesh> create_cube_mesh(const Microsoft::WRL::ComPtr<ID3D11Device>& device);

--- a/trview.app/Mesh.h
+++ b/trview.app/Mesh.h
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include <trlevel/trtypes.h>
+#include <trlevel/LevelVersion.h>
 
 #include "MeshVertex.h"
 #include "TransparentTriangle.h"
@@ -51,17 +52,19 @@ namespace trview
     };
 
     /// Create a new mesh based on the contents of the mesh specified.
+    /// @param level_version The level version - affects texture index
     /// @param mesh The level mesh to generate.
     /// @param device The D3D device to use to create the mesh.
     /// @param texture_storage The textures for the level.
     /// @param transparent_collision Whether to include transparent triangles in collision triangles.
     /// @returns The new mesh.
-    std::unique_ptr<Mesh> create_mesh(const trlevel::tr_mesh& mesh, const Microsoft::WRL::ComPtr<ID3D11Device>& device, const ILevelTextureStorage& texture_storage, bool transparent_collision = true);
+    std::unique_ptr<Mesh> create_mesh(trlevel::LevelVersion level_version, trlevel::tr_mesh& mesh, const Microsoft::WRL::ComPtr<ID3D11Device>& device, const ILevelTextureStorage& texture_storage, bool transparent_collision = true);
 
     /// Create a new cube mesh.
     std::unique_ptr<Mesh> create_cube_mesh(const Microsoft::WRL::ComPtr<ID3D11Device>& device);
 
     /// Convert the textured rectangles into collections required to create a mesh.
+    /// @param level_version The level version - affects texture index.
     /// @param rectangles The rectangles from the mesh or room geometry.
     /// @param input_vertices The vertices that the rectangle indices refer to.
     /// @param texture_storage The texture storage for the level.
@@ -71,6 +74,7 @@ namespace trview
     /// @param collision_triangles The collection to add collision triangles to.
     /// @param transparent_collision Whether to add transparent rectangles as collision triangles.
     void process_textured_rectangles(
+        trlevel::LevelVersion level_version,
         const std::vector<trlevel::tr4_mesh_face4>& rectangles, 
         const std::vector<trlevel::tr_vertex>& input_vertices, 
         const ILevelTextureStorage& texture_storage,
@@ -90,6 +94,7 @@ namespace trview
     /// @param collision_triangles The collection to add collision triangles to.
     /// @param transparent_collision Whether to add transparent rectangles as collision triangles.
     void process_textured_triangles(
+        trlevel::LevelVersion level_version,
         const std::vector<trlevel::tr4_mesh_face3>& triangles,
         const std::vector<trlevel::tr_vertex>& input_vertices,
         const ILevelTextureStorage& texture_storage,

--- a/trview/MeshStorage.cpp
+++ b/trview/MeshStorage.cpp
@@ -17,7 +17,7 @@ namespace trview
         }
 
         auto level_mesh = _level.get_mesh_by_pointer(mesh_pointer);
-        auto new_mesh = create_mesh(level_mesh, _device, _texture_storage);
+        auto new_mesh = create_mesh(_level.get_version(), level_mesh, _device, _texture_storage);
         Mesh* mesh = new_mesh.get();
         _meshes.insert({ mesh_pointer, std::move(new_mesh) });
         return mesh;

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -42,7 +42,7 @@ namespace trview
         _alternate_mode = room.alternate_room != -1 ? AlternateMode::HasAlternate : AlternateMode::None;
 
         _room_offset = Matrix::CreateTranslation(room.info.x / trlevel::Scale_X, 0, room.info.z / trlevel::Scale_Z);
-        generate_geometry(device, room, texture_storage);
+        generate_geometry(level.get_version(), device, room, texture_storage);
         generate_sectors(level, room);
         generate_adjacency();
         generate_static_meshes(level, room, mesh_storage);
@@ -171,7 +171,7 @@ namespace trview
         }
     }
 
-    void Room::generate_geometry(const ComPtr<ID3D11Device>& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage)
+    void Room::generate_geometry(trlevel::LevelVersion level_version, const ComPtr<ID3D11Device>& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage)
     {
         std::vector<trlevel::tr_vertex> room_vertices;
         std::transform(room.data.vertices.begin(), room.data.vertices.end(), std::back_inserter(room_vertices),
@@ -184,8 +184,8 @@ namespace trview
         std::vector<std::vector<uint32_t>> indices(texture_storage.num_tiles());
         std::vector<Triangle> collision_triangles;
 
-        process_textured_rectangles(room.data.rectangles, room_vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
-        process_textured_triangles(room.data.triangles, room_vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
+        process_textured_rectangles(level_version, room.data.rectangles, room_vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
+        process_textured_triangles(level_version, room.data.triangles, room_vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
 
         _mesh = std::make_unique<Mesh>(device, vertices, indices, std::vector<uint32_t>(), transparent_triangles, collision_triangles);
         

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -133,7 +133,7 @@ namespace trview
         /// @returns The bounding box for the room.
         const DirectX::BoundingBox& bounding_box() const;
     private:
-        void generate_geometry(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage);
+        void generate_geometry(trlevel::LevelVersion level_version, const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage);
         void generate_adjacency();
         void generate_static_meshes(const trlevel::ILevel& level, const trlevel::tr3_room& room, const IMeshStorage& mesh_storage);
         void render_contained(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour);


### PR DESCRIPTION
Load Tomb Raider 5 levels.
Tomb Raider 5 rooms are the main difference. Split room loading into a 1-4 version and a 5 version. TR5 version of structs added and converted to what we use.
Texture mask function added to meshes as the mask is different for 4 and 1-3&5.
Issue: #137 