### PR TITLE
Set the window title to the current level

### DIFF
--- a/trview.common/Window.cpp
+++ b/trview.common/Window.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "Window.h"
+#include "Strings.h"
 
 namespace trview
 {
@@ -23,6 +24,12 @@ namespace trview
     Window::operator HWND () const
     {
         return _window;
+    }
+
+    void Window::set_title(const std::string& title)
+    {
+        auto converted = to_utf16(title);
+        SetWindowText(_window, converted.c_str());
     }
 
     // Get the position of the cursor in client coordinates.

--- a/trview.common/Window.h
+++ b/trview.common/Window.h
@@ -2,6 +2,7 @@
 
 #include <Windows.h>
 #include <cstdint>
+#include <string>
 #include "Size.h"
 #include "Point.h"
 
@@ -14,6 +15,10 @@ namespace trview
         Size size() const;
         HWND window() const;
         operator HWND () const;
+
+        /// Set the title of the window.
+        /// @param title The new window title.
+        void set_title(const std::string& title);
     private:
         HWND        _window;
         uint32_t    _width;

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -507,8 +507,9 @@ namespace trview
         // Strip the last part of the path away.
         auto last_index = std::min(filename.find_last_of('\\'), filename.find_last_of('/'));
         auto name = last_index == filename.npos ? filename : filename.substr(std::min(last_index + 1, filename.size()));
-        _level_info->set_level(name);
+        _level_info->set_level(name);        
         _level_info->set_level_version(_current_level->get_version());
+        _window.set_title("trview - " + name);
         _measure->reset();
     }
 


### PR DESCRIPTION
This helps the user keep track of which trview window is for which level.
Issue: #376