### PR TITLE
Make Go to Room window a text area

### DIFF
--- a/trview.app/GoToRoom.cpp
+++ b/trview.app/GoToRoom.cpp
@@ -40,6 +40,7 @@ namespace trview
             Colour::White,
             graphics::TextAlignment::Centre);
         text_area->set_mode(TextArea::Mode::SingleLine);
+        _token_store += text_area->on_escape += [&]() { toggle_visible(); };
         _token_store += text_area->on_enter += [&](const std::wstring& text)
         {
             try

--- a/trview.app/GoToRoom.cpp
+++ b/trview.app/GoToRoom.cpp
@@ -1,7 +1,7 @@
 #include "GoToRoom.h"
 
 #include <Windows.h>
-#include <trview.ui/Label.h>
+#include <trview.ui/TextArea.h>
 #include <trview.ui/GroupBox.h>
 
 namespace trview
@@ -33,17 +33,28 @@ namespace trview
             Colour::Grey,
             L"Go to Room");
 
-        auto label = std::make_unique<Label>(
-            Point((WindowWidth - 10) / 2.0f - Width / 2.0f,
-                  (WindowHeight) / 2.0f - Height / 2.0f + 2),
+        auto text_area = std::make_unique<TextArea>(
+            Point((WindowWidth - 10) / 2.0f - Width / 2.0f, (WindowHeight) / 2.0f - Height / 2.0f + 2),
             Size(Width, Height),
             Colour(1.0f, 0.2f, 0.2f, 0.2f),
-            L"",
-            8,
-            graphics::TextAlignment::Centre,
-            graphics::ParagraphAlignment::Centre);
+            Colour::White,
+            graphics::TextAlignment::Centre);
+        text_area->set_mode(TextArea::Mode::SingleLine);
+        _token_store += text_area->on_enter += [&](const std::wstring& text)
+        {
+            try
+            {
+                auto room = std::stoul(text);
+                room_selected(room);
+                toggle_visible();
+            }
+            catch (...)
+            {
+                // Couldn't convert the number.
+            }
+        };
 
-        _label = box->add_child(std::move(label));
+        _text_area = box->add_child(std::move(text_area));
         window->add_child(std::move(box));
         _window = parent.add_child(std::move(window));
 
@@ -63,49 +74,7 @@ namespace trview
         _window->set_visible(!visible());
         if (visible())
         {
-            _input.clear();
-            _label->set_text(_input);
-        }
-    }
-
-    void GoToRoom::character(uint16_t character)
-    {
-        if (!visible())
-        {
-            return;
-        }
-
-        auto value = character - '0';
-        if (value >= 0 && value <= 9)
-        {
-            _input += character;
-            _label->set_text(_input);
-        }
-    }
-
-    void GoToRoom::input(uint16_t key)
-    {
-        if (!visible())
-        {
-            return;
-        }
-
-        if (key == VK_RETURN)
-        {
-            try
-            {
-                auto room = std::stoul(_input);
-                room_selected(room);
-                toggle_visible();
-            }
-            catch(...)
-            {
-                // Couldn't convert the number.
-            }
-        }
-        else if (key == VK_ESCAPE)
-        {
-            toggle_visible();
+            _text_area->set_text(L"");
         }
     }
 }

--- a/trview.app/GoToRoom.h
+++ b/trview.app/GoToRoom.h
@@ -16,7 +16,7 @@ namespace trview
     namespace ui
     {
         class Control;
-        class Label;
+        class TextArea;
     }
     
     /// This window presents the user with a box where they can enter the room number
@@ -36,23 +36,12 @@ namespace trview
         /// Toggle whether the window is visible.
         void toggle_visible();
 
-        /// Process an input character.
-        /// @param character The character that was pressed. If this is a number it will be appended to the text.
-        /// @remarks This is used for entry of the room number.
-        void character(uint16_t character);
-
-        /// Process the input key.
-        /// @param key The input key that was pressed.
-        /// @remarks This is used to control the shortcut for toggling visibility of the window and for enter/exit.
-        void input(uint16_t key);
-
         /// Event raised when the user selects a new room. The newly selected room is passed as
         /// a parameter when the event is raised.
         Event<uint32_t> room_selected;
     private:
-        std::wstring _input;
-        ui::Control* _window;
-        ui::Label*   _label;
-        TokenStore _token_store;
+        TokenStore    _token_store;
+        ui::Control*  _window;
+        ui::TextArea* _text_area;
     };
 }

--- a/trview.app/ViewerUI.cpp
+++ b/trview.app/ViewerUI.cpp
@@ -19,34 +19,16 @@ namespace trview
 
         _token_store += _mouse.mouse_up += [&](auto) { _control->process_mouse_up(client_cursor_position(window)); };
         _token_store += _mouse.mouse_move += [&](auto, auto) { _control->process_mouse_move(client_cursor_position(window)); };
-        // Add some extra handlers for the user interface. These will be merged in
-        // to one at some point so that the UI can take priority where appropriate.
-        _token_store += _mouse.mouse_down += [&](input::Mouse::Button)
+        _token_store += _mouse.mouse_down += [&](input::Mouse::Button) { _control->process_mouse_down(client_cursor_position(window)); };
+        _token_store += _keyboard.on_key_down += [&](auto key)
         {
-            // The client mouse coordinate is already relative to the root window (at present).
-            _control->process_mouse_down(client_cursor_position(window));
-        };
-
-        _token_store += _keyboard.on_key_down += [&](uint16_t key)
-        {
+            _control->process_key_down(key);
             if (key == 'G' && _keyboard.control())
             {
                 _go_to_room->toggle_visible();
             }
-            else
-            {
-                _go_to_room->input(key);
-            }
         };
-
-        _token_store += _keyboard.on_char += [&](uint16_t key)
-        {
-            if (_go_to_room->visible())
-            {
-                _go_to_room->character(key);
-            }
-        };
-
+        _token_store += _keyboard.on_char += [&](auto key) { _control->process_char(key); };
 
         generate_tool_window(texture_storage);
 

--- a/trview.graphics/Font.cpp
+++ b/trview.graphics/Font.cpp
@@ -75,5 +75,10 @@ namespace trview
             XMStoreFloat2(&size, _font->MeasureString(sanitise(*_font, text).c_str()));
             return Size(size.x, size.y);
         }
+
+        bool Font::is_valid_character(wchar_t character) const
+        {
+            return _font->ContainsCharacter(character);
+        }
     }
 }

--- a/trview.graphics/Font.h
+++ b/trview.graphics/Font.h
@@ -45,6 +45,11 @@ namespace trview
             /// @param text The text to measure.
             /// @returns The size in pixels required to render the specified text.
             Size measure(const std::wstring& text) const;
+
+            /// Determines whether the character is in the image set.
+            /// @param character The character to test.
+            /// @returns True if the character is in the image set.
+            bool is_valid_character(wchar_t character) const;
         private:
             std::shared_ptr<DirectX::SpriteFont> _font;
             std::unique_ptr<DirectX::SpriteBatch> _batch;

--- a/trview.ui.render/LabelNode.cpp
+++ b/trview.ui.render/LabelNode.cpp
@@ -35,6 +35,11 @@ namespace trview
                 return _font->measure(text);
             }
 
+            bool LabelNode::is_valid_character(wchar_t character) const
+            {
+                return _font->is_valid_character(character);
+            }
+
             void LabelNode::render_self(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, graphics::Sprite& sprite)
             {
                 WindowNode::render_self(context, sprite);

--- a/trview.ui.render/LabelNode.h
+++ b/trview.ui.render/LabelNode.h
@@ -23,6 +23,7 @@ namespace trview
                 LabelNode(const graphics::Device& device, Label* label, const graphics::FontFactory& font_factory);
                 virtual ~LabelNode();
                 virtual Size measure(const std::wstring& text) const override;
+                virtual bool is_valid_character(wchar_t character) const override;
             protected:
                 virtual void render_self(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, graphics::Sprite& sprite) override;
             private:

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -372,6 +372,11 @@ namespace trview
 
         bool Control::inner_process_key_down(uint16_t key)
         {
+            if (!visible())
+            {
+                return false;
+            }
+
             for (auto& child : child_elements())
             {
                 if (child->inner_process_key_down(key))
@@ -396,6 +401,11 @@ namespace trview
 
         bool Control::inner_process_char(wchar_t key)
         {
+            if (!visible())
+            {
+                return false;
+            }
+
             for (auto& child : child_elements())
             {
                 if (child->inner_process_char(key))

--- a/trview.ui/IFontMeasurer.h
+++ b/trview.ui/IFontMeasurer.h
@@ -18,6 +18,11 @@ namespace trview
             /// Measure the specified text.
             /// @param text The text to measure.
             virtual Size measure(const std::wstring& text) const = 0;
+
+            /// Determines if the character is in the image set.
+            /// @param character The character to test.
+            /// @returns True if the character has an image.
+            virtual bool is_valid_character(wchar_t character) const = 0;
         };
     }
 }

--- a/trview.ui/Label.cpp
+++ b/trview.ui/Label.cpp
@@ -66,5 +66,14 @@ namespace trview
         {
             _measurer = measurer;
         }
+
+        bool Label::is_valid_character(wchar_t character) const
+        {
+            if (!_measurer)
+            {
+                return true;
+            }
+            return _measurer->is_valid_character(character);
+        }
     }
 }

--- a/trview.ui/Label.cpp
+++ b/trview.ui/Label.cpp
@@ -69,11 +69,7 @@ namespace trview
 
         bool Label::is_valid_character(wchar_t character) const
         {
-            if (!_measurer)
-            {
-                return true;
-            }
-            return _measurer->is_valid_character(character);
+            return !_measurer || _measurer->is_valid_character(character);
         }
     }
 }

--- a/trview.ui/Label.h
+++ b/trview.ui/Label.h
@@ -53,6 +53,9 @@ namespace trview
             /// Set the measurer used to measure how big text will be.
             /// @param measurer The measurer instance.
             void set_measurer(IFontMeasurer* measurer);
+
+            /// Determine whether the character specified is in the character set.
+            bool is_valid_character(wchar_t character) const;
         private:
             std::wstring                   _text;
             int                            _text_size;

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -6,8 +6,8 @@ namespace trview
 {
     namespace ui
     {
-        TextArea::TextArea(const Point& position, const Size& size, const Colour& background_colour, const Colour& text_colour)
-            : Window(position, size, background_colour), _text_colour(text_colour)
+        TextArea::TextArea(const Point& position, const Size& size, const Colour& background_colour, const Colour& text_colour, graphics::TextAlignment text_alignment)
+            : Window(position, size, background_colour), _text_colour(text_colour), _alignment(text_alignment)
         {
             _area = add_child(std::make_unique<StackPanel>(Point(), size, background_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual));
             _area->set_margin(Size(1, 1));
@@ -48,8 +48,15 @@ namespace trview
                     // VK_RETURN
                     case 0xD:
                     {
-                        add_line();
-                        ++_cursor_line;
+                        if (_mode == Mode::SingleLine)
+                        {
+                            on_enter(text);
+                        }
+                        else
+                        {
+                            add_line();
+                            ++_cursor_line;
+                        }
                         return;
                     }
                     default:
@@ -64,6 +71,11 @@ namespace trview
                         // then create a new line and put the character on that line instead.
                         if (line->measure_text(text + character).width > _area->size().width)
                         {
+                            if (_mode == Mode::SingleLine)
+                            {
+                                return;
+                            }
+
                             add_line({ character });
                             ++_cursor_line;
                             return;
@@ -102,6 +114,11 @@ namespace trview
             _cursor_line = _lines.empty() ? 0 : _lines.size() - 1;
             _cursor_position = _lines.empty() ? 0 : _lines.back()->text().size();
             update_cursor(false);
+        }
+
+        void TextArea::set_mode(Mode mode)
+        {
+            _mode = mode;
         }
 
         bool TextArea::mouse_down(const Point& position)
@@ -200,7 +217,7 @@ namespace trview
 
         void TextArea::add_line(std::wstring text, bool raise_event)
         {
-            _lines.push_back(_area->add_child(std::make_unique<Label>(Point(), Size(size().width, 14), background_colour(), text, 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto)));
+            _lines.push_back(_area->add_child(std::make_unique<Label>(Point(), Size(size().width, 14), background_colour(), text, 8, _alignment, graphics::ParagraphAlignment::Near, SizeMode::Manual)));
             if (raise_event)
             {
                 notify_text_updated();
@@ -251,10 +268,12 @@ namespace trview
             auto line = current_line(raise_event);
             auto text = line->text();
 
-            // Place the cursor based on the current cursor position and the size of the text
-            // as it would be renderered.
-            auto size = line->measure_text(text.substr(0, _cursor_position));
-            _cursor->set_position(Point(size.width + 2, line->position().y));
+            // Place the cursor based on the current cursor position and the size of the text as it would be renderered.
+            const auto size = line->measure_text(text.substr(0, _cursor_position));
+            const auto start = _alignment == graphics::TextAlignment::Left ?
+                Point(0, line->position().y) :
+                Point(line->size().width * 0.5f - size.width * 0.5f - 1, line->position().y);
+            _cursor->set_position(start + Point(size.width + 2, 0));
             _cursor->set_size(Size(1, line->size().height == 0 ? _cursor->size().height : line->size().height));
         }
 

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -53,9 +53,16 @@ namespace trview
                         return;
                     }
                     default:
+                    {
+                        // Check if this is character we don't support.
+                        if (!line->is_valid_character(character))
+                        {
+                            break;
+                        }
+
                         // Check if adding the character is going to make the text wider than the text area. If so,
                         // then create a new line and put the character on that line instead.
-                        if (line->measure_text(text + static_cast<wchar_t>(character)).width > _area->size().width)
+                        if (line->measure_text(text + character).width > _area->size().width)
                         {
                             add_line({ character });
                             ++_cursor_line;
@@ -63,9 +70,10 @@ namespace trview
                         }
 
                         // Add the character to the current line.
-                        text.insert(text.begin() + _cursor_position, static_cast<wchar_t>(character));
+                        text.insert(text.begin() + _cursor_position, character);
                         ++_cursor_position;
                         break;
+                    }
                 }
 
                 line->set_text(text);

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -59,6 +59,12 @@ namespace trview
                         }
                         return;
                     }
+                    // VK_ESCAPE
+                    case 0x1B:
+                    {
+                        on_escape();
+                        break;
+                    }
                     default:
                     {
                         // Check if this is character we don't support.

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -40,6 +40,9 @@ namespace trview
 
             /// Event raised when the user has pressed the enter button in single line mode.
             Event<std::wstring> on_enter;
+
+            /// Event raised when the user has pressed the escape button.
+            Event<> on_escape;
         protected:
             virtual bool mouse_down(const Point& position) override;
             virtual bool key_down(uint16_t key) override;

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "StackPanel.h"
+#include <trview.graphics/TextAlignment.h>
 
 namespace trview
 {
@@ -12,19 +13,33 @@ namespace trview
         class TextArea final : public Window
         {
         public:
+            enum class Mode
+            {
+                MultiLine,
+                SingleLine
+            };
+
             /// Create a text area.
             /// @param position The position to place the control.
             /// @param size The size of the control.
             /// @param background_colour The background colour of the text area.
             /// @param text_colour The text colour for the text area.
-            explicit TextArea(const Point& position, const Size& size, const Colour& background_colour, const Colour& text_colour);
+            /// @param text_alignment The text alignment of the label.
+            explicit TextArea(const Point& position, const Size& size, const Colour& background_colour, const Colour& text_colour, graphics::TextAlignment text_alignment = graphics::TextAlignment::Left);
 
             /// Set the text in the text area to be the specified text.
             /// @param text The text to use.
             void set_text(const std::wstring& text);
 
+            /// Set the line mode of the text area.
+            /// @param mode The new mode.
+            void set_mode(Mode mode);
+
             /// Event raised when the text in the text area has changed.
             Event<std::wstring> on_text_changed;
+
+            /// Event raised when the user has pressed the enter button in single line mode.
+            Event<std::wstring> on_enter;
         protected:
             virtual bool mouse_down(const Point& position) override;
             virtual bool key_down(uint16_t key) override;
@@ -51,6 +66,8 @@ namespace trview
             Window*             _cursor;
             uint32_t            _cursor_position{ 0u };
             uint32_t            _cursor_line{ 0u };
+            Mode                _mode{ Mode::MultiLine };
+            graphics::TextAlignment _alignment{ graphics::TextAlignment::Left };
         };
     }
 }


### PR DESCRIPTION
The text area control came into being when the route window was created - change the go to room window to use one of these controls instead of using the hacky label control that was used previously.
Also update the text area to allow single line mode and to have an event on pressing enter.
Also add a check to text area where if the character isn't in the image set, don't add it.
Issue: #495