### PR TITLE
Add 'orbit here' button to the context menu

### DIFF
--- a/trview.app/ContextMenu.cpp
+++ b/trview.app/ContextMenu.cpp
@@ -36,6 +36,11 @@ namespace trview
         };
         _remove_button = _menu->add_child(std::move(remove_button));
 
+        auto orbit_button = std::make_unique<Button>(Point(), Size(100, 24), L"Orbit Here");
+        orbit_button->set_text_background_colour(Colours::Button);
+        orbit_button->on_click += on_orbit_here;
+        _menu->add_child(std::move(orbit_button));
+
         _menu->set_visible(false);
     }
 

--- a/trview.app/ContextMenu.h
+++ b/trview.app/ContextMenu.h
@@ -30,6 +30,9 @@ namespace trview
 
         /// Event raised when the user has clicked the remove waypoint button.
         Event<> on_remove_waypoint;
+
+        /// Event raised when the user has clicked the orbit here button.
+        Event<> on_orbit_here;
     private:
         ui::StackPanel* _menu;
         ui::Button*     _remove_button;

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -289,6 +289,12 @@ namespace trview
             remove_waypoint(_context_pick.index);
             _context_menu->set_visible(false);
         };
+        _token_store += _context_menu->on_orbit_here += [&]()
+        {
+            select_room(room_from_pick(_context_pick));
+            _target = _context_pick.position;
+            _context_menu->set_visible(false);
+        };
 
         _context_menu->set_remove_enabled(false);
 


### PR DESCRIPTION
Right click on a point, click orbit here and the camera will orbit the point that was clicked.
Issue: #483