### PR TITLE
Split top bar of group box outline

### DIFF
--- a/trview.ui/GroupBox.cpp
+++ b/trview.ui/GroupBox.cpp
@@ -8,17 +8,26 @@ namespace trview
         GroupBox::GroupBox(const Point& point, const Size& size, const Colour& background_colour, const Colour& border_colour, const std::wstring& text)
             : Window(point, size, background_colour), _border_colour(border_colour)
         {
-            auto top = std::make_unique<Window>(Point(0, 5), Size(size.width, 2), border_colour);
+            auto top_left = std::make_unique<Window>(Point(0, 5), Size(9, 2), border_colour);
+            auto top_right = std::make_unique<Window>(Point(0, 5), Size(size.width, 2), border_colour);
             auto left = std::make_unique<Window>(Point(0, 5), Size(2, size.height - 10), border_colour);
             auto bottom = std::make_unique<Window>(Point(0, size.height - 2 - 5), Size(size.width, 2), border_colour);
             auto right = std::make_unique<Window>(Point(size.width - 2, 5), Size(2, size.height - 10), border_colour);
             auto label = std::make_unique<Label>(Point(10, 0), Size(55, 20), background_colour, text, 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto);
 
-            add_child(std::move(top));
+            add_child(std::move(top_left));
+            _top_right = add_child(std::move(top_right));
             add_child(std::move(left));
             add_child(std::move(bottom));
             add_child(std::move(right));
             _label = add_child(std::move(label));
+
+            _token_store += _label->on_size_changed += [&](const auto& new_size)
+            {
+                // Adjust top right bar to be the right position and size.
+                _top_right->set_position(_label->position() + Point(new_size.width + 1, 5));
+                _top_right->set_size(Size(this->size().width - _top_right->position().x - 1, 2));
+            };
         }
 
         std::wstring GroupBox::title() const

--- a/trview.ui/GroupBox.h
+++ b/trview.ui/GroupBox.h
@@ -16,6 +16,7 @@ namespace trview
             void set_title(const std::wstring& title);
         private:
             Colour _border_colour;
+            Window* _top_right;
             Label* _label;
         };
     }


### PR DESCRIPTION
Split the top bar so that it doesn't go behind the text. This was only a problem with the new UI.
Bug: #591