### PR TITLE
Keep track of where neighbour generation has been

### DIFF
--- a/trview.app/Neighbours.cpp
+++ b/trview.app/Neighbours.cpp
@@ -18,7 +18,7 @@ namespace trview
         auto enabled = std::make_unique<Checkbox>(Point(12, 20), Size(16, 16), Colour::Transparent, L"Depth");
         enabled->on_state_changed += on_enabled_changed;
 
-        auto depth = std::make_unique<NumericUpDown>(Point(90, 16), Size(40, 20), Colour::Transparent, texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 10);
+        auto depth = std::make_unique<NumericUpDown>(Point(90, 16), Size(40, 20), Colour::Transparent, texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 20);
         depth->set_value(1);
         depth->on_value_changed += on_depth_changed;
 

--- a/trview/Level.h
+++ b/trview/Level.h
@@ -144,7 +144,7 @@ namespace trview
         void generate_triggers();
         void generate_entities(const graphics::Device& device);
         void regenerate_neighbours();
-        void generate_neighbours(std::set<uint16_t>& all_rooms, uint16_t previous_room, uint16_t selected_room, int32_t current_depth, int32_t max_depth);
+        void generate_neighbours(std::set<uint16_t>& results, uint16_t selected_room, int32_t max_depth);
 
         // Render the rooms in the level.
         // context: The device context.


### PR DESCRIPTION
Remove the recursion from neighbour generation.
Keep track of processed rooms so we don't go back to them - this previously only checked against the previous room visited. This means there is less of a performance hit with high depth numbers, so increase the limit to 20. This can probably be increased later.
Issue: #32