### PR TITLE
Add interface to mouse to check windows and system metrics

### DIFF
--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -6,13 +6,14 @@
 #include <trview.app/UI/ContextMenu.h>
 #include <sstream>
 #include <iomanip>
+#include <trview.input/WindowTester.h>
 
 using namespace trview::ui;
 
 namespace trview
 {
     ViewerUI::ViewerUI(const Window& window, const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const ITextureStorage& texture_storage)
-        : _mouse(window), _window(window), _keyboard(window)
+        : _mouse(window, std::make_unique<input::WindowTester>()), _window(window), _keyboard(window)
     {
         _control = std::make_unique<ui::Window>(Point(), window.size(), Colour::Transparent);
 

--- a/trview.input.tests/MouseTests.cpp
+++ b/trview.input.tests/MouseTests.cpp
@@ -173,7 +173,7 @@ namespace trview
         private:
             std::unique_ptr<input::IWindowTester> tester(const Window& window)
             {
-                class TestWindowTester : public IWindowTester
+                class TestWindowTester final : public IWindowTester
                 {
                 public:
                     TestWindowTester(const Window& window)

--- a/trview.input.tests/MouseTests.cpp
+++ b/trview.input.tests/MouseTests.cpp
@@ -162,8 +162,8 @@ namespace trview
                 input.header.dwType = RIM_TYPEMOUSE;
                 input.header.dwSize = sizeof(RAWINPUT);
                 input.data.mouse.usFlags |= MOUSE_MOVE_ABSOLUTE;
-                input.data.mouse.lLastX = 123;
-                input.data.mouse.lLastY = 456;
+                input.data.mouse.lLastX = static_cast<int>(std::round((123.0f / 1000.0f) * 65535.0f));
+                input.data.mouse.lLastY = static_cast<int>(std::round((456.0f / 1000.0f) * 65535.0f));
                 mouse.process_input(input);
 
                 Assert::AreEqual(123, static_cast<int>(mouse.x()));
@@ -184,6 +184,16 @@ namespace trview
                     virtual Window window_under_cursor() const override
                     {
                         return _window;
+                    }
+
+                    virtual int screen_width(bool) const override
+                    {
+                        return 1000;
+                    }
+
+                    virtual int screen_height(bool) const override
+                    {
+                        return 1000;
                     }
                 private:
                     Window _window;

--- a/trview.input.tests/MouseTests.cpp
+++ b/trview.input.tests/MouseTests.cpp
@@ -42,7 +42,8 @@ namespace trview
                 int times_called = 0;
                 Mouse::Button button_received = Mouse::Button::Left;
 
-                Mouse mouse(create_test_window(L"TRViewInputTests"));
+                auto window = create_test_window(L"TRViewInputTests");
+                Mouse mouse(window, tester(window));
 
                 auto token = mouse.mouse_down += 
                     [&times_called, &button_received](auto button)
@@ -69,7 +70,8 @@ namespace trview
                 int times_called = 0;
                 Mouse::Button button_received = Mouse::Button::Left;
 
-                Mouse mouse(create_test_window(L"TRViewInputTests"));
+                auto window = create_test_window(L"TRViewInputTests");
+                Mouse mouse(window, tester(window));
 
                 auto token = mouse.mouse_up +=
                     [&times_called, &button_received](auto button)
@@ -96,7 +98,8 @@ namespace trview
                 int times_called = 0;
                 int16_t scroll_received = 0;
 
-                Mouse mouse(create_test_window(L"TRViewInputTests"));
+                auto window = create_test_window(L"TRViewInputTests");
+                Mouse mouse(window, tester(window));
 
                 auto token = mouse.mouse_wheel +=
                     [&times_called, &scroll_received](auto scroll)
@@ -118,7 +121,8 @@ namespace trview
                 int times_called = 0;
                 long x_received, y_received = 0;
 
-                Mouse mouse(create_test_window(L"TRViewInputTests"));
+                auto window = create_test_window(L"TRViewInputTests");
+                Mouse mouse(window, tester(window));
 
                 auto token = mouse.mouse_move +=
                     [&times_called, &x_received, &y_received](long x, long y)
@@ -150,7 +154,8 @@ namespace trview
             /// is sent to the window.
             TEST_METHOD(MousePosition)
             {
-                Mouse mouse(create_test_window(L"TRViewInputTests"));
+                auto window = create_test_window(L"TRViewInputTests");
+                Mouse mouse(window, tester(window));
 
                 RAWINPUT input;
                 memset(&input, 0, sizeof(input));
@@ -163,6 +168,27 @@ namespace trview
 
                 Assert::AreEqual(123, static_cast<int>(mouse.x()));
                 Assert::AreEqual(456, static_cast<int>(mouse.y()));
+            }
+
+        private:
+            std::unique_ptr<input::IWindowTester> tester(const Window& window)
+            {
+                class TestWindowTester : public IWindowTester
+                {
+                public:
+                    TestWindowTester(const Window& window)
+                        : _window(window)
+                    {
+                    }
+
+                    virtual Window window_under_cursor() const override
+                    {
+                        return _window;
+                    }
+                private:
+                    Window _window;
+                };
+                return std::make_unique<TestWindowTester>(window);
             }
         };
     }

--- a/trview.input/IWindowTester.cpp
+++ b/trview.input/IWindowTester.cpp
@@ -1,0 +1,11 @@
+#include "IWindowTester.h"
+
+namespace trview
+{
+    namespace input
+    {
+        IWindowTester::~IWindowTester()
+        {
+        }
+    }
+}

--- a/trview.input/IWindowTester.h
+++ b/trview.input/IWindowTester.h
@@ -10,6 +10,8 @@ namespace trview
         {
             virtual ~IWindowTester() = 0;
             virtual Window window_under_cursor() const = 0;
+            virtual int screen_width(bool rdp) const = 0;
+            virtual int screen_height(bool rdp) const = 0;
         };
     }
 }

--- a/trview.input/IWindowTester.h
+++ b/trview.input/IWindowTester.h
@@ -6,11 +6,20 @@ namespace trview
 {
     namespace input
     {
+        /// Used to check for Windows information.
         struct IWindowTester
         {
             virtual ~IWindowTester() = 0;
+
+            /// Gets the window that is currently under the cursor.
             virtual Window window_under_cursor() const = 0;
+
+            /// Gets the screen width - or the virtual screen width if on remote desktop.
+            /// @param rdp Whether to check the remote screen size.
             virtual int screen_width(bool rdp) const = 0;
+
+            /// Gets the screen height - or the virtual screen height if on remote desktop.
+            /// @param rdp Whether to check the remote screen size.
             virtual int screen_height(bool rdp) const = 0;
         };
     }

--- a/trview.input/IWindowTester.h
+++ b/trview.input/IWindowTester.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <trview.common/Window.h>
+
+namespace trview
+{
+    namespace input
+    {
+        struct IWindowTester
+        {
+            virtual ~IWindowTester() = 0;
+            virtual Window window_under_cursor() const = 0;
+        };
+    }
+}

--- a/trview.input/Mouse.cpp
+++ b/trview.input/Mouse.cpp
@@ -11,8 +11,8 @@ namespace trview
             const uint32_t ClickDelta = 200;
         }
 
-        Mouse::Mouse(const Window& window)
-            : MessageHandler(window)
+        Mouse::Mouse(const Window& window, std::unique_ptr<IWindowTester>&& window_tester)
+            : MessageHandler(window), _window_tester(std::move(window_tester))
         {
             // Register raw input devices so that the window
             // will receive the raw input messages.
@@ -35,8 +35,7 @@ namespace trview
         {
             if (input.header.dwType == RIM_TYPEMOUSE)
             {
-                auto active_window = window_under_cursor();
-
+                auto active_window = _window_tester->window_under_cursor();
                 if (active_window == window() && input.data.mouse.usButtonFlags & RI_MOUSE_LEFT_BUTTON_DOWN)
                 {
                     mouse_down(Button::Left);

--- a/trview.input/Mouse.cpp
+++ b/trview.input/Mouse.cpp
@@ -75,11 +75,9 @@ namespace trview
                 if (input.data.mouse.usFlags & MOUSE_MOVE_ABSOLUTE)
                 {
                     bool is_rdp = input.data.mouse.usFlags & MOUSE_VIRTUAL_DESKTOP;
-                    int width = GetSystemMetrics(is_rdp ? SM_CXVIRTUALSCREEN : SM_CXSCREEN);
-                    int height = GetSystemMetrics(is_rdp ? SM_CYVIRTUALSCREEN : SM_CYSCREEN);
                     raise_absolute_mouse_move(
-                        (input.data.mouse.lLastX / static_cast<float>(USHRT_MAX)) * width,
-                        (input.data.mouse.lLastY / static_cast<float>(USHRT_MAX)) * height);
+                        (input.data.mouse.lLastX / static_cast<float>(USHRT_MAX)) * _window_tester->screen_width(is_rdp),
+                        (input.data.mouse.lLastY / static_cast<float>(USHRT_MAX)) * _window_tester->screen_height(is_rdp));
                 }
 
                 if (input.data.mouse.usButtonFlags & RI_MOUSE_WHEEL)

--- a/trview.input/Mouse.h
+++ b/trview.input/Mouse.h
@@ -10,12 +10,14 @@
 #include <trview.common/MessageHandler.h>
 #include <cstdint>
 
+#include "IWindowTester.h"
+
 namespace trview
 {
     namespace input
     {
         /// Receives mouse input on a specific window.
-        class Mouse : public MessageHandler
+        class Mouse final : public MessageHandler
         {
         public:
             /// The mouse button that was pressed.
@@ -29,7 +31,8 @@ namespace trview
 
             /// Creates an instance of the Mouse class.
             /// @param window The window to monitor.
-            explicit Mouse(const Window& window);
+            /// @param window_tester The window tester to use.
+            explicit Mouse(const Window& window, std::unique_ptr<IWindowTester>&& window_tester);
 
             /// Destructor for Mouse. This will remove the mouse from the all mice
             /// map. This will stop messages being sent to this mouse.
@@ -74,6 +77,7 @@ namespace trview
         private:
             void raise_absolute_mouse_move(long x, long y);
 
+            std::unique_ptr<IWindowTester> _window_tester;
             bool _any_absolute_previous{ false };
             long _absolute_x;
             long _absolute_y;

--- a/trview.input/WindowTester.cpp
+++ b/trview.input/WindowTester.cpp
@@ -9,5 +9,15 @@ namespace trview
         {
             return trview::window_under_cursor();
         }
+
+        int WindowTester::screen_width(bool rdp) const
+        {
+            return GetSystemMetrics(rdp ? SM_CXVIRTUALSCREEN : SM_CXSCREEN);
+        }
+
+        int WindowTester::screen_height(bool rdp) const
+        {
+            return GetSystemMetrics(rdp ? SM_CYVIRTUALSCREEN : SM_CYSCREEN);
+        }
     }
 }

--- a/trview.input/WindowTester.cpp
+++ b/trview.input/WindowTester.cpp
@@ -1,0 +1,13 @@
+#include "WindowTester.h"
+#include <trview.common/Window.h>
+
+namespace trview
+{
+    namespace input
+    {
+        Window WindowTester::window_under_cursor() const
+        {
+            return trview::window_under_cursor();
+        }
+    }
+}

--- a/trview.input/WindowTester.h
+++ b/trview.input/WindowTester.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "IWindowTester.h"
+
+namespace trview
+{
+    namespace input
+    {
+        class WindowTester final : public IWindowTester
+        {
+        public:
+            virtual ~WindowTester() = default;
+
+            virtual Window window_under_cursor() const override;
+        };
+    }
+}

--- a/trview.input/WindowTester.h
+++ b/trview.input/WindowTester.h
@@ -10,8 +10,9 @@ namespace trview
         {
         public:
             virtual ~WindowTester() = default;
-
             virtual Window window_under_cursor() const override;
+            virtual int screen_width(bool rdp) const override;
+            virtual int screen_height(bool rdp) const override;
         };
     }
 }

--- a/trview.input/trview.input.vcxproj
+++ b/trview.input/trview.input.vcxproj
@@ -19,12 +19,16 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="IWindowTester.cpp" />
     <ClCompile Include="Keyboard.cpp" />
     <ClCompile Include="Mouse.cpp" />
+    <ClCompile Include="WindowTester.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="IWindowTester.h" />
     <ClInclude Include="Keyboard.h" />
     <ClInclude Include="Mouse.h" />
+    <ClInclude Include="WindowTester.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\trview.common\trview.common.vcxproj">

--- a/trview.input/trview.input.vcxproj.filters
+++ b/trview.input/trview.input.vcxproj.filters
@@ -3,9 +3,13 @@
   <ItemGroup>
     <ClCompile Include="Mouse.cpp" />
     <ClCompile Include="Keyboard.cpp" />
+    <ClCompile Include="WindowTester.cpp" />
+    <ClCompile Include="IWindowTester.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Mouse.h" />
     <ClInclude Include="Keyboard.h" />
+    <ClInclude Include="IWindowTester.h" />
+    <ClInclude Include="WindowTester.h" />
   </ItemGroup>
 </Project>

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -1,5 +1,6 @@
 #include "Input.h"
 #include "Control.h"
+#include <trview.input/WindowTester.h>
 
 namespace trview
 {
@@ -14,7 +15,7 @@ namespace trview
         }
 
         Input::Input(const trview::Window& window, Control& control)
-            : _mouse(window), _keyboard(window), _window(window), _control(control)
+            : _mouse(window, std::make_unique<input::WindowTester>()), _keyboard(window), _window(window), _control(control)
         {
             register_events();
         }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -15,6 +15,7 @@
 #include <trview.graphics/RenderTargetStore.h>
 #include <trview.graphics/Sprite.h>
 #include <trview.graphics/ViewportStore.h>
+#include <trview.input/WindowTester.h>
 
 #include "DefaultTextures.h"
 #include "DefaultShaders.h"
@@ -31,7 +32,7 @@ namespace trview
 
     Viewer::Viewer(const Window& window)
         : _window(window), _camera(window.size()), _free_camera(window.size()),
-        _timer(default_time_source()), _keyboard(window), _mouse(window), _level_switcher(window),
+        _timer(default_time_source()), _keyboard(window), _mouse(window, std::make_unique<input::WindowTester>()), _level_switcher(window),
         _window_resizer(window), _recent_files(window), _file_dropper(window), _alternate_group_toggler(window),
         _view_menu(window), _update_checker(window)
     {


### PR DESCRIPTION
Adds an interface that is used to check the window under the cursor and system metrics such as the screen width. This allows the mouse to be unit tested more easily and fixes the test failures introduced recently.
Bug: #560 