### PR TITLE
Improve the triggers filter

### DIFF
--- a/trview.ui.render/Renderer.cpp
+++ b/trview.ui.render/Renderer.cpp
@@ -69,7 +69,7 @@ namespace trview
                 }
 
                 // Process the child nodes and build the structure to match the UI model.
-                auto children = control->child_elements();
+                auto children = control->child_elements(true);
                 for (auto child : children)
                 {
                     node->add_child(process_control(child));
@@ -79,7 +79,7 @@ namespace trview
                 _token_store.add(control->on_hierarchy_changed += [this, control, node_ptr]()
                 {
                     node_ptr->clear_children();
-                    auto children = control->child_elements();
+                    auto children = control->child_elements(true);
                     for (auto child : children)
                     {
                         node_ptr->add_child(process_control(child));

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -183,7 +183,7 @@ namespace trview
         bool Control::inner_process_mouse_move(const Point& position)
         {
             // Bounds check - before child elements are checked.
-            if (!in_bounds(position, _size))
+            if (!visible() || !in_bounds(position, _size))
             {
                 return false;
             }
@@ -225,7 +225,7 @@ namespace trview
         bool Control::inner_process_mouse_up(const Point& position)
         {
             // Bounds check - before child elements are checked.
-            if (!in_bounds(position, _size))
+            if (!visible() || !in_bounds(position, _size))
             {
                 return false;
             }
@@ -258,7 +258,7 @@ namespace trview
         bool Control::inner_process_mouse_scroll(const Point& position, int delta)
         {
             // Bounds check - before child elements are checked.
-            if (!in_bounds(position, _size))
+            if (!visible() || !in_bounds(position, _size))
             {
                 return false;
             }
@@ -382,7 +382,7 @@ namespace trview
 
         bool Control::is_mouse_over(const Point& position) const
         {
-            if (!in_bounds(position, _size))
+            if (!visible() || !in_bounds(position, _size))
             {
                 return false;
             }
@@ -422,7 +422,7 @@ namespace trview
 
         Control* Control::hover_control_at_position(const Point& position)
         {
-            if (!in_bounds(position, size()))
+            if (!visible() || !in_bounds(position, size()))
             {
                 return nullptr;
             }

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -88,9 +88,10 @@ namespace trview
             virtual void clear_child_elements();
 
             /// Get the elements that are direct children of this element.
+            /// @param rendering_order If true, this will sort the controls in reverse z order.
             /// @remarks To add a new child, use add_child.
             /// @returns The child elements.
-            std::vector<Control*> child_elements() const;
+            std::vector<Control*> child_elements(bool rendering_order = false) const;
 
             /// Process a mouse_down event at the position specified.
             /// @param position The position of the mouse relative to the control.
@@ -192,6 +193,9 @@ namespace trview
             /// This should be overriden by child elements to handle a click.
             /// @param position The position of the click relative to the control.
             virtual bool clicked(Point position);
+
+            /// To be called when the user clicks away from a focus control.
+            virtual void clicked_off(Control* new_focus);
 
             /// To be called when the mouse was moved over the element.
             /// This should be overriden by child elements to handle a move.

--- a/trview.ui/Dropdown.cpp
+++ b/trview.ui/Dropdown.cpp
@@ -1,7 +1,7 @@
 #include "Dropdown.h"
 #include "Label.h"
-#include "StackPanel.h"
 #include "Button.h"
+#include "Listbox.h"
 
 namespace trview
 {
@@ -14,15 +14,29 @@ namespace trview
             _token_store.add(_button->on_click += [&]()
             {
                 _dropdown->set_visible(!_dropdown->visible());
+                set_focus_control(this);
                 update_dropdown();
             });
         }
 
         void Dropdown::set_dropdown_scope(ui::Control* scope)
         {
-            auto dropdown = std::make_unique<StackPanel>(Point(), Size(size().width, size().height * _values.size()), Colour(0.4f, 0.0f, 0.4f), Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
+            auto dropdown = std::make_unique<Listbox>(Point(), Size(size().width, size().height * _values.size()), Colour(0.4f, 0.4f, 0.4f));
             dropdown->set_z(-1);
             dropdown->set_visible(false);
+            dropdown->set_columns(
+                { 
+                    { Listbox::Column::Type::String, L"Name", static_cast<uint32_t>(size().width) }
+                });
+            dropdown->set_show_headers(false);
+            dropdown->set_show_scrollbar(false);
+            _token_store.add(dropdown->on_item_selected += [&](const auto& item)
+            {
+                auto value = item.value(L"Name");
+                on_value_selected(value);
+                _button->set_text(value);
+                _dropdown->set_visible(false);
+            });
             _dropdown = scope->add_child(std::move(dropdown));
             update_dropdown();
         }
@@ -47,19 +61,34 @@ namespace trview
 
             // Set the position of the dropdown to be just below us.
             _dropdown->set_position(absolute_position() + Point(0, size().height));
-            _dropdown->clear_child_elements();
             _dropdown->set_size(Size(size().width, size().height * _values.size()));
+
+            std::vector<Listbox::Item> items;
             for (const auto& value : _values)
             {
-                auto button = std::make_unique<Button>(Point(), size(), value);
-                _token_store.add(button->on_click += [&]()
-                {
-                    _button->set_text(value);
-                    _dropdown->set_visible(false);
-                    on_value_selected(value);
-                });
-                _dropdown->add_child(std::move(button));
+                items.push_back({{{ L"Name", value }}});
             }
+            _dropdown->set_items(items);
+        }
+
+        void Dropdown::clicked_off(Control* new_focus)
+        {
+            if (!_dropdown)
+            {
+                return;
+            }
+
+            Control* parent = new_focus;
+            while (parent)
+            {
+                if (parent == this || parent == _dropdown)
+                {
+                    return;
+                }
+                parent = parent->parent();
+            }
+
+            _dropdown->set_visible(false);
         }
     }
 }

--- a/trview.ui/Dropdown.h
+++ b/trview.ui/Dropdown.h
@@ -10,7 +10,7 @@ namespace trview
 {
     namespace ui
     {
-        class StackPanel;
+        class Listbox;
 
         class Dropdown final : public Window
         {
@@ -26,7 +26,7 @@ namespace trview
             /// Set the scope that the dropdown will appear in. This may be required if the parent control
             /// does not have space for the entire dropdown to be rendered.
             /// @param scope The scope to create the dropdown control in.
-            void set_dropdown_scope(ui::Control* scope);
+            void set_dropdown_scope(Control* scope);
 
             /// Set the values to show in the dropdown.
             /// @param values The values to show.
@@ -38,12 +38,14 @@ namespace trview
 
             /// Event raised when a value is selected. The selected value is passed as a parameter.
             Event<std::wstring> on_value_selected;
+        protected:
+            virtual void clicked_off(Control* new_focus) override;
         private:
             void update_dropdown();
 
             std::vector<std::wstring> _values;
             ui::Button*               _button;
-            ui::StackPanel*           _dropdown;
+            ui::Listbox*              _dropdown;
         };
     }
 }


### PR DESCRIPTION
Change triggers filter into a list box.
Add 'clicked_off' - this is called on the focus control when another control is becoming the focus control.
Added rendering sort order option for child_elements - the ui and the renderer need things in opposite orders.
In control, stop as soon as a child control has handled something.
Issue: #371