### PR TITLE
Remove the +/- button on context menu

### DIFF
--- a/trview.app/ContextMenu.cpp
+++ b/trview.app/ContextMenu.cpp
@@ -16,30 +16,25 @@ namespace trview
 
     ContextMenu::ContextMenu(Control& parent)
     {
-        _menu = parent.add_child(std::make_unique<StackPanel>(Point(300, 300), Size(200, 100), Colours::Background, Size(1, 1)));
+        _menu = parent.add_child(std::make_unique<StackPanel>(Point(300, 300), Size(200, 100), Colours::Background, Size()));
 
-        // Add a button in a little area with some writing.
-        auto button_area = std::make_unique<StackPanel>(Point(), Size(100, 20), Colours::Button, Size(), StackPanel::Direction::Horizontal);
-        auto button = std::make_unique<Button>(Point(), Size(24, 24), L"+");
+        // Add waypoint button.
+        auto button = std::make_unique<Button>(Point(), Size(100, 24), L"Add Waypoint");
+        button->set_text_background_colour(Colours::Button);
         button->on_click += on_add_waypoint;
-        button_area->add_child(std::move(button));
-        button_area->add_child(std::make_unique<Label>(Point(), Size(100, 24), Colours::Button, L"Add Waypoint", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
-        _menu->add_child(std::move(button_area));
+        _menu->add_child(std::move(button));
 
         // Add the similar remove waypoint button 
-        auto remove_button_area = std::make_unique<StackPanel>(Point(), Size(100, 20), Colours::Button, Size(), StackPanel::Direction::Horizontal);
-        auto remove_button = std::make_unique<Button>(Point(), Size(24, 24), L"-");
-        _token_store.add(remove_button->on_click += [&]() 
+        auto remove_button = std::make_unique<Button>(Point(), Size(100, 24), L"Remove Waypoint");
+        remove_button->set_text_background_colour(Colours::Button);
+        _token_store.add(remove_button->on_click += [&]()
         {
             if (_remove_enabled)
             {
                 on_remove_waypoint();
             }
         });
-        remove_button_area->add_child(std::move(remove_button));
-        auto remove_label = std::make_unique<Label>(Point(), Size(100, 24), Colours::Button , L"Remove Waypoint", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
-        _remove_label = remove_button_area->add_child(std::move(remove_label));
-        _menu->add_child(std::move(remove_button_area));
+        _remove_button = _menu->add_child(std::move(remove_button));
 
         _menu->set_visible(false);
     }
@@ -57,6 +52,6 @@ namespace trview
     void ContextMenu::set_remove_enabled(bool value)
     {
         _remove_enabled = value;
-        _remove_label->set_text_colour(value ? Colours::Enabled : Colours::Disabled);
+        _remove_button->set_text_colour(value ? Colours::Enabled : Colours::Disabled);
     }
 }

--- a/trview.app/ContextMenu.h
+++ b/trview.app/ContextMenu.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <trview.ui/StackPanel.h>
-#include <trview.ui/Label.h>
+#include <trview.ui/Button.h>
 
 namespace trview
 {
@@ -32,7 +32,7 @@ namespace trview
         Event<> on_remove_waypoint;
     private:
         ui::StackPanel* _menu;
-        ui::Label*      _remove_label;
+        ui::Button*     _remove_button;
         bool            _remove_enabled{ false };
         TokenStore      _token_store;
     };

--- a/trview.ui/Button.cpp
+++ b/trview.ui/Button.cpp
@@ -69,5 +69,13 @@ namespace trview
                 _text->set_background_colour(colour);
             }
         }
+
+        void Button::set_text_colour(const Colour& colour)
+        {
+            if (_text)
+            {
+                _text->set_text_colour(colour);
+            }
+        }
     }
 }

--- a/trview.ui/Button.h
+++ b/trview.ui/Button.h
@@ -59,6 +59,10 @@ namespace trview
             /// Set the background colour of the text, if present.
             /// @param colour The background colour.
             void set_text_background_colour(const Colour& colour);
+
+            /// Set the foreground colour of the text, if present.
+            /// @param colour The foreground colour.
+            void set_text_colour(const Colour& colour);
         protected:
             virtual bool mouse_down(const Point& position) override;
             virtual bool mouse_up(const Point& position) override;


### PR DESCRIPTION
This means we just have the button with the text entry on it, so the user can click anywhere on the entry.
Also add the ability to set the text colour on a button that has text.
Issue: #419