### PR TITLE
Call begin on the device when beginning device window rendering

### DIFF
--- a/trview.app/Windows/CollapsiblePanel.cpp
+++ b/trview.app/Windows/CollapsiblePanel.cpp
@@ -68,7 +68,7 @@ namespace trview
     }
 
 
-    CollapsiblePanel::CollapsiblePanel(const Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent, const std::wstring& window_class, const std::wstring& title, const Size& size)
+    CollapsiblePanel::CollapsiblePanel(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent, const std::wstring& window_class, const std::wstring& title, const Size& size)
         : MessageHandler(create_window(parent, window_class, title, size)), _window_resizer(window()), _device_window(device.create_for_window(window())),
         _ui_renderer(std::make_unique<render::Renderer>(device, shader_storage, font_factory, window().size()))
     {

--- a/trview.app/Windows/CollapsiblePanel.h
+++ b/trview.app/Windows/CollapsiblePanel.h
@@ -43,7 +43,7 @@ namespace trview
         /// @param shader_storage The shader storage instance to use.
         /// @param font_factory The font factory to use.
         /// @param parent The parent window.
-        explicit CollapsiblePanel(const graphics::Device& device,
+        explicit CollapsiblePanel(graphics::Device& device,
             const graphics::IShaderStorage& shader_storage,
             const graphics::FontFactory& font_factory,
             HWND parent,

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -32,7 +32,7 @@ namespace trview
         }
     }
 
-    ItemsWindow::ItemsWindow(const Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent)
+    ItemsWindow::ItemsWindow(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent)
         : CollapsiblePanel(device, shader_storage, font_factory, parent, L"trview.items", L"Items", Size(400, 400))
     {
         set_panels(create_left_panel(), create_right_panel());

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -23,7 +23,7 @@ namespace trview
         /// @param shader_storage The shader storage instance to use.
         /// @param font_factory The font factory to use.
         /// @param parent The parent window.
-        explicit ItemsWindow(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND parent);
+        explicit ItemsWindow(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND parent);
 
         /// Destructor for items window
         virtual ~ItemsWindow() = default;

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -37,7 +37,7 @@ namespace trview
 
     using namespace graphics;
 
-    RouteWindow::RouteWindow(const Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent)
+    RouteWindow::RouteWindow(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent)
         : CollapsiblePanel(device, shader_storage, font_factory, parent, L"trview.route", L"Route", Size(470, 400))
     {
         set_panels(create_left_panel(), create_right_panel());

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -19,7 +19,7 @@ namespace trview
         /// @param shader_storage The shader storage instance to use.
         /// @param font_factory The font factory to use.
         /// @param parent The parent window.
-        explicit RouteWindow(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND parent);
+        explicit RouteWindow(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND parent);
 
         /// Destructor for triggers window
         virtual ~RouteWindow() = default;

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -3,7 +3,7 @@
 
 namespace trview
 {
-    RouteWindowManager::RouteWindowManager(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND window)
+    RouteWindowManager::RouteWindowManager(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND window)
         : _device(device), _shader_storage(shader_storage), _font_factory(font_factory), MessageHandler(window)
     {
     }

--- a/trview.app/Windows/RouteWindowManager.h
+++ b/trview.app/Windows/RouteWindowManager.h
@@ -13,7 +13,7 @@ namespace trview
     class RouteWindowManager final : public MessageHandler
     {
     public:
-        explicit RouteWindowManager(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND window);
+        explicit RouteWindowManager(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND window);
 
         virtual ~RouteWindowManager() = default;
 
@@ -64,7 +64,7 @@ namespace trview
         /// Event raised when a waypoint is deleted.
         Event<uint32_t> on_waypoint_deleted;
     private:
-        const graphics::Device& _device;
+        graphics::Device& _device;
         const graphics::IShaderStorage& _shader_storage;
         const graphics::FontFactory& _font_factory;
         TokenStore _token_store;

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -40,7 +40,7 @@ namespace trview
 
     using namespace graphics;
 
-    TriggersWindow::TriggersWindow(const Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent)
+    TriggersWindow::TriggersWindow(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent)
         : CollapsiblePanel(device, shader_storage, font_factory, parent, L"trview.triggers", L"Triggers", Size(470, 400))
     {
         set_panels(create_left_panel(), create_right_panel());

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -24,7 +24,7 @@ namespace trview
         /// @param shader_storage The shader storage instance to use.
         /// @param font_factory The font factory to use.
         /// @param parent The parent window.
-        explicit TriggersWindow(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND parent);
+        explicit TriggersWindow(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND parent);
 
         /// Destructor for triggers window
         virtual ~TriggersWindow() = default;

--- a/trview.graphics/Device.cpp
+++ b/trview.graphics/Device.cpp
@@ -65,7 +65,7 @@ namespace trview
             return _context;
         }
 
-        std::unique_ptr<DeviceWindow> Device::create_for_window(HWND window) const
+        std::unique_ptr<DeviceWindow> Device::create_for_window(HWND window)
         {
             return std::make_unique<DeviceWindow>(*this, window);
         }

--- a/trview.graphics/Device.h
+++ b/trview.graphics/Device.h
@@ -43,7 +43,7 @@ namespace trview
             /// Create a device window to render to a specific window.
             /// @param window The window to render to.
             /// @returns The device window object.
-            std::unique_ptr<DeviceWindow> create_for_window(HWND window) const;
+            std::unique_ptr<DeviceWindow> create_for_window(HWND window);
         private:
             Microsoft::WRL::ComPtr<ID3D11Device>        _device;
             Microsoft::WRL::ComPtr<ID3D11DeviceContext> _context;

--- a/trview.graphics/DeviceWindow.cpp
+++ b/trview.graphics/DeviceWindow.cpp
@@ -7,7 +7,7 @@ namespace trview
 {
     namespace graphics
     {
-        DeviceWindow::DeviceWindow(const Device& device, const Window& window)
+        DeviceWindow::DeviceWindow(Device& device, const Window& window)
             : _device(device), _context(device.context())
         {
             // Swap chain description.
@@ -46,6 +46,7 @@ namespace trview
 
         void DeviceWindow::begin()
         {
+            _device.begin();
             _render_target->apply(_context);
         }
 

--- a/trview.graphics/DeviceWindow.h
+++ b/trview.graphics/DeviceWindow.h
@@ -23,7 +23,7 @@ namespace trview
             /// Create a new device window.
             /// @param device The device to use to render.
             /// @param window The window to render to.
-            explicit DeviceWindow(const Device& device, const Window& window);
+            explicit DeviceWindow(Device& device, const Window& window);
 
             /// Begin rendering to the main render target.
             void begin();
@@ -41,7 +41,7 @@ namespace trview
         private:
             void create_render_target();
 
-            const Device&                               _device;
+            Device& _device;
             Microsoft::WRL::ComPtr<ID3D11DeviceContext> _context;
             Microsoft::WRL::ComPtr<IDXGISwapChain> _swap_chain;
             std::unique_ptr<RenderTarget> _render_target;


### PR DESCRIPTION
This lets the device set the blend states. They were currently only being set when the main window rendered. The main window is only rendering when required now, so when a tool window was moved (resized), it was rendering without the blend states and make the white boxes.
Had to remove const on the graphics device through the call chain.
Bug: #556