### PR TITLE
Split transparency from non-transparent level rendering

### DIFF
--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -214,7 +214,10 @@ namespace trview
         }
 
         _regenerate_transparency = false;
+    }
 
+    void Level::render_transparency(const graphics::Device& device, const ICamera& camera)
+    {
         // Render the triangles that the transparency buffer has produced.
         _transparency->render(device.context(), camera, *_texture_storage.get());
     }

--- a/trview/Level.h
+++ b/trview/Level.h
@@ -77,6 +77,11 @@ namespace trview
         /// @param render_selection Whether to render selection highlights on selected items.
         void render(const graphics::Device& device, const ICamera& camera, bool render_selection);
 
+        /// Render the transparent triangles in the scene.
+        /// @param device The graphics device to use to render the scene.
+        /// @param camera The current camera.
+        void render_transparency(const graphics::Device& device, const ICamera& camera);
+
         void set_highlight_mode(RoomHighlightMode mode, bool enabled);
         bool highlight_mode_enabled(RoomHighlightMode mode) const;
         void set_selected_room(uint16_t index);

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -801,6 +801,7 @@ namespace trview
                 _route->render(_device, current_camera(), _level->texture_storage());
             }
 
+            _level->render_transparency(_device, current_camera());
             _compass->render(_device, current_camera(), _level->texture_storage());
         }
     }


### PR DESCRIPTION
As there is a bunch of stuff rendered in the level that needs to interact with transparency corretly, split the non-transparent and transparent level rendering.
Bug: #469