### PR TITLE
Show sector geometry that has no matching room geometry

### DIFF
--- a/trview.app/Mesh.cpp
+++ b/trview.app/Mesh.cpp
@@ -22,14 +22,6 @@ namespace trview
             return level_version == trlevel::LevelVersion::Tomb4 ? Texture_Mask_TR4 : Texture_Mask;
         }
 
-        // Convert the vertex to the scale used by the viewer.
-        // vertex: The vertex to convert.
-        // Returns: The scaled vector.
-        Vector3 convert_vertex(const trlevel::tr_vertex& vertex)
-        {
-            return Vector3(vertex.x / trlevel::Scale_X, vertex.y / trlevel::Scale_Y, vertex.z / trlevel::Scale_Z);
-        }
-
         Vector3 calculate_normal(const Vector3* const vertices)
         {
             auto first = vertices[1] - vertices[0];
@@ -553,5 +545,10 @@ namespace trview
                 collision_triangles.emplace_back(verts[2], verts[1], verts[0]);
             }
         }
+    }
+
+    Vector3 convert_vertex(const trlevel::tr_vertex& vertex)
+    {
+        return Vector3(vertex.x / trlevel::Scale_X, vertex.y / trlevel::Scale_Y, vertex.z / trlevel::Scale_Z);
     }
 }

--- a/trview.app/Mesh.h
+++ b/trview.app/Mesh.h
@@ -147,6 +147,11 @@ namespace trview
         std::vector<uint32_t>& output_indices,
         std::vector<Triangle>& collision_triangles);
 
+    /// Convert the vertex to the scale used by the viewer.
+    /// @param vertex The vertex to convert.
+    /// @retrurns The scaled vector.
+    DirectX::SimpleMath::Vector3 convert_vertex(const trlevel::tr_vertex& vertex);
+
     __declspec(align(16)) struct MeshData
     {
         DirectX::SimpleMath::Matrix matrix;

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -189,7 +189,7 @@ namespace trview
         // that need to be rendered in the second pass.
         for (const auto& room : rooms)
         {
-            room.room.render(device, camera, *_texture_storage.get(), room.selection_mode);
+            room.room.render(device, camera, *_texture_storage.get(), room.selection_mode, _show_hidden_geometry);
             if (_regenerate_transparency)
             {
                 room.room.get_transparent_triangles(*_transparency, camera, room.selection_mode, _show_triggers);
@@ -405,7 +405,7 @@ namespace trview
         auto rooms = get_rooms_to_render(camera);
         for (auto& room : rooms)
         {
-            auto result = room.room.pick(position, direction, true, _show_triggers);
+            auto result = room.room.pick(position, direction, true, _show_triggers, _show_hidden_geometry);
             // Choose the nearest pick - but if the previous closest was trigger an entity should take priority over it.
             if (result.hit && (result.distance < final_result.distance || (result.type == PickResult::Type::Entity && final_result.type == PickResult::Type::Trigger)))
             {
@@ -556,6 +556,11 @@ namespace trview
     {
         _show_triggers = show;
         _regenerate_transparency = true;
+    }
+
+    void Level::set_show_hidden_geometry(bool show)
+    {
+        _show_hidden_geometry = show;
     }
 
     bool Level::show_triggers() const

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -334,8 +334,8 @@ namespace trview
                     _triggers.emplace_back(std::make_unique<Trigger>(_triggers.size(), i, sector.second->x(), sector.second->z(), sector.second->trigger()));
                     room->add_trigger(_triggers.back().get());
                 }
-                room->generate_trigger_geometry();
             }
+            room->generate_trigger_geometry();
         }
     }
 

--- a/trview/Level.h
+++ b/trview/Level.h
@@ -118,6 +118,8 @@ namespace trview
 
         void set_show_triggers(bool show);
 
+        void set_show_hidden_geometry(bool show);
+
         bool show_triggers() const;
 
         void set_selected_trigger(uint32_t number);
@@ -201,6 +203,7 @@ namespace trview
         bool _regenerate_transparency{ true };
         bool _alternate_mode{ false };
         bool _show_triggers{ true };
+        bool _show_hidden_geometry{ false };
 
         std::unordered_map<uint32_t, std::wstring> _type_names;
 

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -201,12 +201,15 @@ namespace trview
 
     namespace
     {
-        bool equivalent_triangles(std::vector<Vector3> left, std::vector<Vector3> right)
+        /// Check if the triangle points appear in the position source.
+        /// @param tri The triangle points.
+        /// @param source The point list.
+        bool triangle_contained(const std::vector<Vector3>& tri, const std::vector<Vector3>& source)
         {
-            auto v0 = std::find(right.begin(), right.end(), left[0]);
-            auto v1 = std::find(right.begin(), right.end(), left[1]);
-            auto v2 = std::find(right.begin(), right.end(), left[2]);
-            return v0 != right.end() && v1 != right.end() && v2 != right.end();
+            auto v0 = std::find(source.begin(), source.end(), tri[0]);
+            auto v1 = std::find(source.begin(), source.end(), tri[1]);
+            auto v2 = std::find(source.begin(), source.end(), tri[2]);
+            return v0 != source.end() && v1 != source.end() && v2 != source.end();
         }
     }
 
@@ -476,17 +479,16 @@ namespace trview
 
     namespace
     {
-        bool geometry_matched(
-            const std::vector<Vector3>& triangle,
-            const trlevel::tr3_room_data& data, 
-            const std::vector<Vector3>& room_vertices,
-            const std::vector<TransparentTriangle>& transparent_triangles)
+        /// Check if the triangle appears in any of the rectangles or triangles in the room.
+        /// @param triangle The points in the sector triangle.
+        /// @param data The room data containing the rectangles and triangles.
+        /// @param room_vertices The vertices for the room.
+        /// @param transparent_triangles Transparent triangles in the room.
+        bool geometry_matched(const std::vector<Vector3>& triangle, const trlevel::tr3_room_data& data,  const std::vector<Vector3>& room_vertices, const std::vector<TransparentTriangle>& transparent_triangles)
         {
-            std::vector<Vector3> tri = { triangle.begin(), triangle.begin() + 3 };
-
             for (const auto& r : data.rectangles)
             {
-                if (equivalent_triangles(tri,
+                if (triangle_contained(triangle,
                         {
                             room_vertices[r.vertices[0]],
                             room_vertices[r.vertices[1]],
@@ -500,7 +502,7 @@ namespace trview
 
             for (const auto& t : data.triangles)
             {
-                if (equivalent_triangles(tri,
+                if (triangle_contained(triangle,
                         {
                             room_vertices[t.vertices[0]],
                             room_vertices[t.vertices[1]],
@@ -513,10 +515,7 @@ namespace trview
 
             for (const auto& tt : transparent_triangles)
             {
-                if (equivalent_triangles(tri,
-                    {
-                        tt.vertices, tt.vertices + 3
-                    }))
+                if (triangle_contained(triangle, { tt.vertices, tt.vertices + 3 }))
                 {
                     return true;
                 }

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -24,14 +24,6 @@ namespace trview
     {
         const Color Trigger_Colour{ 1, 0, 1, 0.5f };
         const Color Unmatched_Colour{ 0, 0.75f, 0.75f };
-
-        // Convert the vertex to the scale used by the viewer.
-        // vertex: The vertex to convert.
-        // Returns: The scaled vector.
-        Vector3 convert_vertex(const trlevel::tr_vertex& vertex)
-        {
-            return Vector3(vertex.x / trlevel::Scale_X, vertex.y / trlevel::Scale_Y, vertex.z / trlevel::Scale_Z);
-        }
     }
 
     Room::Room(const graphics::Device& device, 

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -24,6 +24,14 @@ namespace trview
     {
         const Color Trigger_Colour{ 1, 0, 1, 0.5f };
         const Color Unmatched_Colour{ 0, 0.75f, 0.75f };
+
+        Color get_unmatched_colour(const RoomInfo info, const Sector& sector, uint16_t num_z_sectors)
+        {
+            uint32_t x = (sector.x() + info.x / 1024) % 2;
+            uint32_t z_sec = num_z_sectors - 1 - sector.z();
+            uint32_t z = info.z / 1024 + z_sec;
+            return (x + z) % 2 ? Unmatched_Colour : Unmatched_Colour + Color(0, 0.05f, 0.05f);
+        }
     }
 
     Room::Room(const graphics::Device& device, 
@@ -522,13 +530,14 @@ namespace trview
             const std::vector<Vector3>& tri,
             std::vector<MeshVertex>& output_vertices,
             std::vector<uint32_t>& output_indices,
-            std::vector<Triangle>& collision_triangles)
+            std::vector<Triangle>& collision_triangles,
+            const Color& color)
         {
             uint32_t base = output_vertices.size();
 
-            output_vertices.push_back({ tri[0], Vector3::Down, Vector2::Zero, Unmatched_Colour });
-            output_vertices.push_back({ tri[1], Vector3::Down, Vector2::Zero, Unmatched_Colour });
-            output_vertices.push_back({ tri[2], Vector3::Down, Vector2::Zero, Unmatched_Colour });
+            output_vertices.push_back({ tri[0], Vector3::Down, Vector2::Zero, color });
+            output_vertices.push_back({ tri[1], Vector3::Down, Vector2::Zero, color });
+            output_vertices.push_back({ tri[2], Vector3::Down, Vector2::Zero, color });
 
             output_indices.push_back(base);
             output_indices.push_back(base + 1);
@@ -556,12 +565,12 @@ namespace trview
                 const auto tris = sector.second->triangles(_num_z_sectors);
                 if (!geometry_matched({ tris.begin(), tris.begin() + 3 }, data, transformed_room_vertices, transparent_triangles))
                 {
-                    add_triangle({ tris.begin(), tris.begin() + 3 }, output_vertices, output_indices, collision_triangles);
+                    add_triangle({ tris.begin(), tris.begin() + 3 }, output_vertices, output_indices, collision_triangles, get_unmatched_colour(_info, *sector.second, _num_z_sectors));
                 }
 
                 if (!geometry_matched({ tris.begin() + 3, tris.end() }, data, transformed_room_vertices, transparent_triangles))
                 {
-                    add_triangle({ tris.begin() + 3, tris.end() }, output_vertices, output_indices, collision_triangles);
+                    add_triangle({ tris.begin() + 3, tris.end() }, output_vertices, output_indices, collision_triangles, get_unmatched_colour(_info, *sector.second, _num_z_sectors));
                 }
             }
         }

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -25,11 +25,10 @@ namespace trview
         const Color Trigger_Colour{ 1, 0, 1, 0.5f };
         const Color Unmatched_Colour{ 0, 0.75f, 0.75f };
 
-        Color get_unmatched_colour(const RoomInfo info, const Sector& sector, uint16_t num_z_sectors)
+        Color get_unmatched_colour(const RoomInfo info, const Sector& sector)
         {
             uint32_t x = (sector.x() + info.x / 1024) % 2;
-            uint32_t z_sec = num_z_sectors - 1 - sector.z();
-            uint32_t z = info.z / 1024 + z_sec;
+            uint32_t z = info.z / 1024 + sector.z();
             return (x + z) % 2 ? Unmatched_Colour : Unmatched_Colour + Color(0, 0.05f, 0.05f);
         }
     }
@@ -397,8 +396,8 @@ namespace trview
                 }
             }
 
-            if (auto other = get_trigger_sector(trigger->x(), trigger->z() + 1))
-            {
+           if (auto other = get_trigger_sector(trigger->x(), trigger->z() + 1))
+           {
                 auto corners = other->corners();
                 if (y_bottom[3] == corners[2] && y_bottom[1] == corners[0])
                 {
@@ -565,12 +564,12 @@ namespace trview
                 const auto tris = sector.second->triangles(_num_z_sectors);
                 if (!geometry_matched({ tris.begin(), tris.begin() + 3 }, data, transformed_room_vertices, transparent_triangles))
                 {
-                    add_triangle({ tris.begin(), tris.begin() + 3 }, output_vertices, output_indices, collision_triangles, get_unmatched_colour(_info, *sector.second, _num_z_sectors));
+                    add_triangle({ tris.begin(), tris.begin() + 3 }, output_vertices, output_indices, collision_triangles, get_unmatched_colour(_info, *sector.second));
                 }
 
                 if (!geometry_matched({ tris.begin() + 3, tris.end() }, data, transformed_room_vertices, transparent_triangles))
                 {
-                    add_triangle({ tris.begin() + 3, tris.end() }, output_vertices, output_indices, collision_triangles, get_unmatched_colour(_info, *sector.second, _num_z_sectors));
+                    add_triangle({ tris.begin() + 3, tris.end() }, output_vertices, output_indices, collision_triangles, get_unmatched_colour(_info, *sector.second));
                 }
             }
         }

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -166,6 +166,7 @@ namespace trview
         std::vector<std::unique_ptr<StaticMesh>> _static_meshes;
 
         std::unique_ptr<Mesh>       _mesh;
+        std::unique_ptr<Mesh>       _unmatched_mesh;
         DirectX::SimpleMath::Matrix _room_offset;
 
         DirectX::BoundingBox  _bounding_box;

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -146,6 +146,18 @@ namespace trview
         Sector*  get_trigger_sector(int32_t x, int32_t z);
         uint32_t get_sector_id(int32_t x, int32_t z) const;
 
+        /// Process the sectors in the level and find where there are walkable floors that have no matching geometry.
+        /// @param data The room data to check against.
+        /// @param room_vertices The actual room vertices.
+        /// @param output_vertices Where to store vertices.
+        /// @param output_indices Where to store indices.
+        /// @param collision_triangles Where to store collision triangles.
+        void process_unmatched_geometry(const trlevel::tr3_room_data& data, 
+            const std::vector<trlevel::tr_vertex>& room_vertices,
+            std::vector<MeshVertex>& output_vertices,
+            std::vector<uint32_t>& output_indices,
+            std::vector<Triangle>& collision_triangles);
+
         RoomInfo                           _info;
         std::set<uint16_t>                 _neighbours;
         uint32_t _index;

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -154,6 +154,7 @@ namespace trview
         /// @param collision_triangles Where to store collision triangles.
         void process_unmatched_geometry(const trlevel::tr3_room_data& data, 
             const std::vector<trlevel::tr_vertex>& room_vertices,
+            const std::vector<TransparentTriangle>& transparent_triangles,
             std::vector<MeshVertex>& output_vertices,
             std::vector<uint32_t>& output_indices,
             std::vector<Triangle>& collision_triangles);

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -68,14 +68,14 @@ namespace trview
         // direction: The direction of the ray.
         // Returns: The result of the operation. If 'hit' is true, distance and position contain
         // how far along the ray the hit was and the position in world space.
-        PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, bool include_entities = true, bool include_triggers = true) const;
+        PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, bool include_entities, bool include_triggers, bool include_hidden_geometry = false) const;
 
         // Render the level geometry and the objects contained in this room.
         // context: The D3D context.
         // camera: The camera to use to render.
         // texture_storage: The textures for the level.
         // selected: The selection mode to use to highlight geometry and objects.
-        void render(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected);
+        void render(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_hidden_geometry);
 
         void render_contained(const graphics::Device& context, const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected);
 

--- a/trview/RoomNavigator.cpp
+++ b/trview/RoomNavigator.cpp
@@ -16,15 +16,17 @@ namespace trview
     {
         using namespace ui;
 
-        auto rooms_groups = std::make_unique<GroupBox>(Point(), Size(140, 120), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Rooms");
+        auto rooms_groups = std::make_unique<GroupBox>(Point(), Size(140, 150), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Rooms");
         auto highlight = std::make_unique<Checkbox>(Point(12, 20), Size(16, 16), L"Highlight");
         auto triggers = std::make_unique<Checkbox>(Point(76, 20), Size(16, 16), L"Triggers");
         triggers->set_state(true);
+        auto hidden_geometry = std::make_unique<Checkbox>(Point(12, 45), Size(16, 16), L"Geometry");
 
         highlight->on_state_changed += on_highlight;
         triggers->on_state_changed += on_show_triggers;
+        hidden_geometry->on_state_changed += on_show_hidden_geometry;
 
-        auto room_box = std::make_unique<GroupBox>(Point(12, 42), Size(120, 70), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Room");
+        auto room_box = std::make_unique<GroupBox>(Point(12, 72), Size(120, 70), Colour(1.0f, 0.5f, 0.5f, 0.5f), Colour(1.0f, 0.0f, 0.0f, 0.0f), L"Room");
         auto room_controls = std::make_unique<StackPanel>(Point(12, 12), Size(96, 60), Colour(1.f, 0.5f, 0.5f, 0.5f), Size(),StackPanel::Direction::Vertical);
         auto room_number_labels = std::make_unique<StackPanel>(Point(), Size(96, 30), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(), StackPanel::Direction::Horizontal);
         auto room_number = std::make_unique<NumericUpDown>(Point(), Size(40, 20), Colour(1.0f, 0.4f, 0.4f, 0.4f), texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 0);
@@ -51,6 +53,7 @@ namespace trview
 
         _highlight = rooms_groups->add_child(std::move(highlight));
         _triggers = rooms_groups->add_child(std::move(triggers));
+        _hidden_geometry = rooms_groups->add_child(std::move(hidden_geometry));
         rooms_groups->add_child(std::move(room_box));
 
         parent.add_child(std::move(rooms_groups));
@@ -84,8 +87,18 @@ namespace trview
         _triggers->set_state(show);
     }
 
+    void RoomNavigator::set_show_hidden_geometry(bool show)
+    {
+        _hidden_geometry->set_state(show);
+    }
+
     bool RoomNavigator::show_triggers() const
     {
         return _triggers->state();
+    }
+
+    bool RoomNavigator::show_hidden_geometry() const
+    {
+        return _hidden_geometry->state();
     }
 }

--- a/trview/RoomNavigator.h
+++ b/trview/RoomNavigator.h
@@ -52,6 +52,11 @@ namespace trview
         /// @remarks This event is not raised by the set_show_triggers function.
         Event<bool> on_show_triggers;
 
+        /// Event raised when the user toggles the hidden geometry visibility. The boolean passed as a parameter when
+        /// this event is raised indicates whether hidden geomety is visible.
+        /// @remarks This event is not raised by the set_show_hidden_geometry function.
+        Event<bool> on_show_hidden_geometry;
+
         /// Set the room information for the current room. This will be used to populate the labels (eg position).
         /// @param room_info The room information.
         void set_room_info(RoomInfo room_info);
@@ -72,13 +77,22 @@ namespace trview
         /// @param show Whether the triggers are visible.
         void set_show_triggers(bool show);
 
+        /// Set whether hidden geometry is visible or not.
+        /// @param show Whether the hidden geometry is visible.
+        void set_show_hidden_geometry(bool show);
+
         /// Get the current value of the show triggers checkbox.
         /// @returns The current value of the checkbox.
         bool show_triggers() const;
+
+        /// Get the current value of the show hidden geometry checkbox.
+        /// @returns The current value of the checkbox.
+        bool show_hidden_geometry() const;
     private:
         ui::Checkbox*      _highlight;
         ui::Checkbox*      _flip;
         ui::Checkbox*      _triggers;
+        ui::Checkbox*      _hidden_geometry;
         ui::NumericUpDown* _current;
         ui::Label*         _max;
         ui::Label*         _x;

--- a/trview/Sector.cpp
+++ b/trview/Sector.cpp
@@ -275,8 +275,8 @@ namespace trview
         {
             return
             {
-                Vector3(_x + 0.5f, _corners[2], z - 0.5f), Vector3(x - 0.5f, _corners[0], z - 0.5f), Vector3(x - 0.5f, _corners[1], z + 0.5f),
-                Vector3(_x - 0.5f, _corners[1], z + 0.5f), Vector3(x + 0.5f, _corners[3], z + 0.5f), Vector3(x + 0.5f, _corners[2], z - 0.5f)
+                Vector3(x + 0.5f, _corners[2], z - 0.5f), Vector3(x - 0.5f, _corners[0], z - 0.5f), Vector3(x - 0.5f, _corners[1], z + 0.5f),
+                Vector3(x - 0.5f, _corners[1], z + 0.5f), Vector3(x + 0.5f, _corners[3], z + 0.5f), Vector3(x + 0.5f, _corners[2], z - 0.5f)
             };
         }
 

--- a/trview/Sector.cpp
+++ b/trview/Sector.cpp
@@ -149,6 +149,21 @@ namespace trview
                 // Not sure what to do with h1 and h2 values yet.
                 const int16_t h2 = (floor & 0x7C00) >> 10;
                 const int16_t h1 = (floor & 0x03E0) >> 5;
+                const int16_t function = (floor & 0x001F);
+
+                switch (function)
+                {
+                case 0x07:
+                case 0x0B:
+                case 0x0C:
+                    _triangulation_function = TriangulationDirection::NwSe;
+                    break;
+                case 0x08:
+                case 0x0D:
+                case 0x0E:
+                    _triangulation_function = TriangulationDirection::NeSw;
+                    break;
+                }
 
                 const uint16_t corner_values = _level.get_floor_data(++cur_index);
                 const uint16_t c00 = (corner_values & 0x00F0) >> 4;
@@ -243,6 +258,33 @@ namespace trview
     uint32_t Sector::room() const
     {
         return _room;
+    }
+
+    TriangulationDirection Sector::triangulation_function() const
+    {
+        return _triangulation_function;
+    }
+
+    std::vector<DirectX::SimpleMath::Vector3> Sector::triangles(uint32_t num_z_sectors) const
+    {
+        using namespace DirectX::SimpleMath;
+        const float x = _x + 0.5f;
+        const float z = num_z_sectors - 1 - _z + 0.5f;
+
+        if (_triangulation_function == TriangulationDirection::NwSe)
+        {
+            return
+            {
+                Vector3(_x + 0.5f, _corners[2], z - 0.5f), Vector3(x - 0.5f, _corners[0], z - 0.5f), Vector3(x - 0.5f, _corners[1], z + 0.5f),
+                Vector3(_x - 0.5f, _corners[1], z + 0.5f), Vector3(x + 0.5f, _corners[3], z + 0.5f), Vector3(x + 0.5f, _corners[2], z - 0.5f)
+            };
+        }
+
+        return
+        {
+            Vector3(x + 0.5f, _corners[3], z + 0.5f), Vector3(x - 0.5f, _corners[0], z - 0.5f), Vector3(x - 0.5f, _corners[1], z + 0.5f),
+            Vector3(x + 0.5f, _corners[3], z + 0.5f), Vector3(x + 0.5f, _corners[2], z - 0.5f), Vector3(x - 0.5f, _corners[0], z - 0.5f)
+        };
     }
 }
 

--- a/trview/Sector.cpp
+++ b/trview/Sector.cpp
@@ -269,7 +269,7 @@ namespace trview
     {
         using namespace DirectX::SimpleMath;
         const float x = _x + 0.5f;
-        const float z = num_z_sectors - 1 - _z + 0.5f;
+        const float z = _z + 0.5f;
 
         if (_triangulation_function == TriangulationDirection::NwSe)
         {

--- a/trview/Sector.h
+++ b/trview/Sector.h
@@ -14,6 +14,13 @@
 
 namespace trview
 {
+    enum class TriangulationDirection
+    {
+        None,
+        NwSe,
+        NeSw
+    };
+
     class Sector
     {
     public:
@@ -48,6 +55,10 @@ namespace trview
         std::array<float, 4> corners() const;
 
         uint32_t room() const;
+
+        TriangulationDirection triangulation_function() const;
+
+        std::vector<DirectX::SimpleMath::Vector3> triangles(uint32_t num_z_sectors) const;
     private:
         bool parse();
         void parse_slope();
@@ -80,5 +91,7 @@ namespace trview
         std::array<float, 4> _corners;
 
         uint32_t _room;
+
+        TriangulationDirection _triangulation_function{ TriangulationDirection::None };
     };
 }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -321,6 +321,7 @@ namespace trview
         _token_store += _room_navigator->on_room_selected += [&](uint32_t room) { select_room(room); };
         _token_store += _room_navigator->on_highlight += [&](bool) { toggle_highlight(); };
         _token_store += _room_navigator->on_show_triggers += [&](bool show) { set_show_triggers(show); };
+        _token_store += _room_navigator->on_show_hidden_geometry += [&](bool show) { set_show_hidden_geometry(show); };
 
         _flipmaps = std::make_unique<Flipmaps>(*tool_window.get());
         _token_store += _flipmaps->on_flip += [&](bool flip) { set_alternate_mode(flip); };
@@ -654,6 +655,7 @@ namespace trview
         _route_window_manager->set_triggers(_level->triggers());
 
         _level->set_show_triggers(_room_navigator->show_triggers());
+        _level->set_show_hidden_geometry(_room_navigator->show_hidden_geometry());
 
         // Set up the views.
         auto rooms = _level->room_info();
@@ -986,6 +988,15 @@ namespace trview
         {
             _level->set_show_triggers(show);
             _room_navigator->set_show_triggers(show);
+        }
+    }
+
+    void Viewer::set_show_hidden_geometry(bool show)
+    {
+        if (_level)
+        {
+            _level->set_show_hidden_geometry(show);
+            _room_navigator->set_show_hidden_geometry(show);
         }
     }
 

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -131,6 +131,7 @@ namespace trview
         // Set up keyboard and mouse input for the camera.
         void setup_camera_input();
         void set_show_triggers(bool show);
+        void set_show_hidden_geometry(bool show);
         uint32_t room_from_pick(const PickResult& pick) const;
 
         graphics::Device _device;


### PR DESCRIPTION
If a sector floordata indicates a solid floor but it has no textured or untextured room geometry, render a checkerboard floor pattern. This can be clicked on and used as part of the room.
Issue: #153 