### PR TITLE
Fix sprite rendering texture issue

### DIFF
--- a/trview/Entity.cpp
+++ b/trview/Entity.cpp
@@ -133,10 +133,10 @@ namespace trview
         using namespace DirectX::SimpleMath;
         std::vector<MeshVertex> vertices
         {
-            { Vector3(-0.5f, -0.5f, 0), Vector2(u, v + height), Vector4(1,1,1,1) },
-            { Vector3(0.5f, -0.5f, 0), Vector2(u + width, v + height), Vector4(1,1,1,1) },
-            { Vector3(-0.5f, 0.5f, 0), Vector2(u, v), Vector4(1,1,1,1) },
-            { Vector3(0.5f, 0.5f, 0), Vector2(u + width, v), Vector4(1,1,1,1) },
+            { Vector3(-0.5f, -0.5f, 0), Vector3::Zero, Vector2(u, v + height), Vector4(1,1,1,1) },
+            { Vector3(0.5f, -0.5f, 0), Vector3::Zero, Vector2(u + width, v + height), Vector4(1,1,1,1) },
+            { Vector3(-0.5f, 0.5f, 0), Vector3::Zero, Vector2(u, v), Vector4(1,1,1,1) },
+            { Vector3(0.5f, 0.5f, 0), Vector3::Zero, Vector2(u + width, v), Vector4(1,1,1,1) },
         };
 
         std::vector<TransparentTriangle> transparent_triangles


### PR DESCRIPTION
Sprites were using the old layout for MeshVertex so their UV values were going into the normals slot. This caused the image to be black.
Using `Vector3::Zero` for this as it doesn't need normals.
#434