### PR TITLE
Allow user to add items and triggers to route from their windows

### DIFF
--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -159,7 +159,7 @@ namespace trview
         auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
         auto group_box = std::make_unique<GroupBox>(Point(), Size(200, 220), Colours::ItemDetails, Colours::DetailsBorder, L"Item Details");
 
-        auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(180, 210), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(180, 210), Colours::ItemDetails, Size(0, 8), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Add some information about the selected item.
         auto stats_list = std::make_unique<Listbox>(Point(), Size(180, 160), Colours::ItemDetails);
@@ -174,8 +174,15 @@ namespace trview
         stats_list->set_show_highlight(false);
 
         _stats_list = details_panel->add_child(std::move(stats_list));
-        details_panel->add_child(std::make_unique<ui::Window>(Point(), Size(200, 8), Colours::ItemDetails));
-        details_panel->add_child(std::make_unique<Button>(Point(), Size(180, 20), L"Add to Route"));
+        _add_to_route = details_panel->add_child(std::make_unique<Button>(Point(), Size(180, 20), L"Add to Route"));
+        _token_store.add(_add_to_route->on_click += [&]()
+        {
+            if (_selected_item.has_value())
+            {
+                on_add_to_route(_selected_item.value());
+            }
+        });
+
         group_box->add_child(std::move(details_panel));
 
         right_panel->add_child(std::make_unique<ui::Window>(Point(), Size(200, 8), Colours::ItemDetails));

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -157,10 +157,12 @@ namespace trview
         const float height = 400;
 
         auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
-        auto group_box = std::make_unique<GroupBox>(Point(), Size(200, 190), Colours::ItemDetails, Colours::DetailsBorder, L"Item Details");
+        auto group_box = std::make_unique<GroupBox>(Point(), Size(200, 220), Colours::ItemDetails, Colours::DetailsBorder, L"Item Details");
+
+        auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(180, 210), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Add some information about the selected item.
-        auto stats_list = std::make_unique<Listbox>(Point(10,21), Size(180, 160), Colours::ItemDetails);
+        auto stats_list = std::make_unique<Listbox>(Point(), Size(180, 160), Colours::ItemDetails);
         stats_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"Name", 60 },
@@ -171,7 +173,10 @@ namespace trview
         stats_list->set_show_scrollbar(false);
         stats_list->set_show_highlight(false);
 
-        _stats_list = group_box->add_child(std::move(stats_list));
+        _stats_list = details_panel->add_child(std::move(stats_list));
+        details_panel->add_child(std::make_unique<ui::Window>(Point(), Size(200, 8), Colours::ItemDetails));
+        details_panel->add_child(std::make_unique<Button>(Point(), Size(180, 20), L"Add to Route"));
+        group_box->add_child(std::move(details_panel));
 
         right_panel->add_child(std::make_unique<ui::Window>(Point(), Size(200, 8), Colours::ItemDetails));
         right_panel->add_child(std::move(group_box));
@@ -180,9 +185,9 @@ namespace trview
         right_panel->add_child(std::make_unique<ui::Window>(Point(), Size(200, 5), Colours::Triggers));
 
         // Add the trigger details group box.
-        auto trigger_group_box = std::make_unique<GroupBox>(Point(), Size(200, 200), Colours::Triggers, Colours::DetailsBorder, L"Triggered By");
+        auto trigger_group_box = std::make_unique<GroupBox>(Point(), Size(200, 170), Colours::Triggers, Colours::DetailsBorder, L"Triggered By");
 
-        auto trigger_list = std::make_unique<Listbox>(Point(10, 21), Size(190, 160), Colours::Triggers);
+        auto trigger_list = std::make_unique<Listbox>(Point(10, 21), Size(190, 130), Colours::Triggers);
         trigger_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 25 },

--- a/trview.app/ItemsWindow.cpp
+++ b/trview.app/ItemsWindow.cpp
@@ -174,8 +174,8 @@ namespace trview
         stats_list->set_show_highlight(false);
 
         _stats_list = details_panel->add_child(std::move(stats_list));
-        _add_to_route = details_panel->add_child(std::make_unique<Button>(Point(), Size(180, 20), L"Add to Route"));
-        _token_store.add(_add_to_route->on_click += [&]()
+        auto add_to_route = details_panel->add_child(std::make_unique<Button>(Point(), Size(180, 20), L"Add to Route"));
+        _token_store.add(add_to_route->on_click += [&]()
         {
             if (_selected_item.has_value())
             {

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -71,7 +71,6 @@ namespace trview
         ui::Listbox* _stats_list;
         ui::Listbox* _trigger_list;
         ui::Checkbox* _track_room_checkbox;
-        ui::Button* _add_to_route;
         std::vector<Item> _all_items;
         std::vector<Trigger*> _all_triggers;
         /// Whether the item window is tracking the current room.

--- a/trview.app/ItemsWindow.h
+++ b/trview.app/ItemsWindow.h
@@ -45,6 +45,9 @@ namespace trview
         /// Event raised when a trigger is selected in the list.
         Event<Trigger*> on_trigger_selected;
 
+        /// Event raised when the 'add to route' button is pressed.
+        Event<Item> on_add_to_route;
+
         /// Set the current room. This will be used when the track room setting is on.
         /// @param room The current room number.
         void set_current_room(uint32_t room);
@@ -68,6 +71,7 @@ namespace trview
         ui::Listbox* _stats_list;
         ui::Listbox* _trigger_list;
         ui::Checkbox* _track_room_checkbox;
+        ui::Button* _add_to_route;
         std::vector<Item> _all_items;
         std::vector<Trigger*> _all_triggers;
         /// Whether the item window is tracking the current room.

--- a/trview.app/ItemsWindowManager.cpp
+++ b/trview.app/ItemsWindowManager.cpp
@@ -40,6 +40,7 @@ namespace trview
         auto items_window = std::make_unique<ItemsWindow>(_device, _shader_storage, _font_factory, window());
         items_window->on_item_selected += on_item_selected;
         items_window->on_trigger_selected += on_trigger_selected;
+        items_window->on_add_to_route += on_add_to_route;
         items_window->set_items(_items);
         items_window->set_triggers(_triggers);
         items_window->set_current_room(_current_room);

--- a/trview.app/ItemsWindowManager.h
+++ b/trview.app/ItemsWindowManager.h
@@ -43,6 +43,9 @@ namespace trview
         /// Event raised when a trigger is selected in one of the item windows.
         Event<Trigger*> on_trigger_selected;
 
+        /// Event raised when the 'add to route' button is pressed in one of the item windows.
+        Event<Item> on_add_to_route;
+
         /// Render all of the item windows.
         /// @param device The device to use to render.
         /// @param vsync Whether to use vsync.

--- a/trview.app/Route.cpp
+++ b/trview.app/Route.cpp
@@ -50,9 +50,23 @@ namespace trview
         insert(position, room, index, Waypoint::Type::Position, 0u);
     }
 
+    uint32_t Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room)
+    {
+        uint32_t index = next_index();
+        insert(position, room, index);
+        return index;
+    }
+
     void Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index)
     {
         _waypoints.insert(_waypoints.begin() + index, Waypoint(_waypoint_mesh.get(), position, room, type, type_index));
+    }
+
+    uint32_t Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index)
+    {
+        uint32_t index = next_index();
+        insert(position, room, index, type, type_index);
+        return index;
     }
 
     PickResult Route::pick(const Vector3& position, const Vector3& direction) const
@@ -151,6 +165,11 @@ namespace trview
     uint32_t Route::waypoints() const
     {
         return _waypoints.size();
+    }
+
+    uint32_t Route::next_index() const
+    {
+        return _waypoints.empty() ? 0 : _selected_index + 1;
     }
 
     std::unique_ptr<Route> import_route(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const std::string& filename)

--- a/trview.app/Route.h
+++ b/trview.app/Route.h
@@ -39,8 +39,13 @@ namespace trview
         /// @param position The new waypoint.
         /// @param room The room that the waypoint is in.
         /// @param index The index in the route list to put the waypoint.
-        /// @param room The room
         void insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index);
+
+        /// Insert the new waypoint into the route based on the currently selected waypoint.
+        /// @param position The new waypoint.
+        /// @param room The room that the waypoint is in.
+        /// @return The index of the new waypoint.
+        uint32_t insert(const DirectX::SimpleMath::Vector3& position, uint32_t room);
 
         /// Insert a new non-positional waypoint.
         /// @param position The position of the waypoint in the world.
@@ -49,6 +54,14 @@ namespace trview
         /// @param index The index in the route list to put the waypoint.
         /// @param type_index The index of the trigger or entity to reference.
         void insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index);
+
+        /// Insert a new non-positional waypoint based on the currently selected waypoint.
+        /// @param position The position of the waypoint in the world.
+        /// @param room The room that the waypoint is in.
+        /// @param type The type of waypoint.
+        /// @param type_index The index of the trigger or entity to reference.
+        /// @return The index of the new waypoint.
+        uint32_t insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index);
 
         /// Pick against the waypoints in the route.
         /// @param position The position of the camera.
@@ -83,6 +96,8 @@ namespace trview
         /// Get the number of waypoints in the route.
         uint32_t waypoints() const;
     private:
+        uint32_t next_index() const;
+
         std::vector<Waypoint> _waypoints;
         std::unique_ptr<Mesh> _waypoint_mesh;
         SelectionRenderer     _selection_renderer;

--- a/trview.app/Trigger.cpp
+++ b/trview.app/Trigger.cpp
@@ -205,6 +205,16 @@ namespace trview
         }
     }
 
+    void Trigger::set_position(const DirectX::SimpleMath::Vector3& position)
+    {
+        _position = position;
+    }
+
+    DirectX::SimpleMath::Vector3 Trigger::position() const
+    {
+        return _position;
+    }
+
     std::wstring trigger_type_name(TriggerType type)
     {
         auto name = trigger_type_names.find(type);

--- a/trview.app/Trigger.h
+++ b/trview.app/Trigger.h
@@ -60,6 +60,8 @@ namespace trview
         void set_triangles(const std::vector<TransparentTriangle>& transparent_triangles);
         PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const;
         bool has_command(TriggerCommandType type) const;
+        void set_position(const DirectX::SimpleMath::Vector3& position);
+        DirectX::SimpleMath::Vector3 position() const;
 
         virtual void render(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual void get_transparent_triangles(TransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
@@ -68,6 +70,7 @@ namespace trview
         std::vector<Command> _commands;
         std::unique_ptr<Mesh> _mesh;
         Microsoft::WRL::ComPtr<ID3D11Device> _device;
+        DirectX::SimpleMath::Vector3 _position;
         TriggerType _type;
         uint32_t _number;
         uint16_t _room;

--- a/trview.app/TriggersWindow.cpp
+++ b/trview.app/TriggersWindow.cpp
@@ -142,8 +142,10 @@ namespace trview
         auto right_panel = std::make_unique<StackPanel>(Point(), Size(panel_width, window().size().height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
         auto group_box = std::make_unique<GroupBox>(Point(), Size(panel_width, 190), Colours::ItemDetails, Colours::DetailsBorder, L"Trigger Details");
 
+        auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(panel_width - 20, 160), Colours::ItemDetails, Size(0, 16), StackPanel::Direction::Vertical, SizeMode::Manual);
+
         // Add some information about the selected item.
-        auto stats_list = std::make_unique<Listbox>(Point(10, 21), Size(panel_width - 20, 160), Colours::ItemDetails);
+        auto stats_list = std::make_unique<Listbox>(Point(0, 0), Size(panel_width - 20, 120), Colours::ItemDetails);
         stats_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"Name", 100 },
@@ -153,7 +155,18 @@ namespace trview
         stats_list->set_show_headers(false);
         stats_list->set_show_scrollbar(false);
         stats_list->set_show_highlight(false);
-        _stats_list = group_box->add_child(std::move(stats_list));
+        _stats_list = details_panel->add_child(std::move(stats_list));
+
+        auto button = details_panel->add_child(std::make_unique<Button>(Point(), Size(panel_width - 20, 20), L"Add to Route"));
+        _token_store.add(button->on_click += [&]()
+        {
+            if (_selected_trigger.has_value())
+            {
+                on_add_to_route(_selected_trigger.value());
+            }
+        });
+
+        group_box->add_child(std::move(details_panel));
 
         right_panel->add_child(std::make_unique<ui::Window>(Point(), Size(panel_width, 8), Colours::ItemDetails));
         right_panel->add_child(std::move(group_box));

--- a/trview.app/TriggersWindow.cpp
+++ b/trview.app/TriggersWindow.cpp
@@ -145,7 +145,7 @@ namespace trview
         auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(panel_width - 20, 160), Colours::ItemDetails, Size(0, 16), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Add some information about the selected item.
-        auto stats_list = std::make_unique<Listbox>(Point(0, 0), Size(panel_width - 20, 120), Colours::ItemDetails);
+        auto stats_list = std::make_unique<Listbox>(Point(), Size(panel_width - 20, 120), Colours::ItemDetails);
         stats_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"Name", 100 },

--- a/trview.app/TriggersWindow.h
+++ b/trview.app/TriggersWindow.h
@@ -42,6 +42,9 @@ namespace trview
         /// Event raised when an item is selected in the list.
         Event<Item> on_item_selected;
 
+        /// Event raised when the 'add to route' button is pressed.
+        Event<const Trigger*> on_add_to_route;
+
         /// Set the current room. This will be used when the track room setting is on.
         /// @param room The current room number.
         void set_current_room(uint32_t room);

--- a/trview.app/TriggersWindowManager.cpp
+++ b/trview.app/TriggersWindowManager.cpp
@@ -40,6 +40,7 @@ namespace trview
         auto triggers_window = std::make_unique<TriggersWindow>(_device, _shader_storage, _font_factory, window());
         triggers_window->on_item_selected += on_item_selected;
         triggers_window->on_trigger_selected += on_trigger_selected;
+        triggers_window->on_add_to_route += on_add_to_route;
         triggers_window->set_items(_items);
         triggers_window->set_triggers(_triggers);
         triggers_window->set_current_room(_current_room);

--- a/trview.app/TriggersWindowManager.h
+++ b/trview.app/TriggersWindowManager.h
@@ -40,6 +40,9 @@ namespace trview
         /// Event raised when a trigger is selected in one of the trigger windows.
         Event<Trigger*> on_trigger_selected;
 
+        /// Event raised when the 'add to route' button is pressed in one of the trigger windows.
+        Event<const Trigger*> on_add_to_route;
+
         /// Render all of the triggers windows.
         /// @param device The device to use to render.
         /// @param vsync Whether to use vsync.

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -331,6 +331,7 @@ namespace trview
                     _triggers.emplace_back(std::make_unique<Trigger>(_triggers.size(), i, sector.second->x(), sector.second->z(), sector.second->trigger()));
                     room->add_trigger(_triggers.back().get());
                 }
+                room->generate_trigger_geometry();
             }
         }
     }

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -13,6 +13,7 @@
 #include <DirectXCollision.h>
 #include <array>
 #include <iterator>
+#include <numeric>
 
 using namespace Microsoft::WRL;
 using namespace DirectX::SimpleMath;
@@ -246,11 +247,6 @@ namespace trview
 
         if (include_triggers)
         {
-            if (!_trigger_geometry_generated)
-            {
-                generate_trigger_geometry();
-            }
-
             for (const auto& trigger : _triggers)
             {
                 for (const auto& triangle : trigger.second->triangles())
@@ -412,9 +408,11 @@ namespace trview
             }
 
             trigger->set_triangles(triangles);
-        }
 
-        _trigger_geometry_generated = true;
+            float centre_y = std::accumulate(y_top.begin(), y_top.end(), std::accumulate(y_bottom.begin(), y_bottom.end(), 0.0f)) / 8.0f;
+
+            trigger->set_position(Vector3(x, centre_y, z));
+        }
     }
 
     uint32_t Room::get_sector_id(int32_t x, int32_t z) const

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -136,6 +136,8 @@ namespace trview
         /// Get the bounding box of the room. The bounding box is pre-transformed to the coordinates of the room.
         /// @returns The bounding box for the room.
         const DirectX::BoundingBox& bounding_box() const;
+
+        void generate_trigger_geometry();
     private:
         void generate_geometry(trlevel::LevelVersion level_version, const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage);
         void generate_adjacency();
@@ -143,7 +145,6 @@ namespace trview
         void render_contained(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour);
         void get_contained_transparent_triangles(TransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour);
         void generate_sectors(const trlevel::ILevel& level, const trlevel::tr3_room& room);
-        void generate_trigger_geometry();
         Sector*  get_trigger_sector(int32_t x, int32_t z);
         uint32_t get_sector_id(int32_t x, int32_t z) const;
 
@@ -171,6 +172,5 @@ namespace trview
         AlternateMode        _alternate_mode;
 
         std::unordered_map<uint32_t, Trigger*> _triggers;
-        bool _trigger_geometry_generated{ false };
     };
 }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -59,6 +59,13 @@ namespace trview
         }
         _token_store.add(_items_windows->on_item_selected += [this](const auto& item) { select_item(item); });
         _token_store.add(_items_windows->on_trigger_selected += [this](const auto& trigger) { select_trigger(trigger); });
+        _token_store.add(_items_windows->on_add_to_route += [this](const auto& item)
+        {
+            auto entity = _current_level->get_entity(item.number());
+            uint32_t new_index = _route->insert(entity.position(), item.room(), Waypoint::Type::Entity, item.number());
+            _route_window_manager->set_route(_route.get());
+            select_waypoint(new_index);
+        });
 
         _triggers_windows = std::make_unique<TriggersWindowManager>(_device, *_shader_storage.get(), *_font_factory.get(), window);
         if (_settings.triggers_startup)
@@ -168,10 +175,8 @@ namespace trview
         _context_menu = std::make_unique<ContextMenu>(*_control);
         _token_store.add(_context_menu->on_add_waypoint += [&]()
         {
-            uint32_t new_index = _route->waypoints() == 0 ? 0 : _route->selected_waypoint() + 1;
             auto type = _context_pick.type == PickResult::Type::Entity ? Waypoint::Type::Entity : _context_pick.type == PickResult::Type::Trigger ? Waypoint::Type::Trigger : Waypoint::Type::Position;
-
-            _route->insert(_context_pick.position, room_from_pick(_context_pick), new_index, type, _context_pick.index);
+            uint32_t new_index = _route->insert(_context_pick.position, room_from_pick(_context_pick), type, _context_pick.index);
             _context_menu->set_visible(false);
             _route_window_manager->set_route(_route.get());
             select_waypoint(new_index);


### PR DESCRIPTION
User can now click the 'Add to Route' button in Item and Trigger windows to add the currently selected item or trigger to the current route.
Trigger now has a position property that is set after geometry generation. This is used in the viewer instead of the previous picking.
Issue: #412 