### PR TITLE
Add separate margin property in UI

### DIFF
--- a/trview.ui/StackPanel.cpp
+++ b/trview.ui/StackPanel.cpp
@@ -27,7 +27,7 @@ namespace trview
                 auto last_size = last->size();
                 return get_next_position(last_position, last_size);
             }
-            return Point(_padding.width, _padding.height);
+            return Point(_margin.width, _margin.height);
         }
 
         Point StackPanel::get_next_position(Point previous_position, Size previous_size) const
@@ -39,7 +39,7 @@ namespace trview
 
         void StackPanel::recalculate_layout()
         {
-            Point previous_position(_padding.width, _padding.height);
+            Point previous_position(_margin.width, _margin.height);
             Size previous_size(0,0);
             float max_height = 0;
             float max_width = 0;
@@ -57,7 +57,7 @@ namespace trview
 
             if (_size_mode == SizeMode::Auto)
             {
-                auto size = Size(previous_position.x + _padding.width, previous_position.y + _padding.height);
+                auto size = Size(previous_position.x + _margin.width, previous_position.y + _margin.height);
 
                 if (_direction == Direction::Horizontal)
                 {

--- a/trview.ui/StackPanel.cpp
+++ b/trview.ui/StackPanel.cpp
@@ -112,5 +112,11 @@ namespace trview
             _size_dimension = dimension;
             recalculate_layout();
         }
+
+        void StackPanel::set_margin(const Size& margin)
+        {
+            _margin = margin;
+            recalculate_layout();
+        }
     }
 }

--- a/trview.ui/StackPanel.h
+++ b/trview.ui/StackPanel.h
@@ -31,7 +31,7 @@ namespace trview
             /// @param padding The amount of padding to place between each element.
             /// @param direction The direction in which to stack elements. Defaults to Vertical.
             /// @param size_mode Whether or not to resize the panel automatically.
-            StackPanel(Point position, Size size, Colour colour, Size padding, Direction direction = Direction::Vertical, SizeMode size_mode = SizeMode::Auto);
+            StackPanel(Point position, Size size, Colour colour, Size padding = Size(), Direction direction = Direction::Vertical, SizeMode size_mode = SizeMode::Auto);
 
             /// Destructor for StackPanel.
             virtual ~StackPanel() = default;
@@ -39,6 +39,10 @@ namespace trview
             /// Set which dimensions in which the stack panel will automatically expand.
             /// @param dimension The dimension in which to expand.
             void set_auto_size_dimension(SizeDimension dimension);
+
+            /// Set the margin value to space before the first and after the last elements.
+            /// @param margin The margin to apply.
+            void set_margin(const Size& margin);
         protected:
             /// Add a child to this element. This will place the new element in the appropriate
             /// position based on the layout direction and the elements already in the control.
@@ -49,6 +53,7 @@ namespace trview
             Point get_next_position(Point previous_position, Size previous_size) const;
             void recalculate_layout();
             const Size _padding;
+            Size _margin;
             const Direction _direction;
             SizeMode _size_mode;
             SizeDimension _size_dimension{ SizeDimension::All };

--- a/trview/LevelInfo.cpp
+++ b/trview/LevelInfo.cpp
@@ -34,6 +34,7 @@ namespace trview
 
         using namespace ui;
         auto panel = std::make_unique<StackPanel>(Point(control.size().width / 2.0f - 50, 0), Size(100, 24), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(5, 5), StackPanel::Direction::Horizontal, SizeMode::Auto);
+        panel->set_margin(Size(5, 5));
         auto version = std::make_unique<Image>(Point(), Size(16, 16));
         version->set_background_colour(Colour(0, 0, 0, 0));
         version->set_texture(get_version_image(trlevel::LevelVersion::Unknown));

--- a/trview/SettingsWindow.cpp
+++ b/trview/SettingsWindow.cpp
@@ -30,6 +30,7 @@ namespace trview
         // Create the rest of the window contents.
         auto panel = std::make_unique<StackPanel>(Point(), Size(400, 250), background_colour, Size(5,5));
         panel->set_auto_size_dimension(SizeDimension::Height);
+        panel->set_margin(Size(5, 5));
 
         auto vsync = std::make_unique<Checkbox>(Point(), Size(16, 16), L"Vsync");
         vsync->on_state_changed += on_vsync;

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -197,6 +197,7 @@ namespace trview
 
         // This is the main tool window on the side of the screen.
         auto tool_window = std::make_unique<ui::StackPanel>(Point(), Size(150.0f, 348.0f), Colour(1.f, 0.5f, 0.5f, 0.5f), Size(5, 5));
+        tool_window->set_margin(Size(5, 5));
 
         _room_navigator = std::make_unique<RoomNavigator>(*tool_window.get(), *_texture_storage.get());
         _token_store.add(_room_navigator->on_room_selected += [&](uint32_t room) { select_room(room); });


### PR DESCRIPTION
Margin is used for before the first and after the last elements.
Padding (which it has been split from) is for the in-between bits.
This helps with the context menu that is being made for routes.
Issue: #408 