### PR TITLE
Stop excessive GPU usage when minimised

### DIFF
--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -519,10 +519,17 @@ namespace trview
         _level_info->set_level_version(_current_level->get_version());
         _window.set_title("trview - " + name);
         _measure->reset();
-    }
 
+    }
     void Viewer::render()
     {
+        // If minimised, don't render like crazy. Sleep so we don't hammer the CPU either.
+        if (window_is_minimised(_window))
+        {
+            Sleep(1);
+            return;
+        }
+
         _timer.update();
 
         update_camera();


### PR DESCRIPTION
When window is minimised, don't render the scene.
Also add a sleep when minimised so we don't use 100% CPU.
Issue: #391