### PR TITLE
Correctly create bounding box when there are no vertices

### DIFF
--- a/trview.app/Geometry/Mesh.cpp
+++ b/trview.app/Geometry/Mesh.cpp
@@ -136,8 +136,9 @@ namespace trview
             }
         }
 
-        const Vector3 half_size = (vertices.empty() && transparent_triangles.empty()) ? Vector3::Zero : (maximum - minimum) * 0.5f;
-        minimum = (vertices.empty() && transparent_triangles.empty()) ? Vector3::Zero : minimum;
+        const bool no_vertices = vertices.empty() && transparent_triangles.empty();
+        const Vector3 half_size = no_vertices ? Vector3::Zero : (maximum - minimum) * 0.5f;
+        minimum = no_vertices ? Vector3::Zero : minimum;
 
         _bounding_box.Extents = half_size;
         _bounding_box.Center = minimum + half_size;

--- a/trview.app/Geometry/Mesh.cpp
+++ b/trview.app/Geometry/Mesh.cpp
@@ -137,6 +137,8 @@ namespace trview
         }
 
         const Vector3 half_size = (vertices.empty() && transparent_triangles.empty()) ? Vector3::Zero : (maximum - minimum) * 0.5f;
+        minimum = (vertices.empty() && transparent_triangles.empty()) ? Vector3::Zero : minimum;
+
         _bounding_box.Extents = half_size;
         _bounding_box.Center = minimum + half_size;
     }


### PR DESCRIPTION
There are some meshes with vertices but no rectangles or triangles.
At the moment these come through as having zero vertices.
In this case set the minimum of the bounding box to be zero - this was being done for the extent, but the minimum was still being set to -flt_max.
Bug: #575