### PR TITLE
Highlight minimap sectors when hovering over the 3D view

### DIFF
--- a/trview.ui.render/MapRenderer.cpp
+++ b/trview.ui.render/MapRenderer.cpp
@@ -126,6 +126,16 @@ namespace trview
                     // If sector is an up portal, draw a small corner square in the top left to signify this 
                     if (tile.sector->flags & SectorFlag::RoomAbove)
                         draw(context, tile.position, Size(tile.size.width / 4, tile.size.height / 4), Color(0.0f, 0.0f, 0.0f));
+
+                    if (_selected_sector.has_value() &&
+                        _selected_sector.value().first == tile.sector->x() &&
+                        _selected_sector.value().second == tile.sector->z())
+                    {
+                        draw(context, tile.position, Size(tile.size.width, 1), Color(1, 1, 0));
+                        draw(context, tile.position, Size(1, tile.size.height), Color(1, 1, 0));
+                        draw(context, tile.position + Point(0, tile.size.height - 1), Size(tile.size.width, 1), Color(1, 1, 0));
+                        draw(context, tile.position + Point(tile.size.width - 1, 0), Size(1, tile.size.height), Color(1, 1, 0));
+                    }
                 });
             }
 
@@ -265,6 +275,18 @@ namespace trview
             void MapRenderer::set_visible(bool visible)
             {
                 _visible = visible;
+            }
+
+            void MapRenderer::clear_highlight()
+            {
+                _selected_sector.reset();
+                _force_redraw = true;
+            }
+
+            void MapRenderer::set_highlight(uint16_t x, uint16_t z)
+            {
+                _selected_sector = { x, z };
+                _force_redraw = true;
             }
         }
     }

--- a/trview.ui.render/MapRenderer.h
+++ b/trview.ui.render/MapRenderer.h
@@ -79,6 +79,10 @@ namespace trview
                 /// Set whether the map is visible.
                 void set_visible(bool visible);
 
+                void clear_highlight();
+
+                void set_highlight(uint16_t x, uint16_t z);
+
                 /// Event raised when the user hovers over a map sector, or if the mouse leaves the map.
                 Event<std::shared_ptr<Sector>> on_sector_hover;
             private:
@@ -122,6 +126,8 @@ namespace trview
 
                 const float                         _DRAW_MARGIN = 30.0f; 
                 const float                         _DRAW_SCALE = 14.0f; 
+
+                std::optional<std::pair<uint16_t, uint16_t>> _selected_sector;
             };
         }
     }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -209,6 +209,31 @@ namespace trview
         _token_store += _picking->on_pick += [&](const PickResult& result)
         {
             _current_pick = result;
+
+            // Highlight sectors in the minimap.
+            if (_level)
+            {
+                RoomInfo info;
+                if (_current_pick.type == PickResult::Type::Room &&
+                    _current_pick.index == _level->selected_room())
+                {
+                    info = _level->room(_current_pick.index)->info();
+                }
+                else if (_current_pick.type == PickResult::Type::Trigger)
+                {
+                    auto trigger = _level->triggers()[_current_pick.index];
+                    info = _level->room(trigger->room())->info();
+                }
+                else
+                {
+                    _map_renderer->clear_highlight();
+                    return;
+                }
+
+                auto x = _current_pick.position.x - (info.x / trlevel::Scale_X);
+                auto z = _current_pick.position.z - (info.z / trlevel::Scale_Z);
+                _map_renderer->set_highlight(x, z);
+            }
         };
     }
 


### PR DESCRIPTION
Hovering over the 3D view will now highlight the minimap square.
Issue: #129