### PR TITLE
Use the graphics::Device class everywhere

### DIFF
--- a/trview.app/CollapsiblePanel.cpp
+++ b/trview.app/CollapsiblePanel.cpp
@@ -70,7 +70,7 @@ namespace trview
 
     CollapsiblePanel::CollapsiblePanel(const Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent, const std::wstring& window_class, const std::wstring& title, const Size& size)
         : MessageHandler(create_window(parent, window_class, title, size)), _window_resizer(window()), _device_window(device.create_for_window(window())),
-        _ui_renderer(std::make_unique<render::Renderer>(device.device(), shader_storage, font_factory, window().size())),
+        _ui_renderer(std::make_unique<render::Renderer>(device, shader_storage, font_factory, window().size())),
         _mouse(window()), _keyboard(window())
     {
         _token_store += _window_resizer.on_resize += [=]()

--- a/trview.app/Compass.cpp
+++ b/trview.app/Compass.cpp
@@ -41,9 +41,9 @@ namespace trview
 
     Compass::Compass(const graphics::Device& device, const IShaderStorage& shader_storage)
         : _mesh_camera(Size(View_Size, View_Size)),
-          _mesh(create_cube_mesh(device.device())),
-          _sprite(std::make_unique<Sprite>(device.device(), shader_storage, Size(View_Size, View_Size))),
-          _render_target(std::make_unique<RenderTarget>(device.device(), View_Size, View_Size, RenderTarget::DepthStencilMode::Enabled))
+          _mesh(create_cube_mesh(device)),
+          _sprite(std::make_unique<Sprite>(device, shader_storage, Size(View_Size, View_Size))),
+          _render_target(std::make_unique<RenderTarget>(device, View_Size, View_Size, RenderTarget::DepthStencilMode::Enabled))
     {
     }
 

--- a/trview.app/Measure.cpp
+++ b/trview.app/Measure.cpp
@@ -12,7 +12,7 @@ using namespace DirectX::SimpleMath;
 namespace trview
 {
     Measure::Measure(const Device& device, ui::Control& ui)
-        : _mesh(create_cube_mesh(device.device()))
+        : _mesh(create_cube_mesh(device))
     {
         auto label = std::make_unique<ui::Label>(Point(300, 100), Size(50, 30), Colour(1.0f, 0.2f, 0.2f, 0.2f), L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
         label->set_visible(false);

--- a/trview.app/Mesh.h
+++ b/trview.app/Mesh.h
@@ -6,6 +6,7 @@
 
 #include <trlevel/trtypes.h>
 #include <trlevel/LevelVersion.h>
+#include <trview.graphics/Device.h>
 
 #include "MeshVertex.h"
 #include "TransparentTriangle.h"
@@ -24,13 +25,19 @@ namespace trview
         /// @param vertices The vertices that make up the mesh.
         /// @param indices The indices for triangles that use level textures.
         /// @param untextured_indices The indices for triangles that do not use level textures.
+        /// @param transparent_triangles The transparent triangles to use to create the mesh.
         /// @param collision_triangles The triangles for picking.
-        Mesh(const Microsoft::WRL::ComPtr<ID3D11Device>& device,
+        Mesh(const graphics::Device& device,
              const std::vector<MeshVertex>& vertices, 
              const std::vector<std::vector<uint32_t>>& indices, 
              const std::vector<uint32_t>& untextured_indices,
              const std::vector<TransparentTriangle>& transparent_triangles,
              const std::vector<Triangle>& collision_triangles);
+
+        /// Create a mesh using the specified vertices and indices.
+        /// @param transparent_triangles The triangles to use to create the mesh.
+        /// @param collision_triangles The triangles for picking.
+        Mesh(const std::vector<TransparentTriangle>& transparent_triangles, const std::vector<Triangle>& collision_triangles);
 
         void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context,
             const DirectX::SimpleMath::Matrix& world_view_projection,
@@ -44,6 +51,8 @@ namespace trview
 
         PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const;
     private:
+        void calculate_bounding_box(const std::vector<MeshVertex>& vertices, const std::vector<TransparentTriangle>& transparent_triangles);
+
         Microsoft::WRL::ComPtr<ID3D11Buffer>              _vertex_buffer;
         std::vector<uint32_t>                             _index_counts;
         std::vector<Microsoft::WRL::ComPtr<ID3D11Buffer>> _index_buffers;
@@ -62,10 +71,10 @@ namespace trview
     /// @param texture_storage The textures for the level.
     /// @param transparent_collision Whether to include transparent triangles in collision triangles.
     /// @returns The new mesh.
-    std::unique_ptr<Mesh> create_mesh(trlevel::LevelVersion level_version, const trlevel::tr_mesh& mesh, const Microsoft::WRL::ComPtr<ID3D11Device>& device, const ILevelTextureStorage& texture_storage, bool transparent_collision = true);
+    std::unique_ptr<Mesh> create_mesh(trlevel::LevelVersion level_version, const trlevel::tr_mesh& mesh, const graphics::Device& device, const ILevelTextureStorage& texture_storage, bool transparent_collision = true);
 
     /// Create a new cube mesh.
-    std::unique_ptr<Mesh> create_cube_mesh(const Microsoft::WRL::ComPtr<ID3D11Device>& device);
+    std::unique_ptr<Mesh> create_cube_mesh(const graphics::Device& device);
 
     /// Convert the textured rectangles into collections required to create a mesh.
     /// @param level_version The level version - affects texture index.

--- a/trview.app/Route.cpp
+++ b/trview.app/Route.cpp
@@ -21,7 +21,7 @@ namespace trview
     }
 
     Route::Route(const graphics::Device& device, const graphics::IShaderStorage& shader_storage)
-        : _waypoint_mesh(create_cube_mesh(device.device())), _selection_renderer(device, shader_storage)
+        : _waypoint_mesh(create_cube_mesh(device)), _selection_renderer(device, shader_storage)
     {
     }
 

--- a/trview.app/SelectionRenderer.cpp
+++ b/trview.app/SelectionRenderer.cpp
@@ -41,7 +41,7 @@ namespace trview
     {
         _pixel_shader = shader_storage.get("selection_pixel_shader");
         _vertex_shader = shader_storage.get("ui_vertex_shader");
-        _transparency = std::make_unique<TransparencyBuffer>(device.device());
+        _transparency = std::make_unique<TransparencyBuffer>(device);
         create_buffers(device);
     }
 
@@ -117,7 +117,7 @@ namespace trview
         // If the texture hasn't been made yet or the size needs to change, re-create the texture.
         if (!_texture || _texture->size() != Size(viewport.Width, viewport.Height))
         {
-            _texture = std::make_unique<RenderTarget>(device.device(), viewport.Width, viewport.Height, RenderTarget::DepthStencilMode::Enabled);
+            _texture = std::make_unique<RenderTarget>(device, viewport.Width, viewport.Height, RenderTarget::DepthStencilMode::Enabled);
         }
 
         // Render the item (all regular faces and transparent faces) to a render target.

--- a/trview.app/TransparencyBuffer.cpp
+++ b/trview.app/TransparencyBuffer.cpp
@@ -12,7 +12,7 @@ using namespace DirectX::SimpleMath;
 
 namespace trview
 {
-    TransparencyBuffer::TransparencyBuffer(const ComPtr<ID3D11Device>& device)
+    TransparencyBuffer::TransparencyBuffer(const graphics::Device& device)
         : _device(device)
     {
         create_matrix_buffer();
@@ -27,7 +27,7 @@ namespace trview
         alpha_desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ONE;
         alpha_desc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
         alpha_desc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
-        _device->CreateBlendState(&alpha_desc, &_alpha_blend);
+        _device.device()->CreateBlendState(&alpha_desc, &_alpha_blend);
 
         D3D11_BLEND_DESC additive_desc;
         memset(&additive_desc, 0, sizeof(additive_desc));
@@ -39,7 +39,7 @@ namespace trview
         additive_desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ONE;
         additive_desc.RenderTarget[0].BlendOpAlpha = D3D11_BLEND_OP_ADD;
         additive_desc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL;
-        _device->CreateBlendState(&additive_desc, &_additive_blend);
+        _device.device()->CreateBlendState(&additive_desc, &_additive_blend);
 
         // Depth stencil that will test depth, but will not write it.
         D3D11_DEPTH_STENCIL_DESC stencil_desc;
@@ -58,7 +58,7 @@ namespace trview
         stencil_desc.BackFace.StencilDepthFailOp = D3D11_STENCIL_OP_DECR;
         stencil_desc.BackFace.StencilPassOp = D3D11_STENCIL_OP_KEEP;
         stencil_desc.BackFace.StencilFunc = D3D11_COMPARISON_ALWAYS;
-        _device->CreateDepthStencilState(&stencil_desc, &_transparency_depth_state);
+        _device.device()->CreateDepthStencilState(&stencil_desc, &_transparency_depth_state);
     }
 
     void TransparencyBuffer::add(const TransparentTriangle& triangle)
@@ -155,7 +155,7 @@ namespace trview
         memset(&vertex_data, 0, sizeof(vertex_data));
         vertex_data.pSysMem = &_vertices[0];
 
-        _device->CreateBuffer(&vertex_desc, &vertex_data, &_vertex_buffer);
+        _device.device()->CreateBuffer(&vertex_desc, &vertex_data, &_vertex_buffer);
     }
 
     void TransparencyBuffer::create_matrix_buffer()
@@ -170,7 +170,7 @@ namespace trview
         matrix_desc.Usage = D3D11_USAGE_DYNAMIC;
         matrix_desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
 
-        _device->CreateBuffer(&matrix_desc, nullptr, _matrix_buffer.GetAddressOf());
+        _device.device()->CreateBuffer(&matrix_desc, nullptr, _matrix_buffer.GetAddressOf());
     }
 
     void TransparencyBuffer::complete()

--- a/trview.app/TransparencyBuffer.h
+++ b/trview.app/TransparencyBuffer.h
@@ -6,6 +6,7 @@
 #include <d3d11.h>
 #include "MeshVertex.h"
 #include "TransparentTriangle.h"
+#include <trview.graphics/Device.h>
 
 namespace trview
 {
@@ -17,7 +18,7 @@ namespace trview
     class TransparencyBuffer
     {
     public:
-        explicit TransparencyBuffer(const Microsoft::WRL::ComPtr<ID3D11Device>& device);
+        explicit TransparencyBuffer(const graphics::Device& device);
         TransparencyBuffer(const TransparencyBuffer&) = delete;
         TransparencyBuffer& operator=(const TransparencyBuffer&) = delete;
 
@@ -46,7 +47,7 @@ namespace trview
         void complete();
         void set_blend_mode(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, TransparentTriangle::Mode mode) const;
 
-        Microsoft::WRL::ComPtr<ID3D11Device> _device;
+        const graphics::Device& _device;
         Microsoft::WRL::ComPtr<ID3D11Buffer> _vertex_buffer;
         Microsoft::WRL::ComPtr<ID3D11Buffer> _matrix_buffer;
         Microsoft::WRL::ComPtr<ID3D11BlendState> _alpha_blend;

--- a/trview.app/Trigger.cpp
+++ b/trview.app/Trigger.cpp
@@ -168,7 +168,7 @@ namespace trview
         std::vector<Triangle> collision;
         std::transform(transparent_triangles.begin(), transparent_triangles.end(), std::back_inserter(collision),
             [](const auto& tri) { return Triangle(tri.vertices[0], tri.vertices[1], tri.vertices[2]); });
-        _mesh = std::make_unique<Mesh>(_device, std::vector<MeshVertex>(), std::vector<std::vector<uint32_t>>(), std::vector<uint32_t>(), transparent_triangles, collision);
+        _mesh = std::make_unique<Mesh>(transparent_triangles, collision);
     }
 
     PickResult Trigger::pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const

--- a/trview.app/Trigger.h
+++ b/trview.app/Trigger.h
@@ -69,7 +69,6 @@ namespace trview
         std::vector<uint16_t> _objects;
         std::vector<Command> _commands;
         std::unique_ptr<Mesh> _mesh;
-        Microsoft::WRL::ComPtr<ID3D11Device> _device;
         DirectX::SimpleMath::Vector3 _position;
         TriggerType _type;
         uint32_t _number;

--- a/trview.graphics.tests/PixelShaderTests.cpp
+++ b/trview.graphics.tests/PixelShaderTests.cpp
@@ -15,7 +15,8 @@ namespace trview
                 // Tests that trying to create a pixel shader with no data throws.
                 TEST_METHOD(EmptyData)
                 {
-                    Assert::ExpectException<std::exception>([]() { PixelShader{ nullptr, std::vector<uint8_t>() }; });
+                    graphics::Device device;
+                    Assert::ExpectException<std::exception>([&device]() { PixelShader{ device, std::vector<uint8_t>() }; });
                 }
             };
         }

--- a/trview.graphics.tests/VertexShaderTests.cpp
+++ b/trview.graphics.tests/VertexShaderTests.cpp
@@ -15,13 +15,15 @@ namespace trview
                 // Tests that trying to create a vertex shader with no data throws.
                 TEST_METHOD(EmptyData)
                 {
-                    Assert::ExpectException<std::exception>([]() { VertexShader{ nullptr, std::vector<uint8_t>(), std::vector<D3D11_INPUT_ELEMENT_DESC>(1) }; });
+                    graphics::Device device;
+                    Assert::ExpectException<std::exception>([&device]() { VertexShader{ device, std::vector<uint8_t>(), std::vector<D3D11_INPUT_ELEMENT_DESC>(1) }; });
                 }
 
                 // Tests that trying to create a vertex shader with no input descriptions throws.
                 TEST_METHOD(EmptyInputDescription)
                 {
-                    Assert::ExpectException<std::exception>([]() { VertexShader{ nullptr, std::vector<uint8_t>(1), std::vector<D3D11_INPUT_ELEMENT_DESC>() }; });
+                    graphics::Device device;
+                    Assert::ExpectException<std::exception>([&device]() { VertexShader{ device, std::vector<uint8_t>(1), std::vector<D3D11_INPUT_ELEMENT_DESC>() }; });
                 }
             };
         }

--- a/trview.graphics.tests/trview.graphics.tests.vcxproj
+++ b/trview.graphics.tests/trview.graphics.tests.vcxproj
@@ -102,7 +102,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile />
@@ -111,6 +111,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>d3d11.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -118,7 +119,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile />
@@ -127,6 +128,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>d3d11.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -136,7 +138,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile />
@@ -147,6 +149,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>d3d11.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -156,7 +159,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile />
@@ -167,6 +170,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>d3d11.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/trview.graphics/DepthStencil.cpp
+++ b/trview.graphics/DepthStencil.cpp
@@ -10,7 +10,7 @@ namespace trview
         // device: The device to use to create the depth stencil.
         // width: The width of the depth stencil.
         // height: The height of the depth stencil.
-        DepthStencil::DepthStencil(const ComPtr<ID3D11Device>& device, uint32_t width, uint32_t height)
+        DepthStencil::DepthStencil(const graphics::Device& device, uint32_t width, uint32_t height)
         {
             graphics::Texture depth_stencil_buffer{ device, width, height, graphics::Texture::Bind::DepthStencil };
 
@@ -23,7 +23,7 @@ namespace trview
             depthStencilViewDesc.Texture2D.MipSlice = 0;
 
             // Create the depth stencil view.
-            device->CreateDepthStencilView(depth_stencil_buffer.texture().Get(), &depthStencilViewDesc, &_view);
+            device.device()->CreateDepthStencilView(depth_stencil_buffer.texture().Get(), &depthStencilViewDesc, &_view);
         }
 
         // Get the depth stencil view for the depth stencil.

--- a/trview.graphics/DepthStencil.h
+++ b/trview.graphics/DepthStencil.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <d3d11.h>
 #include <wrl/client.h>
+#include <trview.graphics/Device.h>
 
 #include "Texture.h"
 
@@ -18,7 +19,7 @@ namespace trview
             // device: The device to use to create the depth stencil.
             // width: The width of the depth stencil.
             // height: The height of the depth stencil.
-            DepthStencil(const Microsoft::WRL::ComPtr<ID3D11Device>& device, uint32_t width, uint32_t height);
+            DepthStencil(const graphics::Device& device, uint32_t width, uint32_t height);
 
             // Get the depth stencil view for the depth stencil.
             // Returns: The depth stencil view.

--- a/trview.graphics/DeviceWindow.cpp
+++ b/trview.graphics/DeviceWindow.cpp
@@ -8,7 +8,7 @@ namespace trview
     namespace graphics
     {
         DeviceWindow::DeviceWindow(const Device& device, const Window& window)
-            : _device(device.device()), _context(device.context())
+            : _device(device), _context(device.context())
         {
             // Swap chain description.
             DXGI_SWAP_CHAIN_DESC swap_chain_desc{};
@@ -26,12 +26,12 @@ namespace trview
             swap_chain_desc.SampleDesc.Quality = 0;
 
             ComPtr<IDXGIDevice> dxgi_device;
-            _device.As(&dxgi_device);
+            _device.device().As(&dxgi_device);
             ComPtr<IDXGIAdapter> dxgi_adapter;
             dxgi_device->GetAdapter(&dxgi_adapter);
             ComPtr<IDXGIFactory> factory;
             dxgi_adapter->GetParent(__uuidof(IDXGIFactory), &factory);
-            factory->CreateSwapChain(_device.Get(), &swap_chain_desc, &_swap_chain);
+            factory->CreateSwapChain(_device.device().Get(), &swap_chain_desc, &_swap_chain);
 
             create_render_target();
         }

--- a/trview.graphics/DeviceWindow.h
+++ b/trview.graphics/DeviceWindow.h
@@ -41,7 +41,7 @@ namespace trview
         private:
             void create_render_target();
 
-            Microsoft::WRL::ComPtr<ID3D11Device> _device;
+            const Device&                               _device;
             Microsoft::WRL::ComPtr<ID3D11DeviceContext> _context;
             Microsoft::WRL::ComPtr<IDXGISwapChain> _swap_chain;
             std::unique_ptr<RenderTarget> _render_target;

--- a/trview.graphics/FontFactory.cpp
+++ b/trview.graphics/FontFactory.cpp
@@ -9,8 +9,7 @@ namespace trview
 {
     namespace graphics
     {
-        FontFactory::FontFactory(const ComPtr<ID3D11Device>& device)
-            : _device(device)
+        FontFactory::FontFactory()
         {
         }
 

--- a/trview.graphics/FontFactory.h
+++ b/trview.graphics/FontFactory.h
@@ -6,9 +6,7 @@
 #pragma once
 
 #include <string>
-#include <wrl/client.h>
 #include <memory>
-#include <d3d11.h>
 #include <vector>
 #include <unordered_map>
 
@@ -27,8 +25,7 @@ namespace trview
         class FontFactory
         {
         public:
-            /// Creates a new instace of the FontFactory class.
-            explicit FontFactory(const Microsoft::WRL::ComPtr<ID3D11Device>& device);
+            FontFactory();
 
             ~FontFactory();
 
@@ -47,7 +44,6 @@ namespace trview
             /// @returns The new font instance.
             std::unique_ptr<Font> create_font(const std::string& font_face, int size, TextAlignment text_alignment = TextAlignment::Left, ParagraphAlignment paragraph_alignment = ParagraphAlignment::Near) const;
         private:
-            Microsoft::WRL::ComPtr<ID3D11Device> _device;
             mutable std::unordered_map<std::string, std::shared_ptr<DirectX::SpriteFont>> _cache;
         };
     }

--- a/trview.graphics/PixelShader.cpp
+++ b/trview.graphics/PixelShader.cpp
@@ -4,14 +4,14 @@ namespace trview
 {
     namespace graphics
     {
-        PixelShader::PixelShader(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const std::vector<uint8_t>& data)
+        PixelShader::PixelShader(const graphics::Device& device, const std::vector<uint8_t>& data)
         {
             if (data.empty())
             {
                 throw std::exception("Data for PixelShader cannot be empty");
             }
 
-            device->CreatePixelShader(&data[0], data.size(), nullptr, &_pixel_shader);
+            device.device()->CreatePixelShader(&data[0], data.size(), nullptr, &_pixel_shader);
         }
 
         void PixelShader::apply(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context)

--- a/trview.graphics/PixelShader.h
+++ b/trview.graphics/PixelShader.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "IShader.h"
+#include <trview.graphics/Device.h>
 
 namespace trview
 {
@@ -12,7 +13,7 @@ namespace trview
         class PixelShader final : public IShader
         {
         public:
-            PixelShader(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const std::vector<uint8_t>& data);
+            PixelShader(const graphics::Device& device, const std::vector<uint8_t>& data);
 
             virtual ~PixelShader() = default;
 

--- a/trview.graphics/RenderTarget.cpp
+++ b/trview.graphics/RenderTarget.cpp
@@ -26,7 +26,7 @@ namespace trview
         // width: The width of the new render target.
         // height: The height of the new render target.
         // depth_mode: Whether a depth stencil should be created.
-        RenderTarget::RenderTarget(const ComPtr<ID3D11Device>& device, uint32_t width, uint32_t height, DepthStencilMode depth_mode)
+        RenderTarget::RenderTarget(const graphics::Device& device, uint32_t width, uint32_t height, DepthStencilMode depth_mode)
             : _width(width), _height(height), 
             _texture(device, width, height, Texture::Bind::RenderTarget)
         {
@@ -35,14 +35,14 @@ namespace trview
                 _depth_stencil = std::make_unique<DepthStencil>(device, _width, _height);
             }
 
-            device->CreateRenderTargetView(_texture.texture().Get(), nullptr, &_view);
+            device.device()->CreateRenderTargetView(_texture.texture().Get(), nullptr, &_view);
         }
 
         // Create a render target using the specfied pre-existing texture.
         // device: The D3D device.
         // texture: The texture to use as the render target.
         // depth_mode: Whether a depth stencil should be created.
-        RenderTarget::RenderTarget(const ComPtr<ID3D11Device>& device, const ComPtr<ID3D11Texture2D>& texture, DepthStencilMode depth_mode)
+        RenderTarget::RenderTarget(const graphics::Device& device, const ComPtr<ID3D11Texture2D>& texture, DepthStencilMode depth_mode)
             : _texture{ texture, nullptr }
         {
             // Initialise properties from the existing texture.
@@ -56,7 +56,7 @@ namespace trview
                 _depth_stencil = std::make_unique<DepthStencil>(device, _width, _height);
             }
 
-            device->CreateRenderTargetView(_texture.texture().Get(), nullptr, &_view);
+            device.device()->CreateRenderTargetView(_texture.texture().Get(), nullptr, &_view);
         }
 
         RenderTarget::~RenderTarget() 

--- a/trview.graphics/RenderTarget.h
+++ b/trview.graphics/RenderTarget.h
@@ -33,13 +33,13 @@ namespace trview
             // width: The width of the new render target.
             // height: The height of the new render target.
             // depth_mode: Whether a depth stencil should be created.
-            RenderTarget(const Microsoft::WRL::ComPtr<ID3D11Device>& device, uint32_t width, uint32_t height, DepthStencilMode depth_mode = DepthStencilMode::Disabled);
+            RenderTarget(const graphics::Device& device, uint32_t width, uint32_t height, DepthStencilMode depth_mode = DepthStencilMode::Disabled);
 
             // Create a render target using the specfied pre-existing texture.
             // device: The D3D device.
             // texture: The texture to use as the render target.
             // depth_mode: Whether a depth stencil should be created.
-            RenderTarget(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const Microsoft::WRL::ComPtr<ID3D11Texture2D>& texture, DepthStencilMode depth_mode = DepthStencilMode::Disabled);
+            RenderTarget(const graphics::Device& device, const Microsoft::WRL::ComPtr<ID3D11Texture2D>& texture, DepthStencilMode depth_mode = DepthStencilMode::Disabled);
 
             ~RenderTarget();
 

--- a/trview.graphics/Sprite.cpp
+++ b/trview.graphics/Sprite.cpp
@@ -28,7 +28,7 @@ namespace trview
             };
         }
 
-        Sprite::Sprite(const ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const Size& host_size)
+        Sprite::Sprite(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const Size& host_size)
             : _host_size(host_size)
         {
             using namespace DirectX::SimpleMath;
@@ -51,7 +51,7 @@ namespace trview
             memset(&vertex_data, 0, sizeof(vertex_data));
             vertex_data.pSysMem = vertices;
 
-            HRESULT hr = device->CreateBuffer(&vertex_desc, &vertex_data, &_vertex_buffer);
+            HRESULT hr = device.device()->CreateBuffer(&vertex_desc, &vertex_data, &_vertex_buffer);
 
             uint32_t indices[] = { 0, 1, 2, 3 };
 
@@ -65,7 +65,7 @@ namespace trview
             memset(&index_data, 0, sizeof(index_data));
             index_data.pSysMem = indices;
 
-            hr = device->CreateBuffer(&index_desc, &index_data, &_index_buffer);
+            hr = device.device()->CreateBuffer(&index_desc, &index_data, &_index_buffer);
 
             _vertex_shader = shader_storage.get("ui_vertex_shader");
             _pixel_shader = shader_storage.get("ui_pixel_shader");
@@ -82,7 +82,7 @@ namespace trview
             desc.MaxLOD = D3D11_FLOAT32_MAX;
 
             // Create the texture sampler state.
-            device->CreateSamplerState(&desc, &_sampler_state);
+            device.device()->CreateSamplerState(&desc, &_sampler_state);
 
             create_matrix(device);
         }
@@ -109,7 +109,7 @@ namespace trview
             context->DrawIndexed(4, 0, 0);
         }
 
-        void Sprite::create_matrix(const ComPtr<ID3D11Device>& device)
+        void Sprite::create_matrix(const graphics::Device& device)
         {
             using namespace DirectX::SimpleMath;
             D3D11_BUFFER_DESC desc;
@@ -120,7 +120,7 @@ namespace trview
             desc.Usage = D3D11_USAGE_DYNAMIC;
             desc.CPUAccessFlags = D3D11_CPU_ACCESS_WRITE;
 
-            device->CreateBuffer(&desc, nullptr, _matrix_buffer.GetAddressOf());
+            device.device()->CreateBuffer(&desc, nullptr, _matrix_buffer.GetAddressOf());
         }
 
         void Sprite::update_matrix(const ComPtr<ID3D11DeviceContext>& context, float x, float y, float width, float height, const DirectX::SimpleMath::Color& colour)

--- a/trview.graphics/Sprite.h
+++ b/trview.graphics/Sprite.h
@@ -4,6 +4,7 @@
 #include <d3d11.h>
 #include <cstdint>
 #include <trview.common/Size.h>
+#include <trview.graphics/Device.h>
 
 #include <SimpleMath.h>
 
@@ -18,7 +19,7 @@ namespace trview
         class Sprite
         {
         public:
-            Sprite(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const Size& host_size);
+            Sprite(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const Size& host_size);
 
             void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, const Texture& texture, float x, float y, float width, float height, DirectX::SimpleMath::Color colour = { 1,1,1,1 });
 
@@ -29,7 +30,7 @@ namespace trview
             Sprite(const Sprite&) = delete;
             Sprite& operator=(const Sprite&) = delete;
         private:
-            void create_matrix(const Microsoft::WRL::ComPtr<ID3D11Device>& device);
+            void create_matrix(const graphics::Device& device);
 
             void update_matrix(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, float x, float y, float width, float height, const DirectX::SimpleMath::Color& colour);
 

--- a/trview.graphics/Texture.cpp
+++ b/trview.graphics/Texture.cpp
@@ -43,12 +43,12 @@ namespace trview
         {
         }
 
-        Texture::Texture(const ComPtr<ID3D11Device>& device, uint32_t width, uint32_t height, Bind bind)
+        Texture::Texture(const graphics::Device& device, uint32_t width, uint32_t height, Bind bind)
             : Texture(device, width, height, std::vector<uint32_t>(width * height, 0x00000000), bind)
         {
         }
 
-        Texture::Texture(const Microsoft::WRL::ComPtr<ID3D11Device>& device, uint32_t width, uint32_t height, const std::vector<uint32_t>& pixels, Bind bind)
+        Texture::Texture(const graphics::Device& device, uint32_t width, uint32_t height, const std::vector<uint32_t>& pixels, Bind bind)
         {
             D3D11_SUBRESOURCE_DATA srd;
             memset(&srd, 0, sizeof(srd));
@@ -67,10 +67,10 @@ namespace trview
             desc.CPUAccessFlags = 0;
             desc.MiscFlags = 0;
 
-            device->CreateTexture2D(&desc, &srd, &_texture);
+            device.device()->CreateTexture2D(&desc, &srd, &_texture);
             if (bind != Texture::Bind::DepthStencil)
             {
-                device->CreateShaderResourceView(_texture.Get(), nullptr, &_view);
+                device.device()->CreateShaderResourceView(_texture.Get(), nullptr, &_view);
             }
         }
 

--- a/trview.graphics/Texture.h
+++ b/trview.graphics/Texture.h
@@ -11,6 +11,7 @@
 #include <d3d11.h>
 #include <cstdint>
 #include <vector>
+#include <trview.graphics/Device.h>
 
 namespace trview
 {
@@ -50,7 +51,7 @@ namespace trview
             /// @param height The height in pixels of the new texture.
             /// @param bind An optional parameter to specify the bind mode. By default this is set to Bind::Texture.
             /// @see Bind
-            Texture(const Microsoft::WRL::ComPtr<ID3D11Device>& device, uint32_t width, uint32_t height, Bind bind = Bind::Texture);
+            Texture(const graphics::Device& device, uint32_t width, uint32_t height, Bind bind = Bind::Texture);
 
             /// Create a texture of the specified dimensions with the pixel data provided. The optional bind mode will affect the way that this
             /// texture is created and can be used.
@@ -60,7 +61,7 @@ namespace trview
             /// @param pixels The pixel data to use to initialise the texture. This must contain at least as many elements as width x height.
             /// @param bind An optional parameter to specify the bind mode. By default this is set to Bind::Texture.
             /// @see Bind
-            Texture(const Microsoft::WRL::ComPtr<ID3D11Device>& device, uint32_t width, uint32_t height, const std::vector<uint32_t>& pixels, Bind bind = Bind::Texture);
+            Texture(const graphics::Device& device, uint32_t width, uint32_t height, const std::vector<uint32_t>& pixels, Bind bind = Bind::Texture);
 
             /// Indicates whether this texture has any texture content.
             /// @returns True if the texture has content.

--- a/trview.graphics/VertexShader.cpp
+++ b/trview.graphics/VertexShader.cpp
@@ -4,7 +4,7 @@ namespace trview
 {
     namespace graphics
     {
-        VertexShader::VertexShader(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const std::vector<uint8_t>& data, const std::vector<D3D11_INPUT_ELEMENT_DESC>& input_desc)
+        VertexShader::VertexShader(const graphics::Device& device, const std::vector<uint8_t>& data, const std::vector<D3D11_INPUT_ELEMENT_DESC>& input_desc)
         {
             if (data.empty())
             {
@@ -16,8 +16,8 @@ namespace trview
                 throw std::exception("InputLayout for VertexShader cannot be empty");
             }
 
-            device->CreateVertexShader(&data[0], data.size(), nullptr, &_vertex_shader);
-            device->CreateInputLayout(&input_desc[0], static_cast<uint32_t>(input_desc.size()), &data[0], static_cast<uint32_t>(data.size()), &_input_layout);
+            device.device()->CreateVertexShader(&data[0], data.size(), nullptr, &_vertex_shader);
+            device.device()->CreateInputLayout(&input_desc[0], static_cast<uint32_t>(input_desc.size()), &data[0], static_cast<uint32_t>(data.size()), &_input_layout);
         }
 
         void VertexShader::apply(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context)

--- a/trview.graphics/VertexShader.h
+++ b/trview.graphics/VertexShader.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "IShader.h"
+#include <trview.graphics/Device.h>
 
 namespace trview
 {
@@ -16,7 +17,7 @@ namespace trview
             // device: The D3D device to use to create the vertex shader.
             // data: The data to use to compile the shader.
             // input_desc: The input layout description.
-            VertexShader(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const std::vector<uint8_t>& data, const std::vector<D3D11_INPUT_ELEMENT_DESC>& input_desc);
+            VertexShader(const graphics::Device& device, const std::vector<uint8_t>& data, const std::vector<D3D11_INPUT_ELEMENT_DESC>& input_desc);
 
             virtual ~VertexShader() = default;
 

--- a/trview.graphics/trview.graphics.vcxproj
+++ b/trview.graphics/trview.graphics.vcxproj
@@ -60,6 +60,11 @@
     <ClCompile Include="VertexShaderStore.cpp" />
     <ClCompile Include="ViewportStore.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\trview.common\trview.common.vcxproj">
+      <Project>{d0633291-23a6-4b3f-9a5e-e94d20f66a07}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{3270FD29-EDAB-40BE-8CA1-DABC5E261E4C}</ProjectGuid>

--- a/trview.ui.render/ButtonNode.cpp
+++ b/trview.ui.render/ButtonNode.cpp
@@ -15,7 +15,7 @@ namespace trview
     {
         namespace render
         {
-            ButtonNode::ButtonNode(const ComPtr<ID3D11Device>& device, Button* button)
+            ButtonNode::ButtonNode(const graphics::Device& device, Button* button)
                 : RenderNode(device, button), _button(button), _blank(_device, 1, 1, std::vector<uint32_t>(1, 0xffffffff))
             {
             }

--- a/trview.ui.render/ButtonNode.h
+++ b/trview.ui.render/ButtonNode.h
@@ -22,7 +22,7 @@ namespace trview
                 /// Create a new ButtonNode.
                 /// @param device The device to use to render.
                 /// @param button The button to render.
-                explicit ButtonNode(const Microsoft::WRL::ComPtr<ID3D11Device>& device, Button* button);
+                explicit ButtonNode(const graphics::Device& device, Button* button);
 
                 /// Destructor for the button node.
                 virtual ~ButtonNode();

--- a/trview.ui.render/ImageNode.cpp
+++ b/trview.ui.render/ImageNode.cpp
@@ -11,7 +11,7 @@ namespace trview
     {
         namespace render
         {
-            ImageNode::ImageNode(const Microsoft::WRL::ComPtr<ID3D11Device>& device, Image* image)
+            ImageNode::ImageNode(const graphics::Device& device, Image* image)
                 : WindowNode(device, image), _image(image)
             {
             }

--- a/trview.ui.render/ImageNode.h
+++ b/trview.ui.render/ImageNode.h
@@ -13,7 +13,7 @@ namespace trview
             class ImageNode : public WindowNode
             {
             public:
-                explicit ImageNode(const Microsoft::WRL::ComPtr<ID3D11Device>& device, Image* image);
+                explicit ImageNode(const graphics::Device& device, Image* image);
                 virtual ~ImageNode();
             protected:
                 virtual void render_self(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, graphics::Sprite& sprite) override;

--- a/trview.ui.render/LabelNode.cpp
+++ b/trview.ui.render/LabelNode.cpp
@@ -10,7 +10,7 @@ namespace trview
     {
         namespace render
         {
-            LabelNode::LabelNode(const Microsoft::WRL::ComPtr<ID3D11Device>& device, Label* label, const graphics::FontFactory& font_factory)
+            LabelNode::LabelNode(const graphics::Device& device, Label* label, const graphics::FontFactory& font_factory)
                 : WindowNode(device, label), 
                 _font(font_factory.create_font("Arial", label->text_size(), label->text_alignment(), label->paragraph_alignment())), _label(label)
             {

--- a/trview.ui.render/LabelNode.h
+++ b/trview.ui.render/LabelNode.h
@@ -20,7 +20,7 @@ namespace trview
             class LabelNode : public WindowNode, public IFontMeasurer
             {
             public:
-                LabelNode(const Microsoft::WRL::ComPtr<ID3D11Device>& device, Label* label, const graphics::FontFactory& font_factory);
+                LabelNode(const graphics::Device& device, Label* label, const graphics::FontFactory& font_factory);
                 virtual ~LabelNode();
                 virtual Size measure(const std::wstring& text) const override;
             protected:

--- a/trview.ui.render/MapRenderer.cpp
+++ b/trview.ui.render/MapRenderer.cpp
@@ -29,7 +29,7 @@ namespace trview
 
         namespace render
         {
-            MapRenderer::MapRenderer(const ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const Size& window_size)
+            MapRenderer::MapRenderer(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const Size& window_size)
                 : _device(device),
                 _window_width(static_cast<int>(window_size.width)), 
                 _window_height(static_cast<int>(window_size.height)),

--- a/trview.ui.render/MapRenderer.h
+++ b/trview.ui.render/MapRenderer.h
@@ -46,7 +46,7 @@ namespace trview
             class MapRenderer
             {
             public:
-                MapRenderer(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const Size& window_size);
+                MapRenderer(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const Size& window_size);
 
                 // Renders the map 
                 void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context);
@@ -100,7 +100,7 @@ namespace trview
                 // Determines if the minimap needs to be re-drawn.
                 bool needs_redraw();
 
-                Microsoft::WRL::ComPtr<ID3D11Device>               _device;
+                const graphics::Device&                            _device;
                 bool                                               _visible = true;
                 int                                                _window_width, _window_height;
                 graphics::Sprite                                   _sprite; 

--- a/trview.ui.render/RenderNode.cpp
+++ b/trview.ui.render/RenderNode.cpp
@@ -17,7 +17,7 @@ namespace trview
     {
         namespace render
         {
-            RenderNode::RenderNode(const ComPtr<ID3D11Device>& device, Control* control)
+            RenderNode::RenderNode(const graphics::Device& device, Control* control)
                 : _device(device), _control(control)
             {
                 regenerate_texture();

--- a/trview.ui.render/RenderNode.h
+++ b/trview.ui.render/RenderNode.h
@@ -10,6 +10,7 @@
 #include <trview.common/TokenStore.h>
 #include <trview.common/Point.h>
 #include <trview.graphics/RenderTarget.h>
+#include <trview.graphics/Device.h>
 
 namespace trview
 {
@@ -34,7 +35,7 @@ namespace trview
             public:
                 friend class Renderer;
 
-                RenderNode(const Microsoft::WRL::ComPtr<ID3D11Device>& device, Control* control);
+                RenderNode(const graphics::Device& device, Control* control);
 
                 virtual ~RenderNode() = 0;
 
@@ -67,7 +68,7 @@ namespace trview
 
                 void regenerate_texture();
 
-                Microsoft::WRL::ComPtr<ID3D11Device>     _device;
+                const graphics::Device&                  _device;
                 std::unique_ptr<graphics::RenderTarget>  _render_target;
                 std::vector<std::unique_ptr<RenderNode>> _child_nodes;
                 Control*                                 _control;

--- a/trview.ui.render/Renderer.cpp
+++ b/trview.ui.render/Renderer.cpp
@@ -18,7 +18,7 @@ namespace trview
     {
         namespace render
         {
-            Renderer::Renderer(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const Size& host_size)
+            Renderer::Renderer(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const Size& host_size)
                 : _device(device), 
                 _font_factory(font_factory),
                 _sprite(std::make_unique<graphics::Sprite>(device, shader_storage, host_size)),
@@ -26,7 +26,7 @@ namespace trview
             {
                 D3D11_DEPTH_STENCIL_DESC ui_depth_stencil_desc;
                 memset(&ui_depth_stencil_desc, 0, sizeof(ui_depth_stencil_desc));
-                device->CreateDepthStencilState(&ui_depth_stencil_desc, &_depth_stencil_state);
+                device.device()->CreateDepthStencilState(&ui_depth_stencil_desc, &_depth_stencil_state);
             }
 
             Renderer::~Renderer()

--- a/trview.ui.render/Renderer.h
+++ b/trview.ui.render/Renderer.h
@@ -26,7 +26,7 @@ namespace trview
             class Renderer
             {
             public:
-                explicit Renderer(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const Size& host_size);
+                explicit Renderer(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const Size& host_size);
 
                 ~Renderer();
 
@@ -45,7 +45,7 @@ namespace trview
 
                 std::unique_ptr<RenderNode>                     _root_node;
                 std::unique_ptr<graphics::Sprite>               _sprite;
-                Microsoft::WRL::ComPtr<ID3D11Device>            _device;
+                const graphics::Device&                         _device;
                 Microsoft::WRL::ComPtr<ID3D11DepthStencilState> _depth_stencil_state;
                 const graphics::FontFactory&                    _font_factory;
                 Size                                            _host_size;

--- a/trview.ui.render/WindowNode.cpp
+++ b/trview.ui.render/WindowNode.cpp
@@ -7,7 +7,7 @@ namespace trview
     {
         namespace render
         {
-            WindowNode::WindowNode(const Microsoft::WRL::ComPtr<ID3D11Device>& device, Window* window)
+            WindowNode::WindowNode(const graphics::Device& device, Window* window)
                 : _window(window), RenderNode(device, window)
             {
             }

--- a/trview.ui.render/WindowNode.h
+++ b/trview.ui.render/WindowNode.h
@@ -16,7 +16,7 @@ namespace trview
             class WindowNode : public RenderNode
             {
             public:
-                WindowNode(const Microsoft::WRL::ComPtr<ID3D11Device>& device, Window* window);
+                WindowNode(const graphics::Device& device, Window* window);
                 virtual ~WindowNode();
             protected:
                 virtual void render_self(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, graphics::Sprite& sprite) override;

--- a/trview/DefaultFonts.cpp
+++ b/trview/DefaultFonts.cpp
@@ -18,17 +18,17 @@ namespace trview
         /// @param device The Direct3D device to use to load the font.
         /// @param resource_id The integer ID of the font in the resource file.
         /// @returns The font loaded from the resource.
-        std::shared_ptr<SpriteFont> load_font_from_resource(const ComPtr<ID3D11Device>& device, int resource_id)
+        std::shared_ptr<SpriteFont> load_font_from_resource(const graphics::Device& device, int resource_id)
         {
             auto resource_memory = get_resource_memory(resource_id, L"SPRITEFONT");
-            return std::make_shared<SpriteFont>(device.Get(), resource_memory.data, resource_memory.size);
+            return std::make_shared<SpriteFont>(device.device().Get(), resource_memory.data, resource_memory.size);
         }
     }
 
     /// Loads the fonts that have been embedded in the resource file and puts them into the font storage provided.
     /// @param device The Direct3D device to use to load the fonts.
     /// @param font_factory The FontFactory instance to store the fonts in.
-    void load_default_fonts(const ComPtr<ID3D11Device>& device, graphics::FontFactory& font_factory)
+    void load_default_fonts(const graphics::Device& device, graphics::FontFactory& font_factory)
     {
         // Load some sort of manifest that contains the files to load.
         // For each font, load it with the given key.

--- a/trview/DefaultFonts.h
+++ b/trview/DefaultFonts.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <wrl/client.h>
-#include <d3d11.h>
+#include <trview.graphics/Device.h>
 
 namespace trview
 {
@@ -13,5 +12,5 @@ namespace trview
     /// Loads the fonts that have been embedded in the resource file and puts them into the font storage provided.
     /// @param device The Direct3D device to use to load the fonts.
     /// @param font_factory The FontFactory instance to store the fonts in.
-    void load_default_fonts(const Microsoft::WRL::ComPtr<ID3D11Device>& device, graphics::FontFactory& font_factory);
+    void load_default_fonts(const graphics::Device& device, graphics::FontFactory& font_factory);
 }

--- a/trview/DefaultShaders.cpp
+++ b/trview/DefaultShaders.cpp
@@ -21,7 +21,7 @@ namespace trview
             return std::vector<uint8_t>(resource.data, resource.data + resource.size);
         }
 
-        void load_level_shaders(const ComPtr<ID3D11Device>& device, graphics::IShaderStorage& storage)
+        void load_level_shaders(const graphics::Device& device, graphics::IShaderStorage& storage)
         {
             std::vector<D3D11_INPUT_ELEMENT_DESC> input_desc(4);
             memset(&input_desc[0], 0, sizeof(D3D11_INPUT_ELEMENT_DESC) * input_desc.size());
@@ -50,7 +50,7 @@ namespace trview
             storage.add("selection_pixel_shader", std::make_unique<graphics::PixelShader>(device, get_shader_resource(IDR_SELECTION_SHADER)));
         }
 
-        void load_ui_shaders(const ComPtr<ID3D11Device>& device, graphics::IShaderStorage& storage)
+        void load_ui_shaders(const graphics::Device& device, graphics::IShaderStorage& storage)
         {
             std::vector<D3D11_INPUT_ELEMENT_DESC> input_desc(2);
             memset(&input_desc[0], 0, sizeof(D3D11_INPUT_ELEMENT_DESC) * input_desc.size());
@@ -68,7 +68,7 @@ namespace trview
         }
     }
 
-    void load_default_shaders(const ComPtr<ID3D11Device>& device, graphics::IShaderStorage& storage)
+    void load_default_shaders(const graphics::Device& device, graphics::IShaderStorage& storage)
     {
         load_level_shaders(device, storage);
         load_ui_shaders(device, storage);

--- a/trview/DefaultShaders.h
+++ b/trview/DefaultShaders.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <wrl/client.h>
-#include <d3d11.h>
+#include <trview.graphics/Device.h>
 
 namespace trview
 {
@@ -10,5 +9,5 @@ namespace trview
         struct IShaderStorage;
     }
 
-    void load_default_shaders(const Microsoft::WRL::ComPtr<ID3D11Device>& device, graphics::IShaderStorage& storage);
+    void load_default_shaders(const graphics::Device& device, graphics::IShaderStorage& storage);
 }

--- a/trview/DefaultTextures.cpp
+++ b/trview/DefaultTextures.cpp
@@ -18,13 +18,13 @@ namespace trview
         // device: The Direct3D device to use to load the textures.
         // resource_id: The integer ID of the texture in the resource file.
         // Returns: The texture loaded from the resource.
-        graphics::Texture load_texture_from_resource(const ComPtr<ID3D11Device>& device, int resource_id)
+        graphics::Texture load_texture_from_resource(const graphics::Device& device, int resource_id)
         {
             ComPtr<ID3D11Resource> resource;
             ComPtr<ID3D11ShaderResourceView> view;
 
             auto resource_memory = get_resource_memory(resource_id, L"PNG");
-            DirectX::CreateWICTextureFromMemory(device.Get(), resource_memory.data, resource_memory.size, &resource, &view);
+            DirectX::CreateWICTextureFromMemory(device.device().Get(), resource_memory.data, resource_memory.size, &resource, &view);
 
             if (!resource)
             {
@@ -43,7 +43,7 @@ namespace trview
     // the texture storage provided.
     // device: The Direct3D device to use to load the textures.
     // storage: The ITextureStorage instance to store the textures in.
-    void load_default_textures(const ComPtr<ID3D11Device>& device, ITextureStorage& storage)
+    void load_default_textures(const graphics::Device& device, ITextureStorage& storage)
     {
         // Load some sort of manifest that contains the files to load.
         // For each texture, load it with the given key.

--- a/trview/DefaultTextures.h
+++ b/trview/DefaultTextures.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <wrl/client.h>
-#include <d3d11.h>
+#include <trview.graphics/Device.h>
 
 namespace trview
 {
@@ -11,5 +10,5 @@ namespace trview
     // the texture storage provided.
     // device: The Direct3D device to use to load the textures.
     // storage: The ITextureStorage instance to store the textures in.
-    void load_default_textures(const Microsoft::WRL::ComPtr<ID3D11Device>& device, ITextureStorage& storage);
+    void load_default_textures(const graphics::Device& device, ITextureStorage& storage);
 }

--- a/trview/Entity.cpp
+++ b/trview/Entity.cpp
@@ -17,7 +17,7 @@ using namespace Microsoft::WRL;
 
 namespace trview
 {
-    Entity::Entity(const ComPtr<ID3D11Device>& device, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const ILevelTextureStorage& texture_storage, const IMeshStorage& mesh_storage, uint32_t index)
+    Entity::Entity(const graphics::Device& device, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const ILevelTextureStorage& texture_storage, const IMeshStorage& mesh_storage, uint32_t index)
         : _room(entity.Room), _index(index)
     {
         using namespace DirectX;
@@ -117,7 +117,7 @@ namespace trview
         }
     }
 
-    void Entity::load_sprite(const ComPtr<ID3D11Device>& device, const trlevel::tr_sprite_sequence& sprite_sequence, const trlevel::ILevel& level, const ILevelTextureStorage& texture_storage)
+    void Entity::load_sprite(const graphics::Device& device, const trlevel::tr_sprite_sequence& sprite_sequence, const trlevel::ILevel& level, const ILevelTextureStorage& texture_storage)
     {
         // Get the first sprite image.
         auto sprite = level.get_sprite_texture(sprite_sequence.Offset);

--- a/trview/Entity.h
+++ b/trview/Entity.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <wrl/client.h>
-#include <d3d11.h>
 #include <SimpleMath.h>
 
 #include <memory>
@@ -30,7 +28,7 @@ namespace trview
     class Entity : public IRenderable
     {
     public:
-        explicit Entity(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::ILevel& level, const trlevel::tr2_entity& room, const ILevelTextureStorage& texture_storage, const IMeshStorage& mesh_storage, uint32_t index);
+        explicit Entity(const graphics::Device& device, const trlevel::ILevel& level, const trlevel::tr2_entity& room, const ILevelTextureStorage& texture_storage, const IMeshStorage& mesh_storage, uint32_t index);
         virtual ~Entity() = default;
         virtual void render(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         uint16_t room() const;
@@ -42,7 +40,7 @@ namespace trview
     private:
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);
-        void load_sprite(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::tr_sprite_sequence& sprite_sequence, const trlevel::ILevel& level, const ILevelTextureStorage& texture_storage);
+        void load_sprite(const graphics::Device& device, const trlevel::tr_sprite_sequence& sprite_sequence, const trlevel::ILevel& level, const ILevelTextureStorage& texture_storage);
         void generate_bounding_box();
 
         DirectX::SimpleMath::Matrix               _world;

--- a/trview/Flipmaps.cpp
+++ b/trview/Flipmaps.cpp
@@ -23,14 +23,14 @@ namespace trview
 
         // Add two methods of controlling flipmaps:
         // The TR1-3 method:
-        auto tr1_3_panel = std::make_unique<Window>(Point(5, 16), panel_size, Colour(0.5f, 0.5f, 0.5f));
+        auto tr1_3_panel = std::make_unique<ui::Window>(Point(5, 16), panel_size, Colour(0.5f, 0.5f, 0.5f));
         auto flip = std::make_unique<Checkbox>(Point(7,0), Size(16, 16), L"Flip");
         flip->on_state_changed += on_flip;
         _flip = tr1_3_panel->add_child(std::move(flip));
         _tr1_3_panel = flips_group->add_child(std::move(tr1_3_panel));
 
         // The TR4-5 method:
-        auto tr4_5_panel = std::make_unique<Window>(Point(5, 16), panel_size, Colour(0.5f, 0.5f, 0.5f));
+        auto tr4_5_panel = std::make_unique<ui::Window>(Point(5, 16), panel_size, Colour(0.5f, 0.5f, 0.5f));
         auto alternate_groups = std::make_unique<StackPanel>(Point(), Size(130, 16), Colour(0.5f, 0.5f, 0.5f), Size(), StackPanel::Direction::Horizontal, SizeMode::Manual);
         _alternate_groups = tr4_5_panel->add_child(std::move(alternate_groups));
         tr4_5_panel->set_visible(false);

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -44,13 +44,13 @@ namespace trview
         // Create the texture sampler state.
         device.device()->CreateSamplerState(&sampler_desc, &_sampler_state);
 
-        _texture_storage = std::make_unique<LevelTextureStorage>(device.device(), *_level);
-        _mesh_storage = std::make_unique<MeshStorage>(device.device(), *_level, *_texture_storage.get());
-        generate_rooms(device.device());
-        generate_triggers(device);
-        generate_entities(device.device());
+        _texture_storage = std::make_unique<LevelTextureStorage>(device, *_level);
+        _mesh_storage = std::make_unique<MeshStorage>(device, *_level, *_texture_storage.get());
+        generate_rooms(device);
+        generate_triggers();
+        generate_entities(device);
 
-        _transparency = std::make_unique<TransparencyBuffer>(device.device());
+        _transparency = std::make_unique<TransparencyBuffer>(device);
 
         _selection_renderer = std::make_unique<SelectionRenderer>(device, shader_storage);
     }
@@ -293,7 +293,7 @@ namespace trview
         return rooms;
     }
 
-    void Level::generate_rooms(const Microsoft::WRL::ComPtr<ID3D11Device>& device)
+    void Level::generate_rooms(const graphics::Device& device)
     {
         const uint16_t num_rooms = _level->num_rooms();
         for (uint16_t i = 0; i < num_rooms; ++i)
@@ -322,7 +322,7 @@ namespace trview
         }
     }
 
-    void Level::generate_triggers(const graphics::Device& device)
+    void Level::generate_triggers()
     {
         for (auto i = 0; i < _rooms.size(); ++i)
         {
@@ -339,7 +339,7 @@ namespace trview
         }
     }
 
-    void Level::generate_entities(const ComPtr<ID3D11Device>& device)
+    void Level::generate_entities(const graphics::Device& device)
     {
         const uint32_t num_entities = _level->num_entities();
         for (uint32_t i = 0; i < num_entities; ++i)

--- a/trview/Level.h
+++ b/trview/Level.h
@@ -128,9 +128,9 @@ namespace trview
         /// @returns The set of alternate groups in the level.
         std::set<uint16_t> alternate_groups() const;
     private:
-        void generate_rooms(const Microsoft::WRL::ComPtr<ID3D11Device>& device);
-        void generate_triggers(const graphics::Device& device);
-        void generate_entities(const Microsoft::WRL::ComPtr<ID3D11Device>& device);
+        void generate_rooms(const graphics::Device& device);
+        void generate_triggers();
+        void generate_entities(const graphics::Device& device);
         void regenerate_neighbours();
         void generate_neighbours(std::set<uint16_t>& all_rooms, uint16_t previous_room, uint16_t selected_room, int32_t current_depth, int32_t max_depth);
 

--- a/trview/LevelTextureStorage.cpp
+++ b/trview/LevelTextureStorage.cpp
@@ -4,7 +4,7 @@
 
 namespace trview
 {
-    LevelTextureStorage::LevelTextureStorage(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::ILevel& level)
+    LevelTextureStorage::LevelTextureStorage(const graphics::Device& device, const trlevel::ILevel& level)
         : _device(device), _level(level), _texture_storage(std::make_unique<TextureStorage>(device))
     {
         for (uint32_t i = 0; i < level.num_textiles(); ++i)

--- a/trview/LevelTextureStorage.h
+++ b/trview/LevelTextureStorage.h
@@ -10,13 +10,14 @@
 #include <trlevel/ILevel.h>
 
 #include <trview.app/ILevelTextureStorage.h>
+#include <trview.graphics/Device.h>
 
 namespace trview
 {
     class LevelTextureStorage final : public ILevelTextureStorage
     {
     public:
-        explicit LevelTextureStorage(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::ILevel& level);
+        explicit LevelTextureStorage(const graphics::Device& device, const trlevel::ILevel& level);
         virtual ~LevelTextureStorage() = default;
         virtual graphics::Texture texture(uint32_t tile_index) const override;
         virtual graphics::Texture coloured(uint32_t colour) const override;
@@ -29,7 +30,7 @@ namespace trview
         virtual uint16_t attribute(uint32_t texture_index) const override;
         virtual DirectX::SimpleMath::Color palette_from_texture(uint32_t texture) const override;
     private:
-        Microsoft::WRL::ComPtr<ID3D11Device> _device;
+        const graphics::Device& _device;
         std::vector<graphics::Texture> _tiles;
         std::vector<trlevel::tr_object_texture> _object_textures;
         std::unique_ptr<ITextureStorage> _texture_storage;

--- a/trview/MeshStorage.cpp
+++ b/trview/MeshStorage.cpp
@@ -3,7 +3,7 @@
 
 namespace trview
 {
-    MeshStorage::MeshStorage(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::ILevel& level, const ILevelTextureStorage& texture_storage)
+    MeshStorage::MeshStorage(const graphics::Device& device, const trlevel::ILevel& level, const ILevelTextureStorage& texture_storage)
         : _device(device), _level(level), _texture_storage(texture_storage)
     {
     }

--- a/trview/MeshStorage.h
+++ b/trview/MeshStorage.h
@@ -10,6 +10,7 @@
 
 #include "IMeshStorage.h"
 #include <trview.app/Mesh.h>
+#include <trview.graphics/Device.h>
 
 namespace trview
 {
@@ -18,13 +19,13 @@ namespace trview
     class MeshStorage final : public IMeshStorage
     {
     public:
-        explicit MeshStorage(const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::ILevel& level, const ILevelTextureStorage& texture_storage);
+        explicit MeshStorage(const graphics::Device& device, const trlevel::ILevel& level, const ILevelTextureStorage& texture_storage);
 
         virtual ~MeshStorage() = default;
 
         virtual Mesh* mesh(uint32_t mesh_pointer) const override;
     private:
-        Microsoft::WRL::ComPtr<ID3D11Device> _device;
+        const graphics::Device& _device;
         const trlevel::ILevel& _level;
         const ILevelTextureStorage& _texture_storage;
         mutable std::unordered_map<uint32_t, std::unique_ptr<Mesh>> _meshes;

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -25,7 +25,7 @@ namespace trview
         const Color Trigger_Colour{ 1, 0, 1, 0.5f };
     }
 
-    Room::Room(const ComPtr<ID3D11Device>& device, 
+    Room::Room(const graphics::Device& device, 
         const trlevel::ILevel& level, 
         const trlevel::tr3_room& room,
         const ILevelTextureStorage& texture_storage,
@@ -175,7 +175,7 @@ namespace trview
         }
     }
 
-    void Room::generate_geometry(trlevel::LevelVersion level_version, const ComPtr<ID3D11Device>& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage)
+    void Room::generate_geometry(trlevel::LevelVersion level_version, const graphics::Device& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage)
     {
         std::vector<trlevel::tr_vertex> room_vertices;
         std::transform(room.data.vertices.begin(), room.data.vertices.end(), std::back_inserter(room_vertices),

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -6,8 +6,6 @@
 #include <memory>
 #include <optional>
 
-#include <d3d11.h>
-#include <wrl/client.h>
 #include <DirectXCollision.h>
 #include <SimpleMath.h>
 
@@ -52,7 +50,7 @@ namespace trview
             IsAlternate
         };
 
-        explicit Room(const Microsoft::WRL::ComPtr<ID3D11Device>& device, 
+        explicit Room(const graphics::Device& device, 
             const trlevel::ILevel& level, 
             const trlevel::tr3_room& room,
             const ILevelTextureStorage& texture_storage,
@@ -139,7 +137,7 @@ namespace trview
 
         void generate_trigger_geometry();
     private:
-        void generate_geometry(trlevel::LevelVersion level_version, const Microsoft::WRL::ComPtr<ID3D11Device>& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage);
+        void generate_geometry(trlevel::LevelVersion level_version, const graphics::Device& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage);
         void generate_adjacency();
         void generate_static_meshes(const trlevel::ILevel& level, const trlevel::tr3_room& room, const IMeshStorage& mesh_storage);
         void render_contained(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour);

--- a/trview/TextureStorage.cpp
+++ b/trview/TextureStorage.cpp
@@ -3,7 +3,7 @@
 
 namespace trview
 {
-    TextureStorage::TextureStorage(const Microsoft::WRL::ComPtr<ID3D11Device>& device)
+    TextureStorage::TextureStorage(const graphics::Device& device)
         : _device(device)
     {
     }

--- a/trview/TextureStorage.h
+++ b/trview/TextureStorage.h
@@ -2,20 +2,20 @@
 
 #include <trview.app/ITextureStorage.h>
 #include <unordered_map>
-#include <wrl/client.h>
+#include <trview.graphics/Device.h>
 
 namespace trview
 {
     class TextureStorage final : public ITextureStorage
     {
     public:
-        explicit TextureStorage(const Microsoft::WRL::ComPtr<ID3D11Device>& device);
+        explicit TextureStorage(const graphics::Device& device);
         virtual ~TextureStorage() = default;
         virtual graphics::Texture coloured(uint32_t colour) const override;
         virtual graphics::Texture lookup(const std::string& key) const override;
         virtual void store(const std::string& key, const graphics::Texture& texture) override;
     private:
-        Microsoft::WRL::ComPtr<ID3D11Device>     _device;
+        const graphics::Device& _device;
         std::unordered_map<std::string, graphics::Texture> _textures;
     };
 }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -47,13 +47,12 @@ namespace trview
         _settings = load_user_settings();
 
         _shader_storage = std::make_unique<graphics::ShaderStorage>();
-        load_default_shaders(_device.device(), *_shader_storage.get());
+        load_default_shaders(_device, *_shader_storage.get());
 
-        _font_factory = std::make_unique<graphics::FontFactory>(_device.device());
-        load_default_fonts(_device.device(), *_font_factory.get());
+        load_default_fonts(_device, _font_factory);
 
         _main_window = _device.create_for_window(window);
-        _items_windows = std::make_unique<ItemsWindowManager>(_device, *_shader_storage.get(), *_font_factory.get(), window);
+        _items_windows = std::make_unique<ItemsWindowManager>(_device, *_shader_storage.get(), _font_factory, window);
         if (_settings.items_startup)
         {
             _items_windows->create_window();
@@ -68,7 +67,7 @@ namespace trview
             select_waypoint(new_index);
         };
 
-        _triggers_windows = std::make_unique<TriggersWindowManager>(_device, *_shader_storage.get(), *_font_factory.get(), window);
+        _triggers_windows = std::make_unique<TriggersWindowManager>(_device, *_shader_storage.get(), _font_factory, window);
         if (_settings.triggers_startup)
         {
             _triggers_windows->create_window();
@@ -107,8 +106,8 @@ namespace trview
 
         initialise_input();
 
-        _texture_storage = std::make_unique<TextureStorage>(_device.device());
-        load_default_textures(_device.device(), *_texture_storage.get());
+        _texture_storage = std::make_unique<TextureStorage>(_device);
+        load_default_textures(_device, *_texture_storage.get());
 
         generate_ui();
 
@@ -116,7 +115,7 @@ namespace trview
         _compass = std::make_unique<Compass>(_device, *_shader_storage);
         _route = std::make_unique<Route>(_device, *_shader_storage);
 
-        _route_window_manager = std::make_unique<RouteWindowManager>(_device, *_shader_storage, *_font_factory, window);
+        _route_window_manager = std::make_unique<RouteWindowManager>(_device, *_shader_storage, _font_factory, window);
         _token_store += _route_window_manager->on_waypoint_selected += [&](auto index)
         {
             select_waypoint(index);
@@ -250,10 +249,10 @@ namespace trview
         _settings_window->set_auto_orbit(_settings.auto_orbit);
 
         // Create the renderer for the UI based on the controls created.
-        _ui_renderer = std::make_unique<ui::render::Renderer>(_device.device(), *_shader_storage.get(), *_font_factory.get(), _window.size());
+        _ui_renderer = std::make_unique<ui::render::Renderer>(_device, *_shader_storage.get(), _font_factory, _window.size());
         _ui_renderer->load(_control.get());
 
-        _map_renderer = std::make_unique<ui::render::MapRenderer>(_device.device(), *_shader_storage.get(), _window.size());
+        _map_renderer = std::make_unique<ui::render::MapRenderer>(_device, *_shader_storage.get(), _window.size());
     }
 
     void Viewer::generate_tool_window()

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -157,7 +157,7 @@ namespace trview
         std::unique_ptr<LevelInfo> _level_info;
         std::unique_ptr<ITextureStorage> _texture_storage;
         std::unique_ptr<graphics::IShaderStorage> _shader_storage;
-        std::unique_ptr<graphics::FontFactory> _font_factory;
+        graphics::FontFactory _font_factory;
         std::unique_ptr<SettingsWindow> _settings_window;
         UserSettings _settings;
         ui::Label* _picking;


### PR DESCRIPTION
It probably should be an interface instead - at the moment we have to create a device in the unit tests for the shaders, which I don't like very much. Will change in the future.
The device context is still used, but will change that separately.
Issue:  #444 