### PR TITLE
Add route colour picker in route window

### DIFF
--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -202,6 +202,11 @@ namespace trview
             nlohmann::json json;
             file >> json;
 
+            if (json["colour"].is_number_unsigned())
+            {
+                route->set_colour(named_colour(json["colour"].get<std::wstring>()));
+            }
+
             for (const auto& waypoint : json["waypoints"])
             {
                 auto type_string = waypoint["type"].get<std::string>();

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -23,6 +23,7 @@ namespace trview
     Route::Route(const graphics::Device& device, const graphics::IShaderStorage& shader_storage)
         : _waypoint_mesh(create_cube_mesh(device)), _selection_renderer(device, shader_storage)
     {
+        _colour = Colour::Green;
     }
 
     void Route::add(const Vector3& position, uint32_t room)
@@ -33,6 +34,11 @@ namespace trview
     void Route::add(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index)
     {
         _waypoints.emplace_back(_waypoint_mesh.get(), position, room, type, type_index);
+    }
+
+    Colour Route::colour() const
+    {
+        return _colour;
     }
 
     void Route::clear()
@@ -142,6 +148,11 @@ namespace trview
     void Route::select_waypoint(uint32_t index)
     {
         _selected_index = index;
+    }
+
+    void Route::set_colour(const Colour& colour)
+    {
+        _colour = colour;
     }
 
     const Waypoint& Route::waypoint(uint32_t index) const

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -202,9 +202,9 @@ namespace trview
             nlohmann::json json;
             file >> json;
 
-            if (json["colour"].is_number_unsigned())
+            if (json["colour"].is_string())
             {
-                route->set_colour(named_colour(json["colour"].get<std::wstring>()));
+                route->set_colour(named_colour(to_utf16(json["colour"].get<std::string>())));
             }
 
             for (const auto& waypoint : json["waypoints"])
@@ -247,6 +247,8 @@ namespace trview
         try
         {
             nlohmann::json json;
+
+            json["colour"] = to_utf8(route.colour().name());
 
             std::vector<nlohmann::json> waypoints;
 

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -23,7 +23,6 @@ namespace trview
     Route::Route(const graphics::Device& device, const graphics::IShaderStorage& shader_storage)
         : _waypoint_mesh(create_cube_mesh(device)), _selection_renderer(device, shader_storage)
     {
-        _colour = Colour::Green;
     }
 
     void Route::add(const Vector3& position, uint32_t room)
@@ -33,7 +32,7 @@ namespace trview
 
     void Route::add(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index)
     {
-        _waypoints.emplace_back(_waypoint_mesh.get(), position, room, type, type_index);
+        _waypoints.emplace_back(_waypoint_mesh.get(), position, room, type, type_index, _colour);
     }
 
     Colour Route::colour() const
@@ -65,7 +64,7 @@ namespace trview
 
     void Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index)
     {
-        _waypoints.insert(_waypoints.begin() + index, Waypoint(_waypoint_mesh.get(), position, room, type, type_index));
+        _waypoints.insert(_waypoints.begin() + index, Waypoint(_waypoint_mesh.get(), position, room, type, type_index, _colour));
     }
 
     uint32_t Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index)
@@ -129,7 +128,7 @@ namespace trview
                 const auto matrix = Matrix(DirectX::XMMatrixLookAtRH(mid, next_waypoint, Vector3::Up)).Invert();
                 const auto length = (next_waypoint - current).Length();
                 const auto to_wvp = Matrix::CreateScale(RopeThickness, RopeThickness, length) * matrix * camera.view_projection();
-                _waypoint_mesh->render(device.context(), to_wvp, texture_storage, Color(0.0f, 1.0f, 0.0f));
+                _waypoint_mesh->render(device.context(), to_wvp, texture_storage, _colour);
             }
         }
 
@@ -153,6 +152,10 @@ namespace trview
     void Route::set_colour(const Colour& colour)
     {
         _colour = colour;
+        for (auto& waypoint : _waypoints)
+        {
+            waypoint.set_route_colour(colour);
+        }
     }
 
     const Waypoint& Route::waypoint(uint32_t index) const

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -35,6 +35,9 @@ namespace trview
         /// Remove all of the waypoints from the route.
         void clear();
 
+        /// Get the colour of the route.
+        Colour colour() const;
+
         /// Insert the new waypoint into the route.
         /// @param position The new waypoint.
         /// @param room The room that the waypoint is in.
@@ -85,6 +88,10 @@ namespace trview
         /// @param index The index to select.
         void select_waypoint(uint32_t index);
 
+        /// Set the colour for the route.
+        /// @param colour The colour to use.
+        void set_colour(const Colour& colour);
+
         /// Get the waypoint at the specified index.
         /// @param index The index to get.
         const Waypoint& waypoint(uint32_t index) const;
@@ -102,6 +109,7 @@ namespace trview
         std::unique_ptr<Mesh> _waypoint_mesh;
         SelectionRenderer     _selection_renderer;
         uint32_t              _selected_index{ 0u };
+        Colour                _colour;
     };
 
     std::unique_ptr<Route> import_route(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const std::string& filename);

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -109,7 +109,7 @@ namespace trview
         std::unique_ptr<Mesh> _waypoint_mesh;
         SelectionRenderer     _selection_renderer;
         uint32_t              _selected_index{ 0u };
-        Colour                _colour;
+        Colour                _colour{ Colour::Green };
     };
 
     std::unique_ptr<Route> import_route(const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const std::string& filename);

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -16,8 +16,8 @@ namespace trview
     {
     }
 
-    Waypoint::Waypoint(Mesh* mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room, Type type, uint32_t index)
-        : _mesh(mesh), _position(position), _type(type), _index(index), _room(room)
+    Waypoint::Waypoint(Mesh* mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room, Type type, uint32_t index, const Colour& route_colour)
+        : _mesh(mesh), _position(position), _type(type), _index(index), _room(room), _route_colour(route_colour)
     {
     }
 
@@ -34,7 +34,7 @@ namespace trview
 
         // The light blob.
         auto blob_wvp = Matrix::CreateScale(PoleThickness, PoleThickness, PoleThickness) * Matrix::CreateTranslation(_position - Vector3(0, 0.5f + PoleThickness * 0.5f, 0)) * camera.view_projection();
-        _mesh->render(device.context(), blob_wvp, texture_storage, Color(0.0f, 1.0f, 0.0f));
+        _mesh->render(device.context(), blob_wvp, texture_storage, _route_colour);
     }
 
     void Waypoint::get_transparent_triangles(TransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour)
@@ -69,6 +69,11 @@ namespace trview
     void Waypoint::set_notes(const std::wstring& notes)
     {
         _notes = notes;
+    }
+
+    void Waypoint::set_route_colour(const Colour& colour)
+    {
+        _route_colour = colour;
     }
 
     Waypoint::Type waypoint_type_from_string(const std::string& value)

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -3,6 +3,7 @@
 #include <SimpleMath.h>
 #include <trview.app/Geometry/IRenderable.h>
 #include <trview.app/Geometry/Mesh.h>
+#include <trview.common/Colour.h>
 
 namespace trview
 {
@@ -33,7 +34,8 @@ namespace trview
         /// @param room The room that waypoint is in.
         /// @param type The type of waypoint.
         /// @param index The index of the entity or trigger being referenced if this is a non-position type.
-        explicit Waypoint(Mesh* mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room, Type type, uint32_t index);
+        /// @param route_colour The colour of the route.
+        explicit Waypoint(Mesh* mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room, Type type, uint32_t index, const Colour& route_colour);
 
         /// Destructor for waypoint.
         virtual ~Waypoint() = default;
@@ -69,6 +71,8 @@ namespace trview
         /// Set the notes associated with the waypoint.
         /// @param notes The notes to save.
         void set_notes(const std::wstring& notes);
+
+        void set_route_colour(const Colour& colour);
     private:
         std::wstring                 _notes;
         DirectX::SimpleMath::Vector3 _position;
@@ -76,6 +80,7 @@ namespace trview
         Type                         _type;
         uint32_t                     _index;
         uint32_t                     _room;
+        Colour                       _route_colour;
     };
 
     Waypoint::Type waypoint_type_from_string(const std::string& value);

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -72,6 +72,8 @@ namespace trview
         /// @param notes The notes to save.
         void set_notes(const std::wstring& notes);
 
+        /// Set the route colour for the waypoint blob.
+        /// @param colour The colour of the route.
         void set_route_colour(const Colour& colour);
     private:
         std::wstring                 _notes;

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -1,11 +1,8 @@
 #include "RouteWindow.h"
-#include <trview.app/Routing/Waypoint.h>
 #include <trview.app/Routing/Route.h>
 #include <trview.ui/GroupBox.h>
-#include <trview.ui/TextArea.h>
 #include <trview.ui/Button.h>
 #include <trview.common/Strings.h>
-#include <trview.ui/Dropdown.h>
 
 namespace trview
 {

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -5,6 +5,7 @@
 #include <trview.ui/TextArea.h>
 #include <trview.ui/Button.h>
 #include <trview.common/Strings.h>
+#include <trview.ui/Dropdown.h>
 
 namespace trview
 {
@@ -62,12 +63,10 @@ namespace trview
         auto left_panel = std::make_unique<StackPanel>(Point(), Size(200, window().size().height), Colours::LeftPanel, Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         auto buttons = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(0, 0), StackPanel::Direction::Horizontal);
-        auto colour = buttons->add_child(std::make_unique<Button>(Point(), Size(20, 20), create_texture(device, Colour::Green), create_texture(device, Colour::Green)));
-        _token_store += colour->on_click += [&]()
-        {
-            // Show the colour picker window (popout)
-            // Similar to dropdown logic.
-        };
+
+        auto colour = buttons->add_child(std::make_unique<Dropdown>(Point(), Size(20, 20)));
+        colour->set_text_background_colour(Colour::Green);
+
         auto import = buttons->add_child(std::make_unique<Button>(Point(), Size(90, 20), L"Import"));
         _token_store += import->on_click += [&]()
         {

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -66,6 +66,13 @@ namespace trview
 
         auto colour = buttons->add_child(std::make_unique<Dropdown>(Point(), Size(20, 20)));
         colour->set_text_background_colour(Colour::Green);
+        colour->set_dropdown_scope(_ui.get());
+        colour->set_values(
+            {
+                Dropdown::Value { L"", Colour::Green, Colour::Green },
+                { L"", Colour::Red, Colour::Red },
+                { L"", Colour::Blue, Colour::Blue }
+            });;
 
         auto import = buttons->add_child(std::make_unique<Button>(Point(), Size(90, 20), L"Import"));
         _token_store += import->on_click += [&]()

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -64,15 +64,16 @@ namespace trview
 
         auto buttons = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(0, 0), StackPanel::Direction::Horizontal);
 
-        auto colour = buttons->add_child(std::make_unique<Dropdown>(Point(), Size(20, 20)));
+        auto colour = buttons->add_child(std::make_unique<Dropdown>(Point(), Size(100, 20)));
         colour->set_text_background_colour(Colour::Green);
-        colour->set_dropdown_scope(_ui.get());
         colour->set_values(
             {
-                Dropdown::Value { L"", Colour::Green, Colour::Green },
-                { L"", Colour::Red, Colour::Red },
-                { L"", Colour::Blue, Colour::Blue }
-            });;
+                Dropdown::Value { L"Green", Colour::Green, Colour::Green },
+                { L"Red", Colour::Red, Colour::Red },
+                { L"Blue", Colour::Blue, Colour::Blue }
+            });
+        colour->set_selected_value(L"Green");
+        colour->set_dropdown_scope(_ui.get());
 
         auto import = buttons->add_child(std::make_unique<Button>(Point(), Size(90, 20), L"Import"));
         _token_store += import->on_click += [&]()

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -64,7 +64,8 @@ namespace trview
 
         auto buttons = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(0, 0), StackPanel::Direction::Horizontal);
 
-        auto colour = buttons->add_child(std::make_unique<Dropdown>(Point(), Size(100, 20)));
+        auto colour = buttons->add_child(std::make_unique<Dropdown>(Point(), Size(20, 20)));
+        colour->set_text_colour(Colour::Green);
         colour->set_text_background_colour(Colour::Green);
         colour->set_values(
             {
@@ -74,6 +75,25 @@ namespace trview
             });
         colour->set_selected_value(L"Green");
         colour->set_dropdown_scope(_ui.get());
+
+        _token_store += colour->on_value_selected += [=](const auto& value)
+        {
+            if (value == L"Green") 
+            {
+                colour->set_text_colour(Colour::Green);
+                colour->set_text_background_colour(Colour::Green);
+            }
+            else if (value == L"Red")
+            {
+                colour->set_text_colour(Colour::Red);
+                colour->set_text_background_colour(Colour::Red);
+            }
+            else if (value == L"Blue")
+            {
+                colour->set_text_colour(Colour::Blue);
+                colour->set_text_background_colour(Colour::Blue);
+            }
+        };
 
         auto import = buttons->add_child(std::make_unique<Button>(Point(), Size(90, 20), L"Import"));
         _token_store += import->on_click += [&]()

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -56,8 +56,6 @@ namespace trview
         }
         _waypoints->set_items(items);
         load_waypoint_details(_selected_index);
-
-        // Set the colour...
         _colour->set_selected_value(route->colour().name());
     }
 

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -40,7 +40,7 @@ namespace trview
     RouteWindow::RouteWindow(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, const trview::Window& parent)
         : CollapsiblePanel(device, shader_storage, font_factory, parent, L"trview.route", L"Route", Size(470, 400))
     {
-        set_panels(create_left_panel(), create_right_panel());
+        set_panels(create_left_panel(device), create_right_panel());
     }
 
     void RouteWindow::set_route(Route* route) 
@@ -57,12 +57,18 @@ namespace trview
         load_waypoint_details(_selected_index);
     }
 
-    std::unique_ptr<Control> RouteWindow::create_left_panel()
+    std::unique_ptr<Control> RouteWindow::create_left_panel(const Device& device)
     {
         auto left_panel = std::make_unique<StackPanel>(Point(), Size(200, window().size().height), Colours::LeftPanel, Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         auto buttons = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(0, 0), StackPanel::Direction::Horizontal);
-        auto import = buttons->add_child(std::make_unique<Button>(Point(), Size(100, 20), L"Import"));
+        auto colour = buttons->add_child(std::make_unique<Button>(Point(), Size(20, 20), create_texture(device, Colour::Green), create_texture(device, Colour::Green)));
+        _token_store += colour->on_click += [&]()
+        {
+            // Show the colour picker window (popout)
+            // Similar to dropdown logic.
+        };
+        auto import = buttons->add_child(std::make_unique<Button>(Point(), Size(90, 20), L"Import"));
         _token_store += import->on_click += [&]()
         {
             OPENFILENAME ofn;
@@ -82,7 +88,7 @@ namespace trview
                 on_route_import(trview::to_utf8(ofn.lpstrFile));
             }
         };
-        auto export_button = buttons->add_child(std::make_unique<Button>(Point(), Size(100, 20), L"Export"));
+        auto export_button = buttons->add_child(std::make_unique<Button>(Point(), Size(90, 20), L"Export"));
         _token_store += export_button->on_click += [&]()
         {
             OPENFILENAME ofn;

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -71,28 +71,21 @@ namespace trview
             {
                 Dropdown::Value { L"Green", Colour::Green, Colour::Green },
                 { L"Red", Colour::Red, Colour::Red },
-                { L"Blue", Colour::Blue, Colour::Blue }
+                { L"Blue", Colour::Blue, Colour::Blue },
+                { L"Yellow", Colour::Yellow, Colour::Yellow },
+                { L"Cyan", Colour::Cyan, Colour::Cyan },
+                { L"Magenta", Colour::Magenta, Colour::Magenta },
+                { L"Black", Colour::Black, Colour::Black },
+                { L"White", Colour::White, Colour::White }
             });
         colour->set_selected_value(L"Green");
         colour->set_dropdown_scope(_ui.get());
 
         _token_store += colour->on_value_selected += [=](const auto& value)
         {
-            if (value == L"Green") 
-            {
-                colour->set_text_colour(Colour::Green);
-                colour->set_text_background_colour(Colour::Green);
-            }
-            else if (value == L"Red")
-            {
-                colour->set_text_colour(Colour::Red);
-                colour->set_text_background_colour(Colour::Red);
-            }
-            else if (value == L"Blue")
-            {
-                colour->set_text_colour(Colour::Blue);
-                colour->set_text_background_colour(Colour::Blue);
-            }
+            const auto new_colour = named_colour(value);
+            colour->set_text_colour(new_colour);
+            colour->set_text_background_colour(new_colour);
         };
 
         auto import = buttons->add_child(std::make_unique<Button>(Point(), Size(90, 20), L"Import"));

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -56,7 +56,11 @@ namespace trview
         }
         _waypoints->set_items(items);
         load_waypoint_details(_selected_index);
-        _colour->set_selected_value(route->colour().name());
+
+        const auto colour = route->colour();
+        _colour->set_text_colour(colour);
+        _colour->set_text_background_colour(colour);
+        _colour->set_selected_value(colour.name());
     }
 
     std::unique_ptr<Control> RouteWindow::create_left_panel(const Device& device)

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -56,6 +56,9 @@ namespace trview
         }
         _waypoints->set_items(items);
         load_waypoint_details(_selected_index);
+
+        // Set the colour...
+        _colour->set_selected_value(route->colour().name());
     }
 
     std::unique_ptr<Control> RouteWindow::create_left_panel(const Device& device)
@@ -64,28 +67,29 @@ namespace trview
 
         auto buttons = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(0, 0), StackPanel::Direction::Horizontal);
 
-        auto colour = buttons->add_child(std::make_unique<Dropdown>(Point(), Size(20, 20)));
-        colour->set_text_colour(Colour::Green);
-        colour->set_text_background_colour(Colour::Green);
-        colour->set_values(
+        _colour = buttons->add_child(std::make_unique<Dropdown>(Point(), Size(20, 20)));
+        _colour->set_text_colour(Colour::Green);
+        _colour->set_text_background_colour(Colour::Green);
+        _colour->set_values(
             {
-                Dropdown::Value { L"Green", Colour::Green, Colour::Green },
-                { L"Red", Colour::Red, Colour::Red },
-                { L"Blue", Colour::Blue, Colour::Blue },
-                { L"Yellow", Colour::Yellow, Colour::Yellow },
-                { L"Cyan", Colour::Cyan, Colour::Cyan },
-                { L"Magenta", Colour::Magenta, Colour::Magenta },
-                { L"Black", Colour::Black, Colour::Black },
-                { L"White", Colour::White, Colour::White }
+                Dropdown::Value { Colour::Green.name(), Colour::Green, Colour::Green },
+                { Colour::Red.name(), Colour::Red, Colour::Red },
+                { Colour::Blue.name(), Colour::Blue, Colour::Blue },
+                { Colour::Yellow.name(), Colour::Yellow, Colour::Yellow },
+                { Colour::Cyan.name(), Colour::Cyan, Colour::Cyan },
+                { Colour::Magenta.name(), Colour::Magenta, Colour::Magenta },
+                { Colour::Black.name(), Colour::Black, Colour::Black },
+                { Colour::White.name(), Colour::White, Colour::White }
             });
-        colour->set_selected_value(L"Green");
-        colour->set_dropdown_scope(_ui.get());
+        _colour->set_selected_value(Colour::Green.name());
+        _colour->set_dropdown_scope(_ui.get());
 
-        _token_store += colour->on_value_selected += [=](const auto& value)
+        _token_store += _colour->on_value_selected += [=](const auto& value)
         {
             const auto new_colour = named_colour(value);
-            colour->set_text_colour(new_colour);
-            colour->set_text_background_colour(new_colour);
+            _colour->set_text_colour(new_colour);
+            _colour->set_text_background_colour(new_colour);
+            on_colour_changed(new_colour);
         };
 
         auto import = buttons->add_child(std::make_unique<Button>(Point(), Size(90, 20), L"Import"));

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -59,7 +59,7 @@ namespace trview
         void set_triggers(const std::vector<Trigger*>& triggers);
     private:
         void load_waypoint_details(uint32_t index);
-        std::unique_ptr<ui::Control> create_left_panel();
+        std::unique_ptr<ui::Control> create_left_panel(const graphics::Device& device);
         std::unique_ptr<ui::Control> create_right_panel();
         ui::Listbox::Item create_listbox_item(uint32_t index, const Waypoint& waypoint);
 

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -1,7 +1,9 @@
+
 #pragma once
 
 #include <trview.ui/Listbox.h>
 #include <trview.ui/TextArea.h>
+#include <trview.ui/Dropdown.h>
 #include "CollapsiblePanel.h"
 #include <trview.common/Event.h>
 #include <trview.app/Routing/Waypoint.h>
@@ -37,6 +39,9 @@ namespace trview
         /// Event raised when a trigger is selected.
         Event<Trigger*> on_trigger_selected;
 
+        /// Event raised when the route colour has been changed.
+        Event<Colour> on_colour_changed;
+
         /// Event raised when a route file is opened.
         Event<std::string> on_route_import;
 
@@ -63,6 +68,7 @@ namespace trview
         std::unique_ptr<ui::Control> create_right_panel();
         ui::Listbox::Item create_listbox_item(uint32_t index, const Waypoint& waypoint);
 
+        ui::Dropdown* _colour;
         ui::Listbox* _waypoints;
         ui::Listbox* _stats;
         ui::TextArea* _notes_area;

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -29,6 +29,7 @@ namespace trview
 
         // Otherwise create the window.
         _route_window = std::make_unique<RouteWindow>(_device, _shader_storage, _font_factory, window());
+        _route_window->on_colour_changed += on_colour_changed;
         _route_window->on_route_import += on_route_import;
         _route_window->on_route_export += on_route_export;
         _route_window->on_item_selected += on_item_selected;

--- a/trview.app/Windows/RouteWindowManager.h
+++ b/trview.app/Windows/RouteWindowManager.h
@@ -45,6 +45,9 @@ namespace trview
 
         void select_waypoint(uint32_t index);
 
+        /// Event raised when the route colour has changed.
+        Event<Colour> on_colour_changed;
+
         /// Event raised when a route is imported.
         Event<std::string> on_route_import;
 

--- a/trview.common/Colour.cpp
+++ b/trview.common/Colour.cpp
@@ -8,6 +8,8 @@ namespace trview
     Colour Colour::Transparent = Colour(0.0f, 0.0f, 0.0f, 0.0f);
     Colour Colour::White = Colour(1.0f, 1.0f, 1.0f);
     Colour Colour::Green = Colour(0.0f, 1.0f, 0.0f);
+    Colour Colour::Blue = Colour(0.0f, 0.0f, 1.0f);
+    Colour Colour::Red = Colour(1.0f, 0.0f, 0.0f);
 
     Colour::Colour()
         : Colour(1.0f, 1.0f, 1.0f)

--- a/trview.common/Colour.cpp
+++ b/trview.common/Colour.cpp
@@ -7,6 +7,7 @@ namespace trview
     Colour Colour::LightGrey = Colour(0.7f, 0.7f, 0.7f);
     Colour Colour::Transparent = Colour(0.0f, 0.0f, 0.0f, 0.0f);
     Colour Colour::White = Colour(1.0f, 1.0f, 1.0f);
+    Colour Colour::Green = Colour(0.0f, 1.0f, 0.0f);
 
     Colour::Colour()
         : Colour(1.0f, 1.0f, 1.0f)

--- a/trview.common/Colour.cpp
+++ b/trview.common/Colour.cpp
@@ -1,4 +1,5 @@
 #include "Colour.h"
+#include <string>
 
 namespace trview
 {
@@ -34,6 +35,12 @@ namespace trview
     {
     }
 
+    std::wstring Colour::name() const
+    {
+        uint32_t value = *this;
+        return std::to_wstring(value);
+    }
+
     Colour::operator DirectX::SimpleMath::Color() const
     {
         return DirectX::SimpleMath::Color(r, g, b, a);
@@ -58,36 +65,12 @@ namespace trview
 
     Colour named_colour(const std::wstring& name)
     {
-        if (name == L"Red")
-        {
-            return Colour::Red;
-        }
-        else if (name == L"Green")
-        {
-            return Colour::Green;
-        }
-        else if (name == L"Blue")
-        {
-            return Colour::Blue;
-        }
-        else if (name == L"Magenta")
-        {
-            return Colour::Magenta;
-        }
-        else if (name == L"White")
-        {
-            return Colour::White;
-        }
-        else if (name == L"Yellow")
-        {
-            return Colour::Yellow;
-        }
-        else if (name == L"Cyan")
-        {
-            return Colour::Cyan;
-        }
-
-        return Colour::Black;
+        uint32_t value = std::stoul(name);
+        return Colour(
+            ((value >> 24) & 0xff) / 255.0f,
+            ((value >> 16) & 0xff) / 255.0f,
+            ((value >> 8) & 0xff) / 255.0f,
+            (value & 0xff) / 255.0f);
     }
 
     Colour operator+(const Colour& left, const Colour& right)

--- a/trview.common/Colour.cpp
+++ b/trview.common/Colour.cpp
@@ -10,6 +10,9 @@ namespace trview
     Colour Colour::Green = Colour(0.0f, 1.0f, 0.0f);
     Colour Colour::Blue = Colour(0.0f, 0.0f, 1.0f);
     Colour Colour::Red = Colour(1.0f, 0.0f, 0.0f);
+    Colour Colour::Yellow = Colour(1.0f, 1.0f, 0.0f);
+    Colour Colour::Magenta = Colour(1.0f, 0.0f, 1.0f);
+    Colour Colour::Cyan = Colour(0.0f, 1.0f, 1.0f);
 
     Colour::Colour()
         : Colour(1.0f, 1.0f, 1.0f)
@@ -51,6 +54,40 @@ namespace trview
         g += other.g;
         b += other.b;
         return *this;
+    }
+
+    Colour named_colour(const std::wstring& name)
+    {
+        if (name == L"Red")
+        {
+            return Colour::Red;
+        }
+        else if (name == L"Green")
+        {
+            return Colour::Green;
+        }
+        else if (name == L"Blue")
+        {
+            return Colour::Blue;
+        }
+        else if (name == L"Magenta")
+        {
+            return Colour::Magenta;
+        }
+        else if (name == L"White")
+        {
+            return Colour::White;
+        }
+        else if (name == L"Yellow")
+        {
+            return Colour::Yellow;
+        }
+        else if (name == L"Cyan")
+        {
+            return Colour::Cyan;
+        }
+
+        return Colour::Black;
     }
 
     Colour operator+(const Colour& left, const Colour& right)

--- a/trview.common/Colour.h
+++ b/trview.common/Colour.h
@@ -34,6 +34,8 @@ namespace trview
         static Colour Transparent;
         static Colour White;
         static Colour Green;
+        static Colour Blue;
+        static Colour Red;
     };
 
     Colour operator+(const Colour& left, const Colour& right);

--- a/trview.common/Colour.h
+++ b/trview.common/Colour.h
@@ -33,6 +33,7 @@ namespace trview
         static Colour LightGrey;
         static Colour Transparent;
         static Colour White;
+        static Colour Green;
     };
 
     Colour operator+(const Colour& left, const Colour& right);

--- a/trview.common/Colour.h
+++ b/trview.common/Colour.h
@@ -36,7 +36,12 @@ namespace trview
         static Colour Green;
         static Colour Blue;
         static Colour Red;
+        static Colour Yellow;
+        static Colour Magenta;
+        static Colour Cyan;
     };
+
+    Colour named_colour(const std::wstring& name);
 
     Colour operator+(const Colour& left, const Colour& right);
 

--- a/trview.common/Colour.h
+++ b/trview.common/Colour.h
@@ -19,6 +19,8 @@ namespace trview
 
         Colour(float a, float r, float g, float b);
 
+        std::wstring name() const;
+
         operator DirectX::SimpleMath::Color() const;
 
         /// Convert the colour into a packed argb integer format.

--- a/trview.graphics/Font.cpp
+++ b/trview.graphics/Font.cpp
@@ -65,7 +65,7 @@ namespace trview
             }
 
             _batch->Begin(SpriteSortMode_Deferred, blend_state.Get());
-            _font->DrawString(_batch.get(), sanitise(*_font, text).c_str(), XMVectorSet(round(x), round(y), 0, 0), XMVectorSet(colour.b, colour.g, colour.r, colour.a), 0, XMVectorZero(), XMVectorSet(1, 1, 1, 1));
+            _font->DrawString(_batch.get(), sanitise(*_font, text).c_str(), XMVectorSet(round(x), round(y), 0, 0), XMVectorSet(colour.r, colour.g, colour.b, colour.a), 0, XMVectorZero(), XMVectorSet(1, 1, 1, 1));
             _batch->End();
         }
 

--- a/trview.ui/Dropdown.cpp
+++ b/trview.ui/Dropdown.cpp
@@ -87,7 +87,7 @@ namespace trview
             std::vector<Listbox::Item> items;
             for (const auto& value : _values)
             {
-                items.push_back({{{ L"Name", value.text }}});
+                items.push_back({{{ L"Name", value.text }}, value.foreground, value.background});
             }
             _dropdown->set_items(items);
         }

--- a/trview.ui/Dropdown.cpp
+++ b/trview.ui/Dropdown.cpp
@@ -14,6 +14,10 @@ namespace trview
             _button->set_background_colour(Colour(0.25f, 0.25f, 0.25f));
             _token_store += _button->on_click += [&]()
             {
+                if (!_dropdown)
+                {
+                    return;
+                }
                 _dropdown->set_visible(!_dropdown->visible());
                 on_focus_requested();
                 update_dropdown();
@@ -51,6 +55,11 @@ namespace trview
         void Dropdown::set_selected_value(const std::wstring& value)
         {
             _button->set_text(value);
+        }
+
+        void Dropdown::set_text_background_colour(const Colour& colour)
+        {
+            _button->set_text_background_colour(colour);
         }
 
         void Dropdown::update_dropdown()

--- a/trview.ui/Dropdown.cpp
+++ b/trview.ui/Dropdown.cpp
@@ -46,7 +46,18 @@ namespace trview
             update_dropdown();
         }
 
-        void Dropdown::set_values(const std::vector<std::wstring>& values)
+        void Dropdown::set_values(const std::vector<std::wstring>& value_names)
+        {
+            std::vector<Value> values;
+            std::transform(value_names.begin(), value_names.end(), std::back_inserter(values), 
+                [](const std::wstring& name) -> Value
+            {
+                return { name, { 0.25f, 0.25f, 0.25f }, Colour::White };
+            });
+            set_values(values);
+        }
+
+        void Dropdown::set_values(const std::vector<Value>& values)
         {
             _values = values;
             update_dropdown();
@@ -76,7 +87,7 @@ namespace trview
             std::vector<Listbox::Item> items;
             for (const auto& value : _values)
             {
-                items.push_back({{{ L"Name", value }}});
+                items.push_back({{{ L"Name", value.text }}});
             }
             _dropdown->set_items(items);
         }

--- a/trview.ui/Dropdown.cpp
+++ b/trview.ui/Dropdown.cpp
@@ -68,6 +68,11 @@ namespace trview
             _button->set_text(value);
         }
 
+        void Dropdown::set_text_colour(const Colour& colour)
+        {
+            _button->set_text_colour(colour);
+        }
+
         void Dropdown::set_text_background_colour(const Colour& colour)
         {
             _button->set_text_background_colour(colour);

--- a/trview.ui/Dropdown.h
+++ b/trview.ui/Dropdown.h
@@ -15,6 +15,14 @@ namespace trview
         class Dropdown final : public Window
         {
         public:
+            /// A value element for the dropdown.
+            struct Value
+            {
+                std::wstring text;
+                Colour       foreground;
+                Colour       background;
+            };
+
             /// Create a new dropdown box.
             /// @param position The position of the control.
             /// @param size The size of the control.
@@ -29,8 +37,12 @@ namespace trview
             void set_dropdown_scope(Control* scope);
 
             /// Set the values to show in the dropdown.
+            /// @param value_names The values to show.
+            void set_values(const std::vector<std::wstring>& value_names);
+
+            /// Set the values to show in the dropdown.
             /// @param values The values to show.
-            void set_values(const std::vector<std::wstring>& values);
+            void set_values(const std::vector<Value>& values);
 
             /// Set the selected value. This will not raise the on_value_selected event.
             /// @param value The new value.
@@ -47,9 +59,9 @@ namespace trview
         private:
             void update_dropdown();
 
-            std::vector<std::wstring> _values;
-            ui::Button*               _button;
-            ui::Listbox*              _dropdown;
+            std::vector<Value> _values;
+            ui::Button* _button;
+            ui::Listbox* _dropdown;
         };
     }
 }

--- a/trview.ui/Dropdown.h
+++ b/trview.ui/Dropdown.h
@@ -48,6 +48,10 @@ namespace trview
             /// @param value The new value.
             void set_selected_value(const std::wstring& value);
 
+            /// Set the foreground colour of the selected text box.
+            /// @param colour The new value.
+            void set_text_colour(const Colour& colour);
+
             /// Set the background colour of the selected text box.
             /// @param colour The new value.
             void set_text_background_colour(const Colour& colour);

--- a/trview.ui/Dropdown.h
+++ b/trview.ui/Dropdown.h
@@ -36,6 +36,10 @@ namespace trview
             /// @param value The new value.
             void set_selected_value(const std::wstring& value);
 
+            /// Set the background colour of the selected text box.
+            /// @param colour The new value.
+            void set_text_background_colour(const Colour& colour);
+
             /// Event raised when a value is selected. The selected value is passed as a parameter.
             Event<std::wstring> on_value_selected;
 

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -67,10 +67,24 @@ namespace trview
                 /// @param values The column index values for the item.
                 Item(const std::unordered_map<std::wstring, std::wstring>& values);
 
+                /// Create an item.
+                /// @param values The column index values for the item.
+                /// @param foreground The foreground text colour.
+                /// @param background The background colour of the box.
+                Item(const std::unordered_map<std::wstring, std::wstring>& values, const Colour& foreground, const Colour& background);
+
                 /// Get the value that the item has for the specified key.
                 /// @param key The key to search for.
                 /// @returns The value for the key.
                 std::wstring value(const std::wstring& key) const;
+
+                /// Get the foreground colour.
+                /// @returns The foreground text colour.
+                Colour foreground() const;
+
+                /// Get the background colour.
+                /// @returns The backround colour.
+                Colour background() const;
 
                 /// Determines whether two items are equal.
                 /// @param other The item to compare.
@@ -78,6 +92,8 @@ namespace trview
                 bool operator == (const Item& other) const;
             private:
                 std::unordered_map<std::wstring, std::wstring> _values;
+                Colour _foreground;
+                Colour _background;
             };
 
             /// A row in the list box.

--- a/trview.ui/ListboxItem.cpp
+++ b/trview.ui/ListboxItem.cpp
@@ -5,7 +5,12 @@ namespace trview
     namespace ui
     {
         Listbox::Item::Item(const std::unordered_map<std::wstring, std::wstring>& values)
-            : _values(values)
+            : Item(values, Colour::White, { 0.25f, 0.25f, 0.25f })
+        {
+        }
+
+        Listbox::Item::Item(const std::unordered_map<std::wstring, std::wstring>& values, const Colour& foreground, const Colour& background)
+            : _values(values), _foreground(foreground), _background(background)
         {
         }
 
@@ -17,6 +22,16 @@ namespace trview
                 return std::wstring();
             }
             return item->second;
+        }
+
+        Colour Listbox::Item::foreground() const
+        {
+            return _foreground;
+        }
+
+        Colour Listbox::Item::background() const
+        {
+            return _background;
         }
 
         bool Listbox::Item::operator == (const Item& other) const

--- a/trview.ui/ListboxRow.cpp
+++ b/trview.ui/ListboxRow.cpp
@@ -31,7 +31,10 @@ namespace trview
             const auto columns = child_elements();
             for (auto c = 0; c < _columns.size(); ++c)
             {
-                static_cast<Button*>(columns[c])->set_text(item.value(_columns[c].name()));
+                Button* button = static_cast<Button*>(columns[c]);
+                button->set_text(item.value(_columns[c].name()));
+                button->set_text_background_colour(item.background());
+                button->set_text_colour(item.foreground());
             }
         }
 

--- a/trview.ui/ListboxRow.cpp
+++ b/trview.ui/ListboxRow.cpp
@@ -27,6 +27,7 @@ namespace trview
         void Listbox::Row::set_item(const Item& item)
         {
             _item = item;
+            set_background_colour(item.background());
 
             const auto columns = child_elements();
             for (auto c = 0; c < _columns.size(); ++c)

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -210,6 +210,7 @@ namespace trview
         _token_store += _route_window_manager->on_colour_changed += [&](const Colour& colour)
         {
             _route->set_colour(colour);
+            _scene_changed = true;
         };
 
         _token_store += _view_menu.on_show_minimap += [&](bool show) { _ui->set_show_minimap(show); };

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -197,6 +197,7 @@ namespace trview
             {
                 _route = std::move(route);
                 _route_window_manager->set_route(_route.get());
+                _scene_changed = true;
             }
         };
         _token_store += _route_window_manager->on_route_export += [&](const std::string& path)

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -207,6 +207,10 @@ namespace trview
         {
             remove_waypoint(index);
         };
+        _token_store += _route_window_manager->on_colour_changed += [&](const Colour& colour)
+        {
+            _route->set_colour(colour);
+        };
 
         _token_store += _view_menu.on_show_minimap += [&](bool show) { _ui->set_show_minimap(show); };
         _token_store += _view_menu.on_show_tooltip += [&](bool show) { _ui->set_show_tooltip(show); };


### PR DESCRIPTION
User can now select the colour of the route using a dropdown in the route window.
Can currently choose from 8 colours (black, white, yellow, red, green, blue, cyan, magenta).
The colour is saved in the exported route and loaded back.
List box and dropdown are also updated to have foreground and background colours.
Issue: #436 