### PR TITLE
Disable sorting on the waypoints listbox

### DIFF
--- a/trview.app/RouteWindow.cpp
+++ b/trview.app/RouteWindow.cpp
@@ -105,6 +105,7 @@ namespace trview
 
         // List box to show the waypoints in the route.
         auto waypoints = std::make_unique<Listbox>(Point(), Size(200, window().size().height - _buttons->size().height), Colours::LeftPanel);
+        waypoints->set_enable_sorting(false);
         waypoints->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 30 },

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -28,6 +28,11 @@ namespace trview
             generate_ui();
         }
 
+        void Listbox::set_enable_sorting(bool value)
+        {
+            _enable_sorting = value;
+        }
+
         void Listbox::set_items(const std::vector<Item>& items)
         {
             // Reset the index for scrolling.
@@ -268,6 +273,11 @@ namespace trview
                 header_element->set_text_background_colour(background_colour());
                 _token_store += header_element->on_click += [this, column]()
                 {
+                    if (!_enable_sorting)
+                    {
+                        return;
+                    }
+
                     if (_current_sort.name() == column.name())
                     {
                         _current_sort_direction = !_current_sort_direction;

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -127,6 +127,9 @@ namespace trview
             /// @param columns The column names.
             void set_columns(const std::vector<Column>& columns);
 
+            /// Set whether the user can sort the listbox items.
+            void set_enable_sorting(bool value);
+
             /// Set the items for the list box.
             /// @param items The items to add to the list box.
             void set_items(const std::vector<Item>& items);
@@ -188,6 +191,7 @@ namespace trview
             bool _show_scrollbar{ true };
             bool _show_headers{ true };
             bool _show_highlight{ true };
+            bool _enable_sorting{ true };
             std::optional<Item> _selected_item;
             uint32_t _fully_visible_rows{ 0u };
         };


### PR DESCRIPTION
Since sorting the route doesn't make a lot of sense, disable sorting on the waypoints listbox.
Had to add the ability to toggle this into the listbox class.
Issue: #438