### PR TITLE
Store level version in LevelTextureStorage to fix palette

### DIFF
--- a/trview/LevelTextureStorage.cpp
+++ b/trview/LevelTextureStorage.cpp
@@ -5,7 +5,7 @@
 namespace trview
 {
     LevelTextureStorage::LevelTextureStorage(const graphics::Device& device, const trlevel::ILevel& level)
-        : _device(device), _texture_storage(std::make_unique<TextureStorage>(device))
+        : _device(device), _texture_storage(std::make_unique<TextureStorage>(device)), _version(level.get_version())
     {
         for (uint32_t i = 0; i < level.num_textiles(); ++i)
         {


### PR DESCRIPTION
This means it will choose the correct palette index. Previously it was using the 8-bit palette index as the version was set to unknown.
Bug: #551