### PR TITLE
Use the Window class wherever appropriate

### DIFF
--- a/trview.app.tests/AlternateGroupTogglerTests.cpp
+++ b/trview.app.tests/AlternateGroupTogglerTests.cpp
@@ -13,11 +13,9 @@ namespace trview
             /// Tests that when a number key is pressed an alternate group is toggled.
             TEST_METHOD(NumberKeys)
             {
-                auto window = create_test_window(L"AlternateGroupToggler");
-
                 for (uint32_t i = 0; i < 10; ++i)
                 {
-                    AlternateGroupToggler toggler(window);
+                    AlternateGroupToggler toggler(create_test_window(L"AlternateGroupToggler"));
 
                     bool called = false;
                     uint32_t called_group = 0;
@@ -38,8 +36,7 @@ namespace trview
             /// Tests that if a non-numeric character is sent, no event is raised.
             TEST_METHOD(Characters)
             {
-                auto window = create_test_window(L"AlternateGroupToggler");
-                AlternateGroupToggler toggler(window);
+                AlternateGroupToggler toggler(create_test_window(L"AlternateGroupToggler"));
 
                 bool called = false;
                 uint32_t called_group = 0;

--- a/trview.app.tests/AlternateGroupTogglerTests.cpp
+++ b/trview.app.tests/AlternateGroupTogglerTests.cpp
@@ -28,7 +28,7 @@ namespace trview
                         called_group = group;
                     };
 
-                    toggler.process_message(window, WM_CHAR, L'0' + i, 0);
+                    toggler.process_message(WM_CHAR, L'0' + i, 0);
 
                     Assert::IsTrue(called, L"Callback was not raised");
                     Assert::AreEqual(called_group, i);
@@ -50,7 +50,7 @@ namespace trview
                     called_group = group;
                 };
 
-                toggler.process_message(window, WM_CHAR, L'A', 0);
+                toggler.process_message(WM_CHAR, L'A', 0);
 
                 Assert::IsFalse(called, L"Callback should not be raised");
                 Assert::AreEqual(called_group, 0u);

--- a/trview.app.tests/FileDropperTests.cpp
+++ b/trview.app.tests/FileDropperTests.cpp
@@ -49,7 +49,7 @@ namespace trview
                 strcpy_s(reinterpret_cast<char*>(dropfiles + 1), filename.size() + 1, filename.c_str());
                 GlobalUnlock(global);
 
-                dropper.process_message(window, WM_DROPFILES, (WPARAM)global, 0);
+                dropper.process_message(WM_DROPFILES, (WPARAM)global, 0);
 
                 GlobalFree(global);
 

--- a/trview.app.tests/FileDropperTests.cpp
+++ b/trview.app.tests/FileDropperTests.cpp
@@ -30,8 +30,7 @@ namespace trview
             // Tests that sending a dropfile message to the dropper raises the event.
             TEST_METHOD(DropFile)
             {
-                HWND window = create_test_window(L"TRViewFileDropperTests");
-                FileDropper dropper(window);
+                FileDropper dropper(create_test_window(L"TRViewFileDropperTests"));
 
                 uint32_t times_called = 0;
                 std::string file_opened;
@@ -60,7 +59,7 @@ namespace trview
             // Tests that the class enables drag and drop
             TEST_METHOD(EnableDragDrop)
             {
-                HWND window = create_test_window(L"TRViewFileDropperTests");
+                Window window = create_test_window(L"TRViewFileDropperTests");
                 FileDropper dropper(window);
                 LONG_PTR style = GetWindowLongPtr(window, GWL_EXSTYLE);
                 Assert::AreEqual<LONG_PTR>(WS_EX_ACCEPTFILES, style & WS_EX_ACCEPTFILES);

--- a/trview.app.tests/RecentFilesTests.cpp
+++ b/trview.app.tests/RecentFilesTests.cpp
@@ -14,8 +14,7 @@ namespace trview
             /// Tests that opening the first file triggers the event.
             TEST_METHOD(OpenFile)
             {
-                HWND window = create_test_window(L"TRViewRecentFilesTests");
-                RecentFiles recent_files(window);
+                RecentFiles recent_files(create_test_window(L"TRViewRecentFilesTests"));
 
                 const std::list<std::string> files{ "test.tr2", "test2.tr2" };
                 recent_files.set_recent_files(files);

--- a/trview.app.tests/RecentFilesTests.cpp
+++ b/trview.app.tests/RecentFilesTests.cpp
@@ -28,7 +28,7 @@ namespace trview
                     raised_file = file;
                 };
 
-                recent_files.process_message(window, WM_COMMAND, MAKEWPARAM(5000, 0), 0);
+                recent_files.process_message(WM_COMMAND, MAKEWPARAM(5000, 0), 0);
                 Assert::AreEqual(1u, times_called);
                 Assert::AreEqual(std::string("test2.tr2"), files.back());
             }

--- a/trview.app.tests/WindowResizerTests.cpp
+++ b/trview.app.tests/WindowResizerTests.cpp
@@ -20,8 +20,8 @@ namespace trview
                 uint32_t times_called = 0;
                 auto token = resizer.on_resize += [&]() { ++times_called; };
 
-                resizer.process_message(window, WM_ENTERSIZEMOVE, 0, 0);
-                resizer.process_message(window, WM_EXITSIZEMOVE, 0, 0);
+                resizer.process_message(WM_ENTERSIZEMOVE, 0, 0);
+                resizer.process_message(WM_EXITSIZEMOVE, 0, 0);
 
                 Assert::AreEqual(1u, times_called);
             }
@@ -35,7 +35,7 @@ namespace trview
                 uint32_t times_called = 0;
                 auto token = resizer.on_resize += [&]() { ++times_called; };
 
-                resizer.process_message(window, WM_SIZE, SIZE_MAXIMIZED, 0);
+                resizer.process_message(WM_SIZE, SIZE_MAXIMIZED, 0);
 
                 Assert::AreEqual(1u, times_called);
             }
@@ -49,7 +49,7 @@ namespace trview
                 uint32_t times_called = 0;
                 auto token = resizer.on_resize += [&]() { ++times_called; };
 
-                resizer.process_message(window, WM_SIZE, SIZE_RESTORED, 0);
+                resizer.process_message(WM_SIZE, SIZE_RESTORED, 0);
 
                 Assert::AreEqual(1u, times_called);
             }
@@ -63,13 +63,13 @@ namespace trview
                 uint32_t times_called = 0;
                 auto token = resizer.on_resize += [&]() { ++times_called; };
 
-                resizer.process_message(window, WM_ENTERSIZEMOVE, 0, 0);
+                resizer.process_message(WM_ENTERSIZEMOVE, 0, 0);
                 Assert::AreEqual(0u, times_called);
 
-                resizer.process_message(window, WM_SIZE, 0, 0);
+                resizer.process_message(WM_SIZE, 0, 0);
                 Assert::AreEqual(0u, times_called);
 
-                resizer.process_message(window, WM_EXITSIZEMOVE, 0, 0);
+                resizer.process_message(WM_EXITSIZEMOVE, 0, 0);
                 Assert::AreEqual(1u, times_called);
             }
         };

--- a/trview.app.tests/WindowResizerTests.cpp
+++ b/trview.app.tests/WindowResizerTests.cpp
@@ -14,8 +14,7 @@ namespace trview
             // Tests that entering and exiting resizing raises the resize event.
             TEST_METHOD(SizeMove)
             {
-                HWND window = create_test_window(L"TRViewWindowResizerTests");
-                WindowResizer resizer(window);
+                WindowResizer resizer(create_test_window(L"TRViewWindowResizerTests"));
 
                 uint32_t times_called = 0;
                 auto token = resizer.on_resize += [&]() { ++times_called; };
@@ -29,8 +28,7 @@ namespace trview
             // Test that sending a maximize message triggers the event.
             TEST_METHOD(Maximise)
             {
-                HWND window = create_test_window(L"TRViewWindowResizerTests");
-                WindowResizer resizer(window);
+                WindowResizer resizer(create_test_window(L"TRViewWindowResizerTests"));
 
                 uint32_t times_called = 0;
                 auto token = resizer.on_resize += [&]() { ++times_called; };
@@ -43,8 +41,7 @@ namespace trview
             // Test that sending a minimise message triggers the event.
             TEST_METHOD(Minimise)
             {
-                HWND window = create_test_window(L"TRViewWindowResizerTests");
-                WindowResizer resizer(window);
+                WindowResizer resizer(create_test_window(L"TRViewWindowResizerTests"));
 
                 uint32_t times_called = 0;
                 auto token = resizer.on_resize += [&]() { ++times_called; };
@@ -57,8 +54,7 @@ namespace trview
             // Test that size messages during resize don't trigger the event.
             TEST_METHOD(Resizing)
             {
-                HWND window = create_test_window(L"TRViewWindowResizerTests");
-                WindowResizer resizer(window);
+                WindowResizer resizer(create_test_window(L"TRViewWindowResizerTests"));
 
                 uint32_t times_called = 0;
                 auto token = resizer.on_resize += [&]() { ++times_called; };

--- a/trview.app/Menus/AlternateGroupToggler.cpp
+++ b/trview.app/Menus/AlternateGroupToggler.cpp
@@ -2,12 +2,12 @@
 
 namespace trview
 {
-    AlternateGroupToggler::AlternateGroupToggler(HWND window)
+    AlternateGroupToggler::AlternateGroupToggler(const Window& window)
         : MessageHandler(window)
     {
     }
 
-    void AlternateGroupToggler::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    void AlternateGroupToggler::process_message(UINT message, WPARAM wParam, LPARAM lParam)
     {
         if (message == WM_CHAR)
         {

--- a/trview.app/Menus/AlternateGroupToggler.h
+++ b/trview.app/Menus/AlternateGroupToggler.h
@@ -15,14 +15,13 @@ namespace trview
     public:
         /// Create a new AlternateGroupToggler.
         /// @param window The window to monitor.
-        explicit AlternateGroupToggler(HWND window);
+        explicit AlternateGroupToggler(const Window& window);
 
         /// Handles a window message.
-        /// @param window The window that received the message.
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Event raised when an alternate group is toggled by the user. The group
         /// is passed as a parameter.

--- a/trview.app/Menus/FileDropper.cpp
+++ b/trview.app/Menus/FileDropper.cpp
@@ -3,14 +3,14 @@
 
 namespace trview
 {
-    FileDropper::FileDropper(HWND window)
+    FileDropper::FileDropper(const Window& window)
         : MessageHandler(window)
     {
         // Makes this window accept dropped files.
         DragAcceptFiles(window, TRUE);
     }
 
-    void FileDropper::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    void FileDropper::process_message(UINT message, WPARAM wParam, LPARAM lParam)
     {
         if(message == WM_DROPFILES)
         {

--- a/trview.app/Menus/FileDropper.h
+++ b/trview.app/Menus/FileDropper.h
@@ -15,17 +15,16 @@ namespace trview
     public:
         /// Create a new FileDropper.
         /// @param window The window that the user can drop files on to.
-        explicit FileDropper(HWND window);
+        explicit FileDropper(const Window& window);
 
         /// Destructor for FileDropper.
         virtual ~FileDropper() = default;
 
         /// Handles a window message.
-        /// @param window The window that received the message.
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Event raised when the user drops a file on to the window. The file dropped is passed as a parameter.
         Event<std::string> on_file_dropped;

--- a/trview.app/Menus/LevelSwitcher.cpp
+++ b/trview.app/Menus/LevelSwitcher.cpp
@@ -12,7 +12,7 @@ namespace trview
         /// Reset the menu to have no items in it.
         /// @param window The window that the menu bar belongs to.
         /// @param menu The menu to clear.
-        void reset_menu(HWND window, HMENU menu)
+        void reset_menu(const Window& window, HMENU menu)
         {
             int count = GetMenuItemCount(menu);
 
@@ -25,7 +25,7 @@ namespace trview
         /// Create the directory listing menu as a child of the menu in the specified window.
         /// @param window The window that owns the menu.
         /// @returns The new menu.
-        HMENU create_directory_listing_menu(HWND window)
+        HMENU create_directory_listing_menu(const Window& window)
         {
             HMENU menu = GetMenu(window);
             HMENU directory_listing_menu = CreatePopupMenu();
@@ -48,12 +48,12 @@ namespace trview
         }
     }
 
-    LevelSwitcher::LevelSwitcher(HWND window)
+    LevelSwitcher::LevelSwitcher(const Window& window)
         : MessageHandler(window), _directory_listing_menu(create_directory_listing_menu(window))
     {
     }
 
-    void LevelSwitcher::process_message(HWND, UINT message, WPARAM wParam, LPARAM)
+    void LevelSwitcher::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         if (message == WM_COMMAND)
         {

--- a/trview.app/Menus/LevelSwitcher.h
+++ b/trview.app/Menus/LevelSwitcher.h
@@ -19,17 +19,16 @@ namespace trview
     public:
         /// Create a new LevelSwitcher.
         /// @param The window to add the menu to.
-        explicit LevelSwitcher(HWND window);
+        explicit LevelSwitcher(const Window& window);
 
         /// Destructor for LevelSwitcher.
         virtual ~LevelSwitcher() = default;
 
         /// Handles a window message.
-        /// @param window The window that received the message.
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Open the specified file. This will populate the switcher menu.
         /// @param filename The file that was opened.

--- a/trview.app/Menus/RecentFiles.cpp
+++ b/trview.app/Menus/RecentFiles.cpp
@@ -8,7 +8,7 @@ namespace trview
     {
         const int ID_RECENT_FILE_BASE = 5000;
 
-        void update_menu(HWND window, const std::vector<std::string>& recent_files)
+        void update_menu(const Window& window, const std::vector<std::string>& recent_files)
         {
             // Set up the recently used files menu.
             HMENU menu = GetMenu(window);
@@ -29,12 +29,12 @@ namespace trview
         }
     }
 
-    RecentFiles::RecentFiles(HWND window)
+    RecentFiles::RecentFiles(const Window& window)
         : MessageHandler(window)
     {
     }
 
-    void RecentFiles::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    void RecentFiles::process_message(UINT message, WPARAM wParam, LPARAM lParam)
     {
         if (message == WM_COMMAND)
         {

--- a/trview.app/Menus/RecentFiles.h
+++ b/trview.app/Menus/RecentFiles.h
@@ -17,17 +17,16 @@ namespace trview
     public:
         /// Create a new RecentFiles that will manage a menu on the window specified.
         /// @param window The window that has the recent files menu.
-        explicit RecentFiles(HWND window);
+        explicit RecentFiles(const Window& window);
 
         /// Destructor for RecentFiles.
         virtual ~RecentFiles() = default;
 
         /// Handles a window message.
-        /// @param window The window that received the message.
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Event raised when the user opens a file from the recent files list. The file that was opened
         /// is passed as a parameter.

--- a/trview.app/Menus/UpdateChecker.cpp
+++ b/trview.app/Menus/UpdateChecker.cpp
@@ -44,7 +44,7 @@ namespace trview
         }
 
         _thread = std::thread(
-            [](HWND window, const std::string& version)
+            [](Window window, const std::string& version)
         {
             HINTERNET internet = WinHttpOpen(L"trview", WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY, nullptr, nullptr, 0);
             if (!internet)
@@ -110,7 +110,7 @@ namespace trview
         }, window(), _current_version);
     }
 
-    void UpdateChecker::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    void UpdateChecker::process_message(UINT message, WPARAM wParam, LPARAM lParam)
     {
         if (message == WM_COMMAND && LOWORD(wParam) == id_update_available)
         {

--- a/trview.app/Menus/UpdateChecker.h
+++ b/trview.app/Menus/UpdateChecker.h
@@ -22,11 +22,10 @@ namespace trview
         void check_for_updates();
 
         /// Handles a window message.
-        /// @param window The window that received the message.
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
     private:
         std::thread _thread;
         std::string _current_version;

--- a/trview.app/Menus/ViewMenu.cpp
+++ b/trview.app/Menus/ViewMenu.cpp
@@ -42,7 +42,7 @@ namespace trview
         }
     }
 
-    ViewMenu::ViewMenu(HWND window)
+    ViewMenu::ViewMenu(const Window& window)
         : MessageHandler(window)
     {
         // Set all of the items to be initially visible.
@@ -56,14 +56,14 @@ namespace trview
         set_checked(menu, ID_APP_VIEW_TOOLS, true);
     }
 
-    void ViewMenu::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    void ViewMenu::process_message(UINT message, WPARAM wParam, LPARAM lParam)
     {
         if (message != WM_COMMAND)
         {
             return;
         }
 
-        HMENU menu = GetMenu(window);
+        HMENU menu = GetMenu(window());
         UINT id = LOWORD(wParam);
         bool enable = !is_checked(menu, id);
 

--- a/trview.app/Menus/ViewMenu.h
+++ b/trview.app/Menus/ViewMenu.h
@@ -8,9 +8,9 @@ namespace trview
     class ViewMenu final : public MessageHandler
     {
     public:
-        explicit ViewMenu(HWND window);
+        explicit ViewMenu(const Window& window);
         virtual ~ViewMenu() = default;
-        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Event raised when the show minimap option is toggled.
         Event<bool> on_show_minimap;

--- a/trview.app/Windows/CollapsiblePanel.cpp
+++ b/trview.app/Windows/CollapsiblePanel.cpp
@@ -25,12 +25,12 @@ namespace trview
                 return DefWindowProc(hWnd, message, wParam, lParam);
             }
 
-            HWND init_instance(HWND parent, HINSTANCE hInstance, const std::wstring& window_class, const std::wstring& title, const Size& size, int nCmdShow)
+            Window init_instance(const Window& parent, HINSTANCE hInstance, const std::wstring& window_class, const std::wstring& title, const Size& size, int nCmdShow)
             {
                 RECT rect{ 0, 0, static_cast<LONG>(size.width), static_cast<LONG>(size.height) };
                 AdjustWindowRect(&rect, window_style, FALSE);
 
-                HWND items_window = CreateWindowW(window_class.c_str(), title.c_str(), window_style,
+                Window items_window = CreateWindowW(window_class.c_str(), title.c_str(), window_style,
                     CW_USEDEFAULT, 0, rect.right - rect.left, rect.bottom - rect.top, parent, nullptr, hInstance, nullptr);
 
                 ShowWindow(items_window, nCmdShow);
@@ -58,7 +58,7 @@ namespace trview
                 return RegisterClassExW(&wcex);
             }
 
-            HWND create_window(HWND parent, const std::wstring& window_class, const std::wstring& title, const Size& size)
+            Window create_window(const Window& parent, const std::wstring& window_class, const std::wstring& title, const Size& size)
             {
                 HINSTANCE hInstance = GetModuleHandle(nullptr);
                 register_class(hInstance, window_class);
@@ -68,7 +68,7 @@ namespace trview
     }
 
 
-    CollapsiblePanel::CollapsiblePanel(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent, const std::wstring& window_class, const std::wstring& title, const Size& size)
+    CollapsiblePanel::CollapsiblePanel(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, const Window& parent, const std::wstring& window_class, const std::wstring& title, const Size& size)
         : MessageHandler(create_window(parent, window_class, title, size)), _window_resizer(window()), _device_window(device.create_for_window(window())),
         _ui_renderer(std::make_unique<render::Renderer>(device, shader_storage, font_factory, window().size()))
     {
@@ -98,7 +98,7 @@ namespace trview
         }
     }
 
-    void CollapsiblePanel::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    void CollapsiblePanel::process_message(UINT message, WPARAM wParam, LPARAM lParam)
     {
         if (message == WM_CLOSE)
         {

--- a/trview.app/Windows/CollapsiblePanel.h
+++ b/trview.app/Windows/CollapsiblePanel.h
@@ -46,7 +46,7 @@ namespace trview
         explicit CollapsiblePanel(graphics::Device& device,
             const graphics::IShaderStorage& shader_storage,
             const graphics::FontFactory& font_factory,
-            HWND parent,
+            const Window& parent,
             const std::wstring& window_class,
             const std::wstring& title,
             const Size& size);
@@ -54,11 +54,10 @@ namespace trview
         virtual ~CollapsiblePanel() = default;
 
         /// Handles a window message.
-        /// @param window The window that received the message.
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Render the window.
         /// @param device The device to render with.

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -32,7 +32,7 @@ namespace trview
         }
     }
 
-    ItemsWindow::ItemsWindow(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent)
+    ItemsWindow::ItemsWindow(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, const Window& parent)
         : CollapsiblePanel(device, shader_storage, font_factory, parent, L"trview.items", L"Items", Size(400, 400))
     {
         set_panels(create_left_panel(), create_right_panel());

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -23,7 +23,7 @@ namespace trview
         /// @param shader_storage The shader storage instance to use.
         /// @param font_factory The font factory to use.
         /// @param parent The parent window.
-        explicit ItemsWindow(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND parent);
+        explicit ItemsWindow(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const Window& parent);
 
         /// Destructor for items window
         virtual ~ItemsWindow() = default;

--- a/trview.app/Windows/ItemsWindowManager.cpp
+++ b/trview.app/Windows/ItemsWindowManager.cpp
@@ -5,12 +5,12 @@
 
 namespace trview
 {
-    ItemsWindowManager::ItemsWindowManager(graphics::Device& device, graphics::IShaderStorage& shader_storage, graphics::FontFactory& font_factory, HWND window)
+    ItemsWindowManager::ItemsWindowManager(graphics::Device& device, graphics::IShaderStorage& shader_storage, graphics::FontFactory& font_factory, const Window& window)
         : _device(device), _shader_storage(shader_storage), _font_factory(font_factory), MessageHandler(window)
     {
     }
 
-    void ItemsWindowManager::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    void ItemsWindowManager::process_message(UINT message, WPARAM wParam, LPARAM lParam)
     {
         if (message == WM_COMMAND && 
             LOWORD(wParam) == ID_APP_WINDOWS_ITEMS || 

--- a/trview.app/Windows/ItemsWindowManager.h
+++ b/trview.app/Windows/ItemsWindowManager.h
@@ -25,17 +25,16 @@ namespace trview
         /// @param shader_storage The shader storage for items windows.
         /// @param font_factory The font_factory for items windows.
         /// @param window The parent window of the items window.
-        explicit ItemsWindowManager(graphics::Device& device, graphics::IShaderStorage& shader_storage, graphics::FontFactory& font_factory, HWND window);
+        explicit ItemsWindowManager(graphics::Device& device, graphics::IShaderStorage& shader_storage, graphics::FontFactory& font_factory, const Window& window);
 
         /// Destructor for the ItemsWindowManager.
         virtual ~ItemsWindowManager() = default;
 
         /// Handles a window message.
-        /// @param window The window that received the message.
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Event raised when an item is selected in one of the item windows.
         Event<Item> on_item_selected;

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -37,7 +37,7 @@ namespace trview
 
     using namespace graphics;
 
-    RouteWindow::RouteWindow(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent)
+    RouteWindow::RouteWindow(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, const trview::Window& parent)
         : CollapsiblePanel(device, shader_storage, font_factory, parent, L"trview.route", L"Route", Size(470, 400))
     {
         set_panels(create_left_panel(), create_right_panel());

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -19,7 +19,7 @@ namespace trview
         /// @param shader_storage The shader storage instance to use.
         /// @param font_factory The font factory to use.
         /// @param parent The parent window.
-        explicit RouteWindow(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND parent);
+        explicit RouteWindow(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const trview::Window& parent);
 
         /// Destructor for triggers window
         virtual ~RouteWindow() = default;

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -3,12 +3,12 @@
 
 namespace trview
 {
-    RouteWindowManager::RouteWindowManager(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND window)
+    RouteWindowManager::RouteWindowManager(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const Window& window)
         : _device(device), _shader_storage(shader_storage), _font_factory(font_factory), MessageHandler(window)
     {
     }
 
-    void RouteWindowManager::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    void RouteWindowManager::process_message(UINT message, WPARAM wParam, LPARAM lParam)
     {
         if (message == WM_COMMAND &&
             LOWORD(wParam) == ID_APP_WINDOWS_ROUTE ||

--- a/trview.app/Windows/RouteWindowManager.h
+++ b/trview.app/Windows/RouteWindowManager.h
@@ -13,16 +13,15 @@ namespace trview
     class RouteWindowManager final : public MessageHandler
     {
     public:
-        explicit RouteWindowManager(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND window);
+        explicit RouteWindowManager(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const Window& window);
 
         virtual ~RouteWindowManager() = default;
 
         /// Handles a window message.
-        /// @param window The window that received the message.
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Render all of the route windows.
         /// @param device The device to use to render.

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -40,7 +40,7 @@ namespace trview
 
     using namespace graphics;
 
-    TriggersWindow::TriggersWindow(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, HWND parent)
+    TriggersWindow::TriggersWindow(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, const Window& parent)
         : CollapsiblePanel(device, shader_storage, font_factory, parent, L"trview.triggers", L"Triggers", Size(470, 400))
     {
         set_panels(create_left_panel(), create_right_panel());

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -24,7 +24,7 @@ namespace trview
         /// @param shader_storage The shader storage instance to use.
         /// @param font_factory The font factory to use.
         /// @param parent The parent window.
-        explicit TriggersWindow(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, HWND parent);
+        explicit TriggersWindow(graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const Window& parent);
 
         /// Destructor for triggers window
         virtual ~TriggersWindow() = default;

--- a/trview.app/Windows/TriggersWindowManager.cpp
+++ b/trview.app/Windows/TriggersWindowManager.cpp
@@ -5,12 +5,12 @@
 
 namespace trview
 {
-    TriggersWindowManager::TriggersWindowManager(graphics::Device& device, graphics::IShaderStorage& shader_storage, graphics::FontFactory& font_factory, HWND window)
+    TriggersWindowManager::TriggersWindowManager(graphics::Device& device, graphics::IShaderStorage& shader_storage, graphics::FontFactory& font_factory, const Window& window)
         : _device(device), _shader_storage(shader_storage), _font_factory(font_factory), MessageHandler(window)
     {
     }
 
-    void TriggersWindowManager::process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam)
+    void TriggersWindowManager::process_message(UINT message, WPARAM wParam, LPARAM lParam)
     {
         if (message == WM_COMMAND &&
             LOWORD(wParam) == ID_APP_WINDOWS_TRIGGERS ||

--- a/trview.app/Windows/TriggersWindowManager.h
+++ b/trview.app/Windows/TriggersWindowManager.h
@@ -22,17 +22,16 @@ namespace trview
         /// @param shader_storage The shader storage for triggers windows.
         /// @param font_factory The font_factory for triggers windows.
         /// @param window The parent window of the triggers window.
-        explicit TriggersWindowManager(graphics::Device& device, graphics::IShaderStorage& shader_storage, graphics::FontFactory& font_factory, HWND window);
+        explicit TriggersWindowManager(graphics::Device& device, graphics::IShaderStorage& shader_storage, graphics::FontFactory& font_factory, const Window& window);
 
         /// Destructor for the TriggersWindowManager.
         virtual ~TriggersWindowManager() = default;
 
         /// Handles a window message.
-        /// @param window The window that received the message.
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Event raised when an item is selected in one of the trigger windows.
         Event<Item> on_item_selected;

--- a/trview.app/Windows/WindowResizer.cpp
+++ b/trview.app/Windows/WindowResizer.cpp
@@ -3,12 +3,12 @@
 
 namespace trview
 {
-    WindowResizer::WindowResizer(HWND window)
+    WindowResizer::WindowResizer(const Window& window)
         : MessageHandler(window), _previous_size(Window(window).size())
     {
     }
 
-    void WindowResizer::process_message(HWND, UINT message, WPARAM wParam, LPARAM)
+    void WindowResizer::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         switch (message)
         {

--- a/trview.app/Windows/WindowResizer.h
+++ b/trview.app/Windows/WindowResizer.h
@@ -16,17 +16,16 @@ namespace trview
     public:
         /// Create a WindowResizer.
         /// @param window The window to monitor.
-        explicit WindowResizer(HWND window);
+        explicit WindowResizer(const Window& window);
 
         /// Destructor for WindowResizer.
         virtual ~WindowResizer() = default;
 
         /// Handles a window message.
-        /// @param window The window that received the message.
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Event that is raised when the window has resized.
         Event<> on_resize;

--- a/trview.common/MessageHandler.cpp
+++ b/trview.common/MessageHandler.cpp
@@ -21,7 +21,7 @@ namespace trview
         /// Find the next available subclass id.
         /// @param window The window to subclass.
         /// @remarks This will test random subclass IDs until it finds one that isn't set.
-        uint32_t next_subclass_id(HWND window)
+        uint32_t next_subclass_id(const Window& window)
         {
             std::default_random_engine random;
             uint32_t id = random();

--- a/trview.common/MessageHandler.cpp
+++ b/trview.common/MessageHandler.cpp
@@ -13,7 +13,7 @@ namespace trview
             MessageHandler* handler = reinterpret_cast<MessageHandler*>(dwRefData);
             if (handler)
             {
-                handler->process_message(hWnd, message, wParam, lParam);
+                handler->process_message(message, wParam, lParam);
             }
             return DefSubclassProc(hWnd, message, wParam, lParam);
         }
@@ -34,7 +34,7 @@ namespace trview
         }
     }
 
-    MessageHandler::MessageHandler(HWND window)
+    MessageHandler::MessageHandler(const Window& window)
         : _window(window), _subclass_id(next_subclass_id(window))
     {
         SetWindowSubclass(window, HandlerProc, _subclass_id, reinterpret_cast<DWORD_PTR>(this));
@@ -74,7 +74,7 @@ namespace trview
         RemoveWindowSubclass(_window, HandlerProc, _subclass_id);
     }
 
-    Window MessageHandler::window() const
+    const Window& MessageHandler::window() const
     {
         return _window;
     }

--- a/trview.common/MessageHandler.h
+++ b/trview.common/MessageHandler.h
@@ -15,7 +15,7 @@ namespace trview
     public:
         /// Create a new MessageHandler.
         /// @param window The window to listen to.
-        explicit MessageHandler(HWND window);
+        explicit MessageHandler(const Window& window);
 
         /// Copy constructor for MessageHandler.
         /// @param other The handler to copy.
@@ -37,17 +37,16 @@ namespace trview
         virtual ~MessageHandler();
 
         /// Handles a window message.
-        /// @param window The window that received the message.
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) = 0;
+        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) = 0;
 
         /// Gets the window that the handler is listening to.
         /// @returns The window handle.
-        Window window() const;
+        const Window& window() const;
     private:
-        HWND     _window;
+        Window _window;
         uint32_t _subclass_id;
     };
 }

--- a/trview.graphics/Device.cpp
+++ b/trview.graphics/Device.cpp
@@ -65,7 +65,7 @@ namespace trview
             return _context;
         }
 
-        std::unique_ptr<DeviceWindow> Device::create_for_window(HWND window)
+        std::unique_ptr<DeviceWindow> Device::create_for_window(const Window& window)
         {
             return std::make_unique<DeviceWindow>(*this, window);
         }

--- a/trview.graphics/Device.h
+++ b/trview.graphics/Device.h
@@ -43,7 +43,7 @@ namespace trview
             /// Create a device window to render to a specific window.
             /// @param window The window to render to.
             /// @returns The device window object.
-            std::unique_ptr<DeviceWindow> create_for_window(HWND window);
+            std::unique_ptr<DeviceWindow> create_for_window(const Window& window);
         private:
             Microsoft::WRL::ComPtr<ID3D11Device>        _device;
             Microsoft::WRL::ComPtr<ID3D11DeviceContext> _context;

--- a/trview.input.tests/KeyboardTests.cpp
+++ b/trview.input.tests/KeyboardTests.cpp
@@ -20,8 +20,7 @@ namespace trview
                 int times_called = 0;
                 uint16_t key_received = 0;
 
-                HWND window = create_test_window(L"TRViewInputTests");
-                Keyboard keyboard(window);
+                Keyboard keyboard(create_test_window(L"TRViewInputTests"));
                 auto token = keyboard.on_key_down +=
                     [&times_called, &key_received](uint16_t key, bool control) 
                 {
@@ -29,7 +28,7 @@ namespace trview
                     key_received = key; 
                 };
 
-                SendMessage(window, WM_KEYDOWN, VK_SPACE, 0);
+                keyboard.process_message(WM_KEYDOWN, VK_SPACE, 0);
 
                 Assert::AreEqual(1, times_called);
                 Assert::AreEqual(static_cast<int>(VK_SPACE), static_cast<int>(key_received));
@@ -42,8 +41,7 @@ namespace trview
                 int times_called = 0;
                 uint16_t key_received = 0;
 
-                HWND window = create_test_window(L"TRViewInputTests");
-                Keyboard keyboard(window);
+                Keyboard keyboard(create_test_window(L"TRViewInputTests"));
                 auto token = keyboard.on_key_up +=
                     [&times_called, &key_received](uint16_t key, bool control)
                 {
@@ -51,7 +49,7 @@ namespace trview
                     key_received = key;
                 };
 
-                SendMessage(window, WM_KEYUP, VK_SPACE, 0);
+                keyboard.process_message(WM_KEYUP, VK_SPACE, 0);
 
                 Assert::AreEqual(1, times_called);
                 Assert::AreEqual(static_cast<int>(VK_SPACE), static_cast<int>(key_received));
@@ -64,8 +62,7 @@ namespace trview
                 int times_called = 0;
                 uint16_t char_received = 0;
 
-                HWND window = create_test_window(L"TRViewInputTests");
-                Keyboard keyboard(window);
+                Keyboard keyboard(create_test_window(L"TRViewInputTests"));
                 auto token = keyboard.on_char +=
                     [&times_called, &char_received](uint16_t key)
                 {
@@ -73,7 +70,7 @@ namespace trview
                     char_received = key;
                 };
 
-                SendMessage(window, WM_CHAR, 'A', 0);
+                keyboard.process_message(WM_CHAR, 'A', 0);
 
                 Assert::AreEqual(1, times_called);
                 Assert::AreEqual(static_cast<int>('A'), static_cast<int>(char_received));

--- a/trview.input.tests/MouseTests.cpp
+++ b/trview.input.tests/MouseTests.cpp
@@ -42,8 +42,7 @@ namespace trview
                 int times_called = 0;
                 Mouse::Button button_received = Mouse::Button::Left;
 
-                HWND window = create_test_window(L"TRViewInputTests");
-                Mouse mouse(window);
+                Mouse mouse(create_test_window(L"TRViewInputTests"));
 
                 auto token = mouse.mouse_down += 
                     [&times_called, &button_received](auto button)
@@ -70,8 +69,7 @@ namespace trview
                 int times_called = 0;
                 Mouse::Button button_received = Mouse::Button::Left;
 
-                HWND window = create_test_window(L"TRViewInputTests");
-                Mouse mouse(window);
+                Mouse mouse(create_test_window(L"TRViewInputTests"));
 
                 auto token = mouse.mouse_up +=
                     [&times_called, &button_received](auto button)
@@ -98,8 +96,7 @@ namespace trview
                 int times_called = 0;
                 int16_t scroll_received = 0;
 
-                HWND window = create_test_window(L"TRViewInputTests");
-                Mouse mouse(window);
+                Mouse mouse(create_test_window(L"TRViewInputTests"));
 
                 auto token = mouse.mouse_wheel +=
                     [&times_called, &scroll_received](auto scroll)
@@ -108,7 +105,7 @@ namespace trview
                     scroll_received = scroll;
                 };
 
-                SendMessage(window, WM_MOUSEWHEEL, MAKEWPARAM(0, 100), 0);
+                mouse.process_message(WM_MOUSEWHEEL, MAKEWPARAM(0, 100), 0);
 
                 Assert::AreEqual(1, times_called);
                 Assert::AreEqual(static_cast<int>(100), static_cast<int>(scroll_received));
@@ -121,8 +118,7 @@ namespace trview
                 int times_called = 0;
                 long x_received, y_received = 0;
 
-                HWND window = create_test_window(L"TRViewInputTests");
-                Mouse mouse(window);
+                Mouse mouse(create_test_window(L"TRViewInputTests"));
 
                 auto token = mouse.mouse_move +=
                     [&times_called, &x_received, &y_received](long x, long y)
@@ -154,8 +150,7 @@ namespace trview
             /// is sent to the window.
             TEST_METHOD(MousePosition)
             {
-                HWND window = create_test_window(L"TRViewInputTests");
-                Mouse mouse(window);
+                Mouse mouse(create_test_window(L"TRViewInputTests"));
 
                 RAWINPUT input;
                 memset(&input, 0, sizeof(input));

--- a/trview.input/Keyboard.cpp
+++ b/trview.input/Keyboard.cpp
@@ -4,7 +4,7 @@ namespace trview
 {
     namespace input
     {
-        Keyboard::Keyboard(HWND window)
+        Keyboard::Keyboard(const Window& window)
             : MessageHandler(window)
         {
         }
@@ -18,7 +18,7 @@ namespace trview
             return GetAsyncKeyState(VK_CONTROL);
         }
 
-        void Keyboard::process_message(HWND, UINT message, WPARAM wParam, LPARAM)
+        void Keyboard::process_message(UINT message, WPARAM wParam, LPARAM)
         {
             bool control_pressed = control();
             switch (message)

--- a/trview.input/Keyboard.h
+++ b/trview.input/Keyboard.h
@@ -7,10 +7,8 @@
 #pragma once
 
 #include <cstdint>
-#include <vector>
 #include <trview.common/Event.h>
 #include <trview.common/MessageHandler.h>
-#include <Windows.h>
 
 namespace trview
 {
@@ -22,7 +20,7 @@ namespace trview
         public:
             /// Create a keyboard to listen to keyboard messages for a specific window.
             /// @param window The window to listen to.
-            explicit Keyboard(HWND window);
+            explicit Keyboard(const Window& window);
 
             /// Destructor for Keyboard. This will remove the keyboard from the all keyboard
             /// map. This will stop messages being sent to this keyboard.
@@ -45,11 +43,10 @@ namespace trview
             Event<uint16_t> on_char;
 
             /// Handles a window message.
-            /// @param window The window that received the message.
             /// @param message The message that was received.
             /// @param wParam The WPARAM for the message.
             /// @param lParam The LPARAM for the message.
-            virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+            virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         };
     }
 }

--- a/trview.input/Mouse.cpp
+++ b/trview.input/Mouse.cpp
@@ -11,7 +11,7 @@ namespace trview
             const uint32_t ClickDelta = 200;
         }
 
-        Mouse::Mouse(HWND window)
+        Mouse::Mouse(const Window& window)
             : MessageHandler(window)
         {
             // Register raw input devices so that the window
@@ -112,7 +112,7 @@ namespace trview
             _absolute_y = y;
         }
 
-        void Mouse::process_message(HWND, UINT message, WPARAM wParam, LPARAM lParam)
+        void Mouse::process_message(UINT message, WPARAM wParam, LPARAM lParam)
         {
             switch (message)
             {

--- a/trview.input/Mouse.h
+++ b/trview.input/Mouse.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <windows.h>
 #include <trview.common/Event.h>
 #include <trview.common/MessageHandler.h>
 #include <cstdint>
@@ -30,7 +29,7 @@ namespace trview
 
             /// Creates an instance of the Mouse class.
             /// @param window The window to monitor.
-            explicit Mouse(HWND window);
+            explicit Mouse(const Window& window);
 
             /// Destructor for Mouse. This will remove the mouse from the all mice
             /// map. This will stop messages being sent to this mouse.
@@ -68,11 +67,10 @@ namespace trview
             long y() const;
 
             /// Handles a window message.
-            /// @param window The window that received the message.
             /// @param message The message that was received.
             /// @param wParam The WPARAM for the message.
             /// @param lParam The LPARAM for the message.
-            virtual void process_message(HWND window, UINT message, WPARAM wParam, LPARAM lParam) override;
+            virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         private:
             void raise_absolute_mouse_move(long x, long y);
 

--- a/trview.tests.common/Window.cpp
+++ b/trview.tests.common/Window.cpp
@@ -9,7 +9,7 @@ namespace trview
             return DefWindowProc(hWnd, message, wParam, lParam);
         }
 
-        HWND create_test_window(const std::wstring& name)
+        Window create_test_window(const std::wstring& name)
         {
             HINSTANCE hInstance = GetModuleHandle(nullptr);
 

--- a/trview.tests.common/Window.h
+++ b/trview.tests.common/Window.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <windows.h>
 #include <string>
+#include <trview.common/Window.h>
 
 namespace trview
 {
@@ -9,6 +9,6 @@ namespace trview
     {
         /// Makes a hidden test window that can be used to pass messages to for tests.
         /// @param name The name to use for the window class and window name.
-        HWND create_test_window(const std::wstring& name);
+        Window create_test_window(const std::wstring& name);
     }
 }

--- a/trview.tests.common/trview.tests.common.vcxproj
+++ b/trview.tests.common/trview.tests.common.vcxproj
@@ -100,6 +100,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -118,6 +119,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -134,6 +136,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -152,6 +155,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Use the Window class instead of using HWND directly, except where it makes sense to use HWND (function parameters on windows callbacks for example)
Issue: #445