### PR TITLE
Move the CameraInput to trview.app

### DIFF
--- a/trview.app.tests/Camera/CameraInputTests.cpp
+++ b/trview.app.tests/Camera/CameraInputTests.cpp
@@ -22,7 +22,7 @@ namespace trview
                     mode = new_mode;
                 };
 
-                subject.key_down(L'F');
+                subject.key_down(L'F', false);
 
                 Assert::IsTrue(mode.has_value());
                 Assert::AreEqual(CameraMode::Free, mode.value());
@@ -40,7 +40,7 @@ namespace trview
                     mode = new_mode;
                 };
 
-                subject.key_down(L'X');
+                subject.key_down(L'X', false);
 
                 Assert::IsTrue(mode.has_value());
                 Assert::AreEqual(CameraMode::Axis, mode.value());
@@ -58,7 +58,7 @@ namespace trview
                     mode = new_mode;
                 };
 
-                subject.key_down(L'O');
+                subject.key_down(L'O', false);
 
                 Assert::IsTrue(mode.has_value());
                 Assert::AreEqual(CameraMode::Orbit, mode.value());

--- a/trview.app.tests/Camera/CameraInputTests.cpp
+++ b/trview.app.tests/Camera/CameraInputTests.cpp
@@ -1,6 +1,8 @@
 #include "CppUnitTest.h"
 #include <trview.app/Camera/CameraInput.h>
 #include <trview.app.tests/StringConversions.h>
+#include <trview.common/TokenStore.h>
+#include <set>
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
@@ -62,6 +64,123 @@ namespace trview
 
                 Assert::IsTrue(mode.has_value());
                 Assert::AreEqual(CameraMode::Orbit, mode.value());
+            }
+
+            /// Tests that when the mouse is scrolled down the zoom event is raised.
+            TEST_METHOD(ZoomOut)
+            {
+                CameraInput subject;
+
+                std::optional<float> zoom;
+                auto token = subject.on_zoom += [&zoom](float new_zoom)
+                {
+                    zoom = new_zoom;
+                };
+
+                subject.mouse_scroll(200);
+
+                Assert::IsTrue(zoom.has_value());
+                Assert::IsTrue(zoom.value() < 0.0f);
+            }
+
+            /// Tests that when the mouse is scrolled up tzoom event is raised.
+            TEST_METHOD(ZoomIn)
+            {
+                CameraInput subject;
+
+                std::optional<float> zoom;
+                auto token = subject.on_zoom += [&zoom](float new_zoom)
+                {
+                    zoom = new_zoom;
+                };
+
+                subject.mouse_scroll(-200);
+
+                Assert::IsTrue(zoom.has_value());
+                Assert::IsTrue(zoom.value() > 0.0f);
+            }
+
+            /// Tests that right clicking and moving the mouse causes the rotation
+            /// event to be raised.
+            TEST_METHOD(Rotation)
+            {
+                CameraInput subject;
+
+                std::optional<std::tuple<float, float>> rotation;
+                auto token = subject.on_rotate += [&rotation](float x, float y)
+                {
+                    rotation = { x, y };
+                };
+
+                subject.mouse_down(input::Mouse::Button::Right);
+                subject.mouse_move(100, 200);
+                subject.mouse_up(input::Mouse::Button::Right);
+
+                Assert::IsTrue(rotation.has_value());
+                Assert::AreEqual(100.0f, std::get<0>(rotation.value()));
+                Assert::AreEqual(200.0f, std::get<1>(rotation.value()));
+            }
+
+            /// Tests that giving the appropriate input to the camera input results in the
+            /// correct movement vector.
+            TEST_METHOD(Movement)
+            {
+                using namespace DirectX::SimpleMath;
+
+                CameraInput subject;
+
+                Assert::AreEqual(Vector3::Zero, subject.movement());
+
+                subject.key_down(L'W', false);
+                Assert::AreEqual(Vector3(0, 0, 1), subject.movement());
+
+                subject.key_down(L'A', false);
+                Assert::AreEqual(Vector3(-1, 0, 1), subject.movement());
+
+                subject.key_up(L'A');
+                Assert::AreEqual(Vector3(0, 0, 1), subject.movement());
+
+                subject.key_down(L'D', false);
+                Assert::AreEqual(Vector3(1, 0, 1), subject.movement());
+
+                subject.key_up(L'W');
+                Assert::AreEqual(Vector3(1, 0, 0), subject.movement());
+
+                subject.key_down(L'S', false);
+                Assert::AreEqual(Vector3(1, 0, -1), subject.movement());
+
+                subject.key_up(L'S');
+                Assert::AreEqual(Vector3(1, 0, 0), subject.movement());
+
+                subject.key_up(L'D');
+                Assert::AreEqual(Vector3::Zero, subject.movement());
+            }
+
+            /// Tests that if the control key is pressed nothing is done.
+            TEST_METHOD(ControlBlocks)
+            {
+                using namespace DirectX::SimpleMath;
+
+                CameraInput subject;
+
+                std::set<CameraMode> modes;
+                auto token = subject.on_mode_change += [&modes](CameraMode mode)
+                {
+                    modes.insert(mode);
+                };
+
+                subject.key_down('F', true);
+                subject.key_down('O', true);
+                subject.key_down('X', true);
+                Assert::IsTrue(modes.empty());
+
+                subject.key_down('W', true);
+                subject.key_down('A', true);
+                Assert::AreEqual(Vector3::Zero, subject.movement());
+
+                subject.key_down('S', true);
+                subject.key_down('D', true);
+                Assert::AreEqual(Vector3::Zero, subject.movement());
             }
         };
     }

--- a/trview.app.tests/Camera/CameraInputTests.cpp
+++ b/trview.app.tests/Camera/CameraInputTests.cpp
@@ -1,0 +1,68 @@
+#include "CppUnitTest.h"
+#include <trview.app/Camera/CameraInput.h>
+#include <trview.app.tests/StringConversions.h>
+
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace trview
+{
+    namespace tests
+    {
+        TEST_CLASS(CameraInputTests)
+        {
+            /// Tests that when the appropriate shortcut key is pressed the event
+            /// for entering free mode is raised.
+            TEST_METHOD(EnterFreeMode)
+            {
+                CameraInput subject;
+
+                std::optional<CameraMode> mode;
+                auto token = subject.on_mode_change += [&mode](CameraMode new_mode)
+                {
+                    mode = new_mode;
+                };
+
+                subject.key_down(L'F');
+
+                Assert::IsTrue(mode.has_value());
+                Assert::AreEqual(CameraMode::Free, mode.value());
+            }
+
+            /// Tests that when the appropriate shortcut key is pressed the event
+            /// for entering axis mode is raised.
+            TEST_METHOD(EnterAxisMode)
+            {
+                CameraInput subject;
+
+                std::optional<CameraMode> mode;
+                auto token = subject.on_mode_change += [&mode](CameraMode new_mode)
+                {
+                    mode = new_mode;
+                };
+
+                subject.key_down(L'X');
+
+                Assert::IsTrue(mode.has_value());
+                Assert::AreEqual(CameraMode::Axis, mode.value());
+            }
+
+            /// Tests that when the appropriate shortcut key is pressed the event
+            /// for entering orbit mode is raised.
+            TEST_METHOD(EnterOrbitMode)
+            {
+                CameraInput subject;
+
+                std::optional<CameraMode> mode;
+                auto token = subject.on_mode_change += [&mode](CameraMode new_mode)
+                {
+                    mode = new_mode;
+                };
+
+                subject.key_down(L'O');
+
+                Assert::IsTrue(mode.has_value());
+                Assert::AreEqual(CameraMode::Orbit, mode.value());
+            }
+        };
+    }
+}

--- a/trview.app.tests/StringConversions.cpp
+++ b/trview.app.tests/StringConversions.cpp
@@ -1,6 +1,7 @@
 #include "StringConversions.h"
 
 using namespace DirectX::SimpleMath;
+using namespace trview;
 
 namespace Microsoft
 {
@@ -13,6 +14,20 @@ namespace Microsoft
                 return std::to_wstring(vector.x) + L"," +
                        std::to_wstring(vector.y) + L"," +
                        std::to_wstring(vector.z);
+            }
+
+            std::wstring ToString(CameraMode mode)
+            {
+                switch (mode)
+                {
+                case CameraMode::Free:
+                    return L"Free";
+                case CameraMode::Orbit:
+                    return L"Orbit";
+                case CameraMode::Axis:
+                    return L"Axis";
+                }
+                return L"Unknown";
             }
         }
     }

--- a/trview.app.tests/StringConversions.h
+++ b/trview.app.tests/StringConversions.h
@@ -3,6 +3,8 @@
 #include <SimpleMath.h>
 #include <string>
 
+#include <trview.app/Camera/CameraMode.h>
+
 namespace Microsoft
 {
     namespace VisualStudio
@@ -10,6 +12,7 @@ namespace Microsoft
         namespace CppUnitTestFramework
         {
             std::wstring ToString(const DirectX::SimpleMath::Vector3& vector);
+            std::wstring ToString(trview::CameraMode mode);
         }
     }
 }

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AlternateGroupTogglerTests.cpp" />
+    <ClCompile Include="Camera\CameraInputTests.cpp" />
     <ClCompile Include="FileDropperTests.cpp" />
     <ClCompile Include="FreeCameraTests.cpp" />
     <ClCompile Include="OrbitCameraTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -10,6 +10,9 @@
     <ClCompile Include="AlternateGroupTogglerTests.cpp">
       <Filter>Input</Filter>
     </ClCompile>
+    <ClCompile Include="Camera\CameraInputTests.cpp">
+      <Filter>Camera</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="StringConversions.h" />
@@ -17,6 +20,9 @@
   <ItemGroup>
     <Filter Include="Input">
       <UniqueIdentifier>{d3867a39-d160-4aeb-a8e2-02afcb4efbe2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Camera">
+      <UniqueIdentifier>{ce341a85-c22f-4d9f-8275-93cfe4e2359e}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/trview.app/Camera/CameraInput.cpp
+++ b/trview.app/Camera/CameraInput.cpp
@@ -1,4 +1,3 @@
-#include "stdafx.h"
 #include "CameraInput.h"
 
 namespace trview

--- a/trview.app/Camera/CameraInput.cpp
+++ b/trview.app/Camera/CameraInput.cpp
@@ -2,8 +2,6 @@
 
 namespace trview
 {
-    // Get the movement vector based on the current input state.
-    // Returns: The movement vector.
     DirectX::SimpleMath::Vector3 CameraInput::movement() const
     {
         return DirectX::SimpleMath::Vector3(
@@ -12,8 +10,6 @@ namespace trview
             _free_forward ? 1.0f : 0.0f + _free_backward ? -1.0f : 0.0f);
     }
 
-    // Process a key being pressed.
-    // key: The key that was pressed.
     void CameraInput::key_down(uint16_t key)
     {
         if (GetAsyncKeyState(VK_CONTROL))
@@ -71,8 +67,6 @@ namespace trview
         }
     }
 
-    // Process a key being released.
-    // key: The key that was released.
     void CameraInput::key_up(uint16_t key)
     {
         switch (key)
@@ -110,8 +104,6 @@ namespace trview
         }
     }
 
-    // Process a mouse button being pressed.
-    // button: The button that was pressed.
     void CameraInput::mouse_down(input::Mouse::Button button)
     {
         if (button == input::Mouse::Button::Right)
@@ -120,8 +112,6 @@ namespace trview
         }
     }
 
-    // Process a mouse button being released.
-    // button: The button that was released.
     void CameraInput::mouse_up(input::Mouse::Button button)
     {
         if (button == input::Mouse::Button::Right)
@@ -130,9 +120,6 @@ namespace trview
         }
     }
 
-    // Process the mouse being moved.
-    // x: The x movement.
-    // y: The y movement.
     void CameraInput::mouse_move(long x, long y)
     {
         if (_rotating)
@@ -141,8 +128,6 @@ namespace trview
         }
     }
 
-    // Process the mouse wheel being turned.
-    // scroll: The mouse wheel movement.
     void CameraInput::mouse_scroll(int16_t scroll)
     {
         on_zoom(scroll / -100.0f);

--- a/trview.app/Camera/CameraInput.cpp
+++ b/trview.app/Camera/CameraInput.cpp
@@ -10,9 +10,9 @@ namespace trview
             _free_forward ? 1.0f : 0.0f + _free_backward ? -1.0f : 0.0f);
     }
 
-    void CameraInput::key_down(uint16_t key)
+    void CameraInput::key_down(uint16_t key, bool control)
     {
-        if (GetAsyncKeyState(VK_CONTROL))
+        if (control)
         {
             return;
         }

--- a/trview.app/Camera/CameraInput.h
+++ b/trview.app/Camera/CameraInput.h
@@ -10,7 +10,7 @@
 
 namespace trview
 {
-    class CameraInput
+    class CameraInput final
     {
     public:
         // Get the movement vector based on the current input state.

--- a/trview.app/Camera/CameraInput.h
+++ b/trview.app/Camera/CameraInput.h
@@ -10,36 +10,46 @@
 
 namespace trview
 {
+    /// Converts mouse and keyboard input into the control events for the camera.
     class CameraInput final
     {
     public:
-        // Get the movement vector based on the current input state.
-        // Returns: The movement vector.
+        /// Get the movement vector based on the current input state.
+        /// @returns The movement vector.
         DirectX::SimpleMath::Vector3 movement() const;
-        // Process a key being pressed.
-        // key: The key that was pressed.
+
+        /// Process a key being pressed.
+        /// @param key The key that was pressed.
         void key_down(uint16_t key);
-        // Process a key being released.
-        // key: The key that was released.
+
+        /// Process a key being released.
+        /// @param key The key that was released.
         void key_up(uint16_t key);
-        // Process a mouse button being pressed.
-        // button: The button that was pressed.
+
+        /// Process a mouse button being pressed.
+        /// @param button The button that was pressed.
         void mouse_down(input::Mouse::Button button);
-        // Process a mouse button being released.
-        // button: The button that was released.
+
+        /// Process a mouse button being released.
+        /// @param button The button that was released.
         void mouse_up(input::Mouse::Button button);
-        // Process the mouse being moved.
-        // x: The x movement.
-        // y: The y movement.
+
+        /// Process the mouse being moved.
+        /// @param x The x movement.
+        /// @param y The y movement.
         void mouse_move(long x, long y);
-        // Process the mouse wheel being turned.
-        // scroll: The mouse wheel movement.
+
+        /// Process the mouse wheel being turned.
+        /// @param scroll The mouse wheel movement.
         void mouse_scroll(int16_t scroll);
-        // Event raised when the camera needs to be rotated.
+
+        /// Event raised when the camera needs to be rotated.
         Event<float, float> on_rotate;
-        // Event raised when the zoom level needs to change.
+
+        /// Event raised when the zoom level needs to change.
         Event<float> on_zoom;
-        // Event raised when the camera mode needs to change.
+
+        /// Event raised when the camera mode needs to change.
         Event<CameraMode> on_mode_change;
     private:
         bool _free_forward{ false };

--- a/trview.app/Camera/CameraInput.h
+++ b/trview.app/Camera/CameraInput.h
@@ -20,7 +20,8 @@ namespace trview
 
         /// Process a key being pressed.
         /// @param key The key that was pressed.
-        void key_down(uint16_t key);
+        /// @param control Whether the control key is pressed.
+        void key_down(uint16_t key, bool control);
 
         /// Process a key being released.
         /// @param key The key that was released.

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -30,9 +30,9 @@ namespace trview
             }
         };
 
-        _token_store += _keyboard.on_key_down += [&](auto key)
+        _token_store += _keyboard.on_key_down += [&](auto key, bool control)
         {
-            if (_keyboard.control())
+            if (control)
             {
                 std::wstring name;
                 switch (key)

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Camera\Camera.cpp" />
+    <ClCompile Include="Camera\CameraInput.cpp" />
     <ClCompile Include="Camera\CameraMode.cpp" />
     <ClCompile Include="Camera\FreeCamera.cpp" />
     <ClCompile Include="Camera\ICamera.cpp" />
@@ -71,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h" />
+    <ClInclude Include="Camera\CameraInput.h" />
     <ClInclude Include="Camera\CameraMode.h" />
     <ClInclude Include="Camera\FreeCamera.h" />
     <ClInclude Include="Camera\ICamera.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -148,6 +148,9 @@
     <ClCompile Include="Menus\UpdateChecker.cpp">
       <Filter>Menus</Filter>
     </ClCompile>
+    <ClCompile Include="Camera\CameraInput.cpp">
+      <Filter>Camera</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -314,6 +317,9 @@
     </ClInclude>
     <ClInclude Include="Menus\UpdateChecker.h">
       <Filter>Menus</Filter>
+    </ClInclude>
+    <ClInclude Include="Camera\CameraInput.h">
+      <Filter>Camera</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/trview.input.tests/KeyboardTests.cpp
+++ b/trview.input.tests/KeyboardTests.cpp
@@ -23,7 +23,7 @@ namespace trview
                 HWND window = create_test_window(L"TRViewInputTests");
                 Keyboard keyboard(window);
                 auto token = keyboard.on_key_down +=
-                    [&times_called, &key_received](uint16_t key) 
+                    [&times_called, &key_received](uint16_t key, bool control) 
                 {
                     ++times_called; 
                     key_received = key; 
@@ -45,7 +45,7 @@ namespace trview
                 HWND window = create_test_window(L"TRViewInputTests");
                 Keyboard keyboard(window);
                 auto token = keyboard.on_key_up +=
-                    [&times_called, &key_received](uint16_t key)
+                    [&times_called, &key_received](uint16_t key, bool control)
                 {
                     ++times_called;
                     key_received = key;

--- a/trview.input/Keyboard.cpp
+++ b/trview.input/Keyboard.cpp
@@ -20,11 +20,12 @@ namespace trview
 
         void Keyboard::process_message(HWND, UINT message, WPARAM wParam, LPARAM)
         {
+            bool control_pressed = control();
             switch (message)
             {
                 case WM_KEYDOWN:
                 {
-                    on_key_down(static_cast<uint16_t>(wParam));
+                    on_key_down(static_cast<uint16_t>(wParam), control_pressed);
                     break;
                 }
                 case WM_CHAR:
@@ -34,7 +35,7 @@ namespace trview
                 }
                 case WM_KEYUP:
                 {
-                    on_key_up(static_cast<uint16_t>(wParam));
+                    on_key_up(static_cast<uint16_t>(wParam), control_pressed);
                     break;
                 }
             }

--- a/trview.input/Keyboard.h
+++ b/trview.input/Keyboard.h
@@ -34,11 +34,11 @@ namespace trview
 
             /// Event raised when the user presses a key. The key is passed as a parameter
             /// to the event listeners.
-            Event<uint16_t> on_key_down;
+            Event<uint16_t, bool> on_key_down;
 
             /// Event raised when the user releases a key. The key is passed as a parameter
             /// to the event listeners.
-            Event<uint16_t> on_key_up;
+            Event<uint16_t, bool> on_key_up;
 
             /// Event raised when the user enters a text character. The character is passed as
             /// a parameter to the event listener.

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -34,7 +34,7 @@ namespace trview
             _token_store += _mouse.mouse_down += [&](input::Mouse::Button) { process_mouse_down(); };
             _token_store += _mouse.mouse_up += [&](auto) { process_mouse_up(); };
             _token_store += _mouse.mouse_wheel += [&](int16_t delta) { process_mouse_scroll(delta); };
-            _token_store += _keyboard.on_key_down += [&](auto key) { process_key_down(key); };
+            _token_store += _keyboard.on_key_down += [&](auto key, bool control) { process_key_down(key, control); };
             _token_store += _keyboard.on_char += [&](auto key) { process_char(key); };
         }
 
@@ -259,7 +259,7 @@ namespace trview
             return control->scroll(delta);
         }
 
-        void Input::process_key_down(uint16_t key)
+        void Input::process_key_down(uint16_t key, bool control)
         {
             if (_focus_control && _focus_control->key_down(key))
             {

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -32,7 +32,7 @@ namespace trview
             bool     process_mouse_up(Control* control, const Point& position);
             void     process_mouse_scroll(int16_t delta);
             bool     process_mouse_scroll(Control* control, const Point& position, int16_t delta);
-            void     process_key_down(uint16_t key);
+            void     process_key_down(uint16_t key, bool control);
             bool     process_key_down(Control* control, uint16_t key);
             void     process_char(uint16_t key);
             bool     process_char(Control* control, uint16_t key);

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -24,6 +24,11 @@ namespace trview
 
                 switch (character)
                 {
+                    // Reserved
+                    case 0x7:
+                    {
+                        return;
+                    }
                     // VK_BACK
                     case 0x8:
                     {

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -311,14 +311,14 @@ namespace trview
 
     void Viewer::initialise_input()
     {
-        _token_store += _keyboard.on_key_up += std::bind(&Viewer::process_input_key, this, std::placeholders::_1);
+        _token_store += _keyboard.on_key_up += std::bind(&Viewer::process_input_key, this, std::placeholders::_1, std::placeholders::_2);
 
-        _token_store += _keyboard.on_key_down += [&](auto key) {_camera_input.key_down(key); };
-        _token_store += _keyboard.on_key_up += [&](auto key) {_camera_input.key_up(key); };
+        _token_store += _keyboard.on_key_down += [&](auto key, bool control) {_camera_input.key_down(key, control); };
+        _token_store += _keyboard.on_key_up += [&](auto key, bool control) {_camera_input.key_up(key); };
 
-        _token_store += _keyboard.on_key_down += [&](uint16_t key)
+        _token_store += _keyboard.on_key_down += [&](uint16_t key, bool control)
         {
-            if (_ui->go_to_room_visible() || GetAsyncKeyState(VK_CONTROL))
+            if (_ui->go_to_room_visible() || control)
             {
                 return;
             }
@@ -482,7 +482,7 @@ namespace trview
         };
     }
 
-    void Viewer::process_input_key(uint16_t key)
+    void Viewer::process_input_key(uint16_t key, bool control)
     {
         if (!_ui->go_to_room_visible())
         {
@@ -490,7 +490,7 @@ namespace trview
             {
                 case 'G':
                 {
-                    if(_level && !_keyboard.control())
+                    if(_level && !control)
                     {
                         set_show_hidden_geometry(!_level->show_hidden_geometry());
                     }

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -82,7 +82,7 @@ namespace trview
         Event<std::list<std::string>> on_recent_files_changed;
     private:
         void initialise_input();
-        void process_input_key(uint16_t key);
+        void process_input_key(uint16_t key, bool control);
         void toggle_highlight();
         void update_camera();
         void render_scene();

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -19,7 +19,7 @@
 
 #include <trview.app/Camera/FreeCamera.h>
 #include <trview.app/Camera/OrbitCamera.h>
-#include "CameraInput.h"
+#include <trview.app/Camera/CameraInput.h>
 #include <trview.app/Camera/CameraMode.h>
 #include "Level.h"
 #include <trview.app/Settings/UserSettings.h>

--- a/trview/trview.vcxproj
+++ b/trview/trview.vcxproj
@@ -179,7 +179,6 @@
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="CameraInput.h" />
     <ClInclude Include="DefaultFonts.h" />
     <ClInclude Include="DefaultShaders.h" />
     <ClInclude Include="DefaultTextures.h" />
@@ -199,7 +198,6 @@
     <ClInclude Include="Viewer.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="CameraInput.cpp" />
     <ClCompile Include="DefaultFonts.cpp" />
     <ClCompile Include="DefaultShaders.cpp" />
     <ClCompile Include="DefaultTextures.cpp" />

--- a/trview/trview.vcxproj.filters
+++ b/trview/trview.vcxproj.filters
@@ -35,9 +35,6 @@
     <Filter Include="View\Entity">
       <UniqueIdentifier>{de962a03-c92e-459f-b33a-cdd5927fe5bf}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Camera">
-      <UniqueIdentifier>{4c4905f3-010e-4d59-b23f-810136eb84ac}</UniqueIdentifier>
-    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Viewer.h">
@@ -81,9 +78,6 @@
     </ClInclude>
     <ClInclude Include="DefaultShaders.h">
       <Filter>Graphics</Filter>
-    </ClInclude>
-    <ClInclude Include="CameraInput.h">
-      <Filter>Camera</Filter>
     </ClInclude>
     <ClInclude Include="DefaultTextures.h">
       <Filter>Graphics</Filter>
@@ -131,9 +125,6 @@
     </ClCompile>
     <ClCompile Include="DefaultShaders.cpp">
       <Filter>Graphics</Filter>
-    </ClCompile>
-    <ClCompile Include="CameraInput.cpp">
-      <Filter>Camera</Filter>
     </ClCompile>
     <ClCompile Include="DefaultTextures.cpp">
       <Filter>Graphics</Filter>


### PR DESCRIPTION
Move the `CameraInput` class to the trview.app project.
Add some unit tests for this class.
Adjust the `Keyboard` class so that it passes the state of the control key to the key down/up event handlers. There was an issue where previously the `CameraInput` class was calling `GetAsyncKeyState`, which was causing the unit test to fail occasionally.
Adjusted registered listeners on key_down/up accordingly.
Issue: #549 