### PR TITLE
Create UI input controller

### DIFF
--- a/trview.app/CollapsiblePanel.cpp
+++ b/trview.app/CollapsiblePanel.cpp
@@ -80,10 +80,7 @@ namespace trview
             _ui_renderer->set_host_size(window().size());
         };
 
-        _token_store += _keyboard.on_char += [&](auto key) { _ui->process_char(key); };
-
         _ui = std::make_unique<ui::Window>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f));
-
         _input = std::make_unique<ui::Input>(window(), *_ui);
     }
 

--- a/trview.app/CollapsiblePanel.cpp
+++ b/trview.app/CollapsiblePanel.cpp
@@ -81,13 +81,14 @@ namespace trview
         };
 
         _token_store += _mouse.mouse_up += [&](auto) { _ui->process_mouse_up(client_cursor_position(window())); };
-        _token_store += _mouse.mouse_move += [&](auto, auto) { _ui->process_mouse_move(client_cursor_position(window())); };
         _token_store += _mouse.mouse_down += [&](input::Mouse::Button) { _ui->process_mouse_down(client_cursor_position(window())); };
         _token_store += _mouse.mouse_wheel += [&](int16_t delta) { _ui->mouse_scroll(client_cursor_position(window()), delta); };
         _token_store += _keyboard.on_key_down += [&](auto key) { _ui->process_key_down(key); };
         _token_store += _keyboard.on_char += [&](auto key) { _ui->process_char(key); };
 
         _ui = std::make_unique<ui::Window>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f));
+
+        _input = std::make_unique<ui::Input>(window(), *_ui);
     }
 
     void CollapsiblePanel::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)

--- a/trview.app/CollapsiblePanel.cpp
+++ b/trview.app/CollapsiblePanel.cpp
@@ -80,7 +80,6 @@ namespace trview
             _ui_renderer->set_host_size(window().size());
         };
 
-        _token_store += _keyboard.on_key_down += [&](auto key) { _ui->process_key_down(key); };
         _token_store += _keyboard.on_char += [&](auto key) { _ui->process_char(key); };
 
         _ui = std::make_unique<ui::Window>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f));

--- a/trview.app/CollapsiblePanel.cpp
+++ b/trview.app/CollapsiblePanel.cpp
@@ -81,7 +81,6 @@ namespace trview
         };
 
         _token_store += _mouse.mouse_up += [&](auto) { _ui->process_mouse_up(client_cursor_position(window())); };
-        _token_store += _mouse.mouse_down += [&](input::Mouse::Button) { _ui->process_mouse_down(client_cursor_position(window())); };
         _token_store += _mouse.mouse_wheel += [&](int16_t delta) { _ui->mouse_scroll(client_cursor_position(window()), delta); };
         _token_store += _keyboard.on_key_down += [&](auto key) { _ui->process_key_down(key); };
         _token_store += _keyboard.on_char += [&](auto key) { _ui->process_char(key); };

--- a/trview.app/CollapsiblePanel.cpp
+++ b/trview.app/CollapsiblePanel.cpp
@@ -70,8 +70,7 @@ namespace trview
 
     CollapsiblePanel::CollapsiblePanel(const Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent, const std::wstring& window_class, const std::wstring& title, const Size& size)
         : MessageHandler(create_window(parent, window_class, title, size)), _window_resizer(window()), _device_window(device.create_for_window(window())),
-        _ui_renderer(std::make_unique<render::Renderer>(device, shader_storage, font_factory, window().size())),
-        _mouse(window()), _keyboard(window())
+        _ui_renderer(std::make_unique<render::Renderer>(device, shader_storage, font_factory, window().size()))
     {
         _token_store += _window_resizer.on_resize += [=]()
         {

--- a/trview.app/CollapsiblePanel.cpp
+++ b/trview.app/CollapsiblePanel.cpp
@@ -80,7 +80,6 @@ namespace trview
             _ui_renderer->set_host_size(window().size());
         };
 
-        _token_store += _mouse.mouse_wheel += [&](int16_t delta) { _ui->mouse_scroll(client_cursor_position(window()), delta); };
         _token_store += _keyboard.on_key_down += [&](auto key) { _ui->process_key_down(key); };
         _token_store += _keyboard.on_char += [&](auto key) { _ui->process_char(key); };
 

--- a/trview.app/CollapsiblePanel.cpp
+++ b/trview.app/CollapsiblePanel.cpp
@@ -80,7 +80,6 @@ namespace trview
             _ui_renderer->set_host_size(window().size());
         };
 
-        _token_store += _mouse.mouse_up += [&](auto) { _ui->process_mouse_up(client_cursor_position(window())); };
         _token_store += _mouse.mouse_wheel += [&](int16_t delta) { _ui->mouse_scroll(client_cursor_position(window()), delta); };
         _token_store += _keyboard.on_key_down += [&](auto key) { _ui->process_key_down(key); };
         _token_store += _keyboard.on_char += [&](auto key) { _ui->process_char(key); };

--- a/trview.app/CollapsiblePanel.h
+++ b/trview.app/CollapsiblePanel.h
@@ -11,6 +11,7 @@
 #include <trview.common/TokenStore.h>
 #include <trview.ui.render/Renderer.h>
 #include <trview.graphics/DeviceWindow.h>
+#include <trview.ui/Input.h>
 
 #include "WindowResizer.h"
 
@@ -85,6 +86,7 @@ namespace trview
         ui::Control* _left_panel;
         ui::Control* _right_panel;
         std::unique_ptr<ui::Window> _ui;
+        std::unique_ptr<ui::Input> _input;
     private:
         void toggle_expand();
         std::unique_ptr<ui::Control> create_divider();

--- a/trview.app/CollapsiblePanel.h
+++ b/trview.app/CollapsiblePanel.h
@@ -6,8 +6,6 @@
 #include <string>
 #include <trview.graphics/Device.h>
 #include <trview.common/MessageHandler.h>
-#include <trview.input/Mouse.h>
-#include <trview.input/Keyboard.h>
 #include <trview.common/TokenStore.h>
 #include <trview.ui.render/Renderer.h>
 #include <trview.graphics/DeviceWindow.h>
@@ -95,8 +93,6 @@ namespace trview
         std::unique_ptr<ui::render::Renderer>   _ui_renderer;
         ui::StackPanel* _panels;
         WindowResizer   _window_resizer;
-        input::Mouse    _mouse;
-        input::Keyboard _keyboard;
         ui::Control* _divider;
         ui::Button* _expander;
         bool        _expanded{ true };

--- a/trview.app/ViewerUI.cpp
+++ b/trview.app/ViewerUI.cpp
@@ -16,8 +16,6 @@ namespace trview
     {
         _control = std::make_unique<ui::Window>(Point(), window.size(), Colour::Transparent);
         _control->set_handles_input(false);
-
-        // This may need to move later.
         _ui_input = std::make_unique<Input>(window, *_control);
 
         _token_store += _keyboard.on_key_down += [&](auto key)

--- a/trview.app/ViewerUI.cpp
+++ b/trview.app/ViewerUI.cpp
@@ -17,9 +17,9 @@ namespace trview
         _control = std::make_unique<ui::Window>(Point(), window.size(), Colour::Transparent);
         _control->set_handles_input(false);
 
-        _token_store += _mouse.mouse_up += [&](auto) { _control->process_mouse_up(client_cursor_position(window)); };
-        _token_store += _mouse.mouse_move += [&](auto, auto) { _control->process_mouse_move(client_cursor_position(window)); };
-        _token_store += _mouse.mouse_down += [&](input::Mouse::Button) { _control->process_mouse_down(client_cursor_position(window)); };
+        // This may need to move later.
+        _ui_input = std::make_unique<Input>(window, *_control);
+
         _token_store += _keyboard.on_key_down += [&](auto key)
         {
             _control->process_key_down(key);

--- a/trview.app/ViewerUI.cpp
+++ b/trview.app/ViewerUI.cpp
@@ -52,7 +52,6 @@ namespace trview
                 }
             }
         };
-        _token_store += _keyboard.on_char += [&](auto key) { _control->process_char(key); };
 
         generate_tool_window(texture_storage);
 

--- a/trview.app/ViewerUI.cpp
+++ b/trview.app/ViewerUI.cpp
@@ -22,7 +22,6 @@ namespace trview
 
         _token_store += _keyboard.on_key_down += [&](auto key)
         {
-            _control->process_key_down(key);
             if (_keyboard.control())
             {
                 std::wstring name;

--- a/trview.app/ViewerUI.h
+++ b/trview.app/ViewerUI.h
@@ -4,6 +4,7 @@
 #include <trview.common/Window.h>
 #include <trview.ui/Control.h>
 #include <trview.ui.render/Renderer.h>
+#include <trview.ui/Input.h>
 #include <trview.input/Mouse.h>
 #include <trview.input/Keyboard.h>
 #include <trview.ui.render/MapRenderer.h>
@@ -268,6 +269,7 @@ namespace trview
         UserSettings _settings;
         std::unique_ptr<ui::Control> _control;
         std::unique_ptr<ui::render::Renderer> _ui_renderer;
+        std::unique_ptr<ui::Input> _ui_input;
         std::unique_ptr<ContextMenu> _context_menu;
         std::unique_ptr<GoTo> _go_to;
         std::unique_ptr<RoomNavigator> _room_navigator;

--- a/trview.ui.tests/ButtonTests.cpp
+++ b/trview.ui.tests/ButtonTests.cpp
@@ -19,7 +19,7 @@ namespace trview
                     Button button(Point(), Size(20, 20), graphics::Texture(), graphics::Texture());
                     bool raised = false;
                     auto token = button.on_click += [&raised]() { raised = true; };
-                    button.process_mouse_down(Point());
+                    // button.process_mouse_down(Point());
                     Assert::IsTrue(raised);
                 }
             };

--- a/trview.ui.tests/ButtonTests.cpp
+++ b/trview.ui.tests/ButtonTests.cpp
@@ -19,7 +19,7 @@ namespace trview
                     Button button(Point(), Size(20, 20), graphics::Texture(), graphics::Texture());
                     bool raised = false;
                     auto token = button.on_click += [&raised]() { raised = true; };
-                    // button.process_mouse_down(Point());
+                    button.clicked(Point());
                     Assert::IsTrue(raised);
                 }
             };

--- a/trview.ui.tests/CheckboxTests.cpp
+++ b/trview.ui.tests/CheckboxTests.cpp
@@ -45,7 +45,7 @@ namespace trview
                         ++times;
                     };
 
-                    checkbox.process_mouse_down(Point());
+                    // checkbox.process_mouse_down(Point());
                     Assert::IsTrue(raised);
                     Assert::AreEqual(1u, times);
                     Assert::AreEqual(true, raised_state);
@@ -64,8 +64,8 @@ namespace trview
                         states.push_back(state);
                     };
 
-                    checkbox.process_mouse_down(Point());
-                    checkbox.process_mouse_down(Point());
+                    // checkbox.process_mouse_down(Point());
+                    // checkbox.process_mouse_down(Point());
                     Assert::AreEqual((std::size_t)2u, states.size());
                     Assert::AreEqual(true, static_cast<bool>(states[0]));
                     Assert::AreEqual(false, static_cast<bool>(states[1]));

--- a/trview.ui.tests/CheckboxTests.cpp
+++ b/trview.ui.tests/CheckboxTests.cpp
@@ -34,7 +34,7 @@ namespace trview
                 TEST_METHOD(StateChangeEventRaised)
                 {
                     Checkbox checkbox(Point(), Size(20, 20));
-                    
+
                     bool raised = false;
                     uint32_t times = 0;
                     bool raised_state = false;
@@ -45,7 +45,7 @@ namespace trview
                         ++times;
                     };
 
-                    // checkbox.process_mouse_down(Point());
+                    checkbox.clicked(Point());
                     Assert::IsTrue(raised);
                     Assert::AreEqual(1u, times);
                     Assert::AreEqual(true, raised_state);
@@ -64,8 +64,8 @@ namespace trview
                         states.push_back(state);
                     };
 
-                    // checkbox.process_mouse_down(Point());
-                    // checkbox.process_mouse_down(Point());
+                    checkbox.clicked(Point());
+                    checkbox.clicked(Point());
                     Assert::AreEqual((std::size_t)2u, states.size());
                     Assert::AreEqual(true, static_cast<bool>(states[0]));
                     Assert::AreEqual(false, static_cast<bool>(states[1]));

--- a/trview.ui/Button.h
+++ b/trview.ui/Button.h
@@ -64,7 +64,7 @@ namespace trview
             /// Set the foreground colour of the text, if present.
             /// @param colour The foreground colour.
             void set_text_colour(const Colour& colour);
-        protected:
+
             virtual bool mouse_down(const Point& position) override;
             virtual bool mouse_up(const Point& position) override;
             virtual void mouse_enter() override;

--- a/trview.ui/Checkbox.h
+++ b/trview.ui/Checkbox.h
@@ -51,7 +51,7 @@ namespace trview
             /// Set whether the checkbox is enabled.
             /// @param enabled Whether the checkbox is enabled.
             void set_enabled(bool enabled);
-        protected:
+
             virtual bool mouse_down(const Point& position) override;
             virtual bool mouse_up(const Point& position) override;
             virtual bool clicked(Point position) override;

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -22,6 +22,7 @@ namespace trview
 
         Control::~Control()
         {
+            on_deleting();
         }
 
         Align Control::horizontal_alignment() const
@@ -93,12 +94,6 @@ namespace trview
 
         void Control::clear_child_elements()
         {
-            auto focus = focus_control();
-            if (std::find_if(_child_elements.begin(), _child_elements.end(),
-                [&](const auto& control) { return control.get() == focus; }) != _child_elements.end())
-            {
-                set_focus_control(nullptr);
-            }
             _child_elements.clear();
             on_hierarchy_changed();
             on_invalidate();
@@ -232,31 +227,6 @@ namespace trview
         bool Control::key_char(wchar_t key)
         {
             return false;
-        }
-
-        void Control::set_focus_control(Control* control)
-        {
-            if (_parent)
-            {
-                _parent->set_focus_control(control);
-            }
-            else
-            {
-                if (_focus_control)
-                {
-                    _focus_control->clicked_off(control);
-                }
-                inner_set_focus_control(control);
-            }
-        }
-
-        void Control::inner_set_focus_control(Control* control)
-        {
-            _focus_control = control;
-            for (const auto& child : _child_elements)
-            {
-                child->inner_set_focus_control(control);
-            }
         }
 
         Control* Control::focus_control() const

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -170,32 +170,6 @@ namespace trview
             _handles_input = value;
         }
 
-        bool Control::process_char(wchar_t key)
-        {
-            if (_focus_control && _focus_control != this && _focus_control->key_char(key))
-            {
-                return true;
-            }
-            return inner_process_char(key);
-        }
-
-        bool Control::inner_process_char(wchar_t key)
-        {
-            if (!visible())
-            {
-                return false;
-            }
-
-            for (auto& child : child_elements())
-            {
-                if (child->inner_process_char(key))
-                {
-                    return true;
-                }
-            }
-            return key_char(key);
-        }
-
         bool Control::is_mouse_over(const Point& position) const
         {
             if (!visible() || !in_bounds(position, _size))

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -170,39 +170,6 @@ namespace trview
             _handles_input = value;
         }
 
-        bool Control::process_key_down(uint16_t key)
-        {
-            if (_focus_control && _focus_control != this)
-            {
-                if (_focus_control->key_down(key))
-                {
-                    return true;
-                }
-            }
-
-            return inner_process_key_down(key);
-        }
-
-        bool Control::inner_process_key_down(uint16_t key)
-        {
-            if (!visible())
-            {
-                return false;
-            }
-
-            for (auto& child : child_elements())
-            {
-                if (child->inner_process_key_down(key))
-                {
-                    return true;
-                }
-            }
-
-            // If none of the child elements have handled this event themselves, call the key_down
-            // event of the control.
-            return key_down(key);
-        }
-
         bool Control::process_char(wchar_t key)
         {
             if (_focus_control && _focus_control != this && _focus_control->key_char(key))

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -115,47 +115,6 @@ namespace trview
             return output;
         }
 
-        bool Control::process_mouse_up(const Point& position)
-        {
-            if (_focus_control && _focus_control != this)
-            {
-                const auto focus = _focus_control;
-                const auto control_space_position = position - focus->absolute_position();
-                bool focus_handled = focus->mouse_up(control_space_position);
-                if (focus_handled && in_bounds(control_space_position, focus->size()))
-                {
-                    focus->clicked(control_space_position);
-                }
-
-                if (focus_handled)
-                {
-                    return true;
-                }
-            }
-            return inner_process_mouse_up(position);
-        }
-
-        bool Control::inner_process_mouse_up(const Point& position)
-        {
-            // Bounds check - before child elements are checked.
-            if (!visible() || !in_bounds(position, _size))
-            {
-                return false;
-            }
-
-            for (auto& child : child_elements())
-            {
-                // Convert the position into the coordinate space of the child element.
-                if (child->inner_process_mouse_up(position - child->position()))
-                {
-                    return true;
-                }
-            }
-
-            // If none of the child elements have handled this event themselves, call the up of the control.
-            return mouse_up(position);
-        }
-
         bool Control::mouse_scroll(const Point& position, int16_t delta)
         {
             if (_focus_control && _focus_control != this)

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -154,13 +154,9 @@ namespace trview
             return false;
         }
 
-        Control* Control::focus_control() const
+        bool Control::handles_input() const
         {
-            if (_parent)
-            {
-                return _parent->focus_control();
-            }
-            return _focus_control;
+            return _handles_input;
         }
 
         // Set whether this control handles input when tested in is_mouse_over. Defaults to true.
@@ -218,6 +214,11 @@ namespace trview
         {
         }
 
+        bool Control::handles_hover() const
+        {
+            return _handles_hover;
+        }
+
         void Control::set_handles_hover(bool value)
         {
             _handles_hover = value;
@@ -238,6 +239,11 @@ namespace trview
         {
             _child_elements.erase(std::remove_if(_child_elements.begin(), _child_elements.end(), [&](const auto& element) { return element.get() == child_element; }), _child_elements.end());
             on_hierarchy_changed();
+        }
+
+        void Control::set_input_query(IInputQuery* query)
+        {
+            _input_query = query;
         }
     }
 }

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -120,37 +120,6 @@ namespace trview
             return output;
         }
 
-        bool Control::process_mouse_down(const Point& position)
-        {
-            // Bounds check - before child elements are checked.
-            if (!visible() || !in_bounds(position, _size))
-            {
-                return false;
-            }
-
-            for (auto& child : child_elements())
-            {
-                // Convert the position into the coordinate space of the child element.
-                if (child->process_mouse_down(position - child->position()))
-                {
-                    return true;
-                }
-            }
-
-            // Promote controls to focus control, or clear if there are no controls that 
-            // accepted the event.
-            bool handled_by_self = _handles_input && mouse_down(position);
-            if (handled_by_self)
-            {
-                set_focus_control(this);
-            }
-            else if (!_parent)
-            {
-                set_focus_control(nullptr);
-            }
-            return handled_by_self;
-        }
-
         bool Control::process_mouse_up(const Point& position)
         {
             if (_focus_control && _focus_control != this)

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -151,57 +151,6 @@ namespace trview
             return handled_by_self;
         }
 
-        bool Control::process_mouse_move(const Point& position)
-        {
-            // Get the control at the current mouse position.
-            Control* control = hover_control_at_position(position);
-            if (control != _hover_control)
-            {
-                if (_hover_control)
-                {
-                    _hover_control->mouse_leave();
-                }
-                set_hover_control(control);
-                if (_hover_control)
-                {
-                    _hover_control->mouse_enter();
-                }
-            }
-
-            if (_focus_control && _focus_control != this)
-            {
-                auto focus = _focus_control;
-                if (focus->move(position - focus->absolute_position()))
-                {
-                    return true;
-                }
-            }
-
-            return inner_process_mouse_move(position);
-        }
-
-        bool Control::inner_process_mouse_move(const Point& position)
-        {
-            // Bounds check - before child elements are checked.
-            if (!visible() || !in_bounds(position, _size))
-            {
-                return false;
-            }
-
-            for (auto& child : child_elements())
-            {
-                // Convert the position into the coordinate space of the child element.
-                if (child->inner_process_mouse_move(position - child->position()))
-                {
-                    return true;
-                }
-            }
-
-            // If none of the child elements have handled this event themselves, call the 
-            // move function of this control.
-            return move(position);
-        }
-
         bool Control::process_mouse_up(const Point& position)
         {
             if (_focus_control && _focus_control != this)
@@ -456,57 +405,12 @@ namespace trview
         {
         }
 
-        Control* Control::hover_control_at_position(const Point& position)
-        {
-            if (!visible() || !in_bounds(position, size()))
-            {
-                return nullptr;
-            }
-
-            for (const auto& control : child_elements())
-            {
-                auto result = control->hover_control_at_position(position - control->position());
-                if (result && result->_handles_hover)
-                {
-                    return result;
-                }
-            }
-
-            if (_handles_hover)
-            {
-                return this;
-            }
-
-            return nullptr;
-        }
-
         void Control::mouse_enter()
         {
         }
 
         void Control::mouse_leave()
         {
-        }
-
-        void Control::set_hover_control(Control* control)
-        {
-            if (_parent)
-            {
-                _parent->set_hover_control(control);
-            }
-            else
-            {
-                inner_set_hover_control(control);
-            }
-        }
-
-        void Control::inner_set_hover_control(Control* control)
-        {
-            _hover_control = control;
-            for (const auto& child : _child_elements)
-            {
-                child->inner_set_hover_control(control);
-            }
         }
 
         void Control::set_handles_hover(bool value)

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -115,40 +115,6 @@ namespace trview
             return output;
         }
 
-        bool Control::mouse_scroll(const Point& position, int16_t delta)
-        {
-            if (_focus_control && _focus_control != this)
-            {
-                if (_focus_control->inner_process_mouse_scroll(position, delta))
-                {
-                    return true;
-                }
-            }
-            return inner_process_mouse_scroll(position, delta);
-        }
-
-        bool Control::inner_process_mouse_scroll(const Point& position, int delta)
-        {
-            // Bounds check - before child elements are checked.
-            if (!visible() || !in_bounds(position, _size))
-            {
-                return false;
-            }
-
-            for (auto& child : child_elements())
-            {
-                // Convert the position into the coordinate space of the child element.
-                if (child->inner_process_mouse_scroll(position - child->position(), delta))
-                {
-                    return true;
-                }
-            }
-
-            // If none of the child elements have handled this event themselves, call the 
-            // scroll function of this control.
-            return scroll(delta);
-        }
-
         bool Control::mouse_down(const Point&)
         {
             return false;

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -19,6 +19,8 @@ namespace trview
         class Control
         {
         public:
+            friend class Input;
+
             /// Create a new control.
             /// @param position The position in the parent control.
             /// @param size The size of the control.
@@ -102,11 +104,6 @@ namespace trview
             /// @param position The position of the mouse relative to the control.
             /// @returns Whether the mouse up event was handled by the control.
             bool process_mouse_up(const Point& position);
-
-            /// Process a mouse_move event at the position specified.
-            /// @param position The position of the mouse relative to the control.
-            /// @returns Whether the mouse move was handled by the control.
-            bool process_mouse_move(const Point& position);
 
             /// Process a mouse_scroll event.
             /// @param position The position of the mouse relative to the control.
@@ -232,10 +229,6 @@ namespace trview
             /// @param control The current focus control
             void set_focus_control(Control* control);
 
-            /// Set the control in the tree that is the hover element.
-            /// @param control The hovered over control.
-            void set_hover_control(Control* control);
-
             /// Get the currently focused control.
             /// @returns The currently focused control.
             Control* focus_control() const;
@@ -245,14 +238,6 @@ namespace trview
             /// Set the focus control and recurse to child controls.
             /// @param control The new focus control.
             void inner_set_focus_control(Control* control);
-
-            /// Set the hover control and recurse to child controls.
-            /// @param control The new hover control.
-            void inner_set_hover_control(Control* control);
-
-            /// Process a mouse move and recurse to child controls.
-            /// @param position The position of the mouse relative to the control.
-            bool inner_process_mouse_move(const Point& position);
 
             /// Process a mouse up and recurse to child controls.
             /// @param position The position of the mouse relative to the control.
@@ -270,14 +255,10 @@ namespace trview
             /// @param delta The mouse scroll delta.
             bool inner_process_mouse_scroll(const Point& position, int delta);
 
-            /// Get the control at the specified mouse position.
-            Control* hover_control_at_position(const Point& position);
-
             std::vector<std::unique_ptr<Control>> _child_elements;
 
             Control* _parent{ nullptr };
             Control* _focus_control{ nullptr };
-            Control* _hover_control{ nullptr };
             Point    _position;
             Size     _size;
             bool     _visible;

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -95,11 +95,6 @@ namespace trview
             /// @returns The child elements.
             std::vector<Control*> child_elements(bool rendering_order = false) const;
 
-            /// Process a mouse_up event a tthe position specified.
-            /// @param position The position of the mouse relative to the control.
-            /// @returns Whether the mouse up event was handled by the control.
-            bool process_mouse_up(const Point& position);
-
             /// Process a mouse_scroll event.
             /// @param position The position of the mouse relative to the control.
             /// @param delta The mouse wheel movement.
@@ -235,10 +230,6 @@ namespace trview
 
             TokenStore _token_store;
         private:
-            /// Process a mouse up and recurse to child controls.
-            /// @param position The position of the mouse relative to the control.
-            bool inner_process_mouse_up(const Point& position);
-
             /// Process a key down and recurse to child controls.
             /// @param key The key that was pressed.
             bool inner_process_key_down(uint16_t key);

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -10,6 +10,7 @@
 #include <trview.common/Point.h>
 #include <trview.common/TokenStore.h>
 #include "Align.h"
+#include "IInputQuery.h"
 
 namespace trview
 {
@@ -19,8 +20,6 @@ namespace trview
         class Control
         {
         public:
-            friend class Input;
-
             /// Create a new control.
             /// @param position The position in the parent control.
             /// @param size The size of the control.
@@ -101,9 +100,15 @@ namespace trview
             /// @returns True if the control or any child elements are under the cursor and the control handles the event.
             bool is_mouse_over(const Point& position) const;
 
+            /// Gets whether this control handles input when tested in mouse over events.
+            bool handles_input() const;
+
             /// Set whether this control handles input when tested in is_mouse_over. Defaults to true.
             /// @param value Whether the control handles input.
             void set_handles_input(bool value);
+
+            /// Gets whether this control handles mouse hover events.
+            bool handles_hover() const;
 
             /// Set whether this control handles mouse hover events. Defaults to false.
             /// @param value Whether the control handles mouse hover events.
@@ -157,10 +162,6 @@ namespace trview
 
             /// Event raised when the control is being deleted.
             Event<> on_deleting;
-        protected:
-            /// To be called after a child element has been added to the control.
-            /// @param child_element The element that was added.
-            virtual void inner_add_child(Control* child_element);
 
             /// To be called when the mouse has been pressed down over the element.
             /// @param position The position of the mouse down relative to the control.
@@ -208,16 +209,18 @@ namespace trview
             /// @returns True if the key char event was handled.
             virtual bool key_char(wchar_t key);
 
-            /// Get the currently focused control.
-            /// @returns The currently focused control.
-            Control* focus_control() const;
+            void set_input_query(IInputQuery* query);
+        protected:
+            /// To be called after a child element has been added to the control.
+            /// @param child_element The element that was added.
+            virtual void inner_add_child(Control* child_element);
 
             TokenStore _token_store;
+            IInputQuery* _input_query{ nullptr };
         private:
             std::vector<std::unique_ptr<Control>> _child_elements;
 
             Control* _parent{ nullptr };
-            Control* _focus_control{ nullptr };
             Point    _position;
             Size     _size;
             bool     _visible;

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -109,11 +109,6 @@ namespace trview
             /// @param value Whether the control handles mouse hover events.
             void set_handles_hover(bool value);
 
-            /// Process a key down event.
-            /// @param key The key that was pressed down.
-            /// @returns True if the event was processed by the control.
-            bool process_key_down(uint16_t key);
-
             /// Process a char event.
             /// @param key The character that was pressed.
             /// @returns True if the event was processed by the control.
@@ -224,10 +219,6 @@ namespace trview
 
             TokenStore _token_store;
         private:
-            /// Process a key down and recurse to child controls.
-            /// @param key The key that was pressed.
-            bool inner_process_key_down(uint16_t key);
-
             /// Process a character key press and recurse to child controls.
             /// @param key The character that was pressed.
             bool inner_process_char(wchar_t key);

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -109,11 +109,6 @@ namespace trview
             /// @param value Whether the control handles mouse hover events.
             void set_handles_hover(bool value);
 
-            /// Process a char event.
-            /// @param key The character that was pressed.
-            /// @returns True if the event was processed by the control.
-            bool process_char(wchar_t key);
-
             /// Set the size of the control.
             /// @param size The new size of the control.
             void set_size(Size size);
@@ -219,10 +214,6 @@ namespace trview
 
             TokenStore _token_store;
         private:
-            /// Process a character key press and recurse to child controls.
-            /// @param key The character that was pressed.
-            bool inner_process_char(wchar_t key);
-
             std::vector<std::unique_ptr<Control>> _child_elements;
 
             Control* _parent{ nullptr };

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -95,11 +95,6 @@ namespace trview
             /// @returns The child elements.
             std::vector<Control*> child_elements(bool rendering_order = false) const;
 
-            /// Process a mouse_down event at the position specified.
-            /// @param position The position of the mouse relative to the control.
-            /// @returns Whether the mouse down event was handled by the control.
-            bool process_mouse_down(const Point& position);
-
             /// Process a mouse_up event a tthe position specified.
             /// @param position The position of the mouse relative to the control.
             /// @returns Whether the mouse up event was handled by the control.

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -95,12 +95,6 @@ namespace trview
             /// @returns The child elements.
             std::vector<Control*> child_elements(bool rendering_order = false) const;
 
-            /// Process a mouse_scroll event.
-            /// @param position The position of the mouse relative to the control.
-            /// @param delta The mouse wheel movement.
-            /// @returns Whether the mouse scroll was handled by the control.
-            bool mouse_scroll(const Point& position, int16_t delta);
-
             /// Determines whether the mouse is over the element or any child elements that are
             /// interested in taking input.
             /// @param position The mouse position.
@@ -237,10 +231,6 @@ namespace trview
             /// Process a character key press and recurse to child controls.
             /// @param key The character that was pressed.
             bool inner_process_char(wchar_t key);
-
-            /// Process a mouse scroll and recurse to child controls.
-            /// @param delta The mouse scroll delta.
-            bool inner_process_mouse_scroll(const Point& position, int delta);
 
             std::vector<std::unique_ptr<Control>> _child_elements;
 

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -169,6 +169,15 @@ namespace trview
 
             /// Event raised when there has been a change to the children of this control.
             Event<> on_hierarchy_changed;
+
+            /// Event raised when the control wants to become the focus control.
+            Event<> on_focus_requested;
+
+            /// Event raised when the control wants to clear the focus.
+            Event<> on_focus_clear_requested;
+
+            /// Event raised when the control is being deleted.
+            Event<> on_deleting;
         protected:
             /// To be called after a child element has been added to the control.
             /// @param child_element The element that was added.
@@ -220,20 +229,12 @@ namespace trview
             /// @returns True if the key char event was handled.
             virtual bool key_char(wchar_t key);
 
-            /// Set the control in the tree that has focus.
-            /// @param control The current focus control
-            void set_focus_control(Control* control);
-
             /// Get the currently focused control.
             /// @returns The currently focused control.
             Control* focus_control() const;
 
             TokenStore _token_store;
         private:
-            /// Set the focus control and recurse to child controls.
-            /// @param control The new focus control.
-            void inner_set_focus_control(Control* control);
-
             /// Process a mouse up and recurse to child controls.
             /// @param position The position of the mouse relative to the control.
             bool inner_process_mouse_up(const Point& position);

--- a/trview.ui/Dropdown.cpp
+++ b/trview.ui/Dropdown.cpp
@@ -15,7 +15,7 @@ namespace trview
             _token_store += _button->on_click += [&]()
             {
                 _dropdown->set_visible(!_dropdown->visible());
-                set_focus_control(this);
+                on_focus_requested();
                 update_dropdown();
             };
         }

--- a/trview.ui/Dropdown.h
+++ b/trview.ui/Dropdown.h
@@ -38,7 +38,7 @@ namespace trview
 
             /// Event raised when a value is selected. The selected value is passed as a parameter.
             Event<std::wstring> on_value_selected;
-        protected:
+
             virtual void clicked_off(Control* new_focus) override;
         private:
             void update_dropdown();

--- a/trview.ui/IInputQuery.cpp
+++ b/trview.ui/IInputQuery.cpp
@@ -1,0 +1,11 @@
+#include "IInputQuery.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        IInputQuery::~IInputQuery()
+        {
+        }
+    }
+}

--- a/trview.ui/IInputQuery.h
+++ b/trview.ui/IInputQuery.h
@@ -6,9 +6,13 @@ namespace trview
     {
         class Control;
 
+        /// Allows controls to query the current state of user input.
         struct IInputQuery
         {
             virtual ~IInputQuery() = 0;
+
+            /// Get the control that is currently focused.
+            /// @returns The control, or nullptr if no control is focused.
             virtual Control* focus_control() const = 0;
         };
     }

--- a/trview.ui/IInputQuery.h
+++ b/trview.ui/IInputQuery.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace trview
+{
+    namespace ui
+    {
+        class Control;
+
+        struct IInputQuery
+        {
+            virtual ~IInputQuery() = 0;
+            virtual Control* focus_control() const = 0;
+        };
+    }
+}

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -30,6 +30,7 @@ namespace trview
             _token_store += _mouse.mouse_up += [&](auto) { process_mouse_up(); };
             _token_store += _mouse.mouse_wheel += [&](int16_t delta) { process_mouse_scroll(delta); };
             _token_store += _keyboard.on_key_down += [&](auto key) { process_key_down(key); };
+            _token_store += _keyboard.on_char += [&](auto key) { process_char(key); };
         }
 
         void Input::register_focus_controls(Control* control)
@@ -279,6 +280,32 @@ namespace trview
             // If none of the child elements have handled this event themselves, call the key_down
             // event of the control.
             return control->key_down(key);
+        }
+
+        void Input::process_char(uint16_t key)
+        {
+            if (_focus_control && _focus_control->key_char(key))
+            {
+                return;
+            }
+            process_char(&_control, key);
+        }
+
+        bool Input::process_char(Control* control, uint16_t key)
+        {
+            if (!control->visible())
+            {
+                return false;
+            }
+
+            for (auto& child : control->child_elements())
+            {
+                if (process_char(child, key))
+                {
+                    return true;
+                }
+            }
+            return control->key_char(key);
         }
 
         void Input::set_focus_control(Control* control)

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -16,10 +16,31 @@ namespace trview
         Input::Input(const trview::Window& window, Control& control)
             : _mouse(window), _window(window), _control(control)
         {
+            register_focus_controls(&_control);
+
             _token_store += _mouse.mouse_move += [&](auto, auto) { process_mouse_move(); };
             _token_store += _mouse.mouse_down += [&](input::Mouse::Button) { process_mouse_down(); };
             // _token_store += _mouse.mouse_up += [&](auto) { _control->process_mouse_up(client_cursor_position(window)); };
             // _token_store += _mouse.mouse_move += [&](auto, auto) { _control->process_mouse_move(client_cursor_position(window)); };
+        }
+
+        void Input::register_focus_controls(Control* control)
+        {
+            _token_store += control->on_focus_requested += [&]() { set_focus_control(control); };
+            _token_store += control->on_focus_clear_requested += [&]() { set_focus_control(nullptr); };
+            _token_store += control->on_hierarchy_changed += [&]() { register_focus_controls(control); };
+            _token_store += control->on_deleting += [&]() 
+            {
+                if (_focus_control == control)
+                {
+                    _focus_control = nullptr;
+                }
+            };
+
+            for (auto& child : control->child_elements())
+            {
+                register_focus_controls(control);
+            }
         }
 
         void Input::process_mouse_move()
@@ -142,7 +163,7 @@ namespace trview
 
         void Input::set_focus_control(Control* control)
         {
-            if (_focus_control)
+            if (_focus_control && _focus_control != control)
             {
                 _focus_control->clicked_off(control);
             }

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -1,0 +1,11 @@
+#include "Input.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        Input::Input(const trview::Window& window, Control& control)
+        {
+        }
+    }
+}

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -1,12 +1,105 @@
 #include "Input.h"
+#include "Control.h"
+#include <stack>
 
 namespace trview
 {
     namespace ui
     {
-        Input::Input(const trview::Window& window, Control& control)
-            : _mouse(window)
+        namespace
         {
+            bool in_bounds(const Point& position, const Size& size)
+            {
+                return position.x >= 0 && position.y >= 0 && position.x <= size.width && position.y <= size.height;
+            }
+        }
+
+        Input::Input(const trview::Window& window, Control& control)
+            : _mouse(window), _window(window), _control(control)
+        {
+            _token_store += _mouse.mouse_move += [&](auto, auto) { process_mouse_move(); };
+        }
+
+        void Input::process_mouse_move()
+        {
+            auto position = client_cursor_position(_window);
+
+            Control* control = hover_control_at_position(position);
+            if (control != _hover_control)
+            {
+                if (_hover_control)
+                {
+                    _hover_control->mouse_leave();
+                }
+                _hover_control = control;
+                if (_hover_control)
+                {
+                    _hover_control->mouse_enter();
+                }
+            }
+
+            // Now do movement.
+            if (_focus_control)
+            {
+                auto focus = _focus_control;
+                if (focus->move(position - focus->absolute_position()))
+                {
+                    return;
+                }
+            }
+
+            process_mouse_move(&_control, position - _control.position());
+        }
+
+        Control* Input::hover_control_at_position(const Point& position)
+        {
+            return hover_control_at_position(&_control, position);
+        }
+
+        Control* Input::hover_control_at_position(Control* control, const Point& position)
+        {
+            if (!control->visible() || !in_bounds(position, control->size()))
+            {
+                return nullptr;
+            }
+
+            for (const auto& child : control->child_elements())
+            {
+                auto result = hover_control_at_position(child, position - child->position());
+                if (result && result->_handles_hover)
+                {
+                    return result;
+                }
+            }
+
+            if (control->_handles_hover)
+            {
+                return control;
+            }
+
+            return nullptr;
+        }
+
+        bool Input::process_mouse_move(Control* control, const Point& position)
+        {
+            // Bounds check - before child elements are checked.
+            if (!control->visible() || !in_bounds(position, control->size()))
+            {
+                return false;
+            }
+
+            for (auto& child : control->child_elements())
+            {
+                // Convert the position into the coordinate space of the child element.
+                if (process_mouse_move(child, position - child->position()))
+                {
+                    return true;
+                }
+            }
+
+            // If none of the child elements have handled this event themselves, call the 
+            // move function of this control.
+            return control->move(position);
         }
     }
 }

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -19,6 +19,11 @@ namespace trview
             register_events();
         }
 
+        Control* Input::focus_control() const
+        {
+            return _focus_control;
+        }
+
         void Input::register_events()
         {
             _token_store = TokenStore();
@@ -35,6 +40,8 @@ namespace trview
 
         void Input::register_focus_controls(Control* control)
         {
+            control->set_input_query(this);
+
             _token_store += control->on_focus_requested += [this, control]() { set_focus_control(control); };
             _token_store += control->on_focus_clear_requested += [&]() { set_focus_control(nullptr); };
             _token_store += control->on_hierarchy_changed += [this]() 
@@ -124,13 +131,13 @@ namespace trview
             for (const auto& child : control->child_elements())
             {
                 auto result = hover_control_at_position(child, position - child->position());
-                if (result && result->_handles_hover)
+                if (result && result->handles_hover())
                 {
                     return result;
                 }
             }
 
-            if (control->_handles_hover)
+            if (control->handles_hover())
             {
                 return control;
             }
@@ -162,7 +169,7 @@ namespace trview
 
             // Promote controls to focus control, or clear if there are no controls that 
             // accepted the event.
-            bool handled_by_self = control->_handles_input && control->mouse_down(position);
+            bool handled_by_self = control->handles_input() && control->mouse_down(position);
             if (handled_by_self)
             {
                 set_focus_control(control);

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -45,6 +45,7 @@ namespace trview
                 {
                     _focus_control = nullptr;
                 }
+                register_events();
             };
 
             for (auto& child : control->child_elements())

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -5,6 +5,7 @@ namespace trview
     namespace ui
     {
         Input::Input(const trview::Window& window, Control& control)
+            : _mouse(window)
         {
         }
     }

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -26,7 +26,10 @@ namespace trview
             bool     process_mouse_down(Control* control, const Point& position);
             void     process_mouse_up();
             bool     process_mouse_up(Control* control, const Point& position);
-            
+            void     process_mouse_scroll(int16_t delta);
+            bool     process_mouse_scroll(Control* control, const Point& position, int16_t delta);
+
+
             void     set_focus_control(Control* control);
 
             TokenStore     _token_store;

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -44,7 +44,6 @@ namespace trview
             input::Mouse    _mouse;
             input::Keyboard _keyboard;
             trview::Window  _window;
-
             Control&       _control;
             Control*       _hover_control{ nullptr };
             Control*       _focus_control{ nullptr };

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -17,12 +17,12 @@ namespace trview
             explicit Input(const trview::Window& window, Control& control);
         private:
             void     process_mouse_move();
-
-            /// Find the control at the cursor position that has hover enabled.
+            bool     process_mouse_move(Control* control, const Point& position);
             Control* hover_control_at_position(const Point& position);
             Control* hover_control_at_position(Control* control, const Point& position);
-            bool     process_mouse_move(Control* control, const Point& position);
-
+            void     process_mouse_down();
+            bool     process_mouse_down(Control* control, const Point& position);
+            void     set_focus_control(Control* control);
 
             TokenStore     _token_store;
             input::Mouse   _mouse;

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -24,6 +24,9 @@ namespace trview
             Control* hover_control_at_position(Control* control, const Point& position);
             void     process_mouse_down();
             bool     process_mouse_down(Control* control, const Point& position);
+            void     process_mouse_up();
+            bool     process_mouse_up(Control* control, const Point& position);
+            
             void     set_focus_control(Control* control);
 
             TokenStore     _token_store;

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -31,6 +31,9 @@ namespace trview
             bool     process_mouse_scroll(Control* control, const Point& position, int16_t delta);
             void     process_key_down(uint16_t key);
             bool     process_key_down(Control* control, uint16_t key);
+            void     process_char(uint16_t key);
+            bool     process_char(Control* control, uint16_t key);
+
 
             void     set_focus_control(Control* control);
 

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -16,6 +16,7 @@ namespace trview
         public:
             explicit Input(const trview::Window& window, Control& control);
         private:
+            void     register_focus_controls(Control* control);
             void     process_mouse_move();
             bool     process_mouse_move(Control* control, const Point& position);
             Control* hover_control_at_position(const Point& position);

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -3,6 +3,7 @@
 #include <trview.common/Window.h>
 #include <trview.common/TokenStore.h>
 #include <trview.input/Mouse.h>
+#include <trview.input/Keyboard.h>
 
 namespace trview
 {
@@ -28,13 +29,15 @@ namespace trview
             bool     process_mouse_up(Control* control, const Point& position);
             void     process_mouse_scroll(int16_t delta);
             bool     process_mouse_scroll(Control* control, const Point& position, int16_t delta);
-
+            void     process_key_down(uint16_t key);
+            bool     process_key_down(Control* control, uint16_t key);
 
             void     set_focus_control(Control* control);
 
-            TokenStore     _token_store;
-            input::Mouse   _mouse;
-            trview::Window _window;
+            TokenStore      _token_store;
+            input::Mouse    _mouse;
+            input::Keyboard _keyboard;
+            trview::Window  _window;
 
             Control&       _control;
             Control*       _hover_control{ nullptr };

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <trview.common/Window.h>
+
+namespace trview
+{
+    namespace ui
+    {
+        class Control;
+
+        /// Manages the mouse and keyboard input state for a control tree.
+        class Input final
+        {
+        public:
+            explicit Input(const trview::Window& window, Control& control);
+        private:
+
+        };
+    }
+}

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <trview.common/Window.h>
+#include <trview.input/Mouse.h>
 
 namespace trview
 {
@@ -14,7 +15,7 @@ namespace trview
         public:
             explicit Input(const trview::Window& window, Control& control);
         private:
-
+            input::Mouse _mouse;
         };
     }
 }

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -16,6 +16,7 @@ namespace trview
         public:
             explicit Input(const trview::Window& window, Control& control);
         private:
+            void     register_events();
             void     register_focus_controls(Control* control);
             void     process_mouse_move();
             bool     process_mouse_move(Control* control, const Point& position);

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <trview.common/Window.h>
+#include <trview.common/TokenStore.h>
 #include <trview.input/Mouse.h>
 
 namespace trview
@@ -15,7 +16,21 @@ namespace trview
         public:
             explicit Input(const trview::Window& window, Control& control);
         private:
-            input::Mouse _mouse;
+            void     process_mouse_move();
+
+            /// Find the control at the cursor position that has hover enabled.
+            Control* hover_control_at_position(const Point& position);
+            Control* hover_control_at_position(Control* control, const Point& position);
+            bool     process_mouse_move(Control* control, const Point& position);
+
+
+            TokenStore     _token_store;
+            input::Mouse   _mouse;
+            trview::Window _window;
+
+            Control&       _control;
+            Control*       _hover_control{ nullptr };
+            Control*       _focus_control{ nullptr };
         };
     }
 }

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -4,6 +4,7 @@
 #include <trview.common/TokenStore.h>
 #include <trview.input/Mouse.h>
 #include <trview.input/Keyboard.h>
+#include "IInputQuery.h"
 
 namespace trview
 {
@@ -12,10 +13,12 @@ namespace trview
         class Control;
 
         /// Manages the mouse and keyboard input state for a control tree.
-        class Input final
+        class Input final : public IInputQuery
         {
         public:
             explicit Input(const trview::Window& window, Control& control);
+            virtual ~Input() = default;
+            virtual Control* focus_control() const;
         private:
             void     register_events();
             void     register_focus_controls(Control* control);

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -299,7 +299,7 @@ namespace trview
 
         void Listbox::select_item(const Item& item, bool raise_event)
         {
-            set_focus_control(this);
+            on_focus_requested();
             _selected_item = item;
             scroll_to_show(item);
             if (raise_event)

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -102,7 +102,7 @@ namespace trview
                 Event<Item> on_click;
 
                 void set_highlighted(bool value);
-            protected:
+
                 virtual void mouse_enter() override;
                 virtual void mouse_leave() override;
             private:

--- a/trview.ui/Scrollbar.cpp
+++ b/trview.ui/Scrollbar.cpp
@@ -36,7 +36,7 @@ namespace trview
 
         bool Scrollbar::move(Point position)
         {
-            if (focus_control() == this)
+            if (_input_query && _input_query->focus_control() == this)
             {
                 return clicked(position);
             }

--- a/trview.ui/Scrollbar.cpp
+++ b/trview.ui/Scrollbar.cpp
@@ -30,7 +30,7 @@ namespace trview
 
         bool Scrollbar::mouse_up(const Point&)
         {
-            set_focus_control(nullptr);
+            on_focus_clear_requested();
             return true;
         }
 

--- a/trview.ui/Scrollbar.h
+++ b/trview.ui/Scrollbar.h
@@ -31,7 +31,7 @@ namespace trview
 
             /// Event raised when the user has moved the blob in the scrollbar.
             Event<float> on_scroll;
-        protected:
+
             virtual bool mouse_down(const Point& position) override;
             virtual bool mouse_up(const Point& position) override;
             virtual bool move(Point position) override;

--- a/trview.ui/Slider.cpp
+++ b/trview.ui/Slider.cpp
@@ -44,7 +44,7 @@ namespace trview
 
         bool Slider::mouse_up(const Point&)
         {
-            set_focus_control(nullptr);
+            on_focus_clear_requested();
             return true;
         }
 

--- a/trview.ui/Slider.cpp
+++ b/trview.ui/Slider.cpp
@@ -56,7 +56,7 @@ namespace trview
 
         bool Slider::move(Point position)
         {
-            if (focus_control() == this)
+            if (_input_query && _input_query->focus_control() == this)
             {
                 set_blob_position(position);
                 return true;

--- a/trview.ui/Slider.h
+++ b/trview.ui/Slider.h
@@ -16,7 +16,6 @@ namespace trview
             Event<float> on_value_changed;
 
             void set_value(float value);
-        protected:
             virtual bool mouse_down(const Point& position) override;
             virtual bool mouse_up(const Point& position) override;
             virtual bool clicked(Point position) override;

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -43,7 +43,7 @@ namespace trview
 
             /// Event raised when the user has pressed the escape button.
             Event<> on_escape;
-        protected:
+
             virtual bool mouse_down(const Point& position) override;
             virtual bool key_down(uint16_t key) override;
             virtual bool key_char(wchar_t character) override;

--- a/trview.ui/trview.ui.vcxproj
+++ b/trview.ui/trview.ui.vcxproj
@@ -26,6 +26,7 @@
     <ClInclude Include="GroupBox.h" />
     <ClInclude Include="IFontMeasurer.h" />
     <ClInclude Include="Image.h" />
+    <ClInclude Include="Input.h" />
     <ClInclude Include="Label.h" />
     <ClInclude Include="Listbox.h" />
     <ClInclude Include="NumericUpDown.h" />
@@ -45,6 +46,7 @@
     <ClCompile Include="GroupBox.cpp" />
     <ClCompile Include="IFontMeasurer.cpp" />
     <ClCompile Include="Image.cpp" />
+    <ClCompile Include="Input.cpp" />
     <ClCompile Include="Label.cpp" />
     <ClCompile Include="Listbox.cpp" />
     <ClCompile Include="ListboxColumn.cpp" />

--- a/trview.ui/trview.ui.vcxproj
+++ b/trview.ui/trview.ui.vcxproj
@@ -25,6 +25,7 @@
     <ClInclude Include="Dropdown.h" />
     <ClInclude Include="GroupBox.h" />
     <ClInclude Include="IFontMeasurer.h" />
+    <ClInclude Include="IInputQuery.h" />
     <ClInclude Include="Image.h" />
     <ClInclude Include="Input.h" />
     <ClInclude Include="Label.h" />
@@ -45,6 +46,7 @@
     <ClCompile Include="Dropdown.cpp" />
     <ClCompile Include="GroupBox.cpp" />
     <ClCompile Include="IFontMeasurer.cpp" />
+    <ClCompile Include="IInputQuery.cpp" />
     <ClCompile Include="Image.cpp" />
     <ClCompile Include="Input.cpp" />
     <ClCompile Include="Label.cpp" />

--- a/trview.ui/trview.ui.vcxproj.filters
+++ b/trview.ui/trview.ui.vcxproj.filters
@@ -58,6 +58,9 @@
     <ClInclude Include="Input.h">
       <Filter>Input</Filter>
     </ClInclude>
+    <ClInclude Include="IInputQuery.h">
+      <Filter>Input</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Control.cpp">
@@ -115,6 +118,9 @@
       <Filter>Controls\Label</Filter>
     </ClCompile>
     <ClCompile Include="Input.cpp">
+      <Filter>Input</Filter>
+    </ClCompile>
+    <ClCompile Include="IInputQuery.cpp">
       <Filter>Input</Filter>
     </ClCompile>
   </ItemGroup>

--- a/trview.ui/trview.ui.vcxproj.filters
+++ b/trview.ui/trview.ui.vcxproj.filters
@@ -55,6 +55,9 @@
     <ClInclude Include="IFontMeasurer.h">
       <Filter>Controls\Label</Filter>
     </ClInclude>
+    <ClInclude Include="Input.h">
+      <Filter>Input</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Control.cpp">
@@ -111,6 +114,9 @@
     <ClCompile Include="IFontMeasurer.cpp">
       <Filter>Controls\Label</Filter>
     </ClCompile>
+    <ClCompile Include="Input.cpp">
+      <Filter>Input</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Types">
@@ -133,6 +139,9 @@
     </Filter>
     <Filter Include="Controls\Label">
       <UniqueIdentifier>{4a8f2bab-af56-45f4-acfd-cacd829e7763}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Input">
+      <UniqueIdentifier>{4ae4639a-c45d-428e-9104-b6604caaa0cf}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Move the mouse and keyboard handling out of the control structure and into its own class.
This means that there is less crazy traversing and the control class can just focus on doing actual work.
It should also make controls easier to test.
Issue: #24 