### PR TITLE
Toggle alternate groups with number keys

### DIFF
--- a/trview.app.tests/AlternateGroupTogglerTests.cpp
+++ b/trview.app.tests/AlternateGroupTogglerTests.cpp
@@ -1,0 +1,56 @@
+#include "CppUnitTest.h"
+#include <trview.app/AlternateGroupToggler.h>
+#include <trview.tests.common/Window.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace trview
+{
+    namespace tests
+    {
+        TEST_CLASS(AlternateGroupTogglerTests)
+        {
+            /// Tests that when a number key is pressed an alternate group is toggled.
+            TEST_METHOD(NumberKeys)
+            {
+                auto window = create_test_window(L"AlternateGroupToggler");
+                AlternateGroupToggler toggler(window);
+
+                bool called = false;
+                uint32_t called_group = 0;
+
+                auto token = toggler.on_alternate_group += [&](uint32_t group)
+                {
+                    called = true;
+                    called_group = group;
+                };
+
+                toggler.process_message(window, WM_CHAR, L'1', 0);
+
+                Assert::IsTrue(called, L"Callback was not raised");
+                Assert::AreEqual(called_group, 1u);
+            }
+
+            /// Tests that if a non-numeric character is sent, no event is raised.
+            TEST_METHOD(Characters)
+            {
+                auto window = create_test_window(L"AlternateGroupToggler");
+                AlternateGroupToggler toggler(window);
+
+                bool called = false;
+                uint32_t called_group = 0;
+
+                auto token = toggler.on_alternate_group += [&](uint32_t group)
+                {
+                    called = true;
+                    called_group = group;
+                };
+
+                toggler.process_message(window, WM_CHAR, L'A', 0);
+
+                Assert::IsFalse(called, L"Callback should not be raised");
+                Assert::AreEqual(called_group, 0u);
+            }
+        };
+    }
+}

--- a/trview.app.tests/AlternateGroupTogglerTests.cpp
+++ b/trview.app.tests/AlternateGroupTogglerTests.cpp
@@ -14,21 +14,25 @@ namespace trview
             TEST_METHOD(NumberKeys)
             {
                 auto window = create_test_window(L"AlternateGroupToggler");
-                AlternateGroupToggler toggler(window);
 
-                bool called = false;
-                uint32_t called_group = 0;
-
-                auto token = toggler.on_alternate_group += [&](uint32_t group)
+                for (uint32_t i = 0; i < 10; ++i)
                 {
-                    called = true;
-                    called_group = group;
-                };
+                    AlternateGroupToggler toggler(window);
 
-                toggler.process_message(window, WM_CHAR, L'1', 0);
+                    bool called = false;
+                    uint32_t called_group = 0;
 
-                Assert::IsTrue(called, L"Callback was not raised");
-                Assert::AreEqual(called_group, 1u);
+                    auto token = toggler.on_alternate_group += [&](uint32_t group)
+                    {
+                        called = true;
+                        called_group = group;
+                    };
+
+                    toggler.process_message(window, WM_CHAR, L'0' + i, 0);
+
+                    Assert::IsTrue(called, L"Callback was not raised");
+                    Assert::AreEqual(called_group, i);
+                }
             }
 
             /// Tests that if a non-numeric character is sent, no event is raised.

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="AlternateGroupTogglerTests.cpp" />
     <ClCompile Include="FileDropperTests.cpp" />
     <ClCompile Include="FreeCameraTests.cpp" />
     <ClCompile Include="OrbitCameraTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -7,8 +7,16 @@
     <ClCompile Include="FreeCameraTests.cpp" />
     <ClCompile Include="OrbitCameraTests.cpp" />
     <ClCompile Include="StringConversions.cpp" />
+    <ClCompile Include="AlternateGroupTogglerTests.cpp">
+      <Filter>Input</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StringConversions.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Input">
+      <UniqueIdentifier>{d3867a39-d160-4aeb-a8e2-02afcb4efbe2}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
 </Project>

--- a/trview.app/AlternateGroupToggler.cpp
+++ b/trview.app/AlternateGroupToggler.cpp
@@ -12,7 +12,7 @@ namespace trview
         if (message == WM_CHAR)
         {
             const wchar_t value = static_cast<wchar_t>(wParam);
-            if (value > L'0' && value <= L'9')
+            if (value >= L'0' && value <= L'9')
             {
                 on_alternate_group(value - L'0');
             }

--- a/trview.app/AlternateGroupToggler.cpp
+++ b/trview.app/AlternateGroupToggler.cpp
@@ -1,0 +1,21 @@
+#include "AlternateGroupToggler.h"
+
+namespace trview
+{
+    AlternateGroupToggler::AlternateGroupToggler(HWND window)
+        : MessageHandler(window)
+    {
+    }
+
+    void AlternateGroupToggler::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    {
+        if (message == WM_CHAR)
+        {
+            const wchar_t value = static_cast<wchar_t>(wParam);
+            if (value > L'0' && value <= L'9')
+            {
+                on_alternate_group(value - L'0');
+            }
+        }
+    }
+}

--- a/trview.app/AlternateGroupToggler.h
+++ b/trview.app/AlternateGroupToggler.h
@@ -1,0 +1,31 @@
+/// @file AlternateGroupToggler.h
+/// @brief Watches for input and toggles alternate groups when the user presses number keys.
+
+#pragma once
+
+#include <cstdint>
+#include <trview.common/MessageHandler.h>
+#include <trview.common/Event.h>
+
+namespace trview
+{
+    /// Watches for input and toggles alternate groups when the user presses number keys.
+    class AlternateGroupToggler final : public MessageHandler
+    {
+    public:
+        /// Create a new AlternateGroupToggler.
+        /// @param window The window to monitor.
+        explicit AlternateGroupToggler(HWND window);
+
+        /// Handles a window message.
+        /// @param window The window that received the message.
+        /// @param message The message that was received.
+        /// @param wParam The WPARAM for the message.
+        /// @param lParam The LPARAM for the message.
+        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+
+        /// Event raised when an alternate group is toggled by the user. The group
+        /// is passed as a parameter.
+        Event<uint32_t> on_alternate_group;
+    };
+}

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="AlternateGroupToggler.cpp" />
     <ClCompile Include="Camera.cpp" />
     <ClCompile Include="CollapsiblePanel.cpp" />
     <ClCompile Include="Compass.cpp" />
@@ -42,6 +43,7 @@
     <ClCompile Include="WindowResizer.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="AlternateGroupToggler.h" />
     <ClInclude Include="Camera.h" />
     <ClInclude Include="CollapsiblePanel.h" />
     <ClInclude Include="Compass.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -56,6 +56,9 @@
     <ClCompile Include="OrbitCamera.cpp">
       <Filter>Camera</Filter>
     </ClCompile>
+    <ClCompile Include="AlternateGroupToggler.cpp">
+      <Filter>Input</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="WindowResizer.h" />
@@ -121,6 +124,9 @@
     <ClInclude Include="OrbitCamera.h">
       <Filter>Camera</Filter>
     </ClInclude>
+    <ClInclude Include="AlternateGroupToggler.h">
+      <Filter>Input</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Items">
@@ -146,6 +152,9 @@
     </Filter>
     <Filter Include="Camera">
       <UniqueIdentifier>{d691a642-d434-42b6-b4d8-8fde59fea2af}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Input">
+      <UniqueIdentifier>{d7102050-10b8-49dc-bb00-6929c90f8339}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -464,6 +464,11 @@ namespace trview
         }
     }
 
+    bool Level::alternate_group(uint16_t group) const
+    {
+        return _alternate_groups.find(group) != _alternate_groups.end();
+    }
+
     // Determines whether the alternate mode specified is a mismatch with the current setting of 
     // the alternate mode flag.
     bool Level::is_alternate_mismatch(const Room& room) const

--- a/trview/Level.h
+++ b/trview/Level.h
@@ -88,6 +88,11 @@ namespace trview
         /// @param enabled Whether the group is enabled.
         void set_alternate_group(uint16_t group, bool enabled);
 
+        /// Gets whether the specified alternate group is active.
+        /// @param group The group to check.
+        /// @returns True if the group is active.
+        bool alternate_group(uint16_t group) const;
+
         // Event raised when the level needs to change the selected room.
         Event<uint16_t> on_room_selected;
 

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -83,7 +83,13 @@ namespace trview
 
         _token_store.add(_file_dropper.on_file_dropped += [&](const auto& file) { open(file); });
 
-        _token_store.add(_alternate_group_toggler.on_alternate_group += [&](uint32_t group) { set_alternate_group(group, !alternate_group(group)); });
+        _token_store.add(_alternate_group_toggler.on_alternate_group += [&](uint32_t group) 
+        { 
+            if (!_go_to_room->visible())
+            {
+                set_alternate_group(group, !alternate_group(group));
+            }
+        });
 
         initialise_input();
 

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -41,7 +41,7 @@ namespace trview
     Viewer::Viewer(const Window& window)
         : _window(window), _camera(window.size()), _free_camera(window.size()),
         _timer(default_time_source()), _keyboard(window), _mouse(window), _level_switcher(window),
-        _window_resizer(window), _recent_files(window), _file_dropper(window)
+        _window_resizer(window), _recent_files(window), _file_dropper(window), _alternate_group_toggler(window)
     {
         _settings = load_user_settings();
 
@@ -82,6 +82,8 @@ namespace trview
         _token_store.add(on_recent_files_changed += [&](const auto& files) { _recent_files.set_recent_files(files); });
 
         _token_store.add(_file_dropper.on_file_dropped += [&](const auto& file) { open(file); });
+
+        _token_store.add(_alternate_group_toggler.on_alternate_group += [&](uint32_t group) { set_alternate_group(group, !alternate_group(group)); });
 
         initialise_input();
 
@@ -784,6 +786,15 @@ namespace trview
             _level->set_alternate_group(group, enabled);
             _flipmaps->set_alternate_group(group, enabled);
         }
+    }
+
+    bool Viewer::alternate_group(uint16_t group) const
+    {
+        if (_level)
+        {
+            return _level->alternate_group(group);
+        }
+        return false;
     }
 
     void Viewer::resize_elements()

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -33,6 +33,7 @@
 #include <trview.app/Toolbar.h>
 #include <trview.app/Measure.h>
 #include <trview.app/Compass.h>
+#include <trview.app/AlternateGroupToggler.h>
 
 namespace trview
 {
@@ -116,6 +117,7 @@ namespace trview
         void set_camera_mode(CameraMode camera_mode);
         void set_alternate_mode(bool enabled);
         void set_alternate_group(uint16_t group, bool enabled);
+        bool alternate_group(uint16_t group) const;
         // Tell things that need to be resized that they should resize.
         void resize_elements();
         // Set up keyboard and mouse input for the camera.
@@ -157,6 +159,7 @@ namespace trview
         RecentFiles _recent_files;
         FileDropper _file_dropper;
         TokenStore _token_store;
+        AlternateGroupToggler _alternate_group_toggler;
         DirectX::SimpleMath::Vector3 _target;
 
         // Tools:


### PR DESCRIPTION
When a TR4/5 level is loaded, the user can use the number keys to toggle the appropriate alternate group.
This should make clicking on the tiny buttons less of an issue (if it ever was one)
Issue: #400 