### PR TITLE
Make highlight and depth coexist

### DIFF
--- a/trview/Level.h
+++ b/trview/Level.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <unordered_map>
 #include <SimpleMath.h>
+#include <set>
 
 #include <trview.graphics/Texture.h>
 #include <trview.common/Event.h>
@@ -76,8 +77,8 @@ namespace trview
         /// @param render_selection Whether to render selection highlights on selected items.
         void render(const graphics::Device& device, const ICamera& camera, bool render_selection);
 
-        RoomHighlightMode highlight_mode() const;
-        void set_highlight_mode(RoomHighlightMode mode);
+        void set_highlight_mode(RoomHighlightMode mode, bool enabled);
+        bool highlight_mode_enabled(RoomHighlightMode mode) const;
         void set_selected_room(uint16_t index);
         void set_selected_item(uint16_t index);
         void set_neighbour_depth(uint32_t depth);
@@ -191,7 +192,8 @@ namespace trview
         graphics::IShader*          _pixel_shader;
         Microsoft::WRL::ComPtr<ID3D11SamplerState> _sampler_state;
 
-        RoomHighlightMode  _room_highlight_mode{ RoomHighlightMode::None };
+        std::set<RoomHighlightMode> _room_highlight_modes;
+        
         uint16_t           _selected_room{ 0u };
         Entity*            _selected_item{ nullptr };
         Trigger*           _selected_trigger{ nullptr };

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -25,6 +25,14 @@ namespace trview
         const Color Trigger_Colour{ 1, 0, 1, 0.5f };
         const Color Unmatched_Colour{ 0, 0.75f, 0.75f };
 
+        const Color Selected_Colour{ 1, 1, 1 };
+        const Color NotSelected_Colour{ 0.4f, 0.4f, 0.4f };
+
+        Color room_colour(Room::SelectionMode selected)
+        {
+            return selected == Room::SelectionMode::Selected ? Selected_Colour : NotSelected_Colour;
+        }
+
         Color get_unmatched_colour(const RoomInfo info, const Sector& sector)
         {
             uint32_t x = (sector.x() + info.x / 1024) % 2;
@@ -154,8 +162,7 @@ namespace trview
     // render_mode: The type of geometry and object geometry to render.
     void Room::render(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_hidden_geometry)
     {
-        Color colour = selected == SelectionMode::Selected ? Color(1, 1, 1, 1) :
-            selected == SelectionMode::Neighbour ? Color(0.4f, 0.4f, 0.4f, 1) : Color(0.2f, 0.2f, 0.2f, 1);
+        Color colour = room_colour(selected);
 
         auto context = device.context();
 
@@ -175,8 +182,7 @@ namespace trview
 
     void Room::render_contained(const graphics::Device& device, const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected)
     {
-        Color colour = selected == SelectionMode::Selected ? Color(1, 1, 1, 1) :
-            selected == SelectionMode::Neighbour ? Color(0.4f, 0.4f, 0.4f, 1) : Color(0.2f, 0.2f, 0.2f, 1);
+        Color colour = room_colour(selected);
         render_contained(device, camera, texture_storage, colour);
     }
 
@@ -279,8 +285,7 @@ namespace trview
 
     void Room::get_transparent_triangles(TransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool include_triggers)
     {
-        Color colour = selected == SelectionMode::Selected ? Color(1, 1, 1, 1) :
-            selected == SelectionMode::Neighbour ? Color(0.4f, 0.4f, 0.4f, 1) : Color(0.2f, 0.2f, 0.2f, 1);
+        Color colour = room_colour(selected);
 
         for (const auto& triangle : _mesh->transparent_triangles())
         {
@@ -308,8 +313,7 @@ namespace trview
 
     void Room::get_contained_transparent_triangles(TransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected)
     {
-        Color colour = selected == SelectionMode::Selected ? Color(1, 1, 1, 1) :
-            selected == SelectionMode::Neighbour ? Color(0.4f, 0.4f, 0.4f, 1) : Color(0.2f, 0.2f, 0.2f, 1);
+        Color colour = room_colour(selected);
         get_contained_transparent_triangles(transparency, camera, colour);
     }
 

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -36,8 +36,7 @@ namespace trview
         enum class SelectionMode
         {
             Selected,
-            NotSelected,
-            Neighbour
+            NotSelected
         };
 
         enum class AlternateMode

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -343,8 +343,7 @@ namespace trview
         {
             if (_level)
             {
-                _level->set_highlight_mode(enabled ? Level::RoomHighlightMode::Neighbours : Level::RoomHighlightMode::None);
-                _room_navigator->set_highlight(false);
+                _level->set_highlight_mode(Level::RoomHighlightMode::Neighbours, enabled);
             }
         };
 
@@ -822,18 +821,9 @@ namespace trview
     {
         if (_level)
         {
-            if (_level->highlight_mode() == Level::RoomHighlightMode::Highlight)
-            {
-                _level->set_highlight_mode(Level::RoomHighlightMode::None);
-                _room_navigator->set_highlight(false);
-                _neighbours->set_enabled(false);
-            }
-            else
-            {
-                _level->set_highlight_mode(Level::RoomHighlightMode::Highlight);
-                _room_navigator->set_highlight(true);
-                _neighbours->set_enabled(false);
-            }
+            bool new_value = !_level->highlight_mode_enabled(Level::RoomHighlightMode::Highlight);
+            _level->set_highlight_mode(Level::RoomHighlightMode::Highlight, new_value);
+            _room_navigator->set_highlight(new_value);
         }
     }
 


### PR DESCRIPTION
The darkening effect will only happen when higlight is enabled - even when depth is enabled. Otherwise, everything visible will be fully lit.
Also remove the not selected colour - it was too dark. Make it use the darkened neighbour colour.
Issue: #122