### PR TITLE
Create a TextArea control

### DIFF
--- a/trview.app/CollapsiblePanel.cpp
+++ b/trview.app/CollapsiblePanel.cpp
@@ -85,6 +85,7 @@ namespace trview
         _token_store.add(_mouse.mouse_down += [&](input::Mouse::Button) { _ui->process_mouse_down(client_cursor_position(window())); });
         _token_store.add(_mouse.mouse_wheel += [&](int16_t delta) { _ui->mouse_scroll(client_cursor_position(window()), delta); });
         _token_store.add(_keyboard.on_key_down += [&](auto key) { _ui->process_key_down(key); });
+        _token_store.add(_keyboard.on_char += [&](auto key) { _ui->process_char(key); });
 
         _ui = std::make_unique<ui::Window>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f));
     }

--- a/trview.ui.render/LabelNode.cpp
+++ b/trview.ui.render/LabelNode.cpp
@@ -22,11 +22,17 @@ namespace trview
                         generate_font_texture();
                     });
                 }
-                
+                _label->set_measurer(this);
             }
 
             LabelNode::~LabelNode()
             {
+                _label->set_measurer(nullptr);
+            }
+
+            Size LabelNode::measure(const std::wstring& text) const
+            {
+                return _font->measure(text);
             }
 
             void LabelNode::render_self(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, graphics::Sprite& sprite)

--- a/trview.ui.render/LabelNode.h
+++ b/trview.ui.render/LabelNode.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "WindowNode.h"
+#include <trview.ui/IFontMeasurer.h>
 
 namespace trview
 {
@@ -16,11 +17,12 @@ namespace trview
 
         namespace render
         {
-            class LabelNode : public WindowNode
+            class LabelNode : public WindowNode, public IFontMeasurer
             {
             public:
                 LabelNode(const Microsoft::WRL::ComPtr<ID3D11Device>& device, Label* label, const graphics::FontFactory& font_factory);
                 virtual ~LabelNode();
+                virtual Size measure(const std::wstring& text) const override;
             protected:
                 virtual void render_self(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, graphics::Sprite& sprite) override;
             private:

--- a/trview.ui.render/RenderNode.cpp
+++ b/trview.ui.render/RenderNode.cpp
@@ -109,7 +109,8 @@ namespace trview
 
             void RenderNode::regenerate_texture()
             {
-                const auto size = _control->size();
+                auto size = _control->size();
+                size = Size(size.width == 0 ? 1 : size.width, size.height == 0 ? 1 : size.height);
                 _render_target = std::make_unique<graphics::RenderTarget>(_device, static_cast<uint32_t>(size.width), static_cast<uint32_t>(size.height));
             }
 

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -488,5 +488,11 @@ namespace trview
             _z = value;
             on_invalidate();
         }
+
+        void Control::remove_child(Control* child_element)
+        {
+            _child_elements.erase(std::remove_if(_child_elements.begin(), _child_elements.end(), [&](const auto& element) { return element.get() == child_element; }), _child_elements.end());
+            on_hierarchy_changed();
+        }
     }
 }

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -311,6 +311,11 @@ namespace trview
             return false;
         }
 
+        bool Control::key_char(wchar_t key)
+        {
+            return false;
+        }
+
         void Control::set_focus_control(Control* control)
         {
             if (_parent)
@@ -378,6 +383,27 @@ namespace trview
             // If none of the child elements have handled this event themselves, call the key_down
             // event of the control.
             return key_down(key);
+        }
+
+        bool Control::process_char(wchar_t key)
+        {
+            if (_focus_control && _focus_control != this && _focus_control->key_char(key))
+            {
+                return true;
+            }
+            return inner_process_char(key);
+        }
+
+        bool Control::inner_process_char(wchar_t key)
+        {
+            for (auto& child : child_elements())
+            {
+                if (child->inner_process_char(key))
+                {
+                    return true;
+                }
+            }
+            return key_char(key);
         }
 
         bool Control::is_mouse_over(const Point& position) const

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -133,6 +133,11 @@ namespace trview
             /// @returns True if the event was processed by the control.
             bool process_key_down(uint16_t key);
 
+            /// Process a char event.
+            /// @param key The character that was pressed.
+            /// @returns True if the event was processed by the control.
+            bool process_char(wchar_t key);
+
             /// Set the size of the control.
             /// @param size The new size of the control.
             void set_size(Size size);
@@ -217,6 +222,12 @@ namespace trview
             /// @returns True if the key event was handled.
             virtual bool key_down(uint16_t key);
 
+            /// To be called when a key character is pressed.
+            /// This should be overriden by child elements to handle a key char event.
+            /// @param key The key that was pressed.
+            /// @returns True if the key char event was handled.
+            virtual bool key_char(wchar_t key);
+
             /// Set the control in the tree that has focus.
             /// @param control The current focus control
             void set_focus_control(Control* control);
@@ -250,6 +261,10 @@ namespace trview
             /// Process a key down and recurse to child controls.
             /// @param key The key that was pressed.
             bool inner_process_key_down(uint16_t key);
+
+            /// Process a character key press and recurse to child controls.
+            /// @param key The character that was pressed.
+            bool inner_process_char(wchar_t key);
 
             /// Process a mouse scroll and recurse to child controls.
             /// @param delta The mouse scroll delta.

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -160,6 +160,10 @@ namespace trview
             /// @param value The new z order.
             void set_z(int value);
 
+            /// Remove the specified child element.
+            /// @param child_element The element to remove.
+            void remove_child(Control* child_element);
+
             /// Event raised when the size of the control has changed.
             Event<Size> on_size_changed;
 

--- a/trview.ui/IFontMeasurer.cpp
+++ b/trview.ui/IFontMeasurer.cpp
@@ -1,0 +1,11 @@
+#include "IFontMeasurer.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        IFontMeasurer::~IFontMeasurer()
+        {
+        }
+    }
+}

--- a/trview.ui/IFontMeasurer.h
+++ b/trview.ui/IFontMeasurer.h
@@ -1,3 +1,6 @@
+/// @file IFontMeasurer.h
+/// @brief Interface to allow the UI to find out what size a string will be when rendered.
+
 #pragma once
 
 #include <trview.common/Size.h>
@@ -7,6 +10,7 @@ namespace trview
 {
     namespace ui
     {
+        /// Interface to allow the UI to find out what size a string will be when rendered.
         struct IFontMeasurer
         {
             virtual ~IFontMeasurer() = 0;

--- a/trview.ui/IFontMeasurer.h
+++ b/trview.ui/IFontMeasurer.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <trview.common/Size.h>
+#include <string>
+
+namespace trview
+{
+    namespace ui
+    {
+        struct IFontMeasurer
+        {
+            virtual ~IFontMeasurer() = 0;
+
+            /// Measure the specified text.
+            /// @param text The text to measure.
+            virtual Size measure(const std::wstring& text) const = 0;
+        };
+    }
+}

--- a/trview.ui/Label.cpp
+++ b/trview.ui/Label.cpp
@@ -52,5 +52,19 @@ namespace trview
             on_text_changed(_text);
             on_invalidate();
         }
+
+        Size Label::measure_text(const std::wstring& text) const
+        {
+            if (!_measurer)
+            {
+                return Size();
+            }
+            return _measurer->measure(text);
+        }
+
+        void Label::set_measurer(IFontMeasurer* measurer)
+        {
+            _measurer = measurer;
+        }
     }
 }

--- a/trview.ui/Label.h
+++ b/trview.ui/Label.h
@@ -8,6 +8,7 @@
 #include <trview.graphics/TextAlignment.h>
 #include <trview.graphics/ParagraphAlignment.h>
 #include "SizeMode.h"
+#include "IFontMeasurer.h"
 
 namespace trview
 {
@@ -43,13 +44,23 @@ namespace trview
             /// Set the text colour for the label.
             /// @param colour The new text colour.
             void set_text_colour(const Colour& colour);
+
+            /// Measure the specified text.
+            /// @param text The text to measure.
+            /// @returns The size of the rendered text.
+            Size measure_text(const std::wstring& text) const;
+
+            /// Set the measurer used to measure how big text will be.
+            /// @param measurer The measurer instance.
+            void set_measurer(IFontMeasurer* measurer);
         private:
-            std::wstring                 _text;
-            int                          _text_size;
-            graphics::TextAlignment      _text_alignment;
-            graphics::ParagraphAlignment _paragraph_alignment;
-            SizeMode                     _size_mode;
-            Colour                       _text_colour;
+            std::wstring                   _text;
+            int                            _text_size;
+            graphics::TextAlignment        _text_alignment;
+            graphics::ParagraphAlignment   _paragraph_alignment;
+            SizeMode                       _size_mode;
+            Colour                         _text_colour;
+            IFontMeasurer*                 _measurer{ nullptr };
         };
     }
 }

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -56,6 +56,15 @@ namespace trview
             _cursor->set_size(Size(1, line->size().height == 0 ? _cursor->size().height : line->size().height));
         }
 
+        void TextArea::set_text(const std::wstring& text)
+        {
+            while (!_lines.empty())
+            {
+                remove_line();
+            }
+            add_line(text);
+        }
+
         bool TextArea::mouse_down(const Point& position)
         {
             return true;
@@ -70,9 +79,9 @@ namespace trview
             return _lines.back();
         }
 
-        void TextArea::add_line()
+        void TextArea::add_line(std::wstring text)
         {
-            _lines.push_back(_area->add_child(std::make_unique<Label>(Point(), Size(size().width, 14), background_colour(), L"", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto)));
+            _lines.push_back(_area->add_child(std::make_unique<Label>(Point(), Size(size().width, 14), background_colour(), text, 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto)));
         }
 
         void TextArea::remove_line()

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -28,7 +28,15 @@ namespace trview
                 {
                     text.pop_back();
                 }
+                else
+                {
+                    remove_line();
+                    return;
+                }
                 break;
+            case 0xD:
+                add_line();
+                return;
             default:
                 text += static_cast<wchar_t>(character);
                 break;
@@ -46,9 +54,25 @@ namespace trview
         {
             if (_lines.empty())
             {
-                _lines.push_back(add_child(std::make_unique<Label>(Point(), Size(size().width, 20), background_colour(), L"", 8)));
+                add_line();
             }
             return _lines.back();
+        }
+
+        void TextArea::add_line()
+        {
+            _lines.push_back(add_child(std::make_unique<Label>(Point(), Size(size().width, 20), background_colour(), L"", 8)));
+        }
+
+        void TextArea::remove_line()
+        {
+            if (_lines.empty())
+            {
+                return;
+            }
+
+            remove_child(_lines.back());
+            _lines.pop_back();
         }
     }
 }

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -61,7 +61,7 @@ namespace trview
 
         void TextArea::add_line()
         {
-            _lines.push_back(add_child(std::make_unique<Label>(Point(), Size(size().width, 20), background_colour(), L"", 8)));
+            _lines.push_back(add_child(std::make_unique<Label>(Point(), Size(size().width, 14), background_colour(), L"", 8)));
         }
 
         void TextArea::remove_line()

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -94,6 +94,10 @@ namespace trview
             {
                 add_line(line);
             }
+
+            _cursor_line = _lines.empty() ? 0 : _lines.size() - 1;
+            _cursor_position = _lines.empty() ? 0 : _lines.back()->text().size();
+            update_cursor();
         }
 
         bool TextArea::mouse_down(const Point& position)

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -1,0 +1,54 @@
+#include "TextArea.h"
+#include "Label.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        TextArea::TextArea(const Point& position, const Size& size, const Colour& background_colour, const Colour& text_colour)
+            : StackPanel(position, size, background_colour, Size(), Direction::Vertical, SizeMode::Manual), _text_colour(text_colour)
+        {
+            set_handles_input(true);
+        }
+
+        void TextArea::handle_char(uint16_t character)
+        {
+            if (focus_control() != this)
+            {
+                return;
+            }
+
+            auto line = current_line();
+            auto text = line->text();
+
+            switch(character)
+            {
+            case 0x8:
+                if (!text.empty())
+                {
+                    text.pop_back();
+                }
+                break;
+            default:
+                text += static_cast<wchar_t>(character);
+                break;
+            }
+
+            line->set_text(text);
+        }
+
+        bool TextArea::mouse_down(const Point& position)
+        {
+            return true;
+        }
+
+        Label* TextArea::current_line()
+        {
+            if (_lines.empty())
+            {
+                _lines.push_back(add_child(std::make_unique<Label>(Point(), Size(size().width, 20), background_colour(), L"", 8)));
+            }
+            return _lines.back();
+        }
+    }
+}

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -50,10 +50,7 @@ namespace trview
             };
 
             process_char();
-
-            auto line = current_line();
-            _cursor->set_position(Point(line->size().width + 2, line->position().y));
-            _cursor->set_size(Size(1, line->size().height == 0 ? _cursor->size().height : line->size().height));
+            update_cursor();
         }
 
         void TextArea::set_text(const std::wstring& text)
@@ -82,6 +79,7 @@ namespace trview
         void TextArea::add_line(std::wstring text)
         {
             _lines.push_back(_area->add_child(std::make_unique<Label>(Point(), Size(size().width, 14), background_colour(), text, 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto)));
+            update_cursor();
         }
 
         void TextArea::remove_line()
@@ -93,6 +91,13 @@ namespace trview
 
             _area->remove_child(_lines.back());
             _lines.pop_back();
+        }
+
+        void TextArea::update_cursor()
+        {
+            auto line = current_line();
+            _cursor->set_position(Point(line->size().width + 2, line->position().y));
+            _cursor->set_size(Size(1, line->size().height == 0 ? _cursor->size().height : line->size().height));
         }
     }
 }

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -15,13 +15,8 @@ namespace trview
             set_handles_input(true);
         }
 
-        void TextArea::handle_char(uint16_t character)
+        bool TextArea::key_char(wchar_t character)
         {
-            if (focus_control() != this)
-            {
-                return;
-            }
-
             auto process_char = [&]()
             {
                 auto line = current_line();
@@ -79,6 +74,7 @@ namespace trview
 
             process_char();
             update_cursor();
+            return true;
         }
 
         void TextArea::set_text(const std::wstring& text)

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -127,6 +127,11 @@ namespace trview
                     {
                         --_cursor_position;
                     }
+                    else if (_cursor_line > 0)
+                    {
+                        --_cursor_line;
+                        _cursor_position = _lines[_cursor_line]->text().size();
+                    }
                     break;
                 }
                 // VK_UP
@@ -135,13 +140,22 @@ namespace trview
                     if (_cursor_line > 0)
                     {
                         --_cursor_line;
+                        _cursor_position = std::min(static_cast<uint32_t>(_lines[_cursor_line]->text().size()), _cursor_position);
                     }
                     break;
                 }
                 // VK_RIGHT
                 case 0x27:
                 {
-                    _cursor_position = std::min(static_cast<uint32_t>(text.size()), _cursor_position + 1);
+                    if (_cursor_position < text.size())
+                    {
+                        ++_cursor_position;
+                    }
+                    else if (_cursor_line + 1 < _lines.size())
+                    {
+                        ++_cursor_line;
+                        _cursor_position = 0;
+                    }
                     break;
                 }
                 // VK_DOWN
@@ -150,6 +164,7 @@ namespace trview
                     if (!_lines.empty())
                     {
                         _cursor_line = std::min(_cursor_line + 1, static_cast<uint32_t>(_lines.size()) - 1u);
+                        _cursor_position = std::min(static_cast<uint32_t>(_lines[_cursor_line]->text().size()), _cursor_position);
                     }
                     break;
                 }

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -99,6 +99,18 @@ namespace trview
 
             switch (key) 
             {
+                // VK_END
+                case 0x23:
+                {
+                    _cursor_position = text.size();
+                    break;
+                }
+                // VK_HOME
+                case 0x24:
+                {
+                    _cursor_position = 0;
+                    break;
+                }
                 // VK_LEFT
                 case 0x25:
                 {
@@ -123,18 +135,20 @@ namespace trview
                     _cursor_position = std::min(static_cast<uint32_t>(text.size()), _cursor_position + 1);
                     break;
                 }
+                // VK_DOWN
+                case 0x28:
+                {
+                    if (!_lines.empty())
+                    {
+                        _cursor_line = std::min(_cursor_line + 1, static_cast<uint32_t>(_lines.size()) - 1u);
+                    }
+                    break;
+                }
                 // VK_DELETE
                 case 0x2E:
                 {
                     text.erase(_cursor_position, 1);
-                    if (text.empty())
-                    {
-                        remove_line(_cursor_line);
-                    }
-                    else
-                    {
-                        line->set_text(text);
-                    }
+                    line->set_text(text);
                     break;
                 }
             }
@@ -167,6 +181,10 @@ namespace trview
 
             _area->remove_child(_lines.back());
             _lines.pop_back();
+            if (_cursor_line >= _lines.size() && _cursor_line > 0)
+            {
+                --_cursor_line;
+            }
         }
 
         void TextArea::remove_line(uint32_t line)
@@ -178,6 +196,10 @@ namespace trview
 
             _area->remove_child(_lines[line]);
             _lines.erase(_lines.begin() + line);
+            if (_cursor_line >= _lines.size() && _cursor_line > 0)
+            {
+                --_cursor_line;
+            }
         }
 
         void TextArea::update_cursor()

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -85,19 +85,19 @@ namespace trview
         {
             while (!_lines.empty())
             {
-                remove_line();
+                remove_line(false);
             }
 
             std::wstringstream stream(text);
             std::wstring line;
             while (std::getline(stream, line, L'\n'))
             {
-                add_line(line);
+                add_line(line, false);
             }
 
             _cursor_line = _lines.empty() ? 0 : _lines.size() - 1;
             _cursor_position = _lines.empty() ? 0 : _lines.back()->text().size();
-            update_cursor();
+            update_cursor(false);
         }
 
         bool TextArea::mouse_down(const Point& position)
@@ -185,24 +185,27 @@ namespace trview
             return true;
         }
 
-        Label* TextArea::current_line()
+        Label* TextArea::current_line(bool raise_event)
         {
             if (_lines.empty())
             {
-                add_line();
+                add_line(std::wstring(), raise_event);
             }
             return _lines[_cursor_line];
         }
 
-        void TextArea::add_line(std::wstring text)
+        void TextArea::add_line(std::wstring text, bool raise_event)
         {
             _lines.push_back(_area->add_child(std::make_unique<Label>(Point(), Size(size().width, 14), background_colour(), text, 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto)));
-            notify_text_updated();
+            if (raise_event)
+            {
+                notify_text_updated();
+            }
             _cursor_position = text.size();
-            update_cursor();
+            update_cursor(raise_event);
         }
 
-        void TextArea::remove_line()
+        void TextArea::remove_line(bool raise_event)
         {
             if (_lines.empty())
             {
@@ -215,7 +218,11 @@ namespace trview
             {
                 --_cursor_line;
             }
-            notify_text_updated();
+
+            if (raise_event)
+            {
+                notify_text_updated();
+            }
         }
 
         void TextArea::remove_line(uint32_t line)
@@ -234,10 +241,10 @@ namespace trview
             notify_text_updated();
         }
 
-        void TextArea::update_cursor()
+        void TextArea::update_cursor(bool raise_event)
         {
             // Get the current line and the text it is rendering.
-            auto line = current_line();
+            auto line = current_line(raise_event);
             auto text = line->text();
 
             // Place the cursor based on the current cursor position and the size of the text

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -9,6 +9,7 @@ namespace trview
             : Window(position, size, background_colour), _text_colour(text_colour)
         {
             _area = add_child(std::make_unique<StackPanel>(Point(), size, background_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual));
+            _area->set_margin(Size(1, 1));
             _cursor = add_child(std::make_unique<Window>(Point(), Size(1, 14), text_colour));
             set_handles_input(true);
         }
@@ -31,6 +32,7 @@ namespace trview
                     if (!text.empty())
                     {
                         text.pop_back();
+                        --_cursor_position;
                     }
                     else
                     {
@@ -43,6 +45,7 @@ namespace trview
                     return;
                 default:
                     text += static_cast<wchar_t>(character);
+                    ++_cursor_position;
                     break;
                 }
 

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -32,18 +32,18 @@ namespace trview
             virtual bool mouse_down(const Point& position) override;
             virtual bool key_down(uint16_t key) override;
         private:
-            Label* current_line();
+            Label* current_line(bool raise_event = true);
 
             /// Add a new line to the text area with the specified content.
             /// @param text The optional content to use.
-            void add_line(std::wstring text = std::wstring());
+            void add_line(std::wstring text = std::wstring(), bool raise_event = true);
 
-            void remove_line();
+            void remove_line(bool raise_event = true);
 
             void remove_line(uint32_t line);
 
             /// Move the cursor element to be in the correct place.
-            void update_cursor();
+            void update_cursor(bool raise_event = true);
 
             void notify_text_updated();
 

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -21,11 +21,15 @@ namespace trview
 
             /// Handle character input from the keyboard.
             void handle_char(uint16_t character);
+
+            /// Set the text in the text area to be the specified text.
+            /// @param text The text to use.
+            void set_text(const std::wstring& text);
         protected:
             virtual bool mouse_down(const Point& position) override;
         private:
             Label* current_line();
-            void add_line();
+            void add_line(std::wstring text = std::wstring());
             void remove_line();
 
             StackPanel*         _area;

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -19,9 +19,6 @@ namespace trview
             /// @param text_colour The text colour for the text area.
             explicit TextArea(const Point& position, const Size& size, const Colour& background_colour, const Colour& text_colour);
 
-            /// Handle character input from the keyboard.
-            void handle_char(uint16_t character);
-
             /// Set the text in the text area to be the specified text.
             /// @param text The text to use.
             void set_text(const std::wstring& text);
@@ -31,6 +28,7 @@ namespace trview
         protected:
             virtual bool mouse_down(const Point& position) override;
             virtual bool key_down(uint16_t key) override;
+            virtual bool key_char(wchar_t character) override;
         private:
             Label* current_line(bool raise_event = true);
 

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -31,6 +31,7 @@ namespace trview
             Label* current_line();
             void add_line(std::wstring text = std::wstring());
             void remove_line();
+            void update_cursor();
 
             StackPanel*         _area;
             std::vector<Label*> _lines;

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -37,6 +37,7 @@ namespace trview
             std::vector<Label*> _lines;
             Colour              _text_colour;
             Window*             _cursor;
+            uint32_t            _cursor_position{ 0u };
         };
     }
 }

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -37,6 +37,8 @@ namespace trview
 
             void remove_line();
 
+            void remove_line(uint32_t line);
+
             /// Move the cursor element to be in the correct place.
             void update_cursor();
 
@@ -45,6 +47,7 @@ namespace trview
             Colour              _text_colour;
             Window*             _cursor;
             uint32_t            _cursor_position{ 0u };
+            uint32_t            _cursor_line{ 0u };
         };
     }
 }

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -27,10 +27,17 @@ namespace trview
             void set_text(const std::wstring& text);
         protected:
             virtual bool mouse_down(const Point& position) override;
+            virtual bool key_down(uint16_t key) override;
         private:
             Label* current_line();
+
+            /// Add a new line to the text area with the specified content.
+            /// @param text The optional content to use.
             void add_line(std::wstring text = std::wstring());
+
             void remove_line();
+
+            /// Move the cursor element to be in the correct place.
             void update_cursor();
 
             StackPanel*         _area;

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -25,6 +25,9 @@ namespace trview
             /// Set the text in the text area to be the specified text.
             /// @param text The text to use.
             void set_text(const std::wstring& text);
+
+            /// Event raised when the text in the text area has changed.
+            Event<std::wstring> on_text_changed;
         protected:
             virtual bool mouse_down(const Point& position) override;
             virtual bool key_down(uint16_t key) override;
@@ -41,6 +44,8 @@ namespace trview
 
             /// Move the cursor element to be in the correct place.
             void update_cursor();
+
+            void notify_text_updated();
 
             StackPanel*         _area;
             std::vector<Label*> _lines;

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -25,6 +25,8 @@ namespace trview
             virtual bool mouse_down(const Point& position) override;
         private:
             Label* current_line();
+            void add_line();
+            void remove_line();
 
             std::vector<Label*> _lines;
             Colour              _text_colour;

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "StackPanel.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        class Label;
+
+        /// A text area is a number of lines of text.
+        class TextArea final : public StackPanel
+        {
+        public:
+            /// Create a text area.
+            /// @param position The position to place the control.
+            /// @param size The size of the control.
+            /// @param background_colour The background colour of the text area.
+            /// @param text_colour The text colour for the text area.
+            explicit TextArea(const Point& position, const Size& size, const Colour& background_colour, const Colour& text_colour);
+
+            /// Handle character input from the keyboard.
+            void handle_char(uint16_t character);
+        protected:
+            virtual bool mouse_down(const Point& position) override;
+        private:
+            Label* current_line();
+
+            std::vector<Label*> _lines;
+            Colour              _text_colour;
+        };
+    }
+}

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -9,7 +9,7 @@ namespace trview
         class Label;
 
         /// A text area is a number of lines of text.
-        class TextArea final : public StackPanel
+        class TextArea final : public Window
         {
         public:
             /// Create a text area.
@@ -28,8 +28,10 @@ namespace trview
             void add_line();
             void remove_line();
 
+            StackPanel*         _area;
             std::vector<Label*> _lines;
             Colour              _text_colour;
+            Window*             _cursor;
         };
     }
 }

--- a/trview.ui/trview.ui.vcxproj
+++ b/trview.ui/trview.ui.vcxproj
@@ -24,6 +24,7 @@
     <ClInclude Include="Control.h" />
     <ClInclude Include="Dropdown.h" />
     <ClInclude Include="GroupBox.h" />
+    <ClInclude Include="IFontMeasurer.h" />
     <ClInclude Include="Image.h" />
     <ClInclude Include="Label.h" />
     <ClInclude Include="Listbox.h" />
@@ -42,6 +43,7 @@
     <ClCompile Include="Control.cpp" />
     <ClCompile Include="Dropdown.cpp" />
     <ClCompile Include="GroupBox.cpp" />
+    <ClCompile Include="IFontMeasurer.cpp" />
     <ClCompile Include="Image.cpp" />
     <ClCompile Include="Label.cpp" />
     <ClCompile Include="Listbox.cpp" />

--- a/trview.ui/trview.ui.vcxproj
+++ b/trview.ui/trview.ui.vcxproj
@@ -34,6 +34,7 @@
     <ClInclude Include="Slider.h" />
     <ClInclude Include="StackPanel.h" />
     <ClInclude Include="Checkbox.h" />
+    <ClInclude Include="TextArea.h" />
     <ClInclude Include="Window.h" />
   </ItemGroup>
   <ItemGroup>
@@ -52,6 +53,7 @@
     <ClCompile Include="Slider.cpp" />
     <ClCompile Include="StackPanel.cpp" />
     <ClCompile Include="Checkbox.cpp" />
+    <ClCompile Include="TextArea.cpp" />
     <ClCompile Include="Window.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/trview.ui/trview.ui.vcxproj.filters
+++ b/trview.ui/trview.ui.vcxproj.filters
@@ -49,6 +49,9 @@
     <ClInclude Include="Dropdown.h">
       <Filter>Controls\Dropdown</Filter>
     </ClInclude>
+    <ClInclude Include="TextArea.h">
+      <Filter>Controls\TextArea</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Control.cpp">
@@ -99,6 +102,9 @@
     <ClCompile Include="Dropdown.cpp">
       <Filter>Controls\Dropdown</Filter>
     </ClCompile>
+    <ClCompile Include="TextArea.cpp">
+      <Filter>Controls\TextArea</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Types">
@@ -115,6 +121,9 @@
     </Filter>
     <Filter Include="Controls\Dropdown">
       <UniqueIdentifier>{07f12ab6-b126-4ef8-b58d-9a1ef6abb44b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Controls\TextArea">
+      <UniqueIdentifier>{4442810d-913c-42e8-839a-c9de84a71ec3}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/trview.ui/trview.ui.vcxproj.filters
+++ b/trview.ui/trview.ui.vcxproj.filters
@@ -7,9 +7,6 @@
     <ClInclude Include="Window.h">
       <Filter>Controls</Filter>
     </ClInclude>
-    <ClInclude Include="Label.h">
-      <Filter>Controls</Filter>
-    </ClInclude>
     <ClInclude Include="Image.h">
       <Filter>Controls</Filter>
     </ClInclude>
@@ -52,15 +49,18 @@
     <ClInclude Include="TextArea.h">
       <Filter>Controls\TextArea</Filter>
     </ClInclude>
+    <ClInclude Include="Label.h">
+      <Filter>Controls\Label</Filter>
+    </ClInclude>
+    <ClInclude Include="IFontMeasurer.h">
+      <Filter>Controls\Label</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Control.cpp">
       <Filter>Controls</Filter>
     </ClCompile>
     <ClCompile Include="Window.cpp">
-      <Filter>Controls</Filter>
-    </ClCompile>
-    <ClCompile Include="Label.cpp">
       <Filter>Controls</Filter>
     </ClCompile>
     <ClCompile Include="Image.cpp">
@@ -105,6 +105,12 @@
     <ClCompile Include="TextArea.cpp">
       <Filter>Controls\TextArea</Filter>
     </ClCompile>
+    <ClCompile Include="Label.cpp">
+      <Filter>Controls\Label</Filter>
+    </ClCompile>
+    <ClCompile Include="IFontMeasurer.cpp">
+      <Filter>Controls\Label</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Types">
@@ -124,6 +130,9 @@
     </Filter>
     <Filter Include="Controls\TextArea">
       <UniqueIdentifier>{4442810d-913c-42e8-839a-c9de84a71ec3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Controls\Label">
+      <UniqueIdentifier>{4a8f2bab-af56-45f4-acfd-cacd829e7763}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This will be used by the route window to allow the user to enter notes about waypoints.
Adds wm_char handling to the UI.
Adds IFontMeasurer so the UI can know the size that a string will be rendered. Previously this was only known in the renderer itself.
Text area will probably need some improvements at some point, but it is probably OK to start with.
Issue: #414 