### PR TITLE
Correctly update selected index when removing selected waypoint

### DIFF
--- a/trview.app/Route.cpp
+++ b/trview.app/Route.cpp
@@ -87,7 +87,7 @@ namespace trview
             return;
         }
         _waypoints.erase(_waypoints.begin() + index);
-        if (_selected_index > index)
+        if (_selected_index >= index && _selected_index > 0)
         {
             --_selected_index;
         }


### PR DESCRIPTION
When the selected waypoint was removed before, the selected index was not being decremented.
As it is changed to >=, also add a check for it being 0, as decrementing that would become uint_max.
Bug: #422