### PR TITLE
Only present if the scene or UI has changed

### DIFF
--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -23,6 +23,7 @@ namespace trview
 
         _token_store += _mouse.mouse_move += [&](long, long)
         {
+            _map_renderer->set_cursor_position(client_cursor_position(_window));
             if (_map_tooltip && _map_tooltip->visible())
             {
                 _map_tooltip->set_position(client_cursor_position(_window));
@@ -146,6 +147,7 @@ namespace trview
         _map_renderer = std::make_unique<ui::render::MapRenderer>(device, shader_storage, font_factory, window.size());
         _token_store += _map_renderer->on_sector_hover += [this](const std::shared_ptr<Sector>& sector)
         {
+            on_ui_changed();
             on_sector_hover(sector);
 
             if (!sector)
@@ -237,7 +239,6 @@ namespace trview
 
     void ViewerUI::render(const graphics::Device& device)
     {
-        _map_renderer->set_cursor_position(client_cursor_position(_window));
         _map_renderer->render(device.context());
         _ui_renderer->render(device.context());
     }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -20,6 +20,14 @@ namespace trview
         _control->on_invalidate += on_ui_changed;
         _control->on_hierarchy_changed += on_ui_changed;
 
+        std::function<void(Control*)> register_change_detection = [&](Control* child)
+        {
+            child->on_invalidate += on_ui_changed;
+            child->on_hierarchy_changed += on_ui_changed;
+            _token_store += child->on_add_child += register_change_detection;
+        };
+        _token_store += _control->on_add_child += register_change_detection;
+
         _control->set_handles_input(false);
         _ui_input = std::make_unique<Input>(window, *_control);
 

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -15,6 +15,11 @@ namespace trview
         : _mouse(window), _window(window), _keyboard(window)
     {
         _control = std::make_unique<ui::Window>(Point(), window.size(), Colour::Transparent);
+
+        // Change detection - need to add to children.
+        _control->on_invalidate += on_ui_changed;
+        _control->on_hierarchy_changed += on_ui_changed;
+
         _control->set_handles_input(false);
         _ui_input = std::make_unique<Input>(window, *_control);
 

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -264,6 +264,7 @@ namespace trview
     private:
         void generate_tool_window(const ITextureStorage& texture_storage);
         void initialise_camera_controls(ui::Control& parent);
+        void register_change_detection(ui::Control* control);
 
         TokenStore _token_store;
         input::Mouse _mouse;

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -120,6 +120,9 @@ namespace trview
         /// Event raised when a tool is selected.
         Event<Tool> on_tool_selected;
 
+        /// Event raised when something in the ui has changed.
+        Event<> on_ui_changed;
+
         /// Render the UI.
         /// @param device The device to use to render the UI.
         void render(const graphics::Device& device);

--- a/trview.app/Windows/CollapsiblePanel.cpp
+++ b/trview.app/Windows/CollapsiblePanel.cpp
@@ -118,14 +118,16 @@ namespace trview
 
     void CollapsiblePanel::render(const Device& device, bool vsync)
     {
-        if (_ui_changed)
+        if (!_ui_changed)
         {
-            _device_window->begin();
-            _device_window->clear(DirectX::SimpleMath::Color(0.0f, 0.2f, 0.4f, 1.0f));
-            _ui_renderer->render(device.context());
-            _device_window->present(vsync);
-            _ui_changed = false;
+            return;
         }
+
+        _device_window->begin();
+        _device_window->clear(DirectX::SimpleMath::Color(0.0f, 0.2f, 0.4f, 1.0f));
+        _ui_renderer->render(device.context());
+        _device_window->present(vsync);
+        _ui_changed = false;
     }
 
     void CollapsiblePanel::set_panels(std::unique_ptr<ui::Control> left_panel, std::unique_ptr<ui::Control> right_panel)

--- a/trview.app/Windows/CollapsiblePanel.cpp
+++ b/trview.app/Windows/CollapsiblePanel.cpp
@@ -80,7 +80,22 @@ namespace trview
         };
 
         _ui = std::make_unique<ui::Window>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f));
+        register_change_detection(_ui.get());
+
         _input = std::make_unique<ui::Input>(window(), *_ui);
+    }
+
+    void CollapsiblePanel::register_change_detection(Control* control)
+    {
+        _token_store += control->on_invalidate += [&]() { _ui_changed = true; };
+        _token_store += control->on_hierarchy_changed += [&]() { _ui_changed = true; };
+        _token_store += control->on_add_child += std::bind(&CollapsiblePanel::register_change_detection, this, std::placeholders::_1);
+
+        // Go through all of the control's children, as they may have been added previously.
+        for (auto& child : control->child_elements())
+        {
+            register_change_detection(child);
+        }
     }
 
     void CollapsiblePanel::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
@@ -103,10 +118,14 @@ namespace trview
 
     void CollapsiblePanel::render(const Device& device, bool vsync)
     {
-        _device_window->begin();
-        _device_window->clear(DirectX::SimpleMath::Color(0.0f, 0.2f, 0.4f, 1.0f));
-        _ui_renderer->render(device.context());
-        _device_window->present(vsync);
+        if (_ui_changed)
+        {
+            _device_window->begin();
+            _device_window->clear(DirectX::SimpleMath::Color(0.0f, 0.2f, 0.4f, 1.0f));
+            _ui_renderer->render(device.context());
+            _device_window->present(vsync);
+            _ui_changed = false;
+        }
     }
 
     void CollapsiblePanel::set_panels(std::unique_ptr<ui::Control> left_panel, std::unique_ptr<ui::Control> right_panel)

--- a/trview.app/Windows/CollapsiblePanel.h
+++ b/trview.app/Windows/CollapsiblePanel.h
@@ -88,6 +88,7 @@ namespace trview
     private:
         void toggle_expand();
         std::unique_ptr<ui::Control> create_divider();
+        void register_change_detection(ui::Control* control);
 
         std::unique_ptr<graphics::DeviceWindow> _device_window;
         std::unique_ptr<ui::render::Renderer>   _ui_renderer;
@@ -96,5 +97,6 @@ namespace trview
         ui::Control* _divider;
         ui::Button* _expander;
         bool        _expanded{ true };
+        bool        _ui_changed{ true };
     };
 }

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -145,6 +145,9 @@ namespace trview
             /// @param child_element The element to remove.
             void remove_child(Control* child_element);
 
+            /// Event raised when a child is added.
+            Event<Control*> on_add_child;
+
             /// Event raised when the size of the control has changed.
             Event<Size> on_size_changed;
 

--- a/trview.ui/Control.inl
+++ b/trview.ui/Control.inl
@@ -36,6 +36,7 @@ namespace trview
             inner_add_child(element);
             on_invalidate();
             on_hierarchy_changed();
+            on_add_child(static_cast<Control*>(element));
 
             return element;
         }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -623,7 +623,7 @@ namespace trview
             _mouse_changed = false;
         }
 
-        if (_scene_changed)
+        if (_scene_changed || _ui_changed)
         {
             _device.begin();
             _main_window->begin();
@@ -642,7 +642,12 @@ namespace trview
             }
 
             _scene_sprite->render(_device.context(), _scene_target->texture(), 0, 0, _window.size().width, _window.size().height);
-            _ui->render(_device);
+
+            if (_ui_changed)
+            {
+                _ui->render(_device);
+                _ui_changed = false;
+            }
 
             _main_window->present(_settings.vsync);
         }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -107,7 +107,10 @@ namespace trview
         load_default_textures(_device, *_texture_storage.get());
 
         _ui = std::make_unique<ViewerUI>(_window, _device, *_shader_storage, _font_factory, *_texture_storage);
-        _token_store += _ui->on_ui_changed += [&]() { _ui_changed = true; };
+        _token_store += _ui->on_ui_changed += [&]() 
+        {
+            _ui_changed = true; 
+        };
         _token_store += _ui->on_select_item += [&](uint32_t index)
         {
             if (_level && index < _level->items().size())
@@ -528,8 +531,6 @@ namespace trview
         }
 
         current_camera().update(_timer.elapsed());
-
-        _ui->set_camera_position(current_camera().position());
     }
 
     void Viewer::open(const std::string& filename)
@@ -625,6 +626,8 @@ namespace trview
 
         if (_scene_changed || _ui_changed)
         {
+            _ui->set_camera_position(current_camera().position());
+
             _device.begin();
             _main_window->begin();
             _main_window->clear(DirectX::SimpleMath::Color(0.0f, 0.2f, 0.4f, 1.0f));
@@ -643,11 +646,8 @@ namespace trview
 
             _scene_sprite->render(_device.context(), _scene_target->texture(), 0, 0, _window.size().width, _window.size().height);
 
-            if (_ui_changed)
-            {
-                _ui->render(_device);
-                _ui_changed = false;
-            }
+            _ui->render(_device);
+            _ui_changed = false;
 
             _main_window->present(_settings.vsync);
         }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -107,10 +107,7 @@ namespace trview
         load_default_textures(_device, *_texture_storage.get());
 
         _ui = std::make_unique<ViewerUI>(_window, _device, *_shader_storage, _font_factory, *_texture_storage);
-        _token_store += _ui->on_ui_changed += [&]() 
-        {
-            _ui_changed = true; 
-        };
+        _token_store += _ui->on_ui_changed += [&]() {_ui_changed = true; };
         _token_store += _ui->on_select_item += [&](uint32_t index)
         {
             if (_level && index < _level->items().size())

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -158,6 +158,7 @@ namespace trview
         std::unique_ptr<graphics::Sprite> _scene_sprite;
         bool _scene_changed{ true };
         bool _mouse_changed{ true };
+        bool _ui_changed{ true };
 
         UpdateChecker _update_checker;
     };

--- a/trview/trview.cpp
+++ b/trview/trview.cpp
@@ -94,7 +94,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
         }
 
         viewer->render();
-        Sleep(0);
+        Sleep(1);
     }
 
     return (int) msg.wParam;


### PR DESCRIPTION
Only do any kind of rendering if there has been a change in the scene or the UI.
`ViewerUI` and `CollapsiblePanel` now register for changes on all controls that are added. When they change, they mark it for re-rendering.
If there has been no change to the scene or the UI, no rendering work is done (the device is not cleared or presented).
This cuts down on the CPU and GPU usage dramatically.
Issue: #545 