### PR TITLE
Use room water flag for force water colour

### DIFF
--- a/trview/Level.cpp
+++ b/trview/Level.cpp
@@ -204,10 +204,10 @@ namespace trview
             if (!is_alternate_mismatch(room.room) && room.room.alternate_mode() == Room::AlternateMode::IsAlternate)
             {
                 auto& original_room = _rooms[room.room.alternate_room()];
-                original_room->render_contained(device, camera, *_texture_storage.get(), room.selection_mode, _show_water, _show_water);
+                original_room->render_contained(device, camera, *_texture_storage.get(), room.selection_mode, room.room.water(), _show_water);
                 if (_regenerate_transparency)
                 {
-                    original_room->get_contained_transparent_triangles(*_transparency, camera, room.selection_mode, _show_water, _show_water);
+                    original_room->get_contained_transparent_triangles(*_transparency, camera, room.selection_mode, room.room.water(), _show_water);
                 }
             }
         }

--- a/trview/Room.cpp
+++ b/trview/Room.cpp
@@ -663,4 +663,9 @@ namespace trview
             BoundingBox::CreateMerged(_bounding_box, _bounding_box, entity->bounding_box());
         }
     }
+
+    bool Room::water() const
+    {
+        return _water;
+    }
 }

--- a/trview/Room.h
+++ b/trview/Room.h
@@ -140,6 +140,9 @@ namespace trview
 
         uint32_t number() const;
         void update_bounding_box();
+
+        /// Gets whether this room is a water room.
+        bool water() const;
     private:
         void generate_geometry(trlevel::LevelVersion level_version, const graphics::Device& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage);
         void generate_adjacency();


### PR DESCRIPTION
When rendering items that are in the alternate room of the current room, use the water flag of the current room for the force water flag.
It was previously just passing whether water rendering was enabled.
Bug: #522