### PR TITLE
Reset compass axis if not over the compass

### DIFF
--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -169,6 +169,10 @@ namespace trview
                 result.distance = 1.0f;
                 _compass_axis = axis;
             }
+            else
+            {
+                _compass_axis.reset();
+            }
         };
         _token_store += _picking->pick_sources += [&](PickInfo info, PickResult& result)
         {


### PR DESCRIPTION
Previously the compass axis was a bit sticky, so a second click would make you align to compass axis again.
Bug: #463