### PR TITLE
Allow transparent floors to be clickable

### DIFF
--- a/trview/Room.h
+++ b/trview/Room.h
@@ -146,6 +146,11 @@ namespace trview
         Sector*  get_trigger_sector(int32_t x, int32_t z);
         uint32_t get_sector_id(int32_t x, int32_t z) const;
 
+        /// Find any transparent triangles that match floor data geometry.
+        /// @param transparent_triangles The transparent triangles in the sector.
+        /// @param collision_triangles The collision output vector.
+        void process_collision_transparency(const std::vector<TransparentTriangle>& transparent_triangles, std::vector<Triangle>& collision_triangles);
+
         /// Process the sectors in the level and find where there are walkable floors that have no matching geometry.
         /// @param data The room data to check against.
         /// @param room_vertices The actual room vertices.

--- a/trview/Sector.cpp
+++ b/trview/Sector.cpp
@@ -286,5 +286,10 @@ namespace trview
             Vector3(x + 0.5f, _corners[3], z + 0.5f), Vector3(x + 0.5f, _corners[2], z - 0.5f), Vector3(x - 0.5f, _corners[0], z - 0.5f)
         };
     }
+
+    bool Sector::is_floor() const
+    {
+        return room_below() == 0xff && !(flags & SectorFlag::Wall) && !(flags & SectorFlag::Portal);
+    }
 }
 

--- a/trview/Sector.h
+++ b/trview/Sector.h
@@ -59,6 +59,9 @@ namespace trview
         TriangulationDirection triangulation_function() const;
 
         std::vector<DirectX::SimpleMath::Vector3> triangles(uint32_t num_z_sectors) const;
+
+        /// Determines whether this is a walkable floor.
+        bool is_floor() const;
     private:
         bool parse();
         void parse_slope();


### PR DESCRIPTION
If a transparent face maps to a floordata walkable area then allow it to be clickable.
This helps with the metal walkways in diving area or the cages in floating islands for example.
Bug: #166