### PR TITLE
Change button colour on mouse over/leave

### DIFF
--- a/trview.common/Colour.cpp
+++ b/trview.common/Colour.cpp
@@ -2,6 +2,11 @@
 
 namespace trview
 {
+    Colour::Colour()
+        : Colour(1.0f, 1.0f, 1.0f)
+    {
+    }
+
     Colour::Colour(float r, float g, float b)
         : Colour(1.0f, r, g, b)
     {
@@ -24,5 +29,15 @@ namespace trview
         g += other.g;
         b += other.b;
         return *this;
+    }
+
+    Colour operator+(const Colour& left, const Colour& right)
+    {
+        return Colour(left.a + right.a, left.r + right.r, left.g + right.g, left.b + right.b);
+    }
+
+    bool operator==(const Colour& left, const Colour& right)
+    {
+        return left.a == right.a && left.r == right.r && left.g == right.g && left.b == right.b;
     }
 }

--- a/trview.common/Colour.h
+++ b/trview.common/Colour.h
@@ -6,6 +6,8 @@ namespace trview
 {
     struct Colour final
     {
+        Colour();
+
         /// Create a colour with the specified rgb components and a fully opaque alpha value.
         /// @param r The red value from 0 to 1.
         /// @param g The green value from 0 to 1.
@@ -20,4 +22,8 @@ namespace trview
 
         float a, r, g, b;
     };
+
+    Colour operator+(const Colour& left, const Colour& right);
+
+    bool operator==(const Colour& left, const Colour& right);
 }

--- a/trview.ui/Button.cpp
+++ b/trview.ui/Button.cpp
@@ -6,6 +6,12 @@ namespace trview
 {
     namespace ui
     {
+        namespace Colours
+        {
+            const Colour Background{ 0.4f, 0.4f, 0.4f };
+            const Colour Highlight{ 0.0f, 0.05f, 0.05f, 0.05f };
+        }
+
         Button::Button(Point position, Size size, graphics::Texture up_image, graphics::Texture down_image)
             : Control(position, size), _up_image(up_image), _down_image(down_image), _text(nullptr)
         {
@@ -17,7 +23,8 @@ namespace trview
         Button::Button(Point position, Size size, const std::wstring& text)
             : Control(position, size)
         {
-            _text = add_child(std::make_unique<Label>(Point(2, 2), size - Size(4, 4), Colour(1.0f, 0.4f, 0.4f, 0.4f), text, 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
+            _text = add_child(std::make_unique<Label>(Point(2, 2), size - Size(4, 4), Colours::Background, text, 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
+            set_handles_hover(true);
         }
 
         Button::Button(Point position, Size size)
@@ -33,6 +40,26 @@ namespace trview
         bool Button::mouse_up(const Point&)
         {
             return true;
+        }
+
+        void Button::mouse_enter()
+        {
+            if (_text)
+            {
+                // Store the old background colour so that if the background has been changed by a call
+                // to set_background_colour between enter and leave we don't reset it to the wrong colour.
+                _previous_colour = _text->background_colour();
+                _text->set_background_colour(_previous_colour + Colours::Highlight);
+            }
+        }
+
+        void Button::mouse_leave()
+        {
+            // Check that the button has the same background colour as when we changed to the highlight colour.
+            if (_text && _text->background_colour() == _previous_colour + Colours::Highlight)
+            {
+                _text->set_background_colour(_previous_colour);
+            }
         }
 
         bool Button::clicked(Point)

--- a/trview.ui/Button.h
+++ b/trview.ui/Button.h
@@ -5,6 +5,7 @@
 
 #include <trview.graphics/Texture.h>
 #include <trview.common/Event.h>
+#include <trview.common/Colour.h>
 
 #include "Control.h"
 
@@ -66,12 +67,15 @@ namespace trview
         protected:
             virtual bool mouse_down(const Point& position) override;
             virtual bool mouse_up(const Point& position) override;
+            virtual void mouse_enter() override;
+            virtual void mouse_leave() override;
             virtual bool clicked(Point position) override;
         private:
             graphics::Texture _up_image;
             graphics::Texture _down_image;
             float _border_thickness{ 1.0f };
             Label* _text;
+            Colour _previous_colour;
         };
     }
 }


### PR DESCRIPTION
When the button is a text button, change the background of the button when the mouse hovers over the button.
Adds a highlight of 0.05 to the button to make it obvious you can click it.
Doesn't affect image buttons.
Issue: #431