### PR TITLE
Add support for controlling alternate groups

### DIFF
--- a/trview.ui.render/RenderNode.h
+++ b/trview.ui.render/RenderNode.h
@@ -32,6 +32,8 @@ namespace trview
             class RenderNode
             {
             public:
+                friend class Renderer;
+
                 RenderNode(const Microsoft::WRL::ComPtr<ID3D11Device>& device, Control* control);
 
                 virtual ~RenderNode() = 0;
@@ -53,7 +55,7 @@ namespace trview
                 int z() const;
             protected:
                 virtual void render_self(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, graphics::Sprite& sprite) = 0;
-            public:
+
                 TokenStore _token_store;
             public:
                 // Determines if the control itself needs to redraw.

--- a/trview.ui.render/RenderNode.h
+++ b/trview.ui.render/RenderNode.h
@@ -53,7 +53,7 @@ namespace trview
                 int z() const;
             protected:
                 virtual void render_self(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, graphics::Sprite& sprite) = 0;
-
+            public:
                 TokenStore _token_store;
             public:
                 // Determines if the control itself needs to redraw.

--- a/trview.ui.render/Renderer.cpp
+++ b/trview.ui.render/Renderer.cpp
@@ -77,7 +77,7 @@ namespace trview
 
                 auto* node_ptr = node.get();
                 auto* ctrl = control;
-                _token_store.add(control->on_hierarchy_changed += [this, ctrl, node_ptr]()
+                node_ptr->_token_store.add(control->on_hierarchy_changed += [this, ctrl, node_ptr]()
                 {
                     node_ptr->clear_children();
                     auto children = ctrl->child_elements(true);

--- a/trview.ui.render/Renderer.cpp
+++ b/trview.ui.render/Renderer.cpp
@@ -76,11 +76,10 @@ namespace trview
                 }
 
                 auto* node_ptr = node.get();
-                auto* ctrl = control;
-                node_ptr->_token_store.add(control->on_hierarchy_changed += [this, ctrl, node_ptr]()
+                node_ptr->_token_store.add(control->on_hierarchy_changed += [this, control, node_ptr]()
                 {
                     node_ptr->clear_children();
-                    auto children = ctrl->child_elements(true);
+                    auto children = control->child_elements(true);
                     for (auto child : children)
                     {
                         node_ptr->add_child(process_control(child));

--- a/trview.ui.render/Renderer.cpp
+++ b/trview.ui.render/Renderer.cpp
@@ -76,10 +76,11 @@ namespace trview
                 }
 
                 auto* node_ptr = node.get();
-                _token_store.add(control->on_hierarchy_changed += [this, control, node_ptr]()
+                auto* ctrl = control;
+                _token_store.add(control->on_hierarchy_changed += [this, ctrl, node_ptr]()
                 {
                     node_ptr->clear_children();
-                    auto children = control->child_elements(true);
+                    auto children = ctrl->child_elements(true);
                     for (auto child : children)
                     {
                         node_ptr->add_child(process_control(child));

--- a/trview/Flipmaps.cpp
+++ b/trview/Flipmaps.cpp
@@ -2,34 +2,51 @@
 #include "Flipmaps.h"
 #include <trview.ui/GroupBox.h>
 #include <trview.ui/Checkbox.h>
+#include <trview.ui/Button.h>
+#include <string>
 
 namespace trview
 {
     Flipmaps::Flipmaps(ui::Control& parent)
     {
         using namespace ui;
-        auto flips_group = std::make_unique<GroupBox>(Point(), Size(140, 145), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Flipmaps");
+        auto flips_group = std::make_unique<GroupBox>(Point(), Size(140, 45), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Flipmaps");
+
+        // Shared panel size.
+        const auto panel_size = Size(130, 20);
 
         // Add two methods of controlling flipmaps:
         // The TR1-3 method:
-        auto tr1_3_panel = std::make_unique<Window>(Point(10, 15), Size(120, 120), Colour(1.0f, 1.0f, 0.0f, 0.0f));
-        auto flip = std::make_unique<Checkbox>(Point(12, 42), Size(16, 16), L"Flip");
+        auto tr1_3_panel = std::make_unique<Window>(Point(5, 16), panel_size, Colour(1.0f, 0.5f, 0.5f, 0.5f));
+        auto flip = std::make_unique<Checkbox>(Point(), Size(16, 16), L"Flip");
         flip->on_state_changed += on_flip;
         _flip = tr1_3_panel->add_child(std::move(flip));
         _tr1_3_panel = flips_group->add_child(std::move(tr1_3_panel));
 
         // The TR4-5 method:
-        auto tr4_5_panel = std::make_unique<Window>(Point(10, 15), Size(120, 120), Colour(1.0f, 0.0f, 1.0f, 0.0f));
+        auto tr4_5_panel = std::make_unique<Window>(Point(5, 16), panel_size, Colour(1.0f, 0.5f, 0.5f, 0.5f));
+        auto alternate_groups = std::make_unique<StackPanel>(Point(), Size(130, 16), Colour(0.5f, 0.5f, 0.5f), Size(), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        _alternate_groups = tr4_5_panel->add_child(std::move(alternate_groups));
         tr4_5_panel->set_visible(false);
         _tr4_5_panel = flips_group->add_child(std::move(tr4_5_panel));
 
         parent.add_child(std::move(flips_group));
     }
 
-    void Flipmaps::set_alternate_groups(bool value)
+    void Flipmaps::set_use_alternate_groups(bool value)
     {
         _tr1_3_panel->set_visible(!value);
         _tr4_5_panel->set_visible(value);
+    }
+
+    void Flipmaps::set_alternate_groups(const std::set<uint16_t>& groups)
+    {
+        _alternate_groups->clear_child_elements();
+        for (auto& group : groups)
+        {
+            auto button = std::make_unique<ui::Button>(Point(), Size(16, 16), std::to_wstring(group));
+            _alternate_groups->add_child(std::move(button));
+        }
     }
 
     void Flipmaps::set_flip(bool flip)

--- a/trview/Flipmaps.cpp
+++ b/trview/Flipmaps.cpp
@@ -18,7 +18,7 @@ namespace trview
         // Add two methods of controlling flipmaps:
         // The TR1-3 method:
         auto tr1_3_panel = std::make_unique<Window>(Point(5, 16), panel_size, Colour(1.0f, 0.5f, 0.5f, 0.5f));
-        auto flip = std::make_unique<Checkbox>(Point(), Size(16, 16), L"Flip");
+        auto flip = std::make_unique<Checkbox>(Point(7,0), Size(16, 16), L"Flip");
         flip->on_state_changed += on_flip;
         _flip = tr1_3_panel->add_child(std::move(flip));
         _tr1_3_panel = flips_group->add_child(std::move(tr1_3_panel));

--- a/trview/Flipmaps.cpp
+++ b/trview/Flipmaps.cpp
@@ -1,0 +1,45 @@
+#include "stdafx.h"
+#include "Flipmaps.h"
+#include <trview.ui/GroupBox.h>
+#include <trview.ui/Checkbox.h>
+
+namespace trview
+{
+    Flipmaps::Flipmaps(ui::Control& parent)
+    {
+        using namespace ui;
+        auto flips_group = std::make_unique<GroupBox>(Point(), Size(140, 145), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Flipmaps");
+
+        // Add two methods of controlling flipmaps:
+        // The TR1-3 method:
+        auto tr1_3_panel = std::make_unique<Window>(Point(10, 15), Size(120, 120), Colour(1.0f, 1.0f, 0.0f, 0.0f));
+        auto flip = std::make_unique<Checkbox>(Point(12, 42), Size(16, 16), L"Flip");
+        flip->on_state_changed += on_flip;
+        _flip = tr1_3_panel->add_child(std::move(flip));
+        _tr1_3_panel = flips_group->add_child(std::move(tr1_3_panel));
+
+        // The TR4-5 method:
+        auto tr4_5_panel = std::make_unique<Window>(Point(10, 15), Size(120, 120), Colour(1.0f, 0.0f, 1.0f, 0.0f));
+        tr4_5_panel->set_visible(false);
+        _tr4_5_panel = flips_group->add_child(std::move(tr4_5_panel));
+
+        parent.add_child(std::move(flips_group));
+    }
+
+    void Flipmaps::set_alternate_groups(bool value)
+    {
+        _tr1_3_panel->set_visible(!value);
+        _tr4_5_panel->set_visible(value);
+    }
+
+    void Flipmaps::set_flip(bool flip)
+    {
+        _flip->set_state(flip);
+    }
+
+    void Flipmaps::set_flip_enabled(bool enabled)
+    {
+        _flip->set_enabled(enabled);
+    }
+}
+

--- a/trview/Flipmaps.cpp
+++ b/trview/Flipmaps.cpp
@@ -42,9 +42,22 @@ namespace trview
     void Flipmaps::set_alternate_groups(const std::set<uint16_t>& groups)
     {
         _alternate_groups->clear_child_elements();
+        _alternate_group_values.clear();
+
         for (auto& group : groups)
         {
+            _alternate_group_values.insert({ group, false });
             auto button = std::make_unique<ui::Button>(Point(), Size(16, 16), std::to_wstring(group));
+            button->set_text_background_colour(Colour(1.0f, 0.2f, 0.2f, 0.2f));
+
+            auto btn = button.get();
+            _token_store.add(button->on_click += [btn, this, group]()
+            {
+                auto group_value = !_alternate_group_values[group];
+                btn->set_text_background_colour(group_value ? Colour(0.6f, 0.6f, 0.6f) : Colour(0.2f, 0.2f, 0.2f));
+                on_alternate_group(group, group_value);
+                _alternate_group_values[group] = group_value;
+            });
             _alternate_groups->add_child(std::move(button));
         }
     }

--- a/trview/Flipmaps.cpp
+++ b/trview/Flipmaps.cpp
@@ -39,26 +39,41 @@ namespace trview
         _tr4_5_panel->set_visible(value);
     }
 
+    void Flipmaps::set_alternate_group(uint16_t value, bool enabled)
+    {
+        _alternate_group_values[value] = enabled;
+
+        // Update the button.
+        auto button = _alternate_group_buttons.find(value);
+        if (button != _alternate_group_buttons.end())
+        {
+            button->second->set_text_background_colour(enabled ? Colour(0.6f, 0.6f, 0.6f) : Colour(0.2f, 0.2f, 0.2f));
+        }
+    }
+
     void Flipmaps::set_alternate_groups(const std::set<uint16_t>& groups)
     {
         _alternate_groups->clear_child_elements();
         _alternate_group_values.clear();
+        _alternate_group_buttons.clear();
 
         for (auto& group : groups)
         {
             _alternate_group_values.insert({ group, false });
-            auto button = std::make_unique<ui::Button>(Point(), Size(16, 16), std::to_wstring(group));
-            button->set_text_background_colour(Colour(1.0f, 0.2f, 0.2f, 0.2f));
 
-            auto btn = button.get();
-            _token_store.add(button->on_click += [btn, this, group]()
+            auto button = std::make_unique<ui::Button>(Point(), Size(16, 16), std::to_wstring(group));
+            button->set_text_background_colour(Colour(0.2f, 0.2f, 0.2f));
+            auto group_button = _alternate_groups->add_child(std::move(button));
+
+            _token_store.add(group_button->on_click += [group_button, this, group]()
             {
                 auto group_value = !_alternate_group_values[group];
-                btn->set_text_background_colour(group_value ? Colour(0.6f, 0.6f, 0.6f) : Colour(0.2f, 0.2f, 0.2f));
+                group_button->set_text_background_colour(group_value ? Colour(0.6f, 0.6f, 0.6f) : Colour(0.2f, 0.2f, 0.2f));
                 on_alternate_group(group, group_value);
                 _alternate_group_values[group] = group_value;
             });
-            _alternate_groups->add_child(std::move(button));
+
+            _alternate_group_buttons[group] = group_button;
         }
     }
 

--- a/trview/Flipmaps.cpp
+++ b/trview/Flipmaps.cpp
@@ -7,24 +7,30 @@
 
 namespace trview
 {
+    namespace Colours
+    {
+        const Colour FlipOff { 0.2f, 0.2f, 0.2f };
+        const Colour FlipOn { 0.6f, 0.6f, 0.6f };
+    }
+
     Flipmaps::Flipmaps(ui::Control& parent)
     {
         using namespace ui;
-        auto flips_group = std::make_unique<GroupBox>(Point(), Size(140, 45), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Flipmaps");
+        auto flips_group = std::make_unique<GroupBox>(Point(), Size(140, 45), Colour(0.5f, 0.5f, 0.5f), Colour(0.0f, 0.0f, 0.0f), L"Flipmaps");
 
         // Shared panel size.
         const auto panel_size = Size(130, 20);
 
         // Add two methods of controlling flipmaps:
         // The TR1-3 method:
-        auto tr1_3_panel = std::make_unique<Window>(Point(5, 16), panel_size, Colour(1.0f, 0.5f, 0.5f, 0.5f));
+        auto tr1_3_panel = std::make_unique<Window>(Point(5, 16), panel_size, Colour(0.5f, 0.5f, 0.5f));
         auto flip = std::make_unique<Checkbox>(Point(7,0), Size(16, 16), L"Flip");
         flip->on_state_changed += on_flip;
         _flip = tr1_3_panel->add_child(std::move(flip));
         _tr1_3_panel = flips_group->add_child(std::move(tr1_3_panel));
 
         // The TR4-5 method:
-        auto tr4_5_panel = std::make_unique<Window>(Point(5, 16), panel_size, Colour(1.0f, 0.5f, 0.5f, 0.5f));
+        auto tr4_5_panel = std::make_unique<Window>(Point(5, 16), panel_size, Colour(0.5f, 0.5f, 0.5f));
         auto alternate_groups = std::make_unique<StackPanel>(Point(), Size(130, 16), Colour(0.5f, 0.5f, 0.5f), Size(), StackPanel::Direction::Horizontal, SizeMode::Manual);
         _alternate_groups = tr4_5_panel->add_child(std::move(alternate_groups));
         tr4_5_panel->set_visible(false);
@@ -47,7 +53,7 @@ namespace trview
         auto button = _alternate_group_buttons.find(value);
         if (button != _alternate_group_buttons.end())
         {
-            button->second->set_text_background_colour(enabled ? Colour(0.6f, 0.6f, 0.6f) : Colour(0.2f, 0.2f, 0.2f));
+            button->second->set_text_background_colour(enabled ? Colours::FlipOn : Colours::FlipOff);
         }
     }
 
@@ -62,13 +68,13 @@ namespace trview
             _alternate_group_values.insert({ group, false });
 
             auto button = std::make_unique<ui::Button>(Point(), Size(16, 16), std::to_wstring(group));
-            button->set_text_background_colour(Colour(0.2f, 0.2f, 0.2f));
+            button->set_text_background_colour(Colours::FlipOff);
             auto group_button = _alternate_groups->add_child(std::move(button));
 
             _token_store.add(group_button->on_click += [group_button, this, group]()
             {
                 auto group_value = !_alternate_group_values[group];
-                group_button->set_text_background_colour(group_value ? Colour(0.6f, 0.6f, 0.6f) : Colour(0.2f, 0.2f, 0.2f));
+                group_button->set_text_background_colour(group_value ? Colours::FlipOn : Colours::FlipOff);
                 on_alternate_group(group, group_value);
                 _alternate_group_values[group] = group_value;
             });
@@ -87,4 +93,3 @@ namespace trview
         _flip->set_enabled(enabled);
     }
 }
-

--- a/trview/Flipmaps.h
+++ b/trview/Flipmaps.h
@@ -9,6 +9,7 @@ namespace trview
 {
     namespace ui
     {
+        class Button;
         class Control;
         class Checkbox;
         class Window;
@@ -23,6 +24,11 @@ namespace trview
         /// Set whether to use alternate groups method of flipmaps.
         /// @param value Whether to use alternate groups or a single toggle.
         void set_use_alternate_groups(bool value);
+
+        /// Set whether an alternate group is enabled.
+        /// @param value The group to change.
+        /// @param enabled Whether the group is enabled.
+        void set_alternate_group(uint16_t value, bool enabled);
 
         /// Set the alternate groups that are in the level.
         /// @param groups The groups in the level.
@@ -47,5 +53,6 @@ namespace trview
         ui::Window*     _tr4_5_panel;
         ui::StackPanel* _alternate_groups;
         std::unordered_map<uint16_t, bool> _alternate_group_values;
+        std::unordered_map<uint16_t, ui::Button*> _alternate_group_buttons;
     };
 }

--- a/trview/Flipmaps.h
+++ b/trview/Flipmaps.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <trview.common/Event.h>
+
+namespace trview
+{
+    namespace ui
+    {
+        class Control;
+        class Checkbox;
+        class Window;
+    }
+
+    class Flipmaps
+    {
+    public:
+        explicit Flipmaps(ui::Control& parent);
+
+        /// Set whether to use alternate groups method of flipmaps.
+        /// @param value Whether to use alternate groups or a single toggle.
+        void set_alternate_groups(bool value);
+
+        /// Set the current flip mode. This will not raise the on_flip event but will update the user interface appropriately.
+        /// @param flip The new flip mode.
+        void set_flip(bool flip);
+
+        /// Set whether the flip control is enabled or disabled.
+        /// @param enabled Whether the control is enabled.
+        void set_flip_enabled(bool enabled);
+
+        Event<bool> on_flip;
+    private:
+        ui::Checkbox* _flip;
+        ui::Window*   _tr1_3_panel;
+        ui::Window*   _tr4_5_panel;
+    };
+}

--- a/trview/Flipmaps.h
+++ b/trview/Flipmaps.h
@@ -20,7 +20,7 @@ namespace trview
     }
 
     /// UI element that allows the user to control the flipmaps in a level.
-    class Flipmaps
+    class Flipmaps final
     {
     public:
         /// Create a new Flipmaps window.

--- a/trview/Flipmaps.h
+++ b/trview/Flipmaps.h
@@ -1,3 +1,6 @@
+/// @file GoToRoom.h
+/// @brief UI element that allows the user to control the flipmaps in a level.
+
 #pragma once
 
 #include <cstdint>
@@ -16,16 +19,19 @@ namespace trview
         class StackPanel;
     }
 
+    /// UI element that allows the user to control the flipmaps in a level.
     class Flipmaps
     {
     public:
+        /// Create a new Flipmaps window.
+        /// @param parent The control to add the window to.
         explicit Flipmaps(ui::Control& parent);
 
         /// Set whether to use alternate groups method of flipmaps.
         /// @param value Whether to use alternate groups or a single toggle.
         void set_use_alternate_groups(bool value);
 
-        /// Set whether an alternate group is enabled.
+        /// Set whether an alternate group is enabled. This will not raise the on_alternate_group event.
         /// @param value The group to change.
         /// @param enabled Whether the group is enabled.
         void set_alternate_group(uint16_t value, bool enabled);
@@ -42,6 +48,7 @@ namespace trview
         /// @param enabled Whether the control is enabled.
         void set_flip_enabled(bool enabled);
 
+        /// Event raised when a TR1-3 flip in toggled. The flipmap state is passed as a parameter.
         Event<bool> on_flip;
 
         /// Event raised when an alternate group is toggled. The group number and the new state are passed as parameters.

--- a/trview/Flipmaps.h
+++ b/trview/Flipmaps.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <set>
 #include <trview.common/Event.h>
+#include <trview.common/TokenStore.h>
 
 namespace trview
 {
@@ -36,10 +37,15 @@ namespace trview
         void set_flip_enabled(bool enabled);
 
         Event<bool> on_flip;
+
+        /// Event raised when an alternate group is toggled. The group number and the new state are passed as parameters.
+        Event<uint16_t, bool> on_alternate_group;
     private:
+        TokenStore      _token_store;
         ui::Checkbox*   _flip;
         ui::Window*     _tr1_3_panel;
         ui::Window*     _tr4_5_panel;
         ui::StackPanel* _alternate_groups;
+        std::unordered_map<uint16_t, bool> _alternate_group_values;
     };
 }

--- a/trview/Flipmaps.h
+++ b/trview/Flipmaps.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+#include <set>
 #include <trview.common/Event.h>
 
 namespace trview
@@ -9,6 +11,7 @@ namespace trview
         class Control;
         class Checkbox;
         class Window;
+        class StackPanel;
     }
 
     class Flipmaps
@@ -18,7 +21,11 @@ namespace trview
 
         /// Set whether to use alternate groups method of flipmaps.
         /// @param value Whether to use alternate groups or a single toggle.
-        void set_alternate_groups(bool value);
+        void set_use_alternate_groups(bool value);
+
+        /// Set the alternate groups that are in the level.
+        /// @param groups The groups in the level.
+        void set_alternate_groups(const std::set<uint16_t>& groups);
 
         /// Set the current flip mode. This will not raise the on_flip event but will update the user interface appropriately.
         /// @param flip The new flip mode.
@@ -30,8 +37,9 @@ namespace trview
 
         Event<bool> on_flip;
     private:
-        ui::Checkbox* _flip;
-        ui::Window*   _tr1_3_panel;
-        ui::Window*   _tr4_5_panel;
+        ui::Checkbox*   _flip;
+        ui::Window*     _tr1_3_panel;
+        ui::Window*     _tr4_5_panel;
+        ui::StackPanel* _alternate_groups;
     };
 }

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -287,6 +287,8 @@ namespace trview
             _rooms.push_back(std::make_unique<Room>(device, *_level, room, *_texture_storage.get(), *_mesh_storage.get(), i));
         }
 
+        std::set<uint32_t> alternate_groups;
+
         // Fix up the IsAlternate status of the rooms that are referenced by HasAlternate rooms.
         // This can only be done once all the rooms are loaded.
         for (int16_t i = 0; i < _rooms.size(); ++i)
@@ -294,6 +296,8 @@ namespace trview
             const auto& room = _rooms[i];
             if (room->alternate_mode() == Room::AlternateMode::HasAlternate)
             {
+                alternate_groups.insert(room->alternate_group());
+
                 int16_t alternate = room->alternate_room();
                 if (alternate != -1)
                 {
@@ -519,6 +523,20 @@ namespace trview
     const ILevelTextureStorage& Level::texture_storage() const
     {
         return *_texture_storage;
+    }
+
+    std::set<uint16_t> Level::alternate_groups() const
+    {
+        std::set<uint16_t> groups;
+        for (int16_t i = 0; i < _rooms.size(); ++i)
+        {
+            const auto& room = _rooms[i];
+            if (room->alternate_mode() == Room::AlternateMode::HasAlternate)
+            {
+                groups.insert(room->alternate_group());
+            }
+        }
+        return groups;
     }
 
     bool find_item_by_type_id(const Level& level, uint32_t type_id, Item& output_item)

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -565,7 +565,7 @@ namespace trview
         for (int16_t i = 0; i < _rooms.size(); ++i)
         {
             const auto& room = _rooms[i];
-            if (room->alternate_mode() == Room::AlternateMode::HasAlternate)
+            if (room->alternate_mode() != Room::AlternateMode::None)
             {
                 groups.insert(room->alternate_group());
             }

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -132,7 +132,14 @@ namespace trview
         const auto& room = *_rooms[index];
         if (is_alternate_mismatch(room))
         {
-            on_alternate_mode_selected(!_alternate_mode);
+            if (_level->get_version() >= trlevel::LevelVersion::Tomb4)
+            {
+                on_alternate_group_selected(room.alternate_group(), !is_alternate_group_set(room.alternate_group()));
+            }
+            else
+            {
+                on_alternate_mode_selected(!_alternate_mode);
+            }
         }
     }
 
@@ -463,13 +470,8 @@ namespace trview
     {
         if (_level->get_version() >= trlevel::LevelVersion::Tomb4)
         {
-            auto is_set = [this](uint16_t group)
-            {
-                return _alternate_groups.find(group) != _alternate_groups.end();
-            };
-
-            return room.alternate_mode() == Room::AlternateMode::HasAlternate && is_set(room.alternate_group()) ||
-                   room.alternate_mode() == Room::AlternateMode::IsAlternate && !is_set(room.alternate_group());
+            return room.alternate_mode() == Room::AlternateMode::HasAlternate && is_alternate_group_set(room.alternate_group()) ||
+                   room.alternate_mode() == Room::AlternateMode::IsAlternate && !is_alternate_group_set(room.alternate_group());
         }
 
         return room.alternate_mode() == Room::AlternateMode::IsAlternate && !_alternate_mode ||
@@ -569,6 +571,11 @@ namespace trview
             }
         }
         return groups;
+    }
+
+    bool Level::is_alternate_group_set(uint16_t group) const
+    {
+        return _alternate_groups.find(group) != _alternate_groups.end();
     }
 
     bool find_item_by_type_id(const Level& level, uint32_t type_id, Item& output_item)

--- a/trview/Level.h
+++ b/trview/Level.h
@@ -83,6 +83,11 @@ namespace trview
         // enabled: Whether to render the flipmap.
         void set_alternate_mode(bool enabled);
 
+        /// Set whether to render the alternate group specified.
+        /// @param group The group to toggle.
+        /// @param enabled Whether the group is enabled.
+        void set_alternate_group(uint16_t group, bool enabled);
+
         // Event raised when the level needs to change the selected room.
         Event<uint16_t> on_room_selected;
 
@@ -147,7 +152,7 @@ namespace trview
 
         // Determines whether the alternate mode specified is a mismatch with the current setting of 
         // the alternate mode flag.
-        bool is_alternate_mismatch(Room::AlternateMode mode) const;
+        bool is_alternate_mismatch(const Room& room) const;
 
         /// Load the type name lookup table from resources.
         void load_type_name_lookup();
@@ -186,6 +191,7 @@ namespace trview
         std::unordered_map<uint32_t, std::wstring> _type_names;
 
         std::unique_ptr<SelectionRenderer> _selection_renderer;
+        std::set<uint16_t> _alternate_groups;
     };
 
     /// Find the first item with the type id specified.

--- a/trview/Level.h
+++ b/trview/Level.h
@@ -106,6 +106,10 @@ namespace trview
         void set_selected_trigger(uint32_t number);
 
         const ILevelTextureStorage& texture_storage() const;
+
+        /// Gets the alternate groups that exist in the level.
+        /// @returns The set of alternate groups in the level.
+        std::set<uint16_t> alternate_groups() const;
     private:
         void generate_rooms(const Microsoft::WRL::ComPtr<ID3D11Device>& device);
         void generate_triggers(const Microsoft::WRL::ComPtr<ID3D11Device>& device);

--- a/trview/Level.h
+++ b/trview/Level.h
@@ -94,6 +94,9 @@ namespace trview
         // Event raised when the level needs to change the alternate mode.
         Event<bool> on_alternate_mode_selected;   
 
+        /// Event raised when the levle needs to change the alternate group mode.
+        Event<uint16_t, bool> on_alternate_group_selected;
+
         // Returns the room with ID provided 
         inline Room *room(std::size_t id) const { return _rooms.at(id).get(); }
 
@@ -162,6 +165,8 @@ namespace trview
         /// @returns The type name of the item.
         /// @remarks If the type id is not found, this will return the string version of the type id.
         std::wstring lookup_type_name(uint32_t type_id) const;
+
+        bool is_alternate_group_set(uint16_t group) const;
 
         const trlevel::ILevel*               _level;
         std::vector<std::unique_ptr<Room>>   _rooms;

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -32,6 +32,7 @@ namespace trview
         uint32_t index)
         : _info { room.info.x, 0, room.info.z, room.info.yBottom, room.info.yTop }, 
         _alternate_room(room.alternate_room),
+        _alternate_group(room.alternate_group),
         _num_x_sectors(room.num_x_sectors),
         _num_z_sectors(room.num_z_sectors),
         _index(index)
@@ -287,6 +288,11 @@ namespace trview
     int16_t Room::alternate_room() const
     {
         return _alternate_room;
+    }
+
+    int16_t Room::alternate_group() const
+    {
+        return _alternate_group;
     }
 
     // Set this room to be the alternate room of the room specified.

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -114,6 +114,10 @@ namespace trview
         // Returns: The room number of the alternate room.
         int16_t alternate_room() const;
 
+        /// Gets the alternate group for the room.
+        /// @returns The alternate group number.
+        int16_t alternate_group() const;
+
         // Set this room to be the alternate room of the room specified.
         // This will change the alternate_mode of this room to IsAlternate.
         // number: The room number.
@@ -163,6 +167,7 @@ namespace trview
         std::uint16_t       _num_x_sectors, _num_z_sectors; 
 
         int16_t              _alternate_room;
+        int16_t              _alternate_group;
         AlternateMode        _alternate_mode;
 
         std::unordered_map<uint32_t, Trigger*> _triggers;

--- a/trview/RoomNavigator.cpp
+++ b/trview/RoomNavigator.cpp
@@ -16,17 +16,15 @@ namespace trview
     {
         using namespace ui;
 
-        auto rooms_groups = std::make_unique<GroupBox>(Point(), Size(140, 145), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Rooms");
+        auto rooms_groups = std::make_unique<GroupBox>(Point(), Size(140, 120), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Rooms");
         auto highlight = std::make_unique<Checkbox>(Point(12, 20), Size(16, 16), L"Highlight");
-        auto flip = std::make_unique<Checkbox>(Point(76, 20), Size(16, 16), L"Flip");
-        auto triggers = std::make_unique<Checkbox>(Point(12, 42), Size(16, 16), L"Triggers");
+        auto triggers = std::make_unique<Checkbox>(Point(76, 20), Size(16, 16), L"Triggers");
         triggers->set_state(true);
 
         highlight->on_state_changed += on_highlight;
-        flip->on_state_changed += on_flip;
         triggers->on_state_changed += on_show_triggers;
 
-        auto room_box = std::make_unique<GroupBox>(Point(12, 65), Size(120, 70), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Room");
+        auto room_box = std::make_unique<GroupBox>(Point(12, 42), Size(120, 70), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Room");
         auto room_controls = std::make_unique<StackPanel>(Point(12, 12), Size(96, 60), Colour(1.f, 0.5f, 0.5f, 0.5f), Size(),StackPanel::Direction::Vertical);
         auto room_number_labels = std::make_unique<StackPanel>(Point(), Size(96, 30), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(), StackPanel::Direction::Horizontal);
         auto room_number = std::make_unique<NumericUpDown>(Point(), Size(40, 20), Colour(1.0f, 0.4f, 0.4f, 0.4f), texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 0);
@@ -52,7 +50,6 @@ namespace trview
         room_box->add_child(std::move(room_controls));
 
         _highlight = rooms_groups->add_child(std::move(highlight));
-        _flip = rooms_groups->add_child(std::move(flip));
         _triggers = rooms_groups->add_child(std::move(triggers));
         rooms_groups->add_child(std::move(room_box));
 
@@ -80,16 +77,6 @@ namespace trview
     void RoomNavigator::set_selected_room(uint32_t selected_room)
     {
         _current->set_value(selected_room);
-    }
-
-    void RoomNavigator::set_flip(bool flip)
-    {
-        _flip->set_state(flip);
-    }
-
-    void RoomNavigator::set_flip_enabled(bool enabled)
-    {
-        _flip->set_enabled(enabled);
     }
 
     void RoomNavigator::set_show_triggers(bool show)

--- a/trview/RoomNavigator.h
+++ b/trview/RoomNavigator.h
@@ -68,14 +68,6 @@ namespace trview
         /// @param selected_room The room that has been selected.
         void set_selected_room(uint32_t selected_room);
 
-        /// Set the current flip mode. This will not raise the on_flip event but will update the user interface appropriately.
-        /// @param flip The new flip mode.
-        void set_flip(bool flip);
-
-        /// Set whether the flip control is enabled or disabled.
-        /// @param enabled Whether the control is enabled.
-        void set_flip_enabled(bool enabled);
-
         /// Set whether triggers are visible or not.
         /// @param show Whether the triggers are visible.
         void set_show_triggers(bool show);

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -197,6 +197,7 @@ namespace trview
 
         _flipmaps = std::make_unique<Flipmaps>(*tool_window.get());
         _token_store.add(_flipmaps->on_flip += [&](bool flip) { set_alternate_mode(flip); });
+        _token_store.add(_flipmaps->on_alternate_group += [&](uint16_t group, bool value) { set_alternate_group(group, value); });
 
         _neighbours = std::make_unique<Neighbours>(*tool_window.get(), *_texture_storage.get());
         _token_store.add(_neighbours->on_depth_changed += [&](int32_t value)
@@ -764,6 +765,14 @@ namespace trview
         {
             _level->set_alternate_mode(enabled);
             _flipmaps->set_flip(enabled);
+        }
+    }
+
+    void Viewer::set_alternate_group(uint16_t group, bool enabled)
+    {
+        if (_level)
+        {
+            _level->set_alternate_group(group, enabled);
         }
     }
 

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -28,6 +28,7 @@
 #include "RoomNavigator.h"
 #include "TextureStorage.h"
 #include "SettingsWindow.h"
+#include "Flipmaps.h"
 
 namespace trview
 {
@@ -192,8 +193,10 @@ namespace trview
         _room_navigator = std::make_unique<RoomNavigator>(*tool_window.get(), *_texture_storage.get());
         _token_store.add(_room_navigator->on_room_selected += [&](uint32_t room) { select_room(room); });
         _token_store.add(_room_navigator->on_highlight += [&](bool) { toggle_highlight(); });
-        _token_store.add(_room_navigator->on_flip += [&](bool flip) { set_alternate_mode(flip); });
         _token_store.add(_room_navigator->on_show_triggers += [&](bool show) { set_show_triggers(show); });
+
+        _flipmaps = std::make_unique<Flipmaps>(*tool_window.get());
+        _token_store.add(_flipmaps->on_flip += [&](bool flip) { set_alternate_mode(flip); });
 
         _neighbours = std::make_unique<Neighbours>(*tool_window.get(), *_texture_storage.get());
         _token_store.add(_neighbours->on_depth_changed += [&](int32_t value)
@@ -488,8 +491,10 @@ namespace trview
         // Reset UI buttons
         _room_navigator->set_max_rooms(static_cast<uint32_t>(rooms.size()));
         _room_navigator->set_highlight(false);
-        _room_navigator->set_flip(false);
-        _room_navigator->set_flip_enabled(_level->any_alternates());
+
+        _flipmaps->set_alternate_groups(_current_level->get_version() >= trlevel::LevelVersion::Tomb4);
+        _flipmaps->set_flip(false);
+        _flipmaps->set_flip_enabled(_level->any_alternates());
 
         Item lara;
         if (_settings.go_to_lara && find_item_by_type_id(*_level, 0u, lara))
@@ -757,7 +762,7 @@ namespace trview
         if (_level)
         {
             _level->set_alternate_mode(enabled);
-            _room_navigator->set_flip(enabled);
+            _flipmaps->set_flip(enabled);
         }
     }
 

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -492,7 +492,8 @@ namespace trview
         _room_navigator->set_max_rooms(static_cast<uint32_t>(rooms.size()));
         _room_navigator->set_highlight(false);
 
-        _flipmaps->set_alternate_groups(_current_level->get_version() >= trlevel::LevelVersion::Tomb4);
+        _flipmaps->set_use_alternate_groups(_current_level->get_version() >= trlevel::LevelVersion::Tomb4);
+        _flipmaps->set_alternate_groups(_level->alternate_groups());
         _flipmaps->set_flip(false);
         _flipmaps->set_flip_enabled(_level->any_alternates());
 

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -477,6 +477,7 @@ namespace trview
         _level = std::make_unique<Level>(_device.device(), *_shader_storage.get(), _current_level.get());
         _token_store.add(_level->on_room_selected += [&](uint16_t room) { select_room(room); });
         _token_store.add(_level->on_alternate_mode_selected += [&](bool enabled) { set_alternate_mode(enabled); });
+        _token_store.add(_level->on_alternate_group_selected += [&](uint16_t group, bool enabled) { set_alternate_group(group, enabled); });
 
         _items_windows->set_items(_level->items());
         _items_windows->set_triggers(_level->triggers());
@@ -773,6 +774,7 @@ namespace trview
         if (_level)
         {
             _level->set_alternate_group(group, enabled);
+            _flipmaps->set_alternate_group(group, enabled);
         }
     }
 

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -115,6 +115,7 @@ namespace trview
         ICamera& current_camera();
         void set_camera_mode(CameraMode camera_mode);
         void set_alternate_mode(bool enabled);
+        void set_alternate_group(uint16_t group, bool enabled);
         // Tell things that need to be resized that they should resize.
         void resize_elements();
         // Set up keyboard and mouse input for the camera.

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -55,6 +55,7 @@ namespace trview
     class Neighbours;
     class RoomNavigator;
     class SettingsWindow;
+    class Flipmaps;
 
     namespace graphics
     {
@@ -139,6 +140,7 @@ namespace trview
         CameraMode _camera_mode{ CameraMode::Orbit };
         CameraInput _camera_input;
         std::unique_ptr<RoomNavigator> _room_navigator;
+        std::unique_ptr<Flipmaps> _flipmaps;
         std::unique_ptr<CameraControls> _camera_controls;
         std::unique_ptr<Neighbours> _neighbours;
         std::unique_ptr<LevelInfo> _level_info;

--- a/trview/trview.vcxproj
+++ b/trview/trview.vcxproj
@@ -187,6 +187,7 @@
     <ClInclude Include="DefaultTextures.h" />
     <ClInclude Include="DirectoryListing.h" />
     <ClInclude Include="Entity.h" />
+    <ClInclude Include="Flipmaps.h" />
     <ClInclude Include="FreeCamera.h" />
     <ClInclude Include="GoToRoom.h" />
     <ClInclude Include="IMeshStorage.h" />
@@ -222,6 +223,7 @@
     <ClCompile Include="DefaultTextures.cpp" />
     <ClCompile Include="DirectoryListing.cpp" />
     <ClCompile Include="Entity.cpp" />
+    <ClCompile Include="Flipmaps.cpp" />
     <ClCompile Include="FreeCamera.cpp" />
     <ClCompile Include="GoToRoom.cpp" />
     <ClCompile Include="IMeshStorage.cpp" />

--- a/trview/trview.vcxproj.filters
+++ b/trview/trview.vcxproj.filters
@@ -148,6 +148,9 @@
     <ClInclude Include="SelectionRenderer.h">
       <Filter>View\Selection</Filter>
     </ClInclude>
+    <ClInclude Include="Flipmaps.h">
+      <Filter>Program\Windows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Viewer.cpp">
@@ -236,6 +239,9 @@
     </ClCompile>
     <ClCompile Include="SelectionRenderer.cpp">
       <Filter>View\Selection</Filter>
+    </ClCompile>
+    <ClCompile Include="Flipmaps.cpp">
+      <Filter>Program\Windows</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Move flipmap controls out of the rooms box into their own panel.
If the level is >= TR4 then show the alternate groups panel - this has a button for each alternate group in the level.
Click on the button will toggle that alternate group.
Currently if there are more than 8 groups, you won't see them all, but I don't think that happens in anything non-custom. Will see about making it show more rows of buttons if this becomes a problem.
Issue: #152 