### PR TITLE
Change item/trigger windows to be hidden by default

### DIFF
--- a/trview/UserSettings.h
+++ b/trview/UserSettings.h
@@ -15,8 +15,8 @@ namespace trview
         bool                    vsync{ true };
         bool                    go_to_lara{ true };
         bool                    invert_map_controls{ false };
-        bool                    items_startup{ true };
-        bool                    triggers_startup{ true };
+        bool                    items_startup{ false };
+        bool                    triggers_startup{ false };
         bool                    auto_orbit{ true };
     };
 


### PR DESCRIPTION
They're a bit annoying when they always appear on startup.
Issue: #395