### PR TITLE
Change highlight hotkey to H

### DIFF
--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -516,7 +516,7 @@ namespace trview
                 case VK_F1:
                     _settings_window->toggle_visibility();
                     break;
-                case VK_RETURN:
+                case 'H':
                     toggle_highlight();
                     break;
                 case VK_INSERT:


### PR DESCRIPTION
This stops it activating when you press enter, for example when selecting a level to open.
#407