### PR TITLE
Use Debug DLL runtime library in input tests

### DIFF
--- a/trview.input.tests/trview.input.tests.vcxproj
+++ b/trview.input.tests/trview.input.tests.vcxproj
@@ -37,9 +37,9 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{1D81CEF5-5705-4AF8-A76A-B63D6EA53454}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-	<PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <ConfigurationType>Application</ConfigurationType>
-	<CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>Unicode</CharacterSet>
     <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
@@ -73,6 +73,7 @@
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -89,6 +90,7 @@
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/trview.input.tests/trview.input.tests.vcxproj.filters
+++ b/trview.input.tests/trview.input.tests.vcxproj.filters
@@ -3,6 +3,8 @@
   <ItemGroup>
     <ClCompile Include="KeyboardTests.cpp" />
     <ClCompile Include="MouseTests.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest\gtest-all.cc" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
This was causing errors compiling mock as it was set to multi threaded dll.
Bug: #565