### PR TITLE
Don't set camera to orbit on flip

### DIFF
--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -699,11 +699,12 @@ namespace trview
             _level->set_selected_room(static_cast<uint16_t>(room));
             _ui->set_selected_room(_level->room(_level->selected_room()));
 
-            if (_settings.auto_orbit)
+            if (_settings.auto_orbit && !_was_alternate_select)
             {
                 set_camera_mode(CameraMode::Orbit);
             }
 
+            _was_alternate_select = false;
             _target = _level->room(_level->selected_room())->centre();
 
             _items_windows->set_room(room);
@@ -760,6 +761,7 @@ namespace trview
     {
         if (_level)
         {
+            _was_alternate_select = true;
             _level->set_alternate_mode(enabled);
             _ui->set_flip(enabled);
         }
@@ -769,6 +771,7 @@ namespace trview
     {
         if (_level)
         {
+            _was_alternate_select = true;
             _level->set_alternate_group(group, enabled);
             _ui->set_alternate_group(group, enabled);
         }

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -151,6 +151,9 @@ namespace trview
         std::unique_ptr<Route> _route;
         std::unique_ptr<RouteWindowManager> _route_window_manager;
         bool _show_route{ true };
+
+        /// Was the room just changed due to an alternate group or flip being performed?
+        bool _was_alternate_select{ false };
     };
 }
 


### PR DESCRIPTION
If the room was selected due to alternate flip or alternate group change, don't set the camera to orbit mode. This stops the user being broken out of free view and stops the camera being reset when it shouldn't logically be reset.
Bug: #525