### PR TITLE
Allow user to enter camera coordinates

### DIFF
--- a/trview.app.tests/UI/CameraPositionTests.cpp
+++ b/trview.app.tests/UI/CameraPositionTests.cpp
@@ -1,0 +1,61 @@
+#include "gmock/gmock.h"
+#include <trview.app/UI/CameraPosition.h>
+
+using namespace trview;
+using namespace trview::ui;
+using namespace DirectX::SimpleMath;
+using testing::HasSubstr;
+
+/// Tests that the position event is raised when the coordinates are changed.
+TEST(CameraPosition, PositionEventRaised)
+{
+    Window window(Point(), Size(100, 100), Colour::Transparent);
+
+    int times_called = 0;
+    Vector3 new_position;
+
+    auto subject = CameraPosition(window);
+    auto token = subject.on_position_changed += [&times_called, &new_position](const auto& position) 
+    {
+        ++times_called;
+        new_position = position;
+    };
+
+    auto area_x = window.find<TextArea>("X");
+    area_x->gained_focus();
+    area_x->set_text(L"1024");
+    area_x->key_char(0xD);
+
+    auto area_y = window.find<TextArea>("Y");
+    area_y->gained_focus();
+    area_y->set_text(L"2048");
+    area_y->key_char(0xD);
+
+    auto area_z = window.find<TextArea>("Z");
+    area_z->gained_focus();
+    area_z->set_text(L"3072");
+    area_z->key_char(0xD);
+
+    ASSERT_EQ(times_called, 3);
+    // The position is scaled by diving by 1024.
+    ASSERT_EQ(new_position.x, 1.0f);
+    ASSERT_EQ(new_position.y, 2.0f);
+    ASSERT_EQ(new_position.z, 3.0f);
+}
+
+/// Tests that the coordinate labels are updated to have the correct position values.
+TEST(CameraPosition, CoordinatesUpdated)
+{
+    Window window(Point(), Size(100, 100), Colour::Transparent);
+    auto subject = CameraPosition(window);
+
+    auto area_x = window.find<TextArea>("X");
+    auto area_y = window.find<TextArea>("Y");
+    auto area_z = window.find<TextArea>("Z");
+
+    subject.set_position(Vector3(1, 2, 3));
+
+    EXPECT_THAT(area_x->text(), HasSubstr(L"1024.000000"));
+    EXPECT_THAT(area_y->text(), HasSubstr(L"2048.000000"));
+    EXPECT_THAT(area_z->text(), HasSubstr(L"3072.000000"));
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -26,6 +26,7 @@
     <ClCompile Include="Graphics\LevelTextureStorageTests.cpp" />
     <ClCompile Include="OrbitCameraTests.cpp" />
     <ClCompile Include="RecentFilesTests.cpp" />
+    <ClCompile Include="UI\CameraPositionTests.cpp" />
     <ClCompile Include="WindowResizerTests.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -17,6 +17,9 @@
     <ClCompile Include="Graphics\LevelTextureStorageTests.cpp">
       <Filter>Graphics</Filter>
     </ClCompile>
+    <ClCompile Include="UI\CameraPositionTests.cpp">
+      <Filter>UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">
@@ -27,6 +30,9 @@
     </Filter>
     <Filter Include="Graphics">
       <UniqueIdentifier>{f9007a99-8e00-4b17-9dab-6ab7323ed754}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="UI">
+      <UniqueIdentifier>{d7f73817-593e-4331-aadf-516ff57cec5a}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -14,6 +14,17 @@ namespace trview
         {
             return (value >= 0 ? L" " : L"") + std::to_wstring(value);
         }
+
+        ui::TextArea* create_coordinate_entry(TokenStore& token_store, Control& parent, const std::wstring& name)
+        {
+            auto line = std::make_unique<StackPanel>(Point(), Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
+            line->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, name + L": ", 8));
+            auto entry = line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
+            entry->set_mode(TextArea::Mode::SingleLine);
+            token_store += entry->on_selected += [=]() { entry->set_text(L""); };
+            parent.add_child(std::move(line));
+            return entry;
+        }
     }
 
     CameraPosition::CameraPosition(Control& parent)
@@ -21,30 +32,9 @@ namespace trview
         auto display = std::make_unique<StackPanel>(Point(10, parent.size().height - 90), Size(200, 90), Colour(0.5f, 0.0f, 0.0f, 0.0f));
         display->set_margin(Size(5, 5));
 
-        auto x_line = std::make_unique<StackPanel>(Point(), Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
-        x_line->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, L"X: ", 8));
-        _x = x_line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
-        _x->set_text(L"X coordinate");
-        _x->set_mode(TextArea::Mode::SingleLine);
-        _token_store += _x->on_selected += [&]() { _x->set_text(L""); };
-        display->add_child(std::move(x_line));
-
-        auto y_line = std::make_unique<StackPanel>(Point(), Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
-        y_line->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, L"Y: ", 8));
-        _y = y_line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
-        _y->set_text(L"Y coordinate");
-        _y->set_mode(TextArea::Mode::SingleLine);
-        _token_store += _y->on_selected += [&]() { _y->set_text(L""); };
-        display->add_child(std::move(y_line));
-
-        auto z_line = std::make_unique<StackPanel>(Point(), Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
-        z_line->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, L"Z: ", 8));
-        _z = z_line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
-        _z->set_text(L"Z coordinate");
-        _z->set_mode(TextArea::Mode::SingleLine);
-        _token_store += _z->on_selected += [&]() { _z->set_text(L""); };
-        display->add_child(std::move(z_line));
-
+        _x = create_coordinate_entry(_token_store, *display, L"X");
+        _y = create_coordinate_entry(_token_store, *display, L"Y");
+        _z = create_coordinate_entry(_token_store, *display, L"Z");
         _display = parent.add_child(std::move(display));
 
         auto update_position = [&](Size size)

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -51,6 +51,11 @@ namespace trview
 
         _token_store += parent.on_size_changed += update_position;
         update_position(parent.size());
+
+        // Bind manual camera position entry controls.
+        _token_store += _x->on_enter += [](const std::wstring& text) {};
+        _token_store += _y->on_enter += [](const std::wstring& text) {};
+        _token_store += _z->on_enter += [](const std::wstring& text) {};
     }
 
     void CameraPosition::set_position(const DirectX::SimpleMath::Vector3& position)

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -73,6 +73,7 @@ namespace trview
         line->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, name + L": ", 8));
         auto entry = line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
         entry->set_mode(TextArea::Mode::SingleLine);
+        entry->set_text(convert_number(0));
         _token_store += entry->on_selected += [=]() { entry->set_text(L""); };
         _token_store += entry->on_escape += [=]()
         {

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -1,5 +1,6 @@
 #include "CameraPosition.h"
 #include <trlevel/trlevel.h>
+#include <trview.ui/Label.h>
 
 using namespace trview::ui;
 using namespace trview::graphics;
@@ -20,9 +21,24 @@ namespace trview
         auto display = std::make_unique<StackPanel>(Point(10, parent.size().height - 90), Size(200, 90), Colour(0.5f, 0.0f, 0.0f, 0.0f));
         display->set_margin(Size(5, 5));
 
-        _x = display->add_child(std::make_unique<Label>(Point(), Size(100, 20), Colour::Transparent, L"X coordinate", 8));
-        _y = display->add_child(std::make_unique<Label>(Point(), Size(100, 20), Colour::Transparent, L"Y coordinate", 8));
-        _z = display->add_child(std::make_unique<Label>(Point(), Size(100, 20), Colour::Transparent, L"Z coordinate", 8));
+        auto x_line = std::make_unique<StackPanel>(Point(), Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
+        x_line->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, L"X: ", 8));
+        _x = x_line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
+        _x->set_text(L"X coordinate");
+        display->add_child(std::move(x_line));
+
+        auto y_line = std::make_unique<StackPanel>(Point(), Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
+        y_line->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, L"Y: ", 8));
+        _y = y_line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
+        _y->set_text(L"Y coordinate");
+        display->add_child(std::move(y_line));
+
+        auto z_line = std::make_unique<StackPanel>(Point(), Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
+        z_line->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, L"Z: ", 8));
+        _z = z_line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
+        _z->set_text(L"Z coordinate");
+        display->add_child(std::move(z_line));
+
         _display = parent.add_child(std::move(display));
 
         auto update_position = [&](Size size)
@@ -36,8 +52,8 @@ namespace trview
 
     void CameraPosition::set_position(const DirectX::SimpleMath::Vector3& position)
     {
-        _x->set_text(L"X: " + convert_number(position.x * trlevel::Scale_X));
-        _y->set_text(L"Y: " + convert_number(position.y * trlevel::Scale_Y));
-        _z->set_text(L"Z: " + convert_number(position.z * trlevel::Scale_Z));
+        // _x->set_text(L"X: " + convert_number(position.x * trlevel::Scale_X));
+        // _y->set_text(L"Y: " + convert_number(position.y * trlevel::Scale_Y));
+        // _z->set_text(L"Z: " + convert_number(position.z * trlevel::Scale_Z));
     }
 }

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -35,6 +35,7 @@ namespace trview
         _y = y_line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
         _y->set_text(L"Y coordinate");
         _y->set_mode(TextArea::Mode::SingleLine);
+        _token_store += _y->on_selected += [&]() { _y->set_text(L""); };
         display->add_child(std::move(y_line));
 
         auto z_line = std::make_unique<StackPanel>(Point(), Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
@@ -42,6 +43,7 @@ namespace trview
         _z = z_line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
         _z->set_text(L"Z coordinate");
         _z->set_mode(TextArea::Mode::SingleLine);
+        _token_store += _z->on_selected += [&]() { _z->set_text(L""); };
         display->add_child(std::move(z_line));
 
         _display = parent.add_child(std::move(display));
@@ -82,7 +84,13 @@ namespace trview
         {
             _x->set_text(convert_number(position.x * trlevel::Scale_X));
         }
-        _y->set_text(convert_number(position.y * trlevel::Scale_Y));
-        _z->set_text(convert_number(position.z * trlevel::Scale_Z));
+        if (!_y->focused())
+        {
+            _y->set_text(convert_number(position.y * trlevel::Scale_Y));
+        }
+        if (!_z->focused())
+        {
+            _z->set_text(convert_number(position.z * trlevel::Scale_Z));
+        }
     }
 }

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -37,6 +37,36 @@ namespace trview
         _z = create_coordinate_entry(_token_store, *display, L"Z");
         _display = parent.add_child(std::move(display));
 
+        _token_store += _x->on_tab += [&](const std::wstring& text) 
+        { 
+            try
+            {
+                _position.x = std::stof(text) / trlevel::Scale_X;
+                on_position_changed(_position);
+            }
+            catch (...)
+            {
+                // Conversion failed.
+            }
+            _x->on_focus_clear_requested();
+            _y->on_focus_requested(); 
+        };
+
+        _token_store += _y->on_tab += [&](const std::wstring& text)
+        {
+            try
+            {
+                _position.y = std::stof(text) / trlevel::Scale_Y;
+                on_position_changed(_position);
+            }
+            catch (...)
+            {
+                // Conversion failed.
+            }
+            _y->on_focus_clear_requested();
+            _z->on_focus_requested();
+        };
+
         auto update_position = [&](Size size)
         {
             _display->set_position(Point(_display->position().x, size.height - 10 - _display->size().height));

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -37,36 +37,6 @@ namespace trview
         _z = create_coordinate_entry(_token_store, *display, L"Z");
         _display = parent.add_child(std::move(display));
 
-        _token_store += _x->on_tab += [&](const std::wstring& text) 
-        { 
-            try
-            {
-                _position.x = std::stof(text) / trlevel::Scale_X;
-                on_position_changed(_position);
-            }
-            catch (...)
-            {
-                // Conversion failed.
-            }
-            _x->on_focus_clear_requested();
-            _y->on_focus_requested(); 
-        };
-
-        _token_store += _y->on_tab += [&](const std::wstring& text)
-        {
-            try
-            {
-                _position.y = std::stof(text) / trlevel::Scale_Y;
-                on_position_changed(_position);
-            }
-            catch (...)
-            {
-                // Conversion failed.
-            }
-            _y->on_focus_clear_requested();
-            _z->on_focus_requested();
-        };
-
         auto update_position = [&](Size size)
         {
             _display->set_position(Point(_display->position().x, size.height - 10 - _display->size().height));
@@ -76,43 +46,31 @@ namespace trview
         update_position(parent.size());
 
         // Bind manual camera position entry controls.
+        _token_store += _x->on_tab += [&](const std::wstring& text) 
+        { 
+            update_coordinate(_position.x, text);
+            _x->on_focus_clear_requested();
+            _y->on_focus_requested(); 
+        };
+        _token_store += _y->on_tab += [&](const std::wstring& text)
+        {
+            update_coordinate(_position.y, text);
+            _y->on_focus_clear_requested();
+            _z->on_focus_requested();
+        };
         _token_store += _x->on_enter += [&](const std::wstring& text) 
         {
-            try
-            {
-                _position.x = std::stof(text) / trlevel::Scale_X;
-                on_position_changed(_position);
-            }
-            catch (...)
-            {
-                // Conversion failed.
-            }
+            update_coordinate(_position.x, text);
             _x->on_focus_clear_requested();
         };
         _token_store += _y->on_enter += [&](const std::wstring& text)
         {
-            try
-            {
-                _position.y = std::stof(text) / trlevel::Scale_Y;
-                on_position_changed(_position);
-            }
-            catch (...)
-            {
-                // Conversion failed.
-            }
+            update_coordinate(_position.y, text);
             _y->on_focus_clear_requested(); 
         };
         _token_store += _z->on_enter += [&](const std::wstring& text)
         {
-            try
-            {
-                _position.z = std::stof(text) / trlevel::Scale_Z;
-                on_position_changed(_position);
-            }
-            catch (...)
-            {
-                // Conversion failed.
-            }
+            update_coordinate(_position.z, text);
             _z->on_focus_clear_requested(); 
         };
     }
@@ -132,6 +90,19 @@ namespace trview
         if (!_z->focused())
         {
             _z->set_text(convert_number(position.z * trlevel::Scale_Z));
+        }
+    }
+
+    void CameraPosition::update_coordinate(float& coordinate, const std::wstring& text)
+    {
+        try
+        {
+            coordinate = std::stof(text) / trlevel::Scale_X;
+            on_position_changed(_position);
+        }
+        catch (...)
+        {
+            // Conversion failed.
         }
     }
 }

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -77,7 +77,7 @@ namespace trview
         auto entry = line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
         entry->set_mode(TextArea::Mode::SingleLine);
         entry->set_text(convert_number(0));
-        _token_store += entry->on_selected += [=]() { entry->set_text(L""); };
+        _token_store += entry->on_focused += [=]() { entry->set_text(L""); };
         _token_store += entry->on_escape += [=]()
         {
             entry->on_focus_clear_requested();

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -1,7 +1,6 @@
 #include "CameraPosition.h"
 #include <trlevel/trlevel.h>
 #include <trview.ui/Label.h>
-#include <sstream>
 
 using namespace trview::ui;
 using namespace trview::graphics;
@@ -59,27 +58,49 @@ namespace trview
         // Bind manual camera position entry controls.
         _token_store += _x->on_enter += [&](const std::wstring& text) 
         {
-            std::wstringstream stream;
-            stream << text;
-            float coordinate = 0;
-            stream >> coordinate;
-
+            try
+            {
+                _position.x = std::stof(text) / trlevel::Scale_X;
+                on_position_changed(_position);
+            }
+            catch (...)
+            {
+                // Conversion failed.
+            }
             _x->on_focus_clear_requested();
-
-            on_x(coordinate / trlevel::Scale_X);
         };
         _token_store += _y->on_enter += [&](const std::wstring& text)
         {
+            try
+            {
+                _position.y = std::stof(text) / trlevel::Scale_Y;
+                on_position_changed(_position);
+            }
+            catch (...)
+            {
+                // Conversion failed.
+            }
             _y->on_focus_clear_requested(); 
         };
         _token_store += _z->on_enter += [&](const std::wstring& text)
         {
+            try
+            {
+                _position.z = std::stof(text) / trlevel::Scale_Z;
+                on_position_changed(_position);
+            }
+            catch (...)
+            {
+                // Conversion failed.
+            }
             _z->on_focus_clear_requested(); 
         };
     }
 
     void CameraPosition::set_position(const DirectX::SimpleMath::Vector3& position)
     {
+        _position = position;
+
         if (!_x->focused())
         {
             _x->set_text(convert_number(position.x * trlevel::Scale_X));

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -27,6 +27,7 @@ namespace trview
         _x = x_line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
         _x->set_text(L"X coordinate");
         _x->set_mode(TextArea::Mode::SingleLine);
+        _token_store += _x->on_selected += [&]() { _x->set_text(L""); };
         display->add_child(std::move(x_line));
 
         auto y_line = std::make_unique<StackPanel>(Point(), Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
@@ -63,7 +64,6 @@ namespace trview
 
             _x->on_focus_clear_requested();
 
-            // Raise.
             on_x(coordinate / trlevel::Scale_X);
         };
         _token_store += _y->on_enter += [&](const std::wstring& text)
@@ -78,7 +78,10 @@ namespace trview
 
     void CameraPosition::set_position(const DirectX::SimpleMath::Vector3& position)
     {
-        // _x->set_text(L"X: " + convert_number(position.x * trlevel::Scale_X));
+        if (!_x->focused())
+        {
+            _x->set_text(convert_number(position.x * trlevel::Scale_X));
+        }
         _y->set_text(convert_number(position.y * trlevel::Scale_Y));
         _z->set_text(convert_number(position.z * trlevel::Scale_Z));
     }

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -25,18 +25,21 @@ namespace trview
         x_line->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, L"X: ", 8));
         _x = x_line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
         _x->set_text(L"X coordinate");
+        _x->set_mode(TextArea::Mode::SingleLine);
         display->add_child(std::move(x_line));
 
         auto y_line = std::make_unique<StackPanel>(Point(), Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
         y_line->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, L"Y: ", 8));
         _y = y_line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
         _y->set_text(L"Y coordinate");
+        _y->set_mode(TextArea::Mode::SingleLine);
         display->add_child(std::move(y_line));
 
         auto z_line = std::make_unique<StackPanel>(Point(), Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
         z_line->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, L"Z: ", 8));
         _z = z_line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
         _z->set_text(L"Z coordinate");
+        _z->set_mode(TextArea::Mode::SingleLine);
         display->add_child(std::move(z_line));
 
         _display = parent.add_child(std::move(display));

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -70,7 +70,10 @@ namespace trview
     TextArea* CameraPosition::create_coordinate_entry(Control& parent, float& coordinate, const std::wstring& name)
     {
         auto line = std::make_unique<StackPanel>(Point(), Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
-        line->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, name + L": ", 8));
+        auto line_area = std::make_unique<StackPanel>(Point(), Size(10, 20), Colour::Transparent);
+        line_area->add_child(std::make_unique<Window>(Point(), Size(10, 1), Colour::Transparent));
+        line_area->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, name + L": ", 8));
+        line->add_child(std::move(line_area));
         auto entry = line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
         entry->set_mode(TextArea::Mode::SingleLine);
         entry->set_text(convert_number(0));

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -1,6 +1,7 @@
 #include "CameraPosition.h"
 #include <trlevel/trlevel.h>
 #include <trview.ui/Label.h>
+#include <sstream>
 
 using namespace trview::ui;
 using namespace trview::graphics;
@@ -53,15 +54,32 @@ namespace trview
         update_position(parent.size());
 
         // Bind manual camera position entry controls.
-        _token_store += _x->on_enter += [](const std::wstring& text) {};
-        _token_store += _y->on_enter += [](const std::wstring& text) {};
-        _token_store += _z->on_enter += [](const std::wstring& text) {};
+        _token_store += _x->on_enter += [&](const std::wstring& text) 
+        {
+            std::wstringstream stream;
+            stream << text;
+            float coordinate = 0;
+            stream >> coordinate;
+
+            _x->on_focus_clear_requested();
+
+            // Raise.
+            on_x(coordinate / trlevel::Scale_X);
+        };
+        _token_store += _y->on_enter += [&](const std::wstring& text)
+        {
+            _y->on_focus_clear_requested(); 
+        };
+        _token_store += _z->on_enter += [&](const std::wstring& text)
+        {
+            _z->on_focus_clear_requested(); 
+        };
     }
 
     void CameraPosition::set_position(const DirectX::SimpleMath::Vector3& position)
     {
         // _x->set_text(L"X: " + convert_number(position.x * trlevel::Scale_X));
-        // _y->set_text(L"Y: " + convert_number(position.y * trlevel::Scale_Y));
-        // _z->set_text(L"Z: " + convert_number(position.z * trlevel::Scale_Z));
+        _y->set_text(convert_number(position.y * trlevel::Scale_Y));
+        _z->set_text(convert_number(position.z * trlevel::Scale_Z));
     }
 }

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -1,6 +1,7 @@
 #include "CameraPosition.h"
 #include <trlevel/trlevel.h>
 #include <trview.ui/Label.h>
+#include <trview.common/Strings.h>
 
 using namespace trview::ui;
 using namespace trview::graphics;
@@ -77,6 +78,7 @@ namespace trview
         auto entry = line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
         entry->set_mode(TextArea::Mode::SingleLine);
         entry->set_text(convert_number(0));
+        entry->set_name(to_utf8(name));
         _token_store += entry->on_focused += [=]() { entry->set_text(L""); };
         _token_store += entry->on_escape += [=]()
         {

--- a/trview.app/UI/CameraPosition.h
+++ b/trview.app/UI/CameraPosition.h
@@ -6,7 +6,7 @@
 #include <SimpleMath.h>
 #include <trview.ui/Control.h>
 #include <trview.ui/StackPanel.h>
-#include <trview.ui/Label.h>
+#include <trview.ui/TextArea.h>
 #include <trview.common/TokenStore.h>
 
 namespace trview
@@ -25,8 +25,8 @@ namespace trview
     private:
         TokenStore _token_store;
         ui::StackPanel* _display;
-        ui::Label* _x;
-        ui::Label* _y;
-        ui::Label* _z;
+        ui::TextArea* _x;
+        ui::TextArea* _y;
+        ui::TextArea* _z;
     };
 }

--- a/trview.app/UI/CameraPosition.h
+++ b/trview.app/UI/CameraPosition.h
@@ -26,6 +26,10 @@ namespace trview
         /// Event raised when the user changes the camera position.
         Event<DirectX::SimpleMath::Vector3> on_position_changed;
     private:
+        /// Attempt to update the specified coordinate by converting the text to a float.
+        /// If successful this will also raise the on_position_changed event.
+        void update_coordinate(float& coordinate, const std::wstring& text);
+
         TokenStore _token_store;
         ui::StackPanel* _display;
         ui::TextArea* _x;

--- a/trview.app/UI/CameraPosition.h
+++ b/trview.app/UI/CameraPosition.h
@@ -30,6 +30,9 @@ namespace trview
         /// If successful this will also raise the on_position_changed event.
         void update_coordinate(float& coordinate, const std::wstring& text);
 
+        /// Create a coordinate entry text field.
+        ui::TextArea* create_coordinate_entry(ui::Control& parent, float& coordinate, const std::wstring& name);
+
         TokenStore _token_store;
         ui::StackPanel* _display;
         ui::TextArea* _x;

--- a/trview.app/UI/CameraPosition.h
+++ b/trview.app/UI/CameraPosition.h
@@ -23,13 +23,14 @@ namespace trview
         /// @param position The camera position.
         void set_position(const DirectX::SimpleMath::Vector3& position);
 
-        /// Test event for the X coordinate.
-        Event<float> on_x;
+        /// Event raised when the user changes the camera position.
+        Event<DirectX::SimpleMath::Vector3> on_position_changed;
     private:
         TokenStore _token_store;
         ui::StackPanel* _display;
         ui::TextArea* _x;
         ui::TextArea* _y;
         ui::TextArea* _z;
+        DirectX::SimpleMath::Vector3 _position;
     };
 }

--- a/trview.app/UI/CameraPosition.h
+++ b/trview.app/UI/CameraPosition.h
@@ -22,6 +22,9 @@ namespace trview
         /// Update the position text.
         /// @param position The camera position.
         void set_position(const DirectX::SimpleMath::Vector3& position);
+
+        /// Test event for the X coordinate.
+        Event<float> on_x;
     private:
         TokenStore _token_store;
         ui::StackPanel* _display;

--- a/trview.app/UI/GoTo.cpp
+++ b/trview.app/UI/GoTo.cpp
@@ -76,6 +76,11 @@ namespace trview
         if (visible())
         {
             _text_area->set_text(L"");
+            _text_area->on_focus_requested();
+        }
+        else
+        {
+            _text_area->on_focus_clear_requested();
         }
     }
 

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -198,9 +198,10 @@ namespace trview
         return _map_renderer->sector_at_cursor();
     }
 
-    bool ViewerUI::go_to_room_visible() const
+    bool ViewerUI::is_input_active() const
     {
-        return _go_to->visible();
+        const auto focus = _ui_input->focus_control();
+        return focus && focus->visible() && focus->handles_input();
     }
 
     bool ViewerUI::is_cursor_over() const

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -1,5 +1,6 @@
 #include "ViewerUI.h"
 #include <trview.ui/Window.h>
+#include <trview.ui/Label.h>
 #include <trview.graphics/IShaderStorage.h>
 #include <trview.app/Graphics/ILevelTextureStorage.h>
 #include "GoTo.h"

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -141,7 +141,7 @@ namespace trview
         _settings_window->on_movement_speed_changed += on_camera_movement_speed;
 
         _camera_position = std::make_unique<CameraPosition>(*_control);
-        _camera_position->on_x += on_x;
+        _camera_position->on_position_changed += on_camera_position;
 
         // Create the renderer for the UI based on the controls created.
         _ui_renderer = std::make_unique<ui::render::Renderer>(device, shader_storage, font_factory, window.size());

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -141,6 +141,7 @@ namespace trview
         _settings_window->on_movement_speed_changed += on_camera_movement_speed;
 
         _camera_position = std::make_unique<CameraPosition>(*_control);
+        _camera_position->on_x += on_x;
 
         // Create the renderer for the UI based on the controls created.
         _ui_renderer = std::make_unique<ui::render::Renderer>(device, shader_storage, font_factory, window.size());

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -123,6 +123,9 @@ namespace trview
         /// Event raised when something in the ui has changed.
         Event<> on_ui_changed;
 
+        /// Test event for x coordinate.
+        Event<float> on_x;
+
         /// Render the UI.
         /// @param device The device to use to render the UI.
         void render(const graphics::Device& device);

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -123,8 +123,8 @@ namespace trview
         /// Event raised when something in the ui has changed.
         Event<> on_ui_changed;
 
-        /// Test event for x coordinate.
-        Event<float> on_x;
+        /// Event raised when user edits camera position.
+        Event<DirectX::SimpleMath::Vector3> on_camera_position;
 
         /// Render the UI.
         /// @param device The device to use to render the UI.

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -52,9 +52,8 @@ namespace trview
         /// Get the currently hovered minimap sector, if any.
         std::shared_ptr<Sector> current_minimap_sector() const;
 
-        /// Get whether go to room is visible.
-        /// @returns Whether the go to room window is visible.
-        bool go_to_room_visible() const;
+        /// Get whether there is any text input currently active.
+        bool is_input_active() const;
 
         /// Determiens if the cursor is over any ui element.
         /// @returns Whether the cursor is over an element.

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -136,6 +136,9 @@
     <ProjectReference Include="..\trview.common\trview.common.vcxproj">
       <Project>{d0633291-23a6-4b3f-9a5e-e94d20f66a07}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\trview.ui\trview.ui.vcxproj">
+      <Project>{160bd1c8-42c1-46e6-a232-b980b9b6d57e}</Project>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -130,6 +130,10 @@ namespace trview
             return false;
         }
 
+        void Control::clicked_on()
+        {
+        }
+
         void Control::clicked_off(Control*)
         {
         }

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -130,12 +130,15 @@ namespace trview
             return false;
         }
 
-        void Control::clicked_on()
+        void Control::gained_focus()
         {
+            _focused = true;
+            on_focused();
         }
 
-        void Control::clicked_off(Control*)
+        void Control::lost_focus(Control*)
         {
+            _focused = false;
         }
 
         bool Control::move(Point)
@@ -248,6 +251,11 @@ namespace trview
         void Control::set_input_query(IInputQuery* query)
         {
             _input_query = query;
+        }
+
+        bool Control::focused() const
+        {
+            return _focused;
         }
     }
 }

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -166,6 +166,9 @@ namespace trview
             /// Event raised when the control is being deleted.
             Event<> on_deleting;
 
+            /// Event raised when user has selected the control for text tinput.
+            Event<> on_focused;
+
             /// To be called when the mouse has been pressed down over the element.
             /// @param position The position of the mouse down relative to the control.
             /// @return True if the event was handled by the element.
@@ -188,10 +191,10 @@ namespace trview
             virtual bool clicked(Point position);
 
             /// To be called when the control has become the new focus control.
-            virtual void clicked_on();
+            virtual void gained_focus();
 
             /// To be called when the user clicks away from a focus control.
-            virtual void clicked_off(Control* new_focus);
+            virtual void lost_focus(Control* new_focus);
 
             /// To be called when the mouse was moved over the element.
             /// This should be overriden by child elements to handle a move.
@@ -216,6 +219,8 @@ namespace trview
             virtual bool key_char(wchar_t key);
 
             void set_input_query(IInputQuery* query);
+
+            bool focused() const;
         protected:
             /// To be called after a child element has been added to the control.
             /// @param child_element The element that was added.
@@ -236,6 +241,7 @@ namespace trview
             Align    _vertical_alignment{ Align::Near };
             std::string _name;
             int      _z{ 0 };
+            bool     _focused{ false };
         };
     }
 }

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -133,6 +133,13 @@ namespace trview
             template <typename T>
             T* find(const std::string& name) const;
 
+            /// Find the first control with the specified name and type.
+            /// @param name The name to search for.
+            /// @returns The control with the given name as the specified type. If there is
+            ///          no control found, this returns null.
+            template <typename T>
+            T* find(const std::string& name);
+
             /// Get the z order of the control.
             /// @returns The z order.
             int z() const;

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -187,6 +187,9 @@ namespace trview
             /// @param position The position of the click relative to the control.
             virtual bool clicked(Point position);
 
+            /// To be called when the control has become the new focus control.
+            virtual void clicked_on();
+
             /// To be called when the user clicks away from a focus control.
             virtual void clicked_off(Control* new_focus);
 

--- a/trview.ui/Control.inl
+++ b/trview.ui/Control.inl
@@ -25,6 +25,26 @@ namespace trview
         }
 
         template <typename T>
+        T* Control::find(const std::string& name)
+        {
+            if (name == this->name())
+            {
+                return dynamic_cast<T*>(this);
+            }
+
+            for (const auto& child : _child_elements)
+            {
+                T* result = child->find<T>(name);
+                if (result)
+                {
+                    return result;
+                }
+            }
+
+            return nullptr;
+        }
+
+        template <typename T>
         T* Control::add_child(std::unique_ptr<T>&& child_element)
         {
             static_assert(std::is_base_of<Control, T>::value, "Element must be derived from Control");

--- a/trview.ui/Dropdown.cpp
+++ b/trview.ui/Dropdown.cpp
@@ -74,6 +74,8 @@ namespace trview
 
         void Dropdown::lost_focus(Control* new_focus)
         {
+            Window::lost_focus(new_focus);
+
             if (!_dropdown)
             {
                 return;

--- a/trview.ui/Dropdown.cpp
+++ b/trview.ui/Dropdown.cpp
@@ -72,7 +72,7 @@ namespace trview
             _dropdown->set_items(items);
         }
 
-        void Dropdown::clicked_off(Control* new_focus)
+        void Dropdown::lost_focus(Control* new_focus)
         {
             if (!_dropdown)
             {

--- a/trview.ui/Dropdown.h
+++ b/trview.ui/Dropdown.h
@@ -39,7 +39,7 @@ namespace trview
             /// Event raised when a value is selected. The selected value is passed as a parameter.
             Event<std::wstring> on_value_selected;
 
-            virtual void clicked_off(Control* new_focus) override;
+            virtual void lost_focus(Control* new_focus) override;
         private:
             void update_dropdown();
 

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -319,12 +319,12 @@ namespace trview
         {
             if (_focus_control && _focus_control != control)
             {
-                _focus_control->clicked_off(control);
+                _focus_control->lost_focus(control);
             }
             _focus_control = control;
             if (_focus_control)
             {
-                _focus_control->clicked_on();
+                _focus_control->gained_focus();
             }
         }
     }

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -322,6 +322,10 @@ namespace trview
                 _focus_control->clicked_off(control);
             }
             _focus_control = control;
+            if (_focus_control)
+            {
+                _focus_control->clicked_on();
+            }
         }
     }
 }

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -12,24 +12,29 @@ namespace trview
             _area = add_child(std::make_unique<StackPanel>(Point(), size, background_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual));
             _area->set_margin(Size(1, 1));
             _cursor = add_child(std::make_unique<Window>(Point(), Size(1, 14), text_colour));
-            _cursor->set_visible(_cursor_visible);
+            _cursor->set_visible(_focused);
             set_handles_input(true);
         }
 
         void TextArea::clicked_on()
         {
-            _cursor_visible = true;
+            _focused = true;
             update_cursor();
         }
 
         void TextArea::clicked_off(Control*)
         {
-            _cursor_visible = false;
+            _focused = false;
             update_cursor();
         }
 
         bool TextArea::key_char(wchar_t character)
         {
+            if (!_focused)
+            {
+                return false;
+            }
+
             auto process_char = [&]()
             {
                 auto line = current_line();
@@ -152,6 +157,11 @@ namespace trview
 
         bool TextArea::key_down(uint16_t key)
         {
+            if (!_focused)
+            {
+                return false;
+            }
+
             auto line = current_line();
             auto text = line->text();
 
@@ -299,7 +309,7 @@ namespace trview
                 Point(line->size().width * 0.5f - size.width * 0.5f - 1, line->position().y);
             _cursor->set_position(start + Point(size.width + 2, 0));
             _cursor->set_size(Size(1, line->size().height == 0 ? _cursor->size().height : line->size().height));
-            _cursor->set_visible(_cursor_visible);
+            _cursor->set_visible(_focused);
         }
 
         void TextArea::notify_text_updated()

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -12,7 +12,20 @@ namespace trview
             _area = add_child(std::make_unique<StackPanel>(Point(), size, background_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual));
             _area->set_margin(Size(1, 1));
             _cursor = add_child(std::make_unique<Window>(Point(), Size(1, 14), text_colour));
+            _cursor->set_visible(_cursor_visible);
             set_handles_input(true);
+        }
+
+        void TextArea::clicked_on()
+        {
+            _cursor_visible = true;
+            update_cursor();
+        }
+
+        void TextArea::clicked_off(Control*)
+        {
+            _cursor_visible = false;
+            update_cursor();
         }
 
         bool TextArea::key_char(wchar_t character)
@@ -286,6 +299,7 @@ namespace trview
                 Point(line->size().width * 0.5f - size.width * 0.5f - 1, line->position().y);
             _cursor->set_position(start + Point(size.width + 2, 0));
             _cursor->set_size(Size(1, line->size().height == 0 ? _cursor->size().height : line->size().height));
+            _cursor->set_visible(_cursor_visible);
         }
 
         void TextArea::notify_text_updated()

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -12,26 +12,25 @@ namespace trview
             _area = add_child(std::make_unique<StackPanel>(Point(), size, background_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual));
             _area->set_margin(Size(1, 1));
             _cursor = add_child(std::make_unique<Window>(Point(), Size(1, 14), text_colour));
-            _cursor->set_visible(_focused);
+            _cursor->set_visible(focused());
             set_handles_input(true);
         }
 
-        void TextArea::clicked_on()
+        void TextArea::gained_focus()
         {
-            _focused = true;
+            Window::gained_focus();
             update_cursor();
-            on_selected();
         }
 
-        void TextArea::clicked_off(Control*)
+        void TextArea::lost_focus(Control* new_focus)
         {
-            _focused = false;
+            Window::lost_focus(new_focus);
             update_cursor();
         }
 
         bool TextArea::key_char(wchar_t character)
         {
-            if (!_focused)
+            if (!focused())
             {
                 return false;
             }
@@ -167,7 +166,7 @@ namespace trview
 
         bool TextArea::key_down(uint16_t key)
         {
-            if (!_focused)
+            if (!focused())
             {
                 return false;
             }
@@ -319,7 +318,7 @@ namespace trview
                 Point(line->size().width * 0.5f - size.width * 0.5f - 1, line->position().y);
             _cursor->set_position(start + Point(size.width + 2, 0));
             _cursor->set_size(Size(1, line->size().height == 0 ? _cursor->size().height : line->size().height));
-            _cursor->set_visible(_focused);
+            _cursor->set_visible(focused());
         }
 
         void TextArea::notify_text_updated()
@@ -336,11 +335,6 @@ namespace trview
                 full_string += line->text();
             }
             on_text_changed(full_string);
-        }
-
-        bool TextArea::focused() const
-        {
-            return _focused;
         }
     }
 }

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -69,6 +69,15 @@ namespace trview
                         }
                         break;
                     }
+                    // VK_TAB
+                    case 0x9:
+                    {
+                        if (_mode == Mode::SingleLine)
+                        {
+                            on_tab(text);
+                        }
+                        break;
+                    }
                     // VK_RETURN
                     case 0xD:
                     {

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -159,6 +159,22 @@ namespace trview
             _mode = mode;
         }
 
+        std::wstring TextArea::text() const
+        {
+            bool first = true;
+            std::wstring full_string;
+            for (const auto& line : _lines)
+            {
+                if (!first)
+                {
+                    full_string += L'\n';
+                }
+                first = false;
+                full_string += line->text();
+            }
+            return full_string;
+        }
+
         bool TextArea::mouse_down(const Point& position)
         {
             return true;
@@ -323,18 +339,7 @@ namespace trview
 
         void TextArea::notify_text_updated()
         {
-            bool first = true;
-            std::wstring full_string;
-            for (const auto& line : _lines)
-            {
-                if (!first)
-                {
-                    full_string += L'\n';
-                }
-                first = false;
-                full_string += line->text();
-            }
-            on_text_changed(full_string);
+            on_text_changed(text());
         }
     }
 }

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -96,7 +96,7 @@ namespace trview
                     case 0x1B:
                     {
                         on_escape();
-                        break;
+                        return;
                     }
                     default:
                     {

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -20,6 +20,7 @@ namespace trview
         {
             _focused = true;
             update_cursor();
+            on_selected();
         }
 
         void TextArea::clicked_off(Control*)
@@ -326,6 +327,11 @@ namespace trview
                 full_string += line->text();
             }
             on_text_changed(full_string);
+        }
+
+        bool TextArea::focused() const
+        {
+            return _focused;
         }
     }
 }

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -35,6 +35,9 @@ namespace trview
             /// @param mode The new mode.
             void set_mode(Mode mode);
 
+            /// Get the text content of the text area.
+            std::wstring text() const;
+
             /// Event raised when the text in the text area has changed.
             Event<std::wstring> on_text_changed;
 

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -47,6 +47,9 @@ namespace trview
             /// Event raised when the user has pressed the escape button.
             Event<> on_escape;
 
+            /// Event raised when the user has pressed the tab button in single line mode.
+            Event<std::wstring> on_tab;
+
             virtual bool mouse_down(const Point& position) override;
             virtual bool key_down(uint16_t key) override;
             virtual bool key_char(wchar_t character) override;

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -35,9 +35,6 @@ namespace trview
             /// @param mode The new mode.
             void set_mode(Mode mode);
 
-            /// Event raised when user has selected the control for text tinput.
-            Event<> on_selected;
-
             /// Event raised when the text in the text area has changed.
             Event<std::wstring> on_text_changed;
 
@@ -53,10 +50,8 @@ namespace trview
             virtual bool mouse_down(const Point& position) override;
             virtual bool key_down(uint16_t key) override;
             virtual bool key_char(wchar_t character) override;
-            virtual void clicked_on() override;
-            virtual void clicked_off(Control*) override;
-
-            bool focused() const;
+            virtual void gained_focus() override;
+            virtual void lost_focus(Control*) override;
         private:
             Label* current_line(bool raise_event = true);
 

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -47,6 +47,8 @@ namespace trview
             virtual bool mouse_down(const Point& position) override;
             virtual bool key_down(uint16_t key) override;
             virtual bool key_char(wchar_t character) override;
+            virtual void clicked_on() override;
+            virtual void clicked_off(Control*) override;
         private:
             Label* current_line(bool raise_event = true);
 
@@ -70,6 +72,7 @@ namespace trview
             uint32_t            _cursor_position{ 0u };
             uint32_t            _cursor_line{ 0u };
             Mode                _mode{ Mode::MultiLine };
+            bool                _cursor_visible{ false };
             graphics::TextAlignment _alignment{ graphics::TextAlignment::Left };
         };
     }

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -35,6 +35,9 @@ namespace trview
             /// @param mode The new mode.
             void set_mode(Mode mode);
 
+            /// Event raised when user has selected the control for text tinput.
+            Event<> on_selected;
+
             /// Event raised when the text in the text area has changed.
             Event<std::wstring> on_text_changed;
 
@@ -49,6 +52,8 @@ namespace trview
             virtual bool key_char(wchar_t character) override;
             virtual void clicked_on() override;
             virtual void clicked_off(Control*) override;
+
+            bool focused() const;
         private:
             Label* current_line(bool raise_event = true);
 

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -72,7 +72,7 @@ namespace trview
             uint32_t            _cursor_position{ 0u };
             uint32_t            _cursor_line{ 0u };
             Mode                _mode{ Mode::MultiLine };
-            bool                _cursor_visible{ false };
+            bool                _focused{ false };
             graphics::TextAlignment _alignment{ graphics::TextAlignment::Left };
         };
     }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -153,6 +153,18 @@ namespace trview
             _target = _context_pick.position;
         };
         _token_store += _ui->on_settings += [&](auto settings) { _settings = settings; };
+        _token_store += _ui->on_x += [&](float x)
+        {
+            try
+            {
+                FreeCamera& camera = dynamic_cast<FreeCamera&>(current_camera());
+                auto pos = camera.position();
+                camera.set_position(DirectX::SimpleMath::Vector3(x, pos.y, pos.z));
+            }
+            catch(...)
+            {
+            }
+        };
 
         _ui->set_settings(_settings);
 

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -130,15 +130,15 @@ namespace trview
         _token_store += _ui->on_camera_sensitivity += [&](float value) { _settings.camera_sensitivity = value; };
         _token_store += _ui->on_camera_movement_speed += [&](float value) { _settings.camera_movement_speed = value; };
         _token_store += _ui->on_sector_hover += [&](const std::shared_ptr<Sector>& sector)
+        {
+            if (_level)
             {
-                if (_level)
-                {
-                    const auto room_info = _level->room_info(_level->selected_room());
-                    _sector_highlight.set_sector(sector,
-                        DirectX::SimpleMath::Matrix::CreateTranslation(room_info.x / trlevel::Scale_X, 0, room_info.z / trlevel::Scale_Z));
-                    _scene_changed = true;
-                }
-            };
+                const auto room_info = _level->room_info(_level->selected_room());
+                _sector_highlight.set_sector(sector,
+                    DirectX::SimpleMath::Matrix::CreateTranslation(room_info.x / trlevel::Scale_X, 0, room_info.z / trlevel::Scale_Z));
+                _scene_changed = true;
+            }
+        };
         _token_store += _ui->on_add_waypoint += [&]()
         {
             auto type = _context_pick.type == PickResult::Type::Entity ? Waypoint::Type::Entity : _context_pick.type == PickResult::Type::Trigger ? Waypoint::Type::Trigger : Waypoint::Type::Position;
@@ -153,6 +153,7 @@ namespace trview
             _target = _context_pick.position;
         };
         _token_store += _ui->on_settings += [&](auto settings) { _settings = settings; };
+        _token_store += _ui->on_tool_selected += [&](auto tool) { _active_tool = tool; _measure->reset(); };
         _token_store += _ui->on_camera_position += [&](const auto& position)
         {
             if (_camera_mode == CameraMode::Orbit)

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -155,14 +155,11 @@ namespace trview
         _token_store += _ui->on_settings += [&](auto settings) { _settings = settings; };
         _token_store += _ui->on_camera_position += [&](const auto& position)
         {
-            try
+            if (_camera_mode == CameraMode::Orbit)
             {
-                FreeCamera& camera = dynamic_cast<FreeCamera&>(current_camera());
-                camera.set_position(position);
+                set_camera_mode(CameraMode::Free);
             }
-            catch(...)
-            {
-            }
+            _free_camera.set_position(position);
         };
 
         _ui->set_settings(_settings);

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -153,13 +153,12 @@ namespace trview
             _target = _context_pick.position;
         };
         _token_store += _ui->on_settings += [&](auto settings) { _settings = settings; };
-        _token_store += _ui->on_x += [&](float x)
+        _token_store += _ui->on_camera_position += [&](const auto& position)
         {
             try
             {
                 FreeCamera& camera = dynamic_cast<FreeCamera&>(current_camera());
-                auto pos = camera.position();
-                camera.set_position(DirectX::SimpleMath::Vector3(x, pos.y, pos.z));
+                camera.set_position(position);
             }
             catch(...)
             {

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -639,8 +639,6 @@ namespace trview
 
         if (_scene_changed || _ui_changed)
         {
-            _ui->set_camera_position(current_camera().position());
-
             _device.begin();
             _main_window->begin();
             _main_window->clear(DirectX::SimpleMath::Color(0.0f, 0.2f, 0.4f, 1.0f));
@@ -658,6 +656,7 @@ namespace trview
             }
 
             _scene_sprite->render(_device.context(), _scene_target->texture(), 0, 0, _window.size().width, _window.size().height);
+            _ui->set_camera_position(current_camera().position());
 
             _ui->render(_device);
             _ui_changed = false;


### PR DESCRIPTION
User can enter x, y and z camera coordinates. It will change mode to free camera mode if it is currently in orbit mode.
User can tab through the coordinates or press enter to change a single one.
Also fixed the measure button event not being hooked up.
Added tests for the camera position class.
Issue: #479 