### PR TITLE
Merge room bounding box with entity bounding box

### DIFF
--- a/trview/Entity.cpp
+++ b/trview/Entity.cpp
@@ -321,4 +321,9 @@ namespace trview
         // Create an axis-aligned BB from the points of the oriented ones.
         BoundingBox::CreateFromPoints(_bounding_box, corners.size(), &corners[0], sizeof(Vector3));
     }
+
+    DirectX::BoundingBox Entity::bounding_box() const
+    {
+        return _bounding_box;
+    }
 }

--- a/trview/Entity.h
+++ b/trview/Entity.h
@@ -37,6 +37,7 @@ namespace trview
         virtual void get_transparent_triangles(TransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
 
         PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const;
+        DirectX::BoundingBox bounding_box() const;
     private:
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);

--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -50,6 +50,11 @@ namespace trview
         generate_triggers();
         generate_entities(device);
 
+        for (auto& room : _rooms)
+        {
+            room->update_bounding_box();
+        }
+
         _transparency = std::make_unique<TransparencyBuffer>(device);
 
         _selection_renderer = std::make_unique<SelectionRenderer>(device, shader_storage);

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -255,8 +255,7 @@ namespace trview
         _unmatched_mesh = std::make_unique<Mesh>(device, vertices, std::vector<std::vector<uint32_t>>{}, untextured_indices, std::vector<TransparentTriangle>{}, collision_triangles);
 
         // Generate the bounding box based on the room dimensions.
-        const auto extents = Vector3(_num_x_sectors, (_info.yBottom - _info.yTop) / trlevel::Scale_Y, _num_z_sectors) * 0.5f;
-        _bounding_box = DirectX::BoundingBox(centre(), extents);
+        update_bounding_box();
     }
 
     void Room::generate_adjacency()
@@ -647,5 +646,17 @@ namespace trview
     uint32_t Room::number() const
     {
         return _index;
+    }
+
+    void Room::update_bounding_box()
+    {
+        // Get the extents of the room from the information - doesn't take into account any entities.
+        const auto extents = Vector3(_num_x_sectors, (_info.yBottom - _info.yTop) / trlevel::Scale_Y, _num_z_sectors) * 0.5f;
+        _bounding_box = DirectX::BoundingBox(centre(), extents);
+        // Merge all entity bounding boxes with the room bounding box.
+        for (const auto& entity : _entities)
+        {
+            _bounding_box.CreateMerged(_bounding_box, _bounding_box, entity->bounding_box());
+        }
     }
 }

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -650,13 +650,14 @@ namespace trview
 
     void Room::update_bounding_box()
     {
+        using namespace DirectX;
         // Get the extents of the room from the information - doesn't take into account any entities.
         const auto extents = Vector3(_num_x_sectors, (_info.yBottom - _info.yTop) / trlevel::Scale_Y, _num_z_sectors) * 0.5f;
-        _bounding_box = DirectX::BoundingBox(centre(), extents);
+        _bounding_box = BoundingBox(centre(), extents);
         // Merge all entity bounding boxes with the room bounding box.
         for (const auto& entity : _entities)
         {
-            _bounding_box.CreateMerged(_bounding_box, _bounding_box, entity->bounding_box());
+            BoundingBox::CreateMerged(_bounding_box, _bounding_box, entity->bounding_box());
         }
     }
 }

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -139,6 +139,7 @@ namespace trview
         void generate_trigger_geometry();
 
         uint32_t number() const;
+        void update_bounding_box();
     private:
         void generate_geometry(trlevel::LevelVersion level_version, const graphics::Device& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage);
         void generate_adjacency();


### PR DESCRIPTION
This allows for the user to click on entities that have meshes outside the bounds of the room and also stops the room being culled when the entity is still in view, but the room isn't.
Bug: #500