### PR TITLE
Add go to item window

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Key|Action
 ---|------
 CTRL + O    | Open file
 CTRL + G    | Show 'go to room' box
+CTRL + M	| Show 'go to item' box
 CTRL + R    | Open Route window
 CTRL + T    | New Triggers window
 CTRL + I    | New Items window
@@ -120,6 +121,9 @@ Movement Speed      | How fast the camera moves in free mode
 
 ### Go To Room
 Enter the room number - press enter to go to the room, escape to cancel.
+
+### Go To Item
+Enter the item number - press enter to go to the item, escape to cancel.
 
 ### Items Window
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Movement Speed      | How fast the camera moves in free mode
 
 ## Windows
 
-### 1
+### Go To Room
 Enter the room number - press enter to go to the room, escape to cancel.
 
 ### Go To Item

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Key|Action
 ---|------
 CTRL + O    | Open file
 CTRL + G    | Show 'go to room' box
-CTRL + M	| Show 'go to item' box
+CTRL + M    | Show 'go to item' box
 CTRL + R    | Open Route window
 CTRL + T    | New Triggers window
 CTRL + I    | New Items window
@@ -119,7 +119,7 @@ Movement Speed      | How fast the camera moves in free mode
 
 ## Windows
 
-### Go To Room
+### 1
 Enter the room number - press enter to go to the room, escape to cancel.
 
 ### Go To Item

--- a/trview.app/GoTo.cpp
+++ b/trview.app/GoTo.cpp
@@ -81,11 +81,12 @@ namespace trview
 
     std::wstring GoTo::name() const
     {
-        return _group->title();
+        return _name;
     }
 
     void GoTo::set_name(const std::wstring& name)
     {
-        _group->set_title(name);
+        _name = name;
+        _group->set_title(L"Go to " + name);
     }
 }

--- a/trview.app/GoTo.cpp
+++ b/trview.app/GoTo.cpp
@@ -1,4 +1,4 @@
-#include "GoToRoom.h"
+#include "GoTo.h"
 
 #include <Windows.h>
 #include <trview.ui/TextArea.h>
@@ -14,7 +14,7 @@ namespace trview
         const float Height = 20.0f;
     }
 
-    GoToRoom::GoToRoom(ui::Control& parent)
+    GoTo::GoTo(ui::Control& parent)
     {
         using namespace ui;
 
@@ -45,8 +45,8 @@ namespace trview
         {
             try
             {
-                auto room = std::stoul(text);
-                room_selected(room);
+                auto index = std::stoul(text);
+                on_selected(index);
                 toggle_visible();
             }
             catch (...)
@@ -56,7 +56,7 @@ namespace trview
         };
 
         _text_area = box->add_child(std::move(text_area));
-        window->add_child(std::move(box));
+        _group = window->add_child(std::move(box));
         _window = parent.add_child(std::move(window));
 
         _token_store += parent.on_size_changed += [&](const Size& size)
@@ -65,17 +65,27 @@ namespace trview
         };
     }
 
-    bool GoToRoom::visible() const
+    bool GoTo::visible() const
     {
         return _window->visible();
     }
 
-    void GoToRoom::toggle_visible()
+    void GoTo::toggle_visible()
     {
         _window->set_visible(!visible());
         if (visible())
         {
             _text_area->set_text(L"");
         }
+    }
+
+    std::wstring GoTo::name() const
+    {
+        return _group->title();
+    }
+
+    void GoTo::set_name(const std::wstring& name)
+    {
+        _group->set_title(name);
     }
 }

--- a/trview.app/GoTo.h
+++ b/trview.app/GoTo.h
@@ -1,8 +1,8 @@
 /// @file GoToRoom.h
-/// @brief UI element that allows the user to type in a room number to focus on that room.
+/// @brief UI element that allows the user to type in a number to focus on that.
 /// 
 /// Creates a text box that can be activated with a shortcut. The user can then type in a
-/// room number and the camera will be focused on that room.
+/// room or item number and the camera will be focused on that room.
 
 #pragma once
 
@@ -16,18 +16,18 @@ namespace trview
     namespace ui
     {
         class Control;
+        class GroupBox;
         class TextArea;
     }
     
     /// This window presents the user with a box where they can enter the room number
     /// that they want to go to. Then when they press enter, that will be the selected room.
-    class GoToRoom
+    class GoTo
     {
     public:
-        /// Creates an instance of the GoToRoom class. This will add UI elements to the 
-        /// control provided.
+        /// Creates an instance of the GoTo class. This will add UI elements to the control provided.
         /// @param parent The control to which the instance will be added as a child.
-        explicit GoToRoom(ui::Control& parent);
+        explicit GoTo(ui::Control& parent);
 
         /// Gets whether the window is currently visible.
         /// @returns True if the window is visible.
@@ -38,10 +38,16 @@ namespace trview
 
         /// Event raised when the user selects a new room. The newly selected room is passed as
         /// a parameter when the event is raised.
-        Event<uint32_t> room_selected;
+        Event<uint32_t> on_selected;
+
+        std::wstring name() const;
+
+        /// Set the name of the type of thing that is being gone to.
+        void set_name(const std::wstring& name);
     private:
         TokenStore    _token_store;
         ui::Control*  _window;
+        ui::GroupBox* _group;
         ui::TextArea* _text_area;
     };
 }

--- a/trview.app/GoTo.h
+++ b/trview.app/GoTo.h
@@ -40,6 +40,7 @@ namespace trview
         /// a parameter when the event is raised.
         Event<uint32_t> on_selected;
 
+        /// Get the name of the type of thing being selected.
         std::wstring name() const;
 
         /// Set the name of the type of thing that is being gone to.
@@ -49,5 +50,6 @@ namespace trview
         ui::Control*  _window;
         ui::GroupBox* _group;
         ui::TextArea* _text_area;
+        std::wstring  _name;
     };
 }

--- a/trview.app/GoTo.h
+++ b/trview.app/GoTo.h
@@ -22,7 +22,7 @@ namespace trview
     
     /// This window presents the user with a box where they can enter the room number
     /// that they want to go to. Then when they press enter, that will be the selected room.
-    class GoTo
+    class GoTo final
     {
     public:
         /// Creates an instance of the GoTo class. This will add UI elements to the control provided.

--- a/trview.app/GoTo.h
+++ b/trview.app/GoTo.h
@@ -20,8 +20,8 @@ namespace trview
         class TextArea;
     }
     
-    /// This window presents the user with a box where they can enter the room number
-    /// that they want to go to. Then when they press enter, that will be the selected room.
+    /// This window presents the user with a box where they can enter the number of the thing
+    /// that they want to go to. Then when they press enter, that will be the selected.
     class GoTo final
     {
     public:

--- a/trview.app/ViewerUI.cpp
+++ b/trview.app/ViewerUI.cpp
@@ -29,10 +29,10 @@ namespace trview
                 switch (key)
                 {
                 case 'G':
-                    name = L"Go to Room";
+                    name = L"Room";
                     break;
                 case 'M':
-                    name = L"Go to Item";
+                    name = L"Item";
                     break;
                 default:
                     return;
@@ -60,7 +60,7 @@ namespace trview
         _go_to = std::make_unique<GoTo>(*_control.get());
         _token_store += _go_to->on_selected += [&](uint32_t index)
         {
-            if (_go_to->name() == L"Go to Item")
+            if (_go_to->name() == L"Item")
             {
                 on_select_item(index);
             }

--- a/trview.app/ViewerUI.cpp
+++ b/trview.app/ViewerUI.cpp
@@ -2,7 +2,7 @@
 #include <trview.ui/Window.h>
 #include <trview.graphics/IShaderStorage.h>
 #include "ILevelTextureStorage.h"
-#include "GoToRoom.h"
+#include "GoTo.h"
 #include "ContextMenu.h"
 #include <sstream>
 #include <iomanip>
@@ -23,17 +23,52 @@ namespace trview
         _token_store += _keyboard.on_key_down += [&](auto key)
         {
             _control->process_key_down(key);
-            if (key == 'G' && _keyboard.control())
+            if (_keyboard.control())
             {
-                _go_to_room->toggle_visible();
+                std::wstring name;
+                switch (key)
+                {
+                case 'G':
+                    name = L"Go to Room";
+                    break;
+                case 'M':
+                    name = L"Go to Item";
+                    break;
+                default:
+                    return;
+                }
+
+                if (!_go_to->visible())
+                {
+                    _go_to->set_name(name);
+                    _go_to->toggle_visible();
+                }
+                else if (_go_to->name() == name)
+                {
+                    _go_to->toggle_visible();
+                }
+                else
+                {
+                    _go_to->set_name(name);
+                }
             }
         };
         _token_store += _keyboard.on_char += [&](auto key) { _control->process_char(key); };
 
         generate_tool_window(texture_storage);
 
-        _go_to_room = std::make_unique<GoToRoom>(*_control.get());
-        _token_store += _go_to_room->room_selected += [&](uint32_t room) { on_select_room(room); };
+        _go_to = std::make_unique<GoTo>(*_control.get());
+        _token_store += _go_to->on_selected += [&](uint32_t index)
+        {
+            if (_go_to->name() == L"Go to Item")
+            {
+                on_select_item(index);
+            }
+            else
+            {
+                on_select_room(index);
+            }
+        };
 
         _toolbar = std::make_unique<Toolbar>(*_control);
         _toolbar->add_tool(L"Measure", L"|....|");
@@ -117,7 +152,7 @@ namespace trview
 
     bool ViewerUI::go_to_room_visible() const
     {
-        return _go_to_room->visible();
+        return _go_to->visible();
     }
 
     bool ViewerUI::is_cursor_over() const

--- a/trview.app/ViewerUI.h
+++ b/trview.app/ViewerUI.h
@@ -11,7 +11,7 @@
 #include "Toolbar.h"
 #include "LevelInfo.h"
 #include "RoomNavigator.h"
-#include "GoToRoom.h"
+#include "GoTo.h"
 #include "SettingsWindow.h"
 #include "Flipmaps.h"
 #include "Neighbours.h"
@@ -97,6 +97,9 @@ namespace trview
 
         /// Event raised when a minimap sector is hovered over.
         Event<std::shared_ptr<Sector>> on_sector_hover;
+
+        /// Event raised when an item is selected.
+        Event<uint32_t> on_select_item;
 
         /// Event raised when a room is selected.
         Event<int32_t> on_select_room;
@@ -266,7 +269,7 @@ namespace trview
         std::unique_ptr<ui::Control> _control;
         std::unique_ptr<ui::render::Renderer> _ui_renderer;
         std::unique_ptr<ContextMenu> _context_menu;
-        std::unique_ptr<GoToRoom> _go_to_room;
+        std::unique_ptr<GoTo> _go_to;
         std::unique_ptr<RoomNavigator> _room_navigator;
         std::unique_ptr<Toolbar> _toolbar;
         std::unique_ptr<LevelInfo> _level_info;

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -31,7 +31,7 @@
     <ClCompile Include="FileDropper.cpp" />
     <ClCompile Include="Flipmaps.cpp" />
     <ClCompile Include="FreeCamera.cpp" />
-    <ClCompile Include="GoToRoom.cpp" />
+    <ClCompile Include="GoTo.cpp" />
     <ClCompile Include="ICamera.cpp" />
     <ClCompile Include="ILevelTextureStorage.cpp" />
     <ClCompile Include="IRenderable.cpp" />
@@ -81,7 +81,7 @@
     <ClInclude Include="FileDropper.h" />
     <ClInclude Include="Flipmaps.h" />
     <ClInclude Include="FreeCamera.h" />
-    <ClInclude Include="GoToRoom.h" />
+    <ClInclude Include="GoTo.h" />
     <ClInclude Include="ICamera.h" />
     <ClInclude Include="ILevelTextureStorage.h" />
     <ClInclude Include="IRenderable.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -112,9 +112,6 @@
     <ClCompile Include="ViewerUI.cpp">
       <Filter>Viewer\UI</Filter>
     </ClCompile>
-    <ClCompile Include="GoToRoom.cpp">
-      <Filter>Viewer\UI</Filter>
-    </ClCompile>
     <ClCompile Include="LevelInfo.cpp">
       <Filter>Viewer\UI</Filter>
     </ClCompile>
@@ -137,6 +134,9 @@
       <Filter>Camera</Filter>
     </ClCompile>
     <ClCompile Include="UserSettings.cpp" />
+    <ClCompile Include="GoTo.cpp">
+      <Filter>Viewer\UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="WindowResizer.h" />
@@ -263,9 +263,6 @@
     <ClInclude Include="ViewerUI.h">
       <Filter>Viewer\UI</Filter>
     </ClInclude>
-    <ClInclude Include="GoToRoom.h">
-      <Filter>Viewer\UI</Filter>
-    </ClInclude>
     <ClInclude Include="LevelInfo.h">
       <Filter>Viewer\UI</Filter>
     </ClInclude>
@@ -289,6 +286,9 @@
       <Filter>Camera</Filter>
     </ClInclude>
     <ClInclude Include="UserSettings.h" />
+    <ClInclude Include="GoTo.h">
+      <Filter>Viewer\UI</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Items">

--- a/trview.ui/GroupBox.cpp
+++ b/trview.ui/GroupBox.cpp
@@ -18,7 +18,17 @@ namespace trview
             add_child(std::move(left));
             add_child(std::move(bottom));
             add_child(std::move(right));
-            add_child(std::move(label));
+            _label = add_child(std::move(label));
+        }
+
+        std::wstring GroupBox::title() const
+        {
+            return _label->text();
+        }
+
+        void GroupBox::set_title(const std::wstring& title)
+        {
+            _label->set_text(title);
         }
     }
 }

--- a/trview.ui/GroupBox.h
+++ b/trview.ui/GroupBox.h
@@ -6,12 +6,17 @@ namespace trview
 {
     namespace ui
     {
+        class Label;
+
         class GroupBox : public Window
         {
         public:
             GroupBox(const Point& point, const Size& size, const Colour& background_colour, const Colour& border_colour, const std::wstring& text);
+            std::wstring title() const;
+            void set_title(const std::wstring& title);
         private:
-            Colour       _border_colour;
+            Colour _border_colour;
+            Label* _label;
         };
     }
 }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -97,6 +97,13 @@ namespace trview
         load_default_textures(_device, *_texture_storage.get());
 
         _ui = std::make_unique<ViewerUI>(_window, _device, *_shader_storage, _font_factory, *_texture_storage);
+        _token_store += _ui->on_select_item += [&](uint32_t index)
+        {
+            if (_level && index < _level->items().size())
+            {
+                select_item(_level->items()[index]);
+            }
+        };
         _token_store += _ui->on_select_room += [&](uint32_t room) { select_room(room); };
         _token_store += _ui->on_highlight += [&](bool) { toggle_highlight(); };
         _token_store += _ui->on_show_hidden_geometry += [&](bool value) { set_show_hidden_geometry(value); };
@@ -295,7 +302,7 @@ namespace trview
 
         _token_store += _keyboard.on_key_down += [&](uint16_t key)
         {
-            if (GetAsyncKeyState(VK_CONTROL))
+            if (_ui->go_to_room_visible() || GetAsyncKeyState(VK_CONTROL))
             {
                 return;
             }


### PR DESCRIPTION
Or, more specifically convert the `GoToRoom` class to the `GoTo` class, which basically is just a text box that you can type a number into. Then the Viewer UI calls the appropriate event handler to select the room or the item.
Issue: #302 