### PR TITLE
Regenerate UI nodes on render and cache blank texture in transparency

### DIFF
--- a/trview.app/Geometry/TransparencyBuffer.cpp
+++ b/trview.app/Geometry/TransparencyBuffer.cpp
@@ -13,7 +13,7 @@ using namespace DirectX::SimpleMath;
 namespace trview
 {
     TransparencyBuffer::TransparencyBuffer(const graphics::Device& device)
-        : _device(device)
+        : _device(device), _untextured(create_texture(device, Colour::White))
     {
         create_matrix_buffer();
 
@@ -110,8 +110,6 @@ namespace trview
         TransparentTriangle::Mode previous_mode = TransparentTriangle::Mode::Normal;
 
         // Untextured texture for transparent triangles that don't use the texture storage indexes.
-        auto untextured = texture_storage.coloured(0xffffffff);
-
         for (const auto& run : _texture_run)
         {
             if (run.mode != previous_mode && !ignore_blend)
@@ -120,7 +118,7 @@ namespace trview
             }
             previous_mode = run.mode;
 
-            auto texture = run.texture == TransparentTriangle::Untextured ? untextured : texture_storage.texture(run.texture);
+            auto texture = run.texture == TransparentTriangle::Untextured ? _untextured : texture_storage.texture(run.texture);
             context->PSSetShaderResources(0, 1, texture.view().GetAddressOf());
             context->Draw(run.count * 3, sum);
             sum += run.count * 3;

--- a/trview.app/Geometry/TransparencyBuffer.cpp
+++ b/trview.app/Geometry/TransparencyBuffer.cpp
@@ -109,7 +109,6 @@ namespace trview
         uint32_t sum = 0;
         TransparentTriangle::Mode previous_mode = TransparentTriangle::Mode::Normal;
 
-        // Untextured texture for transparent triangles that don't use the texture storage indexes.
         for (const auto& run : _texture_run)
         {
             if (run.mode != previous_mode && !ignore_blend)

--- a/trview.app/Geometry/TransparencyBuffer.h
+++ b/trview.app/Geometry/TransparencyBuffer.h
@@ -7,6 +7,7 @@
 #include <trview.app/Geometry/MeshVertex.h>
 #include <trview.app/Geometry/TransparentTriangle.h>
 #include <trview.graphics/Device.h>
+#include <trview.graphics/Texture.h>
 
 namespace trview
 {
@@ -65,5 +66,6 @@ namespace trview
         };
 
         std::vector<TextureRun> _texture_run;
+        graphics::Texture _untextured;
     };
 }

--- a/trview.common/Colour.cpp
+++ b/trview.common/Colour.cpp
@@ -33,6 +33,14 @@ namespace trview
         return DirectX::SimpleMath::Color(r, g, b, a);
     }
 
+    Colour::operator uint32_t() const
+    {
+        return static_cast<uint32_t>(a * 255.0f) << 24 |
+               static_cast<uint32_t>(r * 255.0f) << 16 |
+               static_cast<uint32_t>(g * 255.0f) << 8 |
+               static_cast<uint32_t>(b * 255.0f);
+    }
+
     Colour& Colour::operator += (const Colour& other)
     {
         a += other.a;

--- a/trview.common/Colour.h
+++ b/trview.common/Colour.h
@@ -21,6 +21,9 @@ namespace trview
 
         operator DirectX::SimpleMath::Color() const;
 
+        /// Convert the colour into a packed argb integer format.
+        operator uint32_t() const;
+
         Colour& operator += (const Colour& other);
 
         float a, r, g, b;

--- a/trview.graphics/Texture.cpp
+++ b/trview.graphics/Texture.cpp
@@ -93,5 +93,15 @@ namespace trview
         {
             return _view;
         }
+
+        Texture create_texture(const graphics::Device& device, uint32_t width, uint32_t height, const Colour& colour)
+        {
+            return Texture(device, width, height, std::vector<uint32_t>(width * height, colour));
+        }
+
+        Texture create_texture(const graphics::Device& device, const Colour& colour)
+        {
+            return create_texture(device, 1, 1, colour);
+        }
     }
 }

--- a/trview.graphics/Texture.h
+++ b/trview.graphics/Texture.h
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <vector>
 #include <trview.graphics/Device.h>
+#include <trview.common/Colour.h>
 
 namespace trview
 {
@@ -86,5 +87,17 @@ namespace trview
             /// with the Bind::DepthStencil bind mode.
             Microsoft::WRL::ComPtr<ID3D11ShaderResourceView> _view;
         };
+
+        /// Create a texture of the specified size filled with the specified colour.
+        /// @param device The device to use.
+        /// @param width The width of the texture.
+        /// @param height The height of the texture.
+        /// @param colour The colour to fill the texture.
+        Texture create_texture(const graphics::Device& device, uint32_t width, uint32_t height, const Colour& colour);
+
+        /// Create a 1x1 texture filled with the specified colour.
+        /// @param device The device to use.
+        /// @param colour The colour to fill the texture.
+        Texture create_texture(const graphics::Device& device, const Colour& colour);
     }
 }

--- a/trview.ui.render/MapRenderer.cpp
+++ b/trview.ui.render/MapRenderer.cpp
@@ -35,11 +35,9 @@ namespace trview
                 _window_width(static_cast<int>(window_size.width)),
                 _window_height(static_cast<int>(window_size.height)),
                 _sprite(device, shader_storage, window_size),
-                _font(font_factory.create_font("Arial", 7, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre))
+                _font(font_factory.create_font("Arial", 7, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre)),
+                _texture(create_texture(device, Colour::White))
             {
-                TextureStorage texture_storage{ device };
-                _texture = texture_storage.coloured(0xFFFFFFFF);
-
                 D3D11_DEPTH_STENCIL_DESC ui_depth_stencil_desc;
                 memset(&ui_depth_stencil_desc, 0, sizeof(ui_depth_stencil_desc));
                 device.device()->CreateDepthStencilState(&ui_depth_stencil_desc, &_depth_stencil_state);

--- a/trview.ui.render/MapRenderer.h
+++ b/trview.ui.render/MapRenderer.h
@@ -11,7 +11,6 @@
 
 #include <trview.graphics/Sprite.h>
 #include <trview.app/Elements/Types.h>
-#include "trview\TextureStorage.h"
 #include <trview.graphics/Texture.h>
 #include <trview.common/Point.h>
 #include <trview.common/Size.h>

--- a/trview.ui.render/RenderNode.cpp
+++ b/trview.ui.render/RenderNode.cpp
@@ -86,10 +86,20 @@ namespace trview
                 _needs_redraw = true;
             }
 
+            Control* RenderNode::control() const
+            {
+                return _control;
+            }
+
             void RenderNode::clear_children()
             {
                 _child_nodes.clear();
                 _needs_redraw = true;
+            }
+
+            bool RenderNode::heirarchy_changed() const
+            {
+                return _hierarchy_changed;
             }
 
             Point RenderNode::position() const
@@ -112,6 +122,11 @@ namespace trview
                 auto size = _control->size();
                 size = Size(size.width == 0 ? 1 : size.width, size.height == 0 ? 1 : size.height);
                 _render_target = std::make_unique<graphics::RenderTarget>(_device, static_cast<uint32_t>(size.width), static_cast<uint32_t>(size.height));
+            }
+
+            void RenderNode::set_hierarchy_changed(bool value)
+            {
+                _hierarchy_changed = value;
             }
 
             // Determines if the control itself needs to redraw.

--- a/trview.ui.render/RenderNode.h
+++ b/trview.ui.render/RenderNode.h
@@ -45,9 +45,15 @@ namespace trview
 
                 void add_child(std::unique_ptr<RenderNode>&& child);
 
+                Control* control() const;
+
                 void clear_children();
 
+                bool heirarchy_changed() const;
+
                 Point position() const;
+
+                void set_hierarchy_changed(bool value);
 
                 Size size() const;
 
@@ -73,6 +79,7 @@ namespace trview
                 std::vector<std::unique_ptr<RenderNode>> _child_nodes;
                 Control*                                 _control;
                 bool                                     _needs_redraw{ true };
+                bool                                     _hierarchy_changed{ false };
             };
         }
     }

--- a/trview.ui.render/Renderer.h
+++ b/trview.ui.render/Renderer.h
@@ -43,6 +43,10 @@ namespace trview
             private:
                 std::unique_ptr<RenderNode> process_control(Control* control);
 
+                /// Go through the hierarchy and regenerate any nodes that need to be updated.
+                /// @param node The node to process.
+                void update_hierarchy(RenderNode& node);
+
                 std::unique_ptr<RenderNode>                     _root_node;
                 std::unique_ptr<graphics::Sprite>               _sprite;
                 const graphics::Device&                         _device;
@@ -50,6 +54,7 @@ namespace trview
                 const graphics::FontFactory&                    _font_factory;
                 Size                                            _host_size;
                 TokenStore                                      _token_store;
+                bool                                            _hierarchy_changed{ false };
             };
         }
     }

--- a/trview.ui.tests/trview.ui.tests.vcxproj
+++ b/trview.ui.tests/trview.ui.tests.vcxproj
@@ -164,6 +164,9 @@
     <ClCompile Include="CheckboxTests.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\trview.graphics\trview.graphics.vcxproj">
+      <Project>{3270fd29-edab-40be-8ca1-dabc5e261e4c}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\trview.ui\trview.ui.vcxproj">
       <Project>{160bd1c8-42c1-46e6-a232-b980b9b6d57e}</Project>
     </ProjectReference>

--- a/trview.ui.tests/trview.ui.tests.vcxproj
+++ b/trview.ui.tests/trview.ui.tests.vcxproj
@@ -164,9 +164,6 @@
     <ClCompile Include="CheckboxTests.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\trview.graphics\trview.graphics.vcxproj">
-      <Project>{3270fd29-edab-40be-8ca1-dabc5e261e4c}</Project>
-    </ProjectReference>
     <ProjectReference Include="..\trview.ui\trview.ui.vcxproj">
       <Project>{160bd1c8-42c1-46e6-a232-b980b9b6d57e}</Project>
     </ProjectReference>


### PR DESCRIPTION
Only regenerate the UI on the next time we render, instead of doing it every time something changes. This means we don't do work that we immediately discard.
In transparency buffer - cache the blank texture we use for untextured things instead of creating it every frame.
Issue: #543 