### PR TITLE
Add camera panning

### DIFF
--- a/trview.app.tests/Camera/CameraInputTests.cpp
+++ b/trview.app.tests/Camera/CameraInputTests.cpp
@@ -181,10 +181,10 @@ TEST(CameraInput, Panning)
 {
     CameraInput subject;
 
-    std::optional<std::tuple<float, float>> pan_movement;
+    std::optional<std::tuple<bool, float, float>> pan_movement;
     auto token = subject.on_pan += [&pan_movement](bool vertical, float x, float y)
     {
-        pan_movement = { x, y };
+        pan_movement = { vertical, x, y };
     };
 
     subject.mouse_down(input::Mouse::Button::Left);
@@ -192,6 +192,29 @@ TEST(CameraInput, Panning)
     subject.mouse_up(input::Mouse::Button::Left);
 
     ASSERT_TRUE(pan_movement.has_value());
-    ASSERT_EQ(100.0f, std::get<0>(pan_movement.value()));
-    ASSERT_EQ(200.0f, std::get<1>(pan_movement.value()));
+    ASSERT_EQ(false, std::get<0>(pan_movement.value()));
+    ASSERT_EQ(100.0f, std::get<1>(pan_movement.value()));
+    ASSERT_EQ(200.0f, std::get<2>(pan_movement.value()));
 }
+
+TEST(CameraInput, PanningVertical)
+{
+    CameraInput subject;
+
+    std::optional<std::tuple<bool, float, float>> pan_movement;
+    auto token = subject.on_pan += [&pan_movement](bool vertical, float x, float y)
+    {
+        pan_movement = { vertical, x, y };
+    };
+
+    subject.mouse_down(input::Mouse::Button::Left);
+    subject.mouse_down(input::Mouse::Button::Right);
+    subject.mouse_move(100, 200);
+    subject.mouse_up(input::Mouse::Button::Left);
+
+    ASSERT_TRUE(pan_movement.has_value());
+    ASSERT_EQ(true, std::get<0>(pan_movement.value()));
+    ASSERT_EQ(100.0f, std::get<1>(pan_movement.value()));
+    ASSERT_EQ(200.0f, std::get<2>(pan_movement.value()));
+}
+

--- a/trview.app.tests/Camera/CameraInputTests.cpp
+++ b/trview.app.tests/Camera/CameraInputTests.cpp
@@ -182,14 +182,14 @@ TEST(CameraInput, Panning)
     CameraInput subject;
 
     std::optional<std::tuple<float, float>> pan_movement;
-    auto token = subject.on_pan += [&pan_movement](float x, float y)
+    auto token = subject.on_pan += [&pan_movement](bool vertical, float x, float y)
     {
         pan_movement = { x, y };
     };
 
-    subject.mouse_down(input::Mouse::Button::Middle);
+    subject.mouse_down(input::Mouse::Button::Left);
     subject.mouse_move(100, 200);
-    subject.mouse_up(input::Mouse::Button::Middle);
+    subject.mouse_up(input::Mouse::Button::Left);
 
     ASSERT_TRUE(pan_movement.has_value());
     ASSERT_EQ(100.0f, std::get<0>(pan_movement.value()));

--- a/trview.app.tests/Camera/CameraInputTests.cpp
+++ b/trview.app.tests/Camera/CameraInputTests.cpp
@@ -175,3 +175,23 @@ TEST(CameraInput, ControlBlocks)
     subject.key_down('D', true);
     ASSERT_EQ(Vector3::Zero, subject.movement());
 }
+
+/// Tests that the panning event is raised when the pan button is held down.
+TEST(CameraInput, Panning)
+{
+    CameraInput subject;
+
+    std::optional<std::tuple<float, float>> pan_movement;
+    auto token = subject.on_pan += [&pan_movement](float x, float y)
+    {
+        pan_movement = { x, y };
+    };
+
+    subject.mouse_down(input::Mouse::Button::Middle);
+    subject.mouse_move(100, 200);
+    subject.mouse_up(input::Mouse::Button::Middle);
+
+    ASSERT_TRUE(pan_movement.has_value());
+    ASSERT_EQ(100.0f, std::get<0>(pan_movement.value()));
+    ASSERT_EQ(200.0f, std::get<1>(pan_movement.value()));
+}

--- a/trview.app/Camera/CameraInput.cpp
+++ b/trview.app/Camera/CameraInput.cpp
@@ -110,6 +110,10 @@ namespace trview
         {
             _rotating = true;
         }
+        else if (button == input::Mouse::Button::Middle)
+        {
+            _panning = true;
+        }
     }
 
     void CameraInput::mouse_up(input::Mouse::Button button)
@@ -118,6 +122,10 @@ namespace trview
         {
             _rotating = false;
         }
+        else if (button == input::Mouse::Button::Middle)
+        {
+            _panning = false;
+        }
     }
 
     void CameraInput::mouse_move(long x, long y)
@@ -125,6 +133,11 @@ namespace trview
         if (_rotating)
         {
             on_rotate(static_cast<float>(x), static_cast<float>(y));
+        }
+
+        if (_panning)
+        {
+            on_pan(static_cast<float>(x), static_cast<float>(y));
         }
     }
 

--- a/trview.app/Camera/CameraInput.cpp
+++ b/trview.app/Camera/CameraInput.cpp
@@ -109,10 +109,12 @@ namespace trview
         if (button == input::Mouse::Button::Right)
         {
             _rotating = true;
+            _panning_vertical = _panning;
         }
         else if (button == input::Mouse::Button::Left)
         {
             _panning = true;
+            _panning_vertical = _rotating;
         }
     }
 
@@ -121,23 +123,25 @@ namespace trview
         if (button == input::Mouse::Button::Right)
         {
             _rotating = false;
+            _panning_vertical = false;
         }
         else if (button == input::Mouse::Button::Left)
         {
             _panning = false;
+            _panning_vertical = false;
         }
     }
 
     void CameraInput::mouse_move(long x, long y)
     {
-        if (_rotating)
+        if (_rotating && !_panning_vertical)
         {
             on_rotate(static_cast<float>(x), static_cast<float>(y));
         }
 
         if (_panning)
         {
-            on_pan(static_cast<float>(x), static_cast<float>(y));
+            on_pan(_panning_vertical, static_cast<float>(x), static_cast<float>(y));
         }
     }
 

--- a/trview.app/Camera/CameraInput.cpp
+++ b/trview.app/Camera/CameraInput.cpp
@@ -110,7 +110,7 @@ namespace trview
         {
             _rotating = true;
         }
-        else if (button == input::Mouse::Button::Middle)
+        else if (button == input::Mouse::Button::Left)
         {
             _panning = true;
         }
@@ -122,7 +122,7 @@ namespace trview
         {
             _rotating = false;
         }
-        else if (button == input::Mouse::Button::Middle)
+        else if (button == input::Mouse::Button::Left)
         {
             _panning = false;
         }

--- a/trview.app/Camera/CameraInput.h
+++ b/trview.app/Camera/CameraInput.h
@@ -50,6 +50,9 @@ namespace trview
         /// Event raised when the zoom level needs to change.
         Event<float> on_zoom;
 
+        /// Event raised when the user pans around the scene.
+        Event<float, float> on_pan;
+
         /// Event raised when the camera mode needs to change.
         Event<CameraMode> on_mode_change;
     private:
@@ -60,5 +63,6 @@ namespace trview
         bool _free_up{ false };
         bool _free_down{ false };
         bool _rotating{ false };
+        bool _panning{ false };
     };
 }

--- a/trview.app/Camera/CameraInput.h
+++ b/trview.app/Camera/CameraInput.h
@@ -51,6 +51,7 @@ namespace trview
         Event<float> on_zoom;
 
         /// Event raised when the user pans around the scene.
+        /// The boolean parameter indicates whether vertical panning is in effect.
         Event<bool, float, float> on_pan;
 
         /// Event raised when the camera mode needs to change.

--- a/trview.app/Camera/CameraInput.h
+++ b/trview.app/Camera/CameraInput.h
@@ -51,7 +51,7 @@ namespace trview
         Event<float> on_zoom;
 
         /// Event raised when the user pans around the scene.
-        Event<float, float> on_pan;
+        Event<bool, float, float> on_pan;
 
         /// Event raised when the camera mode needs to change.
         Event<CameraMode> on_mode_change;
@@ -64,5 +64,6 @@ namespace trview
         bool _free_down{ false };
         bool _rotating{ false };
         bool _panning{ false };
+        bool _panning_vertical{ false };
     };
 }

--- a/trview.app/Settings/UserSettings.cpp
+++ b/trview.app/Settings/UserSettings.cpp
@@ -75,6 +75,7 @@ namespace trview
             settings.triggers_startup = json["triggersstartup"].get<bool>();
             settings.auto_orbit = json["autoorbit"].get<bool>();
             settings.recent_files = json["recent"].get<std::list<std::string>>();
+            settings.invert_vertical_pan = json["invertverticalpan"].get<bool>();
         }
         catch (...)
         {
@@ -113,6 +114,7 @@ namespace trview
             json["triggersstartup"] = settings.triggers_startup;
             json["autoorbit"] = settings.auto_orbit;
             json["recent"] = settings.recent_files;
+            json["invertverticalpan"] = settings.invert_vertical_pan;
 
             std::ofstream file(file_path);
             file << json;

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -18,6 +18,7 @@ namespace trview
         bool                    items_startup{ false };
         bool                    triggers_startup{ false };
         bool                    auto_orbit{ true };
+        bool                    invert_vertical_pan{ true };
     };
 
     // Load the user settings from the settings file.

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -56,6 +56,10 @@ namespace trview
         auto_orbit->on_state_changed += on_auto_orbit;
         _auto_orbit = panel->add_child(std::move(auto_orbit));
 
+        auto invert_vertical_pan = std::make_unique<Checkbox>(Point(), Size(16, 16), Colour::Transparent, L"Invert vertical panning");
+        invert_vertical_pan->on_state_changed += on_invert_vertical_pan;
+        _invert_vertical_pan = panel->add_child(std::move(invert_vertical_pan));
+
         auto camera_panel = std::make_unique<StackPanel>(Point(), Size(400, 40), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
         camera_panel->set_margin(Size(5, 5));
 
@@ -133,5 +137,10 @@ namespace trview
     void SettingsWindow::set_movement_speed(float value)
     {
         _movement_speed->set_value(value);
+    }
+
+    void SettingsWindow::set_invert_vertical_pan(bool value)
+    {
+        _invert_vertical_pan->set_state(value);
     }
 }

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -52,6 +52,9 @@ namespace trview
         /// Event raised when the 'Switch to orbit on selection' setting has been changed. The new setting is passed as the parameter.
         Event<bool> on_auto_orbit;
 
+        /// Event raised when the 'Invert vertical pan' setting has been changed. The new setting is passed as the parameter.
+        Event<bool> on_invert_vertical_pan;
+
         /// Set the new value of the vsync setting. This will not raise the on_vsync event.
         /// @param value The new vsync setting.
         void set_vsync(bool value);
@@ -86,6 +89,11 @@ namespace trview
         /// @remarks This will not raise the on_sensitivity_changed event.
         void set_sensitivity(float value);
 
+        /// Set the value of invert vertical pan.
+        /// @param value The new setting value.
+        /// @remarks This will not raise the on_invert_vertical_pan event.
+        void set_invert_vertical_pan(bool value);
+
         /// Toggle the visibility of the settings window.
         void toggle_visibility();
     private:
@@ -98,6 +106,7 @@ namespace trview
         ui::Slider* _sensitivity;
         ui::Slider* _movement_speed;
         ui::Control* _window;
+        ui::Checkbox* _invert_vertical_pan;
         TokenStore _token_store;
     };
 }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -137,6 +137,11 @@ namespace trview
             _settings.auto_orbit = value;
             on_settings(_settings);
         };
+        _token_store += _settings_window->on_invert_vertical_pan += [&](bool value)
+        {
+            _settings.invert_vertical_pan = value;
+            on_settings(_settings);
+        };
         _settings_window->on_sensitivity_changed += on_camera_sensitivity;
         _settings_window->on_movement_speed_changed += on_camera_movement_speed;
 
@@ -367,6 +372,7 @@ namespace trview
         _settings_window->set_items_startup(settings.items_startup);
         _settings_window->set_triggers_startup(settings.triggers_startup);
         _settings_window->set_vsync(settings.vsync);
+        _settings_window->set_invert_vertical_pan(settings.invert_vertical_pan);
     }
 
     void ViewerUI::set_selected_room(Room* room)

--- a/trview.input/Mouse.h
+++ b/trview.input/Mouse.h
@@ -25,6 +25,8 @@ namespace trview
             {
                 /// The left mouse button.
                 Left,
+                /// The middle mouse button.
+                Middle,
                 /// The right mouse button.
                 Right
             };
@@ -77,12 +79,21 @@ namespace trview
         private:
             void raise_absolute_mouse_move(long x, long y);
 
+            /// Update the state of the specified button and raise the appropriate events.
+            /// @param button The button to use in any events raised.
+            /// @flags The raw input flags to process.
+            /// @down_mask The flag mask for the button being down.
+            /// @up_mask The flag mask for the button being up.
+            /// @param last_down The timing variable to update to determine whether there was a click.
+            void update_button(Button button, USHORT flags, USHORT down_mask, USHORT up_mask, DWORD& last_down);
+
             std::unique_ptr<IWindowTester> _window_tester;
             bool _any_absolute_previous{ false };
             long _absolute_x;
             long _absolute_y;
 
             DWORD _left_down{ 0u };
+            DWORD _middle_down{ 0u };
             DWORD _right_down{ 0u };
         };
     }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -149,7 +149,7 @@ namespace trview
         _token_store += _ui->on_remove_waypoint += [&]() { remove_waypoint(_context_pick.index); };
         _token_store += _ui->on_orbit += [&]()
         {
-            select_room(room_from_pick(_context_pick));
+            select_room(room_from_pick(_context_pick), true);
             _target = _context_pick.position;
         };
         _token_store += _ui->on_settings += [&](auto settings) { _settings = settings; };
@@ -747,7 +747,7 @@ namespace trview
         }
     }
 
-    void Viewer::select_room(uint32_t room)
+    void Viewer::select_room(uint32_t room, bool force_orbit)
     {
         if (!_level || room >= _level->number_of_rooms())
         {
@@ -757,7 +757,7 @@ namespace trview
         _level->set_selected_room(static_cast<uint16_t>(room));
         _ui->set_selected_room(_level->room(_level->selected_room()));
 
-        if (_settings.auto_orbit && !_was_alternate_select)
+        if (force_orbit || (_settings.auto_orbit && !_was_alternate_select))
         {
             set_camera_mode(CameraMode::Orbit);
         }
@@ -914,7 +914,8 @@ namespace trview
             const auto right = Vector3::Transform(Vector3::Right, rotation);
 
             // Add them on to the position.
-            _target += 0.1f * (forward * -y + right * -x);
+            const auto movement = 0.05f * (forward * -y + right * -x);
+            _target += movement;
 
             if (_level)
             {

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -915,7 +915,7 @@ namespace trview
 
             if (vertical)
             {
-                _target += 0.05f * Vector3::Up * -y;
+                _target += 0.05f * Vector3::Up * y * (_settings.invert_vertical_pan ? -1.0f : 1.0f);
             }
             else
             {

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -902,20 +902,27 @@ namespace trview
             }
         };
 
-        _token_store += _camera_input.on_pan += [&](float x, float y)
+        _token_store += _camera_input.on_pan += [&](bool vertical, float x, float y)
         {
             ICamera& camera = current_camera();
 
             using namespace DirectX::SimpleMath;
 
-            // Rotate forward and right by the camera yaw...
-            const auto rotation = Matrix::CreateRotationY(camera.rotation_yaw());
-            const auto forward = Vector3::Transform(Vector3::Forward, rotation);
-            const auto right = Vector3::Transform(Vector3::Right, rotation);
+            if (vertical)
+            {
+                _target += 0.05f * Vector3::Up * -y;
+            }
+            else
+            {
+                // Rotate forward and right by the camera yaw...
+                const auto rotation = Matrix::CreateRotationY(camera.rotation_yaw());
+                const auto forward = Vector3::Transform(Vector3::Forward, rotation);
+                const auto right = Vector3::Transform(Vector3::Right, rotation);
 
-            // Add them on to the position.
-            const auto movement = 0.05f * (forward * -y + right * -x);
-            _target += movement;
+                // Add them on to the position.
+                const auto movement = 0.05f * (forward * -y + right * -x);
+                _target += movement;
+            }
 
             if (_level)
             {

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -904,6 +904,11 @@ namespace trview
 
         _token_store += _camera_input.on_pan += [&](bool vertical, float x, float y)
         {
+            if (_camera_mode != CameraMode::Orbit)
+            {
+                return;
+            }
+
             ICamera& camera = current_camera();
 
             using namespace DirectX::SimpleMath;

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -392,7 +392,7 @@ namespace trview
 
         using namespace input;
 
-        _token_store += _mouse.mouse_down += [&](Mouse::Button button)
+        _token_store += _mouse.mouse_click += [&](Mouse::Button button)
         {
             if (button == Mouse::Button::Left)
             {

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -902,6 +902,27 @@ namespace trview
             }
         };
 
+        _token_store += _camera_input.on_pan += [&](float x, float y)
+        {
+            ICamera& camera = current_camera();
+
+            using namespace DirectX::SimpleMath;
+
+            // Rotate forward and right by the camera yaw...
+            const auto rotation = Matrix::CreateRotationY(camera.rotation_yaw());
+            const auto forward = Vector3::Transform(Vector3::Forward, rotation);
+            const auto right = Vector3::Transform(Vector3::Right, rotation);
+
+            // Add them on to the position.
+            _target += 0.1f * (forward * -y + right * -x);
+
+            if (_level)
+            {
+                _level->on_camera_moved();
+            }
+            _scene_changed = true;
+        };
+
         _token_store += _camera_input.on_mode_change += [&](CameraMode mode) { set_camera_mode(mode); };
     }
 

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -86,7 +86,7 @@ namespace trview
         void toggle_highlight();
         void update_camera();
         void render_scene();
-        void select_room(uint32_t room);
+        void select_room(uint32_t room, bool force_orbit = false);
         void select_item(const Item& item);
         void select_trigger(const Trigger* const trigger);
         void select_waypoint(uint32_t index);


### PR DESCRIPTION
Allow the user to pan the camera using the left mouse button (by holding it down).
Also adds middle mouse support to mouse, but that isn't used at the moment.
Issue: #578 