### PR TITLE
Remove the check for size changing after sizemove

### DIFF
--- a/trview.app/Windows/WindowResizer.cpp
+++ b/trview.app/Windows/WindowResizer.cpp
@@ -19,7 +19,7 @@ namespace trview
             }
             case WM_SIZE:
             {
-                if (!_resizing && (wParam == SIZE_MAXIMIZED || wParam == SIZE_RESTORED) && has_size_changed())
+                if (!_resizing && (wParam == SIZE_MAXIMIZED || wParam == SIZE_RESTORED || has_size_changed()))
                 {
                     on_resize();
                 }
@@ -28,10 +28,7 @@ namespace trview
             case WM_EXITSIZEMOVE:
             {
                 _resizing = false;
-                if (has_size_changed())
-                {
-                    on_resize();
-                }
+                on_resize();
                 break;
             }
         }


### PR DESCRIPTION
The window can be dragged off the screen and since the size hadn't changed the scene wasn't being refreshed so the window was white until you did something.
Remove the size check after sizemove and just always raise on_resize. The size check survives in the wm_size handler.
Move size changed check in wm_size to be alongside checks for maximise/minimise.
Bug: #553