### PR TITLE
Fix align camera to axis rotation movement in free mode

### DIFF
--- a/trview.app/Camera.cpp
+++ b/trview.app/Camera.cpp
@@ -100,10 +100,13 @@ namespace trview
             float amount = std::min(speed * elapsed, abs(diff));
             _rotation_yaw += amount * (diff > 0 ? 1 : -1);
 
-            if (abs(_target_rotation_yaw.value() - _rotation_yaw) < 0.01f)
+            if (abs(diff) < 0.01f)
             {
+                _rotation_yaw = _target_rotation_yaw.value();
                 _target_rotation_yaw.reset();
             }
+
+            update_vectors();
         }
 
         if (_target_rotation_pitch.has_value())
@@ -112,10 +115,13 @@ namespace trview
             float amount = std::min(speed * elapsed, abs(diff));
             _rotation_pitch += amount * (diff > 0 ? 1 : -1);
 
-            if (abs(_target_rotation_pitch.value() - _rotation_pitch) < 0.01f)
+            if (abs(diff) < 0.01f)
             {
+                _rotation_pitch = _target_rotation_pitch.value();
                 _target_rotation_pitch.reset();
             }
+
+            update_vectors();
         }
     }
 

--- a/trview.app/FreeCamera.cpp
+++ b/trview.app/FreeCamera.cpp
@@ -38,7 +38,9 @@ namespace trview
 
     void FreeCamera::update_vectors()
     {
-        _forward = Vector3::Transform(Vector3::Backward, Matrix::CreateFromYawPitchRoll(_rotation_yaw, _rotation_pitch, 0));
+        const auto rotation = Matrix::CreateFromYawPitchRoll(_rotation_yaw, _rotation_pitch, 0);
+        _forward = Vector3::Transform(Vector3::Backward, rotation);
+        _up = Vector3::Transform(Vector3::Down, rotation);
         calculate_view_matrix();
     }
 }


### PR DESCRIPTION
Free mode needs to update vectors whenever the rotation is changed.
Also rotate the up vector so that the world doesn't disappear when looking directly up or down.
Bug: #452