### PR TITLE
Remove call to register_events on control deletion

### DIFF
--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -54,7 +54,6 @@ namespace trview
                 {
                     _focus_control = nullptr;
                 }
-                register_events();
             };
 
             for (auto& child : control->child_elements())


### PR DESCRIPTION
Not required - it is called by hierarchy change (when the control is deleted and actually removed from the control list).
Bug: #515