### PR TITLE
Add portal information to the minimap

### DIFF
--- a/trview.app/UI/Tooltip.cpp
+++ b/trview.app/UI/Tooltip.cpp
@@ -1,0 +1,47 @@
+#include "Tooltip.h"
+#include <trview.ui/StackPanel.h>
+#include <trview.ui/Label.h>
+
+using namespace trview::ui;
+
+namespace trview
+{
+    Tooltip::Tooltip(ui::Control& control)
+    {
+        auto container = std::make_unique<StackPanel>(Point(), Size(), Colour(0.5f, 0.0f, 0.0f, 0.0f));
+        container->set_margin(Size(5, 5));
+        container->set_visible(false);
+        container->set_handles_input(false);
+
+        auto label = std::make_unique<ui::Label>(Point(500, 0), Size(38, 30), Colour::Transparent, L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre, SizeMode::Auto);
+        label->set_handles_input(false);
+
+        _label = container->add_child(std::move(label));
+        _container = control.add_child(std::move(container));
+    }
+
+    void Tooltip::set_position(const Point& position)
+    {
+        _container->set_position(Point(position.x - _container->size().width, position.y - _container->size().height));
+    }
+
+    void Tooltip::set_text(const std::wstring& text)
+    {
+        _label->set_text(text);
+    }
+
+    void Tooltip::set_text_colour(const Colour& colour)
+    {
+        _label->set_text_colour(colour);
+    }
+
+    void Tooltip::set_visible(bool value)
+    {
+        _container->set_visible(value);
+    }
+
+    bool Tooltip::visible() const
+    {
+        return _container->visible();
+    }
+}

--- a/trview.app/UI/Tooltip.h
+++ b/trview.app/UI/Tooltip.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <string>
+#include <trview.common/Point.h>
+#include <trview.common/Colour.h>
+
+namespace trview
+{
+    namespace ui
+    {
+        class StackPanel;
+        class Label;
+        class Control;
+    }
+
+    /// Shows text in a floating control.
+    class Tooltip final
+    {
+    public:
+        /// Create a new tooltip.
+        /// @param control The parent control.
+        explicit Tooltip(ui::Control& control);
+
+        /// Set the position of the tooltip. The tooltip will be offset so as not to cover the subject.
+        /// @param position The new location of the tooltip.
+        void set_position(const Point& position);
+
+        /// Set the tooltip text.
+        /// @param text The text to show.
+        void set_text(const std::wstring& text);
+
+        /// Set the colour of the text.
+        /// @param colour The text colour.
+        void set_text_colour(const Colour& colour);
+
+        /// Set whether the tooltip is visible.
+        /// @param value Whether the tooltip is visible.
+        void set_visible(bool value);
+
+        /// Gets whether the tooltip is visible.
+        bool visible() const;
+    private:
+        ui::StackPanel* _container;
+        ui::Label* _label;
+    };
+}

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -20,10 +20,9 @@ namespace trview
 
         _token_store += _mouse.mouse_move += [&](long, long)
         {
-            if (_map_tooltip_container && _map_tooltip_container->visible())
+            if (_map_tooltip && _map_tooltip->visible())
             {
-                auto pos = client_cursor_position(_window);
-                _map_tooltip_container->set_position(Point(pos.x - _map_tooltip_container->size().width, pos.y - _map_tooltip_container->size().height));
+                _map_tooltip->set_position(client_cursor_position(_window));
             }
         };
 
@@ -85,17 +84,8 @@ namespace trview
             }
         };
 
-        auto picking = std::make_unique<ui::Label>(Point(500, 0), Size(38, 30), Colour(0.5f, 0.0f, 0.0f, 0.0f), L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
-        picking->set_visible(false);
-        picking->set_handles_input(false);
-        _tooltip = _control->add_child(std::move(picking));
-
-        auto map_tooltip_container = std::make_unique<StackPanel>(Point(), Size(), Colour(0.5f, 0.0f, 0.0f, 0.0f));
-        map_tooltip_container->set_margin(Size(5, 5));
-        auto map_tooltip = std::make_unique<ui::Label>(Point(500, 0), Size(38, 30), Colour::Transparent, L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre, SizeMode::Auto);
-        map_tooltip->set_handles_input(false);
-        _map_tooltip = map_tooltip_container->add_child(std::move(map_tooltip));
-        _map_tooltip_container = _control->add_child(std::move(map_tooltip_container));
+        _tooltip = std::make_unique<Tooltip>(*_control);
+        _map_tooltip = std::make_unique<Tooltip>(*_control);
 
         auto measure = std::make_unique<ui::Label>(Point(300, 100), Size(50, 30), Colour(1.0f, 0.2f, 0.2f, 0.2f), L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
         measure->set_visible(false);
@@ -153,7 +143,7 @@ namespace trview
 
             if (!sector)
             {
-                _map_tooltip_container->set_visible(false);
+                _map_tooltip->set_visible(false);
                 return;
             }
 
@@ -168,9 +158,8 @@ namespace trview
                     std::wstring(L"Below: ") + std::to_wstring(sector->room_below());
             }
             _map_tooltip->set_text(text);
-            auto pos = client_cursor_position(_window);
-            _map_tooltip_container->set_position(Point(pos.x - _map_tooltip_container->size().width, pos.y - _map_tooltip_container->size().height));
-            _map_tooltip_container->set_visible(!text.empty());
+            _map_tooltip->set_position(client_cursor_position(_window));
+            _map_tooltip->set_visible(!text.empty());
         };
 
         _camera_position = std::make_unique<CameraPosition>(*_control);
@@ -340,11 +329,9 @@ namespace trview
         _tooltip->set_visible(result.hit && _show_tooltip);
         if (result.hit)
         {
-            _map_tooltip_container->set_visible(false);
-
-            auto screen_pos = info.screen_position;
-            _tooltip->set_position(Point(screen_pos.x - _tooltip->size().width, screen_pos.y - _tooltip->size().height));
+            _map_tooltip->set_visible(false);
             _tooltip->set_text(pick_to_string(result));
+            _tooltip->set_position(info.screen_position);
             _tooltip->set_text_colour(pick_to_colour(result));
         }
     }
@@ -400,7 +387,7 @@ namespace trview
     {
         _show_tooltip = value;
         _tooltip->set_visible(_tooltip->visible() && _show_tooltip);
-        _map_tooltip_container->set_visible(_map_tooltip_container->visible() && _show_tooltip);
+        _map_tooltip->set_visible(_map_tooltip->visible() && _show_tooltip);
     }
 
     void ViewerUI::set_show_triggers(bool value)

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -223,10 +223,8 @@ namespace trview
 
     void ViewerUI::render(const graphics::Device& device)
     {
-        Point point = client_cursor_position(_window);
-        _map_renderer->set_cursor_position(point);
+        _map_renderer->set_cursor_position(client_cursor_position(_window));
         _map_renderer->render(device.context());
-
         _ui_renderer->render(device.context());
     }
 

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -85,14 +85,14 @@ namespace trview
             }
         };
 
-        auto picking = std::make_unique<ui::Label>(Point(500, 0), Size(38, 30), Colour(0.2f, 0.2f, 0.2f), L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
+        auto picking = std::make_unique<ui::Label>(Point(500, 0), Size(38, 30), Colour(0.5f, 0.0f, 0.0f, 0.0f), L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
         picking->set_visible(false);
         picking->set_handles_input(false);
         _tooltip = _control->add_child(std::move(picking));
 
-        auto map_tooltip_container = std::make_unique<StackPanel>(Point(), Size(), Colour(0.2f, 0.2f, 0.2f));
+        auto map_tooltip_container = std::make_unique<StackPanel>(Point(), Size(), Colour(0.5f, 0.0f, 0.0f, 0.0f));
         map_tooltip_container->set_margin(Size(5, 5));
-        auto map_tooltip = std::make_unique<ui::Label>(Point(500, 0), Size(38, 30), Colour(0.2f, 0.2f, 0.2f), L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre, SizeMode::Auto);
+        auto map_tooltip = std::make_unique<ui::Label>(Point(500, 0), Size(38, 30), Colour::Transparent, L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre, SizeMode::Auto);
         map_tooltip->set_handles_input(false);
         _map_tooltip = map_tooltip_container->add_child(std::move(map_tooltip));
         _map_tooltip_container = _control->add_child(std::move(map_tooltip_container));

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -130,7 +130,7 @@ namespace trview
         _ui_renderer = std::make_unique<ui::render::Renderer>(device, shader_storage, font_factory, window.size());
         _ui_renderer->load(_control.get());
 
-        _map_renderer = std::make_unique<ui::render::MapRenderer>(device, shader_storage, window.size());
+        _map_renderer = std::make_unique<ui::render::MapRenderer>(device, shader_storage, font_factory, window.size());
         _map_renderer->on_sector_hover += on_sector_hover;
 
         _camera_position = std::make_unique<CameraPosition>(*_control);
@@ -260,6 +260,7 @@ namespace trview
     {
         _control->set_size(size);
         _ui_renderer->set_host_size(size);
+        _map_renderer->set_window_size(size);
     }
 
     void ViewerUI::set_level(const std::string& name, trlevel::LevelVersion version)

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -282,6 +282,8 @@ namespace trview
         std::unique_ptr<CameraPosition> _camera_position;
         std::unique_ptr<ui::render::MapRenderer> _map_renderer;
         ui::Label* _tooltip;
+        ui::StackPanel* _map_tooltip_container;
+        ui::Label* _map_tooltip;
         ui::Label* _measure;
         bool _show_tooltip{ true };
     };

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -22,6 +22,7 @@
 #include <trview.app/Geometry/PickResult.h>
 #include <trview.app/UI/ContextMenu.h>
 #include <trview.app/Settings/UserSettings.h>
+#include <trview.app/UI/Tooltip.h>
 
 namespace trview
 {
@@ -281,9 +282,8 @@ namespace trview
         std::unique_ptr<CameraControls> _camera_controls;
         std::unique_ptr<CameraPosition> _camera_position;
         std::unique_ptr<ui::render::MapRenderer> _map_renderer;
-        ui::Label* _tooltip;
-        ui::StackPanel* _map_tooltip_container;
-        ui::Label* _map_tooltip;
+        std::unique_ptr<Tooltip> _map_tooltip;
+        std::unique_ptr<Tooltip> _tooltip;
         ui::Label* _measure;
         bool _show_tooltip{ true };
     };

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -58,6 +58,7 @@
     <ClCompile Include="UI\Neighbours.cpp" />
     <ClCompile Include="UI\RoomNavigator.cpp" />
     <ClCompile Include="UI\SettingsWindow.cpp" />
+    <ClCompile Include="UI\Tooltip.cpp" />
     <ClCompile Include="UI\ViewerUI.cpp" />
     <ClCompile Include="Windows\CollapsiblePanel.cpp" />
     <ClCompile Include="Windows\ItemsWindow.cpp" />
@@ -113,6 +114,7 @@
     <ClInclude Include="UI\Neighbours.h" />
     <ClInclude Include="UI\RoomNavigator.h" />
     <ClInclude Include="UI\SettingsWindow.h" />
+    <ClInclude Include="UI\Tooltip.h" />
     <ClInclude Include="UI\ViewerUI.h" />
     <ClInclude Include="Windows\CollapsiblePanel.h" />
     <ClInclude Include="Windows\ItemsWindow.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -145,6 +145,9 @@
     <ClCompile Include="Menus\AlternateGroupToggler.cpp">
       <Filter>Menus</Filter>
     </ClCompile>
+    <ClCompile Include="UI\Tooltip.cpp">
+      <Filter>UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -308,6 +311,9 @@
     </ClInclude>
     <ClInclude Include="Menus\AlternateGroupToggler.h">
       <Filter>Menus</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Tooltip.h">
+      <Filter>UI</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/trview.common/Colour.cpp
+++ b/trview.common/Colour.cpp
@@ -13,6 +13,11 @@ namespace trview
     {
     }
 
+    Colour::Colour(const DirectX::SimpleMath::Color& color)
+        : Colour(color.A(), color.R(), color.G(), color.B())
+    {
+    }
+
     Colour::Colour(float r, float g, float b)
         : Colour(1.0f, r, g, b)
     {

--- a/trview.common/Colour.h
+++ b/trview.common/Colour.h
@@ -8,6 +8,8 @@ namespace trview
     {
         Colour();
 
+        Colour(const DirectX::SimpleMath::Color& colour);
+
         /// Create a colour with the specified rgb components and a fully opaque alpha value.
         /// @param r The red value from 0 to 1.
         /// @param g The green value from 0 to 1.

--- a/trview.common/Colour.h
+++ b/trview.common/Colour.h
@@ -8,6 +8,7 @@ namespace trview
     {
         Colour();
 
+        /// Create a colour from a DirectX::SimpleMath::Color.
         Colour(const DirectX::SimpleMath::Color& colour);
 
         /// Create a colour with the specified rgb components and a fully opaque alpha value.

--- a/trview.graphics/Font.cpp
+++ b/trview.graphics/Font.cpp
@@ -37,6 +37,11 @@ namespace trview
 
         void Font::render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, const std::wstring& text, float width, float height, const Colour& colour)
         {
+            render(context, text, 0, 0, width, height, colour);
+        }
+
+        void Font::render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, const std::wstring& text, float x, float y, float width, float height, const Colour& colour)
+        {
             if (!_batch)
             {
                 _batch = std::make_unique<SpriteBatch>(context.Get());
@@ -48,17 +53,15 @@ namespace trview
 
             // Calculate the position at which to render the text based on the alignment settings.
             const auto size = measure(text);
-            float x = 0;
-            float y = 0;
 
             if (_text_alignment == TextAlignment::Centre)
             {
-                x = width * 0.5f - size.width * 0.5f;
+                x += width * 0.5f - size.width * 0.5f;
             }
 
             if (_paragraph_alignment == ParagraphAlignment::Centre)
             {
-                y = height * 0.5f - size.height * 0.5f;
+                y += height * 0.5f - size.height * 0.5f;
             }
 
             _batch->Begin(SpriteSortMode_Deferred, blend_state.Get());

--- a/trview.graphics/Font.h
+++ b/trview.graphics/Font.h
@@ -41,6 +41,15 @@ namespace trview
             /// @param colour The colour to render the text.
             void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, const std::wstring& text, float width, float height, const Colour& colour);
 
+            /// Renders the text to the specified font texture.
+            /// @param text The text to render on to the font texture.
+            /// @param x The x position to render the text.
+            /// @param y The y position to render the text.
+            /// @param width The optional width of the rectangle in which to render text.
+            /// @param height The optional height of the rectangle in which to render text.
+            /// @param colour The colour to render the text.
+            void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, const std::wstring& text, float x, float y, float width, float height, const Colour& colour);
+
             /// Determines the size in pixels that the text specified will be when rendered.
             /// @param text The text to measure.
             /// @returns The size in pixels required to render the specified text.

--- a/trview.ui.render/MapRenderer.cpp
+++ b/trview.ui.render/MapRenderer.cpp
@@ -168,6 +168,7 @@ namespace trview
                 });
 
                 _previous_sector.reset();
+                on_sector_hover(nullptr);
             }
 
             Point MapRenderer::get_position(const Sector& sector)

--- a/trview.ui.render/MapRenderer.cpp
+++ b/trview.ui.render/MapRenderer.cpp
@@ -2,6 +2,7 @@
 #include <trview.graphics/RenderTargetStore.h>
 #include <trview.graphics/ViewportStore.h>
 #include <trview.graphics/SpriteSizeStore.h>
+#include <trview.common/Colour.h>
 
 using namespace DirectX::SimpleMath;
 using namespace Microsoft::WRL;
@@ -29,11 +30,12 @@ namespace trview
 
         namespace render
         {
-            MapRenderer::MapRenderer(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const Size& window_size)
+            MapRenderer::MapRenderer(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const Size& window_size)
                 : _device(device),
-                _window_width(static_cast<int>(window_size.width)), 
+                _window_width(static_cast<int>(window_size.width)),
                 _window_height(static_cast<int>(window_size.height)),
-                _sprite(device, shader_storage, window_size)
+                _sprite(device, shader_storage, window_size),
+                _font(font_factory.create_font("Arial", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre))
             {
                 TextureStorage texture_storage{ device };
                 _texture = texture_storage.coloured(0xFFFFFFFF);
@@ -79,6 +81,7 @@ namespace trview
                     // To determine the base colour we order the floor functions by the *minimum* enabled flag (ranked by order asc)
                     int minimum_flag_enabled = -1;
                     Color draw_color = Color(0.0f, 0.7f, 0.7f); // fallback 
+                    Color text_color = Colour::White;
 
                     if (!(tile.sector->flags & SectorFlag::Portal) && (tile.sector->flags & SectorFlag::Wall && tile.sector->flags & SectorFlag::FloorSlant)) // is it no-space?
                     {
@@ -106,6 +109,7 @@ namespace trview
                          _selected_sector.value().second == tile.sector->z()))
                     {
                         draw_color.Negate();
+                        text_color.Negate();
                     }
 
                     // Draw the base tile 
@@ -131,6 +135,11 @@ namespace trview
                     // If sector is an up portal, draw a small corner square in the top left to signify this 
                     if (tile.sector->flags & SectorFlag::RoomAbove)
                         draw(context, tile.position, Size(tile.size.width / 4, tile.size.height / 4), Color(0.0f, 0.0f, 0.0f));
+
+                    if (tile.sector->flags & SectorFlag::Portal)
+                    {
+                        _font->render(context, std::to_wstring(tile.sector->portal()), tile.position.x - 1, tile.position.y, tile.size.width, tile.size.height, text_color);
+                    }
                 });
             }
 

--- a/trview.ui.render/MapRenderer.cpp
+++ b/trview.ui.render/MapRenderer.cpp
@@ -166,6 +166,8 @@ namespace trview
                 std::for_each(sectors.begin(), sectors.end(), [&] (const auto& pair) {
                     _tiles.emplace_back(std::shared_ptr<Sector>(pair.second), get_position(*pair.second), get_size());
                 });
+
+                _previous_sector.reset();
             }
 
             Point MapRenderer::get_position(const Sector& sector)
@@ -211,13 +213,13 @@ namespace trview
 
             void MapRenderer::set_cursor_position(const Point& cursor)
             {
-                auto previous_sector = sector_at_cursor();
                 _cursor = cursor - _first;
 
                 auto sector = sector_at_cursor();
-                if(sector != previous_sector)
+                if(sector != _previous_sector)
                 {
                     on_sector_hover(sector);
+                    _previous_sector = sector;
                 }
             }
 

--- a/trview.ui.render/MapRenderer.h
+++ b/trview.ui.render/MapRenderer.h
@@ -18,6 +18,8 @@
 #include "trview\Room.h"
 #include <trview.graphics/RenderTarget.h>
 #include <trview.common/Event.h>
+#include <trview.graphics/FontFactory.h>
+#include <trview.graphics/Font.h>
 
 namespace trview
 {
@@ -47,7 +49,7 @@ namespace trview
             class MapRenderer
             {
             public:
-                MapRenderer(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const Size& window_size);
+                MapRenderer(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const Size& window_size);
 
                 // Renders the map 
                 void render(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context);
@@ -125,9 +127,10 @@ namespace trview
                 bool                                _force_redraw = true;
 
                 const float                         _DRAW_MARGIN = 30.0f; 
-                const float                         _DRAW_SCALE = 14.0f; 
+                const float                         _DRAW_SCALE = 20.0f; 
 
                 std::optional<std::pair<uint16_t, uint16_t>> _selected_sector;
+                std::unique_ptr<graphics::Font> _font;
             };
         }
     }

--- a/trview.ui.render/MapRenderer.h
+++ b/trview.ui.render/MapRenderer.h
@@ -131,6 +131,7 @@ namespace trview
 
                 std::optional<std::pair<uint16_t, uint16_t>> _selected_sector;
                 std::unique_ptr<graphics::Font> _font;
+                std::shared_ptr<Sector> _previous_sector;
             };
         }
     }


### PR DESCRIPTION
Show the room number that a portal leads to.
Also add a tooltip to show the room above and below when you hover over a minimap sector.
Create a tooltip class and use that for the original tooltip and the minimap tooltip.
Issue: #511 

Fixes bug where minimap renderer was not being notified of window resizing.
Bug: #512 