### PR TITLE
Delete waypoints from the route window

### DIFF
--- a/trview.app/RouteWindow.cpp
+++ b/trview.app/RouteWindow.cpp
@@ -126,9 +126,11 @@ namespace trview
         auto right_panel = std::make_unique<StackPanel>(Point(), Size(panel_width, window().size().height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
         right_panel->set_margin(Size(0, 8));
 
-        auto group_box = std::make_unique<GroupBox>(Point(), Size(panel_width, 110), Colours::ItemDetails, Colours::DetailsBorder, L"Waypoint Details");
+        auto group_box = std::make_unique<GroupBox>(Point(), Size(panel_width, 140), Colours::ItemDetails, Colours::DetailsBorder, L"Waypoint Details");
 
-        auto stats_box = std::make_unique<Listbox>(Point(10, 21), Size(panel_width - 20, 100), Colours::ItemDetails);
+        auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(panel_width - 20, 120), Colours::ItemDetails, Size(0, 8), StackPanel::Direction::Vertical, SizeMode::Manual);
+
+        auto stats_box = std::make_unique<Listbox>(Point(10, 21), Size(panel_width - 20, 80), Colours::ItemDetails);
         stats_box->set_show_headers(false);
         stats_box->set_show_scrollbar(false);
         stats_box->set_columns(
@@ -155,11 +157,22 @@ namespace trview
                 break;
             }
         });
-        _stats = group_box->add_child(std::move(stats_box));
+        _stats = details_panel->add_child(std::move(stats_box));
+
+        auto delete_button = details_panel->add_child(std::make_unique<Button>(Point(), Size(panel_width - 20, 20), L"Delete Waypoint"));
+        _token_store.add(delete_button->on_click += [&]()
+        {
+            if (_route && _selected_index < _route->waypoints())
+            {
+                on_waypoint_deleted(_selected_index);
+            }
+        });
+
+        group_box->add_child(std::move(details_panel));
         right_panel->add_child(std::move(group_box));
 
         // Notes area.
-        auto notes_box = std::make_unique<GroupBox>(Point(), Size(panel_width, window().size().height - 110), Colours::Notes, Colours::DetailsBorder, L"Notes");
+        auto notes_box = std::make_unique<GroupBox>(Point(), Size(panel_width, window().size().height - 140), Colours::Notes, Colours::DetailsBorder, L"Notes");
 
         auto notes_area = std::make_unique<TextArea>(Point(10, 21), Size(panel_width - 20, notes_box->size().height - 41), Colour(0.2f, 0.2f, 0.2f), Colour(1.0f, 1.0f, 1.0f));
         _notes_area = notes_box->add_child(std::move(notes_area));

--- a/trview.app/RouteWindow.cpp
+++ b/trview.app/RouteWindow.cpp
@@ -116,6 +116,10 @@ namespace trview
             load_waypoint_details(index);
             on_waypoint_selected(index);
         });
+        _token_store.add(waypoints->on_delete += [&]() {
+            on_waypoint_deleted(_selected_index);
+        });
+
         _waypoints = left_panel->add_child(std::move(waypoints));
         return left_panel;
     }

--- a/trview.app/RouteWindow.h
+++ b/trview.app/RouteWindow.h
@@ -43,6 +43,9 @@ namespace trview
         /// Event raised when a route is exported.
         Event<std::string> on_route_export;
 
+        /// Event raised when a waypoint is deleted.
+        Event<uint32_t> on_waypoint_deleted;
+
         /// Select the specified waypoint.
         /// @param index The index of the waypoint to select.
         void select_waypoint(uint32_t index);

--- a/trview.app/RouteWindowManager.cpp
+++ b/trview.app/RouteWindowManager.cpp
@@ -34,6 +34,7 @@ namespace trview
         _route_window->on_item_selected += on_item_selected;
         _route_window->on_trigger_selected += on_trigger_selected;
         _route_window->on_waypoint_selected += on_waypoint_selected;
+        _route_window->on_waypoint_deleted += on_waypoint_deleted;
         _token_store.add(_route_window->on_window_closed += [&]() { _closing = true; });
 
         _route_window->set_items(_all_items);

--- a/trview.app/RouteWindowManager.h
+++ b/trview.app/RouteWindowManager.h
@@ -60,6 +60,9 @@ namespace trview
 
         /// Event raised when a trigger is selected.
         Event<Trigger*> on_trigger_selected;
+
+        /// Event raised when a waypoint is deleted.
+        Event<uint32_t> on_waypoint_deleted;
     private:
         const graphics::Device& _device;
         const graphics::IShaderStorage& _shader_storage;

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -185,6 +185,12 @@ namespace trview
 
         bool Listbox::key_down(uint16_t key)
         {
+            if (key == VK_DELETE)
+            {
+                on_delete();
+                return true;
+            }
+
             if (key != VK_UP && key != VK_DOWN)
             {
                 return false;

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -150,6 +150,9 @@ namespace trview
 
             /// Event raised when an item is selected
             Event<Item> on_item_selected;
+
+            /// Event raised when the delete key is pressed.
+            Event<> on_delete;
         protected:
             virtual bool scroll(int delta) override;
             virtual bool key_down(uint16_t key) override;

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -135,6 +135,10 @@ namespace trview
         {
             export_route(*_route, path);
         });
+        _token_store.add(_route_window_manager->on_waypoint_deleted += [&](auto index)
+        {
+            remove_waypoint(index);
+        });
     }
 
     Viewer::~Viewer()
@@ -189,13 +193,8 @@ namespace trview
         });
         _token_store.add(_context_menu->on_remove_waypoint += [&]()
         {
-            _route->remove(_current_pick.index);
+            remove_waypoint(_current_pick.index);
             _context_menu->set_visible(false);
-            _route_window_manager->set_route(_route.get());
-            if (_route->waypoints() > 0)
-            {
-                _route_window_manager->select_waypoint(_route->selected_waypoint());
-            }
         });
 
         _context_menu->set_remove_enabled(false);
@@ -882,6 +881,16 @@ namespace trview
         if (_settings.auto_orbit)
         {
             set_camera_mode(CameraMode::Orbit);
+        }
+    }
+
+    void Viewer::remove_waypoint(uint32_t index)
+    {
+        _route->remove(index);
+        _route_window_manager->set_route(_route.get());
+        if (_route->waypoints() > 0)
+        {
+            select_waypoint(_route->selected_waypoint());
         }
     }
 

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -111,6 +111,7 @@ namespace trview
         void select_item(const Item& item);
         void select_trigger(const Trigger* const trigger);
         void select_waypoint(uint32_t index);
+        void remove_waypoint(uint32_t index);
         // Determines whether the cursor is over a UI element that would take any input.
         // Returns: True if there is any UI under the cursor that would take input.
         bool over_ui() const;


### PR DESCRIPTION
User can now delete waypoints by clicking the 'Delete Waypoint' button in the route window or by pressing the delete key when navigating the waypoint list.
Issue: #421 