### PR TITLE
Add margin to Items and Triggers window

### DIFF
--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -93,9 +93,11 @@ namespace trview
     {
         using namespace ui;
         auto left_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colours::LeftPanel, Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
+        left_panel->set_margin(Size(0, 3));
 
         // Control modes:.
         auto controls = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        controls->set_margin(Size(2, 2));
         auto track_room = std::make_unique<Checkbox>(Point(), Size(16, 16), Colours::LeftPanel, L"Track Room");
         _token_store.add(track_room->on_state_changed += [this](bool value)
         {

--- a/trview.app/TriggersWindow.cpp
+++ b/trview.app/TriggersWindow.cpp
@@ -51,10 +51,13 @@ namespace trview
         using namespace ui;
 
         auto left_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colours::LeftPanel, Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
+        left_panel->set_margin(Size(0, 3));
 
         // Control modes:.
         auto controls_box = std::make_unique<StackPanel>(Point(), Size(200, 50), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Vertical, SizeMode::Manual);
+        controls_box->set_margin(Size(2, 2));
         auto controls = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        controls->set_margin(Size(2, 2));
         auto track_room = std::make_unique<Checkbox>(Point(), Size(16, 16), Colours::LeftPanel, L"Track Room");
         _token_store.add(track_room->on_state_changed += [this](bool value)
         {
@@ -79,8 +82,9 @@ namespace trview
 
         // Command filter:
         auto controls_row2 = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 0), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        controls_row2->set_margin(Size(2, 0));
 
-        auto command_filter = std::make_unique<Dropdown>(Point(), Size(183, 20));
+        auto command_filter = std::make_unique<Dropdown>(Point(), Size(186, 20));
         command_filter->set_values({L"All"});
         command_filter->set_dropdown_scope(_ui.get());
         command_filter->set_selected_value(L"All");


### PR DESCRIPTION
They were using it to space out the elements.
Add margin to replace changed meaning of padding.
#409