### PR TITLE
Detect triggers in other rooms when generating trigger geometry

### DIFF
--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -286,7 +286,7 @@ namespace trview
         for (uint16_t i = 0; i < num_rooms; ++i)
         {
             auto room = _level->get_room(i);
-            _rooms.push_back(std::make_unique<Room>(device, *_level, room, *_texture_storage.get(), *_mesh_storage.get(), i));
+            _rooms.push_back(std::make_unique<Room>(device, *_level, room, *_texture_storage.get(), *_mesh_storage.get(), i, *this));
         }
 
         std::set<uint32_t> alternate_groups;
@@ -322,6 +322,10 @@ namespace trview
                     room->add_trigger(_triggers.back().get());
                 }
             }
+        }
+
+        for (auto& room : _rooms)
+        {
             room->generate_trigger_geometry();
         }
     }

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -29,6 +29,7 @@ namespace trview
     struct ICamera;
     class Mesh;
     class TransparencyBuffer;
+    class Level;
 
     class Room
     {
@@ -54,7 +55,8 @@ namespace trview
             const trlevel::tr3_room& room,
             const ILevelTextureStorage& texture_storage,
             const IMeshStorage& mesh_storage,
-            uint32_t index);
+            uint32_t index,
+            Level& parent_level);
 
         Room(const Room&) = delete;
         Room& operator=(const Room&) = delete;
@@ -189,5 +191,6 @@ namespace trview
 
         std::unordered_map<uint32_t, Trigger*> _triggers;
         bool _water{ false };
+        Level& _level;
     };
 }


### PR DESCRIPTION
If there are no triggers in the adjacent sector but there is a portal square, check the geometry of the triggers in the sectors in the room to which the portal leads.
This stops walls appearing in contiguous blocks that span rooms.
Bug: #472