### PR TITLE
Check waypoint exists before updating notes

### DIFF
--- a/trview.app/RouteWindow.cpp
+++ b/trview.app/RouteWindow.cpp
@@ -187,7 +187,7 @@ namespace trview
 
         _token_store += _notes_area->on_text_changed += [&](const std::wstring& text)
         {
-            if (_route)
+            if (_route && _selected_index < _route->waypoints())
             {
                 _route->waypoint(_selected_index).set_notes(text);
             }


### PR DESCRIPTION
Check that the selected index is a valid waypoint before trying to get the waypoint and update the notes on it.
Issue: #441