### PR TITLE
Convert settings object to json

### DIFF
--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <sstream>
 #include <iterator>
+#include <trview.common/Strings.h>
 
 #include <external/zlib/zlib.h>
 
@@ -262,17 +263,20 @@ namespace trlevel
         }
     }
 
-    Level::Level(const std::wstring& filename)
+    Level::Level(const std::string& filename)
     {
         // Load the level from the file.
         try
         {
+            // Convert the filename to UTF-16
+            auto converted = trview::to_utf16(filename);
+
             std::ifstream file;
             file.exceptions(std::ifstream::failbit | std::ifstream::badbit | std::ifstream::eofbit);
-            file.open(filename.c_str(), std::ios::binary);
+            file.open(converted.c_str(), std::ios::binary);
 
             _version = convert_level_version(read<uint32_t>(file));
-            if (is_tr5(_version, filename))
+            if (is_tr5(_version, converted))
             {
                 _version = LevelVersion::Tomb5;
             }

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -13,7 +13,7 @@ namespace trlevel
     class Level : public ILevel
     {
     public:
-        explicit Level(const std::wstring& filename);
+        explicit Level(const std::string& filename);
 
         virtual ~Level();
 

--- a/trlevel/trlevel.cpp
+++ b/trlevel/trlevel.cpp
@@ -3,7 +3,7 @@
 
 namespace trlevel
 {
-    std::unique_ptr<ILevel> load_level(const std::wstring& filename)
+    std::unique_ptr<ILevel> load_level(const std::string& filename)
     {
         return std::make_unique<Level>(filename);
     }

--- a/trlevel/trlevel.h
+++ b/trlevel/trlevel.h
@@ -9,5 +9,5 @@ namespace trlevel
 {
     // Load the level at the specified location.
     // Returns: The loaded level.
-    std::unique_ptr<ILevel> load_level(const std::wstring& filename);
+    std::unique_ptr<ILevel> load_level(const std::string& filename);
 }

--- a/trview.app.tests/FileDropperTests.cpp
+++ b/trview.app.tests/FileDropperTests.cpp
@@ -34,7 +34,7 @@ namespace trview
                 FileDropper dropper(window);
 
                 uint32_t times_called = 0;
-                std::wstring file_opened;
+                std::string file_opened;
                 auto token = dropper.on_file_dropped += [&](const auto& file)
                 {
                     ++times_called;
@@ -54,7 +54,7 @@ namespace trview
                 GlobalFree(global);
 
                 Assert::AreEqual(1u, times_called);
-                Assert::AreEqual(std::wstring(L"test_filename"), file_opened);
+                Assert::AreEqual(std::string("test_filename"), file_opened);
             }
 
             // Tests that the class enables drag and drop

--- a/trview.app.tests/RecentFilesTests.cpp
+++ b/trview.app.tests/RecentFilesTests.cpp
@@ -17,11 +17,11 @@ namespace trview
                 HWND window = create_test_window(L"TRViewRecentFilesTests");
                 RecentFiles recent_files(window);
 
-                const std::list<std::wstring> files{ L"test.tr2", L"test2.tr2" };
+                const std::list<std::string> files{ "test.tr2", "test2.tr2" };
                 recent_files.set_recent_files(files);
 
                 uint32_t times_called{ 0 };
-                std::wstring raised_file;
+                std::string raised_file;
                 auto token = recent_files.on_file_open += [&](const auto& file)
                 {
                     ++times_called;
@@ -30,7 +30,7 @@ namespace trview
 
                 recent_files.process_message(window, WM_COMMAND, MAKEWPARAM(5000, 0), 0);
                 Assert::AreEqual(1u, times_called);
-                Assert::AreEqual(std::wstring(L"test2.tr2"), files.back());
+                Assert::AreEqual(std::string("test2.tr2"), files.back());
             }
         };
     }

--- a/trview.app/FileDropper.cpp
+++ b/trview.app/FileDropper.cpp
@@ -1,4 +1,5 @@
 #include "FileDropper.h"
+#include <trview.common/Strings.h>
 
 namespace trview
 {
@@ -16,7 +17,7 @@ namespace trview
             wchar_t filename[MAX_PATH];
             memset(&filename, 0, sizeof(filename));
             DragQueryFile((HDROP)wParam, 0, filename, MAX_PATH);
-            on_file_dropped(filename);
+            on_file_dropped(to_utf8(filename));
         }
     }
 }

--- a/trview.app/FileDropper.h
+++ b/trview.app/FileDropper.h
@@ -28,6 +28,6 @@ namespace trview
         virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Event raised when the user drops a file on to the window. The file dropped is passed as a parameter.
-        Event<std::wstring> on_file_dropped;
+        Event<std::string> on_file_dropped;
     };
 }

--- a/trview.app/RecentFiles.cpp
+++ b/trview.app/RecentFiles.cpp
@@ -1,5 +1,6 @@
 #include "RecentFiles.h"
 #include "WindowIDs.h"
+#include <trview.common/Strings.h>
 
 namespace trview
 {
@@ -7,7 +8,7 @@ namespace trview
     {
         const int ID_RECENT_FILE_BASE = 5000;
 
-        void update_menu(HWND window, const std::vector<std::wstring>& recent_files)
+        void update_menu(HWND window, const std::vector<std::string>& recent_files)
         {
             // Set up the recently used files menu.
             HMENU menu = GetMenu(window);
@@ -15,7 +16,7 @@ namespace trview
 
             for (int i = 0; i < recent_files.size(); ++i)
             {
-                AppendMenu(popup, MF_STRING, ID_RECENT_FILE_BASE + i, recent_files[i].c_str());
+                AppendMenu(popup, MF_STRING, ID_RECENT_FILE_BASE + i, to_utf16(recent_files[i]).c_str());
             }
 
             MENUITEMINFO info;
@@ -49,7 +50,7 @@ namespace trview
         }
     }
 
-    void RecentFiles::set_recent_files(const std::list<std::wstring>& files)
+    void RecentFiles::set_recent_files(const std::list<std::string>& files)
     {
         _recent_files.assign(files.begin(), files.end());
         update_menu(window(), _recent_files);

--- a/trview.app/RecentFiles.h
+++ b/trview.app/RecentFiles.h
@@ -31,12 +31,12 @@ namespace trview
 
         /// Event raised when the user opens a file from the recent files list. The file that was opened
         /// is passed as a parameter.
-        Event<std::wstring> on_file_open;
+        Event<std::string> on_file_open;
 
         /// Set the current list of recent files.
         /// @param files The list of recent files.
-        void set_recent_files(const std::list<std::wstring>& files);
+        void set_recent_files(const std::list<std::string>& files);
     private:
-        std::vector<std::wstring> _recent_files;
+        std::vector<std::string> _recent_files;
     };
 }

--- a/trview.common/Strings.cpp
+++ b/trview.common/Strings.cpp
@@ -1,0 +1,26 @@
+#include "Strings.h"
+#include <vector>
+#include <Windows.h>
+
+namespace trview
+{
+    std::string to_utf8(const std::wstring& value)
+    {
+        std::vector<char> output(WideCharToMultiByte(CP_UTF8, 0, value.c_str(), -1, nullptr, 0, nullptr, nullptr), 0);
+        if (!output.empty())
+        {
+            WideCharToMultiByte(CP_UTF8, 0, value.c_str(), -1, &output[0], output.size(), nullptr, nullptr);
+        }
+        return &output[0];
+    }
+
+    std::wstring to_utf16(const std::string& value)
+    {
+        std::vector<wchar_t> output(MultiByteToWideChar(CP_UTF8, 0, value.c_str(), -1, nullptr, 0), 0);
+        if (!output.empty())
+        {
+            MultiByteToWideChar(CP_UTF8, 0, value.c_str(), -1, &output[0], output.size());
+        }
+        return &output[0];
+    }
+}

--- a/trview.common/Strings.h
+++ b/trview.common/Strings.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+namespace trview
+{
+    /// Convert the specified string to utf-8.
+    /// @param value The UTF-16 value to convert.
+    /// @returns The converted string.
+    std::string to_utf8(const std::wstring& value);
+
+    /// Convert the specified string to utf-16.
+    /// @param value The utf-8 value to convert.
+    /// @returns The converted string.
+    std::wstring to_utf16(const std::string& value);
+}

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -25,6 +25,7 @@
     <ClInclude Include="MessageHandler.h" />
     <ClInclude Include="Point.h" />
     <ClInclude Include="Size.h" />
+    <ClInclude Include="Strings.h" />
     <ClInclude Include="Timer.h" />
     <ClInclude Include="TokenStore.h" />
     <ClInclude Include="Window.h" />
@@ -36,6 +37,7 @@
     <ClCompile Include="MessageHandler.cpp" />
     <ClCompile Include="Point.cpp" />
     <ClCompile Include="Size.cpp" />
+    <ClCompile Include="Strings.cpp" />
     <ClCompile Include="Timer.cpp" />
     <ClCompile Include="TokenStore.cpp" />
     <ClCompile Include="Window.cpp" />

--- a/trview.common/trview.common.vcxproj.filters
+++ b/trview.common/trview.common.vcxproj.filters
@@ -16,6 +16,7 @@
     <ClInclude Include="TokenStore.h">
       <Filter>Events</Filter>
     </ClInclude>
+    <ClInclude Include="Strings.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FileLoader.cpp" />
@@ -33,6 +34,7 @@
     <ClCompile Include="TokenStore.cpp">
       <Filter>Events</Filter>
     </ClCompile>
+    <ClCompile Include="Strings.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview/DirectoryListing.h
+++ b/trview/DirectoryListing.h
@@ -8,7 +8,7 @@ namespace trview
 
 struct File
 {
-    std::wstring path, friendly_name; 
+    std::string path, friendly_name; 
     uint32_t size; 
 };
 
@@ -17,13 +17,13 @@ class DirectoryListing
 public:
     /// Create a new directory listing.
     /// @param path The directory to get the file listing from.
-    explicit DirectoryListing(const std::wstring& path);
+    explicit DirectoryListing(const std::string& path);
 
     /// Gets a list of files in the directory.
     /// @pattern Comma separated list of file filters.
     /// @returns An empty vector if no path has been set, otherwise 
     ///          the files in the directory.
-    std::vector<File> GetFiles(const std::wstring& pattern=L"\\*.TR*,\\*.PHD") const; 
+    std::vector<File> GetFiles(const std::string& pattern="\\*.TR*,\\*.PHD") const; 
 private:
     std::vector<File> GetFiles(const std::vector<std::wstring>& patterns) const;
 

--- a/trview/LevelInfo.cpp
+++ b/trview/LevelInfo.cpp
@@ -7,6 +7,7 @@
 #include <trview.ui/StackPanel.h>
 #include <trview.ui/Button.h>
 #include <trview.app/ITextureStorage.h>
+#include <trview.common/Strings.h>
 
 namespace trview
 {
@@ -62,9 +63,9 @@ namespace trview
 
     // Set the name of the level.
     // name: The level name.
-    void LevelInfo::set_level(const std::wstring& name)
+    void LevelInfo::set_level(const std::string& name)
     {
-        _name->set_text(name);
+        _name->set_text(to_utf16(name));
     }
 
     // Set the version of the game that level was created for.

--- a/trview/LevelInfo.h
+++ b/trview/LevelInfo.h
@@ -38,7 +38,7 @@ namespace trview
 
         /// Sets the name of the level.
         /// @param name The level name.
-        void set_level(const std::wstring& name);
+        void set_level(const std::string& name);
 
         /// Set the version of the game that level was created for.
         /// @param version The version of the game.

--- a/trview/LevelSwitcher.cpp
+++ b/trview/LevelSwitcher.cpp
@@ -2,6 +2,7 @@
 #include "LevelSwitcher.h"
 #include "resource.h"
 #include "DirectoryListing.h"
+#include <trview.common/Strings.h>
 
 namespace trview
 {
@@ -66,10 +67,10 @@ namespace trview
         }
     }
 
-    void LevelSwitcher::open_file(const std::wstring& filepath)
+    void LevelSwitcher::open_file(const std::string& filepath)
     {
-        const std::size_t pos = filepath.find_last_of(L"\\/");
-        const std::wstring folder = filepath.substr(0, pos);
+        const std::size_t pos = filepath.find_last_of("\\/");
+        const std::string folder = filepath.substr(0, pos);
 
         DirectoryListing dir_lister(folder);
         _file_switcher_list = dir_lister.GetFiles();
@@ -81,7 +82,7 @@ namespace trview
         reset_menu(window(), _directory_listing_menu);
         for (int i = 0; i < _file_switcher_list.size(); ++i)
         {
-            AppendMenuW(_directory_listing_menu, MF_STRING, ID_SWITCHFILE_BASE + i, _file_switcher_list[i].friendly_name.c_str());
+            AppendMenu(_directory_listing_menu, MF_STRING, ID_SWITCHFILE_BASE + i, to_utf16(_file_switcher_list[i].friendly_name).c_str());
         }
 
         DrawMenuBar(window());

--- a/trview/LevelSwitcher.h
+++ b/trview/LevelSwitcher.h
@@ -33,10 +33,10 @@ namespace trview
 
         /// Open the specified file. This will populate the switcher menu.
         /// @param filename The file that was opened.
-        void open_file(const std::wstring& filename);
+        void open_file(const std::string& filename);
 
         /// Event raised when the user switches level. The opened level is passed as a parameter.
-        Event<std::wstring> on_switch_level;
+        Event<std::string> on_switch_level;
     private:
 
         HMENU             _directory_listing_menu;

--- a/trview/UserSettings.h
+++ b/trview/UserSettings.h
@@ -7,9 +7,9 @@ namespace trview
 {
     struct UserSettings
     {
-        void add_recent_file(const std::wstring& file);
+        void add_recent_file(const std::string& file);
 
-        std::list<std::wstring> recent_files;
+        std::list<std::string>  recent_files;
         float                   camera_sensitivity{ 0 };
         float                   camera_movement_speed{ 0 };
         bool                    vsync{ true };

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -29,8 +29,6 @@
 #include "TextureStorage.h"
 #include "SettingsWindow.h"
 
-#include <trview.common/Strings.h>
-
 namespace trview
 {
     namespace
@@ -509,7 +507,7 @@ namespace trview
         // Strip the last part of the path away.
         auto last_index = std::min(filename.find_last_of('\\'), filename.find_last_of('/'));
         auto name = last_index == filename.npos ? filename : filename.substr(std::min(last_index + 1, filename.size()));
-        _level_info->set_level(to_utf16(name));
+        _level_info->set_level(name);
         _level_info->set_level_version(_current_level->get_version());
         _measure->reset();
     }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -29,6 +29,8 @@
 #include "TextureStorage.h"
 #include "SettingsWindow.h"
 
+#include <trview.common/Strings.h>
+
 namespace trview
 {
     namespace
@@ -453,7 +455,7 @@ namespace trview
         }
     }
 
-    void Viewer::open(const std::wstring filename)
+    void Viewer::open(const std::string& filename)
     {
         try
         {
@@ -507,7 +509,7 @@ namespace trview
         // Strip the last part of the path away.
         auto last_index = std::min(filename.find_last_of('\\'), filename.find_last_of('/'));
         auto name = last_index == filename.npos ? filename : filename.substr(std::min(last_index + 1, filename.size()));
-        _level_info->set_level(name);
+        _level_info->set_level(to_utf16(name));
         _level_info->set_level_version(_current_level->get_version());
         _measure->reset();
     }

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -79,7 +79,7 @@ namespace trview
 
         /// Attempt to open the specified level file.
         /// @param filename The level file to open.
-        void open(const std::wstring filename);
+        void open(const std::string& filename);
 
         /// Get the current user settings.
         /// @returns The current settings.
@@ -87,11 +87,11 @@ namespace trview
 
         /// Event raised when a level file is successfully opened.
         /// @remarks The filename is passed as a parameter to the listener functions.
-        Event<std::wstring> on_file_loaded;
+        Event<std::string> on_file_loaded;
 
         /// Event raised when the recent files list is updated.
         /// @remarks The list of filenames is passed as a parameter to the listener functions.
-        Event<std::list<std::wstring>> on_recent_files_changed;
+        Event<std::list<std::string>> on_recent_files_changed;
     private:
         void generate_ui();
         void generate_tool_window();

--- a/trview/trview.cpp
+++ b/trview/trview.cpp
@@ -10,6 +10,7 @@
 #include <commdlg.h>
 #include <shellapi.h>
 #include <Shlwapi.h>
+#include <trview.common/Strings.h>
 
 #define MAX_LOADSTRING 100
 
@@ -70,7 +71,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
     const LPWSTR* const arguments = CommandLineToArgvW(GetCommandLine(), &number_of_arguments);
     if (number_of_arguments > 1)
     {
-        viewer->open(arguments[1]);
+        viewer->open(trview::to_utf8(arguments[1]));
     }
 
     MSG msg;
@@ -198,7 +199,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                 if (GetOpenFileName(&ofn))
                 {
                     SetCurrentDirectory(cd);
-                    viewer->open(ofn.lpstrFile);
+                    viewer->open(trview::to_utf8(ofn.lpstrFile));
                 }
                 break;
             } 


### PR DESCRIPTION
Use json instead of the custom settings parser.
A knock on effect of this is as the json library uses utf-8, we have to store the recent filenames as utf-8. This is ok, but that means we have to convert the utf-16 we get back from Windows to utf-8 (and the other way around).
Unfortunately the format change means that user will lose their saved settings, but it shouldn't happen in the future as the format won't be changed.
Issue: #328 