### PR TITLE
Un-invert the sector z coordinates

### DIFF
--- a/trview.ui.render/MapRenderer.cpp
+++ b/trview.ui.render/MapRenderer.cpp
@@ -158,7 +158,7 @@ namespace trview
             {
                 return Point {
                     /* X */ _DRAW_SCALE * sector.x(),
-                    /* Y */ _DRAW_SCALE * sector.z()
+                    /* Y */ _rows * _DRAW_SCALE - _DRAW_SCALE * (sector.z() + 1)
                 } + Point(1,1); 
             }
 

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -344,7 +344,7 @@ namespace trview
                 }
             }
 
-            if (auto other = get_trigger_sector(trigger->x(), trigger->z() + 1))
+            if (auto other = get_trigger_sector(trigger->x(), static_cast<int32_t>(trigger->z()) - 1))
             {
                 auto corners = other->corners();
                 if (y_bottom[2] == corners[3] && y_bottom[0] == corners[1])
@@ -353,7 +353,7 @@ namespace trview
                 }
             }
 
-            if (auto other = get_trigger_sector(trigger->x(), static_cast<int32_t>(trigger->z()) - 1))
+            if (auto other = get_trigger_sector(trigger->x(), trigger->z() + 1))
             {
                 auto corners = other->corners();
                 if (y_bottom[3] == corners[2] && y_bottom[1] == corners[0])
@@ -364,7 +364,7 @@ namespace trview
 
             // Calculate the X/Z position.
             const float x = _info.x / trlevel::Scale_X + trigger->x() + 0.5f;
-            const float z = _info.z / trlevel::Scale_Z + (_num_z_sectors - 1 - trigger->z()) + 0.5f;
+            const float z = _info.z / trlevel::Scale_Z + trigger->z() + 0.5f;
             const float height = 0.25f;
 
             std::array<float, 4> y_top = { 0,0,0,0 };
@@ -417,7 +417,7 @@ namespace trview
 
     uint32_t Room::get_sector_id(int32_t x, int32_t z) const
     {
-        return x * _num_z_sectors + (_num_z_sectors - z - 1);
+        return x * _num_z_sectors + z;
     }
 
     Sector* Room::get_trigger_sector(int32_t x, int32_t z)

--- a/trview/Sector.cpp
+++ b/trview/Sector.cpp
@@ -7,7 +7,7 @@ namespace trview
         : _level(level), _sector(sector), _sector_id(sector_id), _room_above(sector.room_above), _room_below(sector.room_below), _room(room_number)
     {
         _x = sector_id / room.num_z_sectors;
-        _z = room.num_z_sectors - (sector_id % room.num_z_sectors) - 1;
+        _z = sector_id % room.num_z_sectors;
         parse();
     }
 


### PR DESCRIPTION
This makes working with sectors easier, as you don't have to invert the number all the time using the num_z_sectors field from the room.
Issue: #453