### PR TITLE
Add position-less constructors for UI elements

### DIFF
--- a/trview.app/Tools/Toolbar.cpp
+++ b/trview.app/Tools/Toolbar.cpp
@@ -8,7 +8,7 @@ namespace trview
     Toolbar::Toolbar(Control& control)
     {
         // Create a panel at the bottom of the parent control - have to add it to the control first so we can find out where to put it.
-        auto toolbar = std::make_unique<StackPanel>(Point(), Size(100, 40), Colour(0.0f, 0.0f, 0.0f, 0.0f), Size(5,5), StackPanel::Direction::Horizontal);
+        auto toolbar = std::make_unique<StackPanel>(Size(100, 40), Colour(0.0f, 0.0f, 0.0f, 0.0f), Size(5,5), StackPanel::Direction::Horizontal);
         _toolbar = control.add_child(std::move(toolbar));
 
         // Put the toolbar in the middle bottom of the window.

--- a/trview.app/Tools/Toolbar.cpp
+++ b/trview.app/Tools/Toolbar.cpp
@@ -31,7 +31,7 @@ namespace trview
 
     void Toolbar::add_tool(const std::wstring& name, const std::wstring& text)
     {
-        auto tool = std::make_unique<Button>(Point(), Size(32, 32), text);
+        auto tool = std::make_unique<Button>(Size(32, 32), text);
         _token_store += tool->on_click += [=]()
         {
             on_tool_clicked(name);

--- a/trview.app/UI/CameraControls.cpp
+++ b/trview.app/UI/CameraControls.cpp
@@ -19,13 +19,13 @@ namespace trview
 
         auto reset_camera_label = std::make_unique<Label>(Point(30, 20), Size(40, 16), Colour::Transparent, L"Reset", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Centre);
 
-        auto orbit_camera = std::make_unique<Checkbox>(Point(86, 20), Size(16, 16), Colour::Transparent, L"Orbit");
+        auto orbit_camera = std::make_unique<Checkbox>(Point(86, 20), Colour::Transparent, L"Orbit");
         _token_store += orbit_camera->on_state_changed += [&](auto) { change_mode(CameraMode::Orbit); };
 
-        auto free_camera = std::make_unique<Checkbox>(Point(12, 42), Size(16, 16), Colour::Transparent, L"Free");
+        auto free_camera = std::make_unique<Checkbox>(Point(12, 42), Colour::Transparent, L"Free");
         _token_store += free_camera->on_state_changed += [&](auto) { change_mode(CameraMode::Free); };
 
-        auto axis_camera = std::make_unique<Checkbox>(Point(86, 42), Size(16, 16), Colour::Transparent, L"Axis");
+        auto axis_camera = std::make_unique<Checkbox>(Point(86, 42), Colour::Transparent, L"Axis");
         _token_store += axis_camera->on_state_changed += [&](auto) { change_mode(CameraMode::Axis); };
 
         camera_window->add_child(std::move(reset_camera));

--- a/trview.app/UI/CameraControls.cpp
+++ b/trview.app/UI/CameraControls.cpp
@@ -12,7 +12,7 @@ namespace trview
     {
         using namespace ui;
 
-        auto camera_window = std::make_unique<GroupBox>(Point(), Size(150, 72), Colour::Transparent, Colour::Grey, L"Camera");
+        auto camera_window = std::make_unique<GroupBox>(Size(150, 72), Colour::Transparent, Colour::Grey, L"Camera");
 
         auto reset_camera = std::make_unique<Button>(Point(12, 20), Size(16, 16));
         reset_camera->on_click += on_reset;

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -70,8 +70,8 @@ namespace trview
 
     TextArea* CameraPosition::create_coordinate_entry(Control& parent, float& coordinate, const std::wstring& name)
     {
-        auto line = std::make_unique<StackPanel>(Point(), Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
-        auto line_area = std::make_unique<StackPanel>(Point(), Size(10, 20), Colour::Transparent);
+        auto line = std::make_unique<StackPanel>(Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
+        auto line_area = std::make_unique<StackPanel>(Size(10, 20), Colour::Transparent);
         line_area->add_child(std::make_unique<Window>(Point(), Size(10, 1), Colour::Transparent));
         line_area->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, name + L": ", 8));
         line->add_child(std::move(line_area));

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -75,7 +75,7 @@ namespace trview
         line_area->add_child(std::make_unique<Window>(Point(), Size(10, 1), Colour::Transparent));
         line_area->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, name + L": ", 8));
         line->add_child(std::move(line_area));
-        auto entry = line->add_child(std::make_unique<TextArea>(Point(), Size(80, 20), Colour::Transparent, Colour::White));
+        auto entry = line->add_child(std::make_unique<TextArea>(Size(80, 20), Colour::Transparent, Colour::White));
         entry->set_mode(TextArea::Mode::SingleLine);
         entry->set_text(convert_number(0));
         entry->set_name(to_utf8(name));

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -72,7 +72,7 @@ namespace trview
     {
         auto line = std::make_unique<StackPanel>(Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
         auto line_area = std::make_unique<StackPanel>(Size(10, 20), Colour::Transparent);
-        line_area->add_child(std::make_unique<Window>(Point(), Size(10, 1), Colour::Transparent));
+        line_area->add_child(std::make_unique<Window>(Size(10, 1), Colour::Transparent));
         line_area->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, name + L": ", 8));
         line->add_child(std::move(line_area));
         auto entry = line->add_child(std::make_unique<TextArea>(Size(80, 20), Colour::Transparent, Colour::White));

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -73,7 +73,7 @@ namespace trview
         auto line = std::make_unique<StackPanel>(Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
         auto line_area = std::make_unique<StackPanel>(Size(10, 20), Colour::Transparent);
         line_area->add_child(std::make_unique<Window>(Size(10, 1), Colour::Transparent));
-        line_area->add_child(std::make_unique<Label>(Point(), Size(10, 20), Colour::Transparent, name + L": ", 8));
+        line_area->add_child(std::make_unique<Label>(Size(10, 20), Colour::Transparent, name + L": ", 8));
         line->add_child(std::move(line_area));
         auto entry = line->add_child(std::make_unique<TextArea>(Size(80, 20), Colour::Transparent, Colour::White));
         entry->set_mode(TextArea::Mode::SingleLine);

--- a/trview.app/UI/ContextMenu.cpp
+++ b/trview.app/UI/ContextMenu.cpp
@@ -19,7 +19,7 @@ namespace trview
         _menu = parent.add_child(std::make_unique<StackPanel>(Point(300, 300), Size(200, 100), Colours::Background, Size()));
 
         // Add waypoint button.
-        auto button = std::make_unique<Button>(Point(), Size(100, 24), L"Add Waypoint");
+        auto button = std::make_unique<Button>(Size(100, 24), L"Add Waypoint");
         button->set_text_background_colour(Colours::Button);
         _token_store += button->on_click += [&]()
         {
@@ -29,7 +29,7 @@ namespace trview
         _menu->add_child(std::move(button));
 
         // Add the similar remove waypoint button 
-        auto remove_button = std::make_unique<Button>(Point(), Size(100, 24), L"Remove Waypoint");
+        auto remove_button = std::make_unique<Button>(Size(100, 24), L"Remove Waypoint");
         remove_button->set_text_background_colour(Colours::Button);
         _token_store += remove_button->on_click += [&]()
         {
@@ -41,7 +41,7 @@ namespace trview
         };
         _remove_button = _menu->add_child(std::move(remove_button));
 
-        auto orbit_button = std::make_unique<Button>(Point(), Size(100, 24), L"Orbit Here");
+        auto orbit_button = std::make_unique<Button>(Size(100, 24), L"Orbit Here");
         orbit_button->set_text_background_colour(Colours::Button);
         _token_store += orbit_button->on_click += [&]()
         {

--- a/trview.app/UI/LevelInfo.cpp
+++ b/trview.app/UI/LevelInfo.cpp
@@ -41,7 +41,7 @@ namespace trview
         auto name = std::make_unique<Label>(Point(), Size(74, 16), Colour::Transparent, L"No level", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre, SizeMode::Auto);
         name->set_vertical_alignment(Align::Centre);
 
-        auto settings = std::make_unique<Button>(Point(), Size(16, 16), texture_storage.lookup("settings"), texture_storage.lookup("settings"));
+        auto settings = std::make_unique<Button>(Size(16, 16), texture_storage.lookup("settings"), texture_storage.lookup("settings"));
         settings->on_click += on_toggle_settings;
 
         _version = panel->add_child(std::move(version));

--- a/trview.app/UI/LevelInfo.cpp
+++ b/trview.app/UI/LevelInfo.cpp
@@ -34,7 +34,7 @@ namespace trview
         using namespace ui;
         auto panel = std::make_unique<StackPanel>(Point(control.size().width / 2.0f - 50, 0), Size(100, 24), Colour(0.5f, 0.0f, 0.0f, 0.0f), Size(5, 5), StackPanel::Direction::Horizontal, SizeMode::Auto);
         panel->set_margin(Size(5, 5));
-        auto version = std::make_unique<Image>(Point(), Size(16, 16));
+        auto version = std::make_unique<Image>(Size(16, 16));
         version->set_background_colour(Colour(0, 0, 0, 0));
         version->set_texture(get_version_image(trlevel::LevelVersion::Unknown));
 

--- a/trview.app/UI/LevelInfo.cpp
+++ b/trview.app/UI/LevelInfo.cpp
@@ -38,7 +38,7 @@ namespace trview
         version->set_background_colour(Colour(0, 0, 0, 0));
         version->set_texture(get_version_image(trlevel::LevelVersion::Unknown));
 
-        auto name = std::make_unique<Label>(Point(), Size(74, 16), Colour::Transparent, L"No level", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre, SizeMode::Auto);
+        auto name = std::make_unique<Label>(Size(74, 16), Colour::Transparent, L"No level", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre, SizeMode::Auto);
         name->set_vertical_alignment(Align::Centre);
 
         auto settings = std::make_unique<Button>(Size(16, 16), texture_storage.lookup("settings"), texture_storage.lookup("settings"));

--- a/trview.app/UI/RoomNavigator.cpp
+++ b/trview.app/UI/RoomNavigator.cpp
@@ -19,7 +19,7 @@ namespace trview
         auto rooms_groups = std::make_unique<GroupBox>(Size(150, 90), Colour::Transparent, Colour::Grey, L"Room");
 
         auto room_controls = std::make_unique<StackPanel>(Point(4, 12), Size(140, 30), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
-        _current = room_controls->add_child(std::make_unique<NumericUpDown>(Point(), Size(50, 20), Colour::Transparent, texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 0));
+        _current = room_controls->add_child(std::make_unique<NumericUpDown>(Size(50, 20), Colour::Transparent, texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 0));
         _current->on_value_changed += on_room_selected;
 
         room_controls->add_child(std::make_unique<Label>(Size(40, 20), Colour::Transparent, L"of", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));

--- a/trview.app/UI/RoomNavigator.cpp
+++ b/trview.app/UI/RoomNavigator.cpp
@@ -22,8 +22,8 @@ namespace trview
         _current = room_controls->add_child(std::make_unique<NumericUpDown>(Point(), Size(50, 20), Colour::Transparent, texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 0));
         _current->on_value_changed += on_room_selected;
 
-        room_controls->add_child(std::make_unique<Label>(Point(), Size(40, 20), Colour::Transparent, L"of", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
-        _max = room_controls->add_child(std::make_unique<Label>(Point(), Size(50, 20), Colour::Transparent, L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
+        room_controls->add_child(std::make_unique<Label>(Size(40, 20), Colour::Transparent, L"of", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
+        _max = room_controls->add_child(std::make_unique<Label>(Size(50, 20), Colour::Transparent, L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
         rooms_groups->add_child(std::move(room_controls));
 
         auto listbox = std::make_unique<Listbox>(Point(4, 36), Size(140, 80), Colour::Transparent);

--- a/trview.app/UI/RoomNavigator.cpp
+++ b/trview.app/UI/RoomNavigator.cpp
@@ -16,7 +16,7 @@ namespace trview
     {
         using namespace ui;
 
-        auto rooms_groups = std::make_unique<GroupBox>(Point(), Size(150, 90), Colour::Transparent, Colour::Grey, L"Room");
+        auto rooms_groups = std::make_unique<GroupBox>(Size(150, 90), Colour::Transparent, Colour::Grey, L"Room");
 
         auto room_controls = std::make_unique<StackPanel>(Point(4, 12), Size(140, 30), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
         _current = room_controls->add_child(std::make_unique<NumericUpDown>(Point(), Size(50, 20), Colour::Transparent, texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 0));

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -22,7 +22,7 @@ namespace trview
 
         // Create the title bar.
         auto title_bar = std::make_unique<StackPanel>(Size(400, 20), title_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
-        auto title = std::make_unique<Label>(Point(), Size(400, 20), title_colour, L"Settings", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
+        auto title = std::make_unique<Label>(Size(400, 20), title_colour, L"Settings", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
         title->set_horizontal_alignment(Align::Centre);
         title_bar->add_child(std::move(title));
         window->add_child(std::move(title_bar));
@@ -63,9 +63,9 @@ namespace trview
         auto camera_panel = std::make_unique<StackPanel>(Size(400, 40), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
         camera_panel->set_margin(Size(5, 5));
 
-        camera_panel->add_child(std::make_unique<Label>(Point(), Size(), Colour::Transparent, L"Sensitivity", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto));
+        camera_panel->add_child(std::make_unique<Label>(Size(), Colour::Transparent, L"Sensitivity", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto));
         _sensitivity = camera_panel->add_child(std::make_unique<Slider>(Point(6, 12), Size(118, 16)));
-        camera_panel->add_child(std::make_unique<Label>(Point(), Size(), Colour::Transparent, L"Movement Speed", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto));
+        camera_panel->add_child(std::make_unique<Label>(Size(), Colour::Transparent, L"Movement Speed", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto));
         _movement_speed = camera_panel->add_child(std::make_unique<Slider>(Point(6, 12), Size(118, 16)));
 
         _sensitivity->on_value_changed += on_sensitivity_changed;

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -32,31 +32,31 @@ namespace trview
         panel->set_auto_size_dimension(SizeDimension::Height);
         panel->set_margin(Size(5, 5));
 
-        auto vsync = std::make_unique<Checkbox>(Point(), Size(16, 16), Colour::Transparent, L"Vsync");
+        auto vsync = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Vsync");
         vsync->on_state_changed += on_vsync;
         _vsync = panel->add_child(std::move(vsync));
 
-        auto go_to_lara = std::make_unique<Checkbox>(Point(), Size(16, 16), Colour::Transparent, L"Go to Lara");
+        auto go_to_lara = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Go to Lara");
         go_to_lara->on_state_changed += on_go_to_lara;
         _go_to_lara = panel->add_child(std::move(go_to_lara));
 
-        auto invert_map_controls = std::make_unique<Checkbox>(Point(), Size(16, 16), Colour::Transparent, L"Invert map controls");
+        auto invert_map_controls = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Invert map controls");
         invert_map_controls->on_state_changed += on_invert_map_controls;
         _invert_map_controls = panel->add_child(std::move(invert_map_controls));
 
-        auto items_startup = std::make_unique<Checkbox>(Point(), Size(16, 16), Colour::Transparent, L"Open Items Window at startup");
+        auto items_startup = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Open Items Window at startup");
         items_startup->on_state_changed += on_items_startup;
         _items_startup = panel->add_child(std::move(items_startup));
 
-        auto triggers_startup = std::make_unique<Checkbox>(Point(), Size(16, 16), Colour::Transparent, L"Open Triggers Window at startup");
+        auto triggers_startup = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Open Triggers Window at startup");
         triggers_startup->on_state_changed += on_triggers_startup;
         _triggers_startup = panel->add_child(std::move(triggers_startup));
 
-        auto auto_orbit = std::make_unique<Checkbox>(Point(), Size(16, 16), Colour::Transparent, L"Switch to orbit on selection");
+        auto auto_orbit = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Switch to orbit on selection");
         auto_orbit->on_state_changed += on_auto_orbit;
         _auto_orbit = panel->add_child(std::move(auto_orbit));
 
-        auto invert_vertical_pan = std::make_unique<Checkbox>(Point(), Size(16, 16), Colour::Transparent, L"Invert vertical panning");
+        auto invert_vertical_pan = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Invert vertical panning");
         invert_vertical_pan->on_state_changed += on_invert_vertical_pan;
         _invert_vertical_pan = panel->add_child(std::move(invert_vertical_pan));
 

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -32,31 +32,31 @@ namespace trview
         panel->set_auto_size_dimension(SizeDimension::Height);
         panel->set_margin(Size(5, 5));
 
-        auto vsync = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Vsync");
+        auto vsync = std::make_unique<Checkbox>(Colour::Transparent, L"Vsync");
         vsync->on_state_changed += on_vsync;
         _vsync = panel->add_child(std::move(vsync));
 
-        auto go_to_lara = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Go to Lara");
+        auto go_to_lara = std::make_unique<Checkbox>(Colour::Transparent, L"Go to Lara");
         go_to_lara->on_state_changed += on_go_to_lara;
         _go_to_lara = panel->add_child(std::move(go_to_lara));
 
-        auto invert_map_controls = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Invert map controls");
+        auto invert_map_controls = std::make_unique<Checkbox>(Colour::Transparent, L"Invert map controls");
         invert_map_controls->on_state_changed += on_invert_map_controls;
         _invert_map_controls = panel->add_child(std::move(invert_map_controls));
 
-        auto items_startup = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Open Items Window at startup");
+        auto items_startup = std::make_unique<Checkbox>(Colour::Transparent, L"Open Items Window at startup");
         items_startup->on_state_changed += on_items_startup;
         _items_startup = panel->add_child(std::move(items_startup));
 
-        auto triggers_startup = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Open Triggers Window at startup");
+        auto triggers_startup = std::make_unique<Checkbox>(Colour::Transparent, L"Open Triggers Window at startup");
         triggers_startup->on_state_changed += on_triggers_startup;
         _triggers_startup = panel->add_child(std::move(triggers_startup));
 
-        auto auto_orbit = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Switch to orbit on selection");
+        auto auto_orbit = std::make_unique<Checkbox>(Colour::Transparent, L"Switch to orbit on selection");
         auto_orbit->on_state_changed += on_auto_orbit;
         _auto_orbit = panel->add_child(std::move(auto_orbit));
 
-        auto invert_vertical_pan = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Invert vertical panning");
+        auto invert_vertical_pan = std::make_unique<Checkbox>(Colour::Transparent, L"Invert vertical panning");
         invert_vertical_pan->on_state_changed += on_invert_vertical_pan;
         _invert_vertical_pan = panel->add_child(std::move(invert_vertical_pan));
 

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -21,14 +21,14 @@ namespace trview
         window->set_visible(false);
 
         // Create the title bar.
-        auto title_bar = std::make_unique<StackPanel>(Point(), Size(400, 20), title_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto title_bar = std::make_unique<StackPanel>(Size(400, 20), title_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
         auto title = std::make_unique<Label>(Point(), Size(400, 20), title_colour, L"Settings", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
         title->set_horizontal_alignment(Align::Centre);
         title_bar->add_child(std::move(title));
         window->add_child(std::move(title_bar));
 
         // Create the rest of the window contents.
-        auto panel = std::make_unique<StackPanel>(Point(), Size(400, 250), Colour::Transparent , Size(5, 5));
+        auto panel = std::make_unique<StackPanel>(Size(400, 250), Colour::Transparent , Size(5, 5));
         panel->set_auto_size_dimension(SizeDimension::Height);
         panel->set_margin(Size(5, 5));
 
@@ -60,7 +60,7 @@ namespace trview
         invert_vertical_pan->on_state_changed += on_invert_vertical_pan;
         _invert_vertical_pan = panel->add_child(std::move(invert_vertical_pan));
 
-        auto camera_panel = std::make_unique<StackPanel>(Point(), Size(400, 40), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
+        auto camera_panel = std::make_unique<StackPanel>(Size(400, 40), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
         camera_panel->set_margin(Size(5, 5));
 
         camera_panel->add_child(std::make_unique<Label>(Point(), Size(), Colour::Transparent, L"Sensitivity", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto));

--- a/trview.app/UI/Tooltip.cpp
+++ b/trview.app/UI/Tooltip.cpp
@@ -8,7 +8,7 @@ namespace trview
 {
     Tooltip::Tooltip(ui::Control& control)
     {
-        auto container = std::make_unique<StackPanel>(Point(), Size(), Colour(0.5f, 0.0f, 0.0f, 0.0f));
+        auto container = std::make_unique<StackPanel>(Size(), Colour(0.5f, 0.0f, 0.0f, 0.0f));
         container->set_margin(Size(5, 5));
         container->set_visible(false);
         container->set_handles_input(false);

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -19,7 +19,7 @@ namespace trview
     {
         using namespace ui;
 
-        auto rooms_groups = std::make_unique<GroupBox>(Point(), Size(150, 130), Colour::Transparent, Colour::Grey, L"View Options");
+        auto rooms_groups = std::make_unique<GroupBox>(Size(150, 130), Colour::Transparent, Colour::Grey, L"View Options");
         auto highlight = std::make_unique<Checkbox>(Point(12, 20), Colour::Transparent, L"Highlight");
         auto triggers = std::make_unique<Checkbox>(Point(86, 20), Colour::Transparent, L"Triggers");
         triggers->set_state(true);

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -53,7 +53,7 @@ namespace trview
         // Add two methods of controlling flipmaps:
         // The TR1-3 method:
         auto tr1_3_panel = std::make_unique<ui::Window>(Point(12, 96), panel_size, Colour::Transparent);
-        auto flip = std::make_unique<Checkbox>(Point(), Size(16, 16), Colour::Transparent, L"Flip");
+        auto flip = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Flip");
         flip->on_state_changed += on_flip;
         _flip = tr1_3_panel->add_child(std::move(flip));
         _tr1_3_panel = rooms_groups->add_child(std::move(tr1_3_panel));
@@ -90,7 +90,7 @@ namespace trview
         {
             _alternate_group_values.insert({ group, false });
 
-            auto button = std::make_unique<ui::Button>(Point(), Size(16, 16), std::to_wstring(group));
+            auto button = std::make_unique<ui::Button>(Size(16, 16), std::to_wstring(group));
             button->set_text_background_colour(Colours::FlipOff);
             auto group_button = _alternate_groups->add_child(std::move(button));
 

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -60,7 +60,7 @@ namespace trview
 
         // The TR4-5 method:
         auto tr4_5_panel = std::make_unique<ui::Window>(Point(12, 96), panel_size, Colour::Transparent);
-        auto alternate_groups = std::make_unique<StackPanel>(Point(), Size(140, 16), Colour::Transparent, Size(), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        auto alternate_groups = std::make_unique<StackPanel>(Size(140, 16), Colour::Transparent, Size(), StackPanel::Direction::Horizontal, SizeMode::Manual);
         _alternate_groups = tr4_5_panel->add_child(std::move(alternate_groups));
         tr4_5_panel->set_visible(false);
         _tr4_5_panel = rooms_groups->add_child(std::move(tr4_5_panel));

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -20,11 +20,11 @@ namespace trview
         using namespace ui;
 
         auto rooms_groups = std::make_unique<GroupBox>(Point(), Size(150, 130), Colour::Transparent, Colour::Grey, L"View Options");
-        auto highlight = std::make_unique<Checkbox>(Point(12, 20), Size(16, 16), Colour::Transparent, L"Highlight");
-        auto triggers = std::make_unique<Checkbox>(Point(86, 20), Size(16, 16), Colour::Transparent, L"Triggers");
+        auto highlight = std::make_unique<Checkbox>(Point(12, 20), Colour::Transparent, L"Highlight");
+        auto triggers = std::make_unique<Checkbox>(Point(86, 20), Colour::Transparent, L"Triggers");
         triggers->set_state(true);
-        auto hidden_geometry = std::make_unique<Checkbox>(Point(12, 45), Size(16, 16), Colour::Transparent, L"Geometry");
-        auto water = std::make_unique<Checkbox>(Point(86, 45), Size(16, 16), Colour::Transparent, L"Water");
+        auto hidden_geometry = std::make_unique<Checkbox>(Point(12, 45), Colour::Transparent, L"Geometry");
+        auto water = std::make_unique<Checkbox>(Point(86, 45), Colour::Transparent, L"Water");
         water->set_state(true);
 
         highlight->on_state_changed += on_highlight;
@@ -32,7 +32,7 @@ namespace trview
         hidden_geometry->on_state_changed += on_show_hidden_geometry;
         water->on_state_changed += on_show_water;
 
-        auto enabled = std::make_unique<Checkbox>(Point(12, 70), Size(16, 16), Colour::Transparent, L"Depth");
+        auto enabled = std::make_unique<Checkbox>(Point(12, 70), Colour::Transparent, L"Depth");
         enabled->on_state_changed += on_depth_enabled;
 
         auto depth = std::make_unique<NumericUpDown>(Point(86, 70), Size(50, 20), Colour::Transparent, texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 20);
@@ -53,7 +53,7 @@ namespace trview
         // Add two methods of controlling flipmaps:
         // The TR1-3 method:
         auto tr1_3_panel = std::make_unique<ui::Window>(Point(12, 96), panel_size, Colour::Transparent);
-        auto flip = std::make_unique<Checkbox>(Size(16, 16), Colour::Transparent, L"Flip");
+        auto flip = std::make_unique<Checkbox>(Colour::Transparent, L"Flip");
         flip->on_state_changed += on_flip;
         _flip = tr1_3_panel->add_child(std::move(flip));
         _tr1_3_panel = rooms_groups->add_child(std::move(tr1_3_panel));

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -218,7 +218,7 @@ namespace trview
     void ViewerUI::generate_tool_window(const ITextureStorage& texture_storage)
     {
         // This is the main tool window on the side of the screen.
-        auto tool_window = std::make_unique<StackPanel>(Point(), Size(150.0f, 348.0f), Colour(0.5f, 0.0f, 0.0f, 0.0f), Size(5, 5));
+        auto tool_window = std::make_unique<StackPanel>(Size(150.0f, 348.0f), Colour(0.5f, 0.0f, 0.0f, 0.0f), Size(5, 5));
         tool_window->set_margin(Size(5, 5));
 
         _view_options = std::make_unique<ViewOptions>(*tool_window, texture_storage);

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -16,7 +16,7 @@ namespace trview
     ViewerUI::ViewerUI(const Window& window, const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const ITextureStorage& texture_storage)
         : _mouse(window, std::make_unique<input::WindowTester>()), _window(window), _keyboard(window)
     {
-        _control = std::make_unique<ui::Window>(Point(), window.size(), Colour::Transparent);
+        _control = std::make_unique<ui::Window>(window.size(), Colour::Transparent);
 
         register_change_detection(_control.get());
 

--- a/trview.app/Windows/CollapsiblePanel.cpp
+++ b/trview.app/Windows/CollapsiblePanel.cpp
@@ -79,7 +79,7 @@ namespace trview
             _ui_renderer->set_host_size(window().size());
         };
 
-        _ui = std::make_unique<ui::Window>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f));
+        _ui = std::make_unique<ui::Window>(window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f));
         register_change_detection(_ui.get());
 
         _input = std::make_unique<ui::Input>(window(), *_ui);
@@ -142,7 +142,7 @@ namespace trview
 
     std::unique_ptr<Control> CollapsiblePanel::create_divider()
     {
-        return std::make_unique<ui::Window>(Point(), Size(1, window().size().height), Colours::Divider);
+        return std::make_unique<ui::Window>(Size(1, window().size().height), Colours::Divider);
     }
 
     void CollapsiblePanel::update_layout()

--- a/trview.app/Windows/CollapsiblePanel.cpp
+++ b/trview.app/Windows/CollapsiblePanel.cpp
@@ -169,7 +169,7 @@ namespace trview
 
     void CollapsiblePanel::add_expander(Control& parent)
     {
-        auto expander = std::make_unique<Button>(Point(), Size(16, 16), L"<<");
+        auto expander = std::make_unique<Button>(Size(16, 16), L"<<");
         _token_store += expander->on_click += [this]()
         {
             toggle_expand();

--- a/trview.app/Windows/CollapsiblePanel.cpp
+++ b/trview.app/Windows/CollapsiblePanel.cpp
@@ -132,7 +132,7 @@ namespace trview
 
     void CollapsiblePanel::set_panels(std::unique_ptr<ui::Control> left_panel, std::unique_ptr<ui::Control> right_panel)
     {
-        auto panel = std::make_unique<StackPanel>(Point(), window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(0, 0), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        auto panel = std::make_unique<StackPanel>(window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f), Size(0, 0), StackPanel::Direction::Horizontal, SizeMode::Manual);
         _left_panel = panel->add_child(std::move(left_panel));
         _divider = panel->add_child(create_divider());
         _right_panel = panel->add_child(std::move(right_panel));

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -122,7 +122,7 @@ namespace trview
 
         _controls = left_panel->add_child(std::move(controls));
 
-        auto items_list = std::make_unique<Listbox>(Point(), Size(200, window().size().height - _controls->size().height), Colours::LeftPanel);
+        auto items_list = std::make_unique<Listbox>(Size(200, window().size().height - _controls->size().height), Colours::LeftPanel);
         items_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 30 },
@@ -162,7 +162,7 @@ namespace trview
         auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(180, 210), Colours::ItemDetails, Size(0, 8), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Add some information about the selected item.
-        auto stats_list = std::make_unique<Listbox>(Point(), Size(180, 160), Colours::ItemDetails);
+        auto stats_list = std::make_unique<Listbox>(Size(180, 160), Colours::ItemDetails);
         stats_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"Name", 60 },

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -92,11 +92,11 @@ namespace trview
     std::unique_ptr<ui::Control> ItemsWindow::create_left_panel()
     {
         using namespace ui;
-        auto left_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colours::LeftPanel, Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto left_panel = std::make_unique<StackPanel>(Size(200, window().size().height), Colours::LeftPanel, Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
         left_panel->set_margin(Size(0, 3));
 
         // Control modes:.
-        auto controls = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        auto controls = std::make_unique<StackPanel>(Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
         controls->set_margin(Size(2, 2));
         auto track_room = std::make_unique<Checkbox>(Colours::LeftPanel, L"Track Room");
         _token_store += track_room->on_state_changed += [this](bool value)
@@ -156,7 +156,7 @@ namespace trview
 
         const float height = 400;
 
-        auto right_panel = std::make_unique<StackPanel>(Point(), Size(200, height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto right_panel = std::make_unique<StackPanel>(Size(200, height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
         auto group_box = std::make_unique<GroupBox>(Point(), Size(200, 220), Colours::ItemDetails, Colours::DetailsBorder, L"Item Details");
 
         auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(180, 210), Colours::ItemDetails, Size(0, 8), StackPanel::Direction::Vertical, SizeMode::Manual);

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -98,7 +98,7 @@ namespace trview
         // Control modes:.
         auto controls = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
         controls->set_margin(Size(2, 2));
-        auto track_room = std::make_unique<Checkbox>(Point(), Size(16, 16), Colours::LeftPanel, L"Track Room");
+        auto track_room = std::make_unique<Checkbox>(Size(16, 16), Colours::LeftPanel, L"Track Room");
         _token_store += track_room->on_state_changed += [this](bool value)
         {
             set_track_room(value);
@@ -109,7 +109,7 @@ namespace trview
         // Spacing between checkboxes.
         controls->add_child(std::make_unique<ui::Window>(Point(), Size(10, 20), Colours::LeftPanel));
 
-        auto sync_item = std::make_unique<Checkbox>(Point(), Size(16, 16), Colours::LeftPanel, L"Sync Item");
+        auto sync_item = std::make_unique<Checkbox>(Size(16, 16), Colours::LeftPanel, L"Sync Item");
         sync_item->set_state(_sync_item);
         _token_store += sync_item->on_state_changed += [this](bool value) { set_sync_item(value); };
         controls->add_child(std::move(sync_item));
@@ -174,7 +174,7 @@ namespace trview
         stats_list->set_show_highlight(false);
 
         _stats_list = details_panel->add_child(std::move(stats_list));
-        auto add_to_route = details_panel->add_child(std::make_unique<Button>(Point(), Size(180, 20), L"Add to Route"));
+        auto add_to_route = details_panel->add_child(std::make_unique<Button>(Size(180, 20), L"Add to Route"));
         _token_store += add_to_route->on_click += [&]()
         {
             if (_selected_item.has_value())

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -98,7 +98,7 @@ namespace trview
         // Control modes:.
         auto controls = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
         controls->set_margin(Size(2, 2));
-        auto track_room = std::make_unique<Checkbox>(Size(16, 16), Colours::LeftPanel, L"Track Room");
+        auto track_room = std::make_unique<Checkbox>(Colours::LeftPanel, L"Track Room");
         _token_store += track_room->on_state_changed += [this](bool value)
         {
             set_track_room(value);
@@ -109,7 +109,7 @@ namespace trview
         // Spacing between checkboxes.
         controls->add_child(std::make_unique<ui::Window>(Point(), Size(10, 20), Colours::LeftPanel));
 
-        auto sync_item = std::make_unique<Checkbox>(Size(16, 16), Colours::LeftPanel, L"Sync Item");
+        auto sync_item = std::make_unique<Checkbox>(Colours::LeftPanel, L"Sync Item");
         sync_item->set_state(_sync_item);
         _token_store += sync_item->on_state_changed += [this](bool value) { set_sync_item(value); };
         controls->add_child(std::move(sync_item));

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -107,7 +107,7 @@ namespace trview
         _track_room_checkbox = controls->add_child(std::move(track_room));
 
         // Spacing between checkboxes.
-        controls->add_child(std::make_unique<ui::Window>(Point(), Size(10, 20), Colours::LeftPanel));
+        controls->add_child(std::make_unique<ui::Window>(Size(10, 20), Colours::LeftPanel));
 
         auto sync_item = std::make_unique<Checkbox>(Colours::LeftPanel, L"Sync Item");
         sync_item->set_state(_sync_item);
@@ -115,7 +115,7 @@ namespace trview
         controls->add_child(std::move(sync_item));
 
         // Space out the button
-        controls->add_child(std::make_unique<ui::Window>(Point(), Size(15, 20), Colours::LeftPanel));
+        controls->add_child(std::make_unique<ui::Window>(Size(15, 20), Colours::LeftPanel));
 
         // Add the expander button at this point.
         add_expander(*controls);
@@ -157,7 +157,7 @@ namespace trview
         const float height = 400;
 
         auto right_panel = std::make_unique<StackPanel>(Size(200, height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
-        auto group_box = std::make_unique<GroupBox>(Point(), Size(200, 220), Colours::ItemDetails, Colours::DetailsBorder, L"Item Details");
+        auto group_box = std::make_unique<GroupBox>(Size(200, 220), Colours::ItemDetails, Colours::DetailsBorder, L"Item Details");
 
         auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(180, 210), Colours::ItemDetails, Size(0, 8), StackPanel::Direction::Vertical, SizeMode::Manual);
 
@@ -185,14 +185,14 @@ namespace trview
 
         group_box->add_child(std::move(details_panel));
 
-        right_panel->add_child(std::make_unique<ui::Window>(Point(), Size(200, 8), Colours::ItemDetails));
+        right_panel->add_child(std::make_unique<ui::Window>(Size(200, 8), Colours::ItemDetails));
         right_panel->add_child(std::move(group_box));
 
         // Spacer element.
-        right_panel->add_child(std::make_unique<ui::Window>(Point(), Size(200, 5), Colours::Triggers));
+        right_panel->add_child(std::make_unique<ui::Window>(Size(200, 5), Colours::Triggers));
 
         // Add the trigger details group box.
-        auto trigger_group_box = std::make_unique<GroupBox>(Point(), Size(200, 170), Colours::Triggers, Colours::DetailsBorder, L"Triggered By");
+        auto trigger_group_box = std::make_unique<GroupBox>(Size(200, 170), Colours::Triggers, Colours::DetailsBorder, L"Triggered By");
 
         auto trigger_list = std::make_unique<Listbox>(Point(10, 21), Size(190, 130), Colours::Triggers);
         trigger_list->set_columns(

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -66,7 +66,7 @@ namespace trview
 
         auto buttons = std::make_unique<StackPanel>(Size(200, 20), Colours::LeftPanel, Size(0, 0), StackPanel::Direction::Horizontal);
 
-        _colour = buttons->add_child(std::make_unique<Dropdown>(Point(), Size(20, 20)));
+        _colour = buttons->add_child(std::make_unique<Dropdown>(Size(20, 20)));
         _colour->set_text_colour(Colour::Green);
         _colour->set_text_background_colour(Colour::Green);
         _colour->set_values(

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -62,9 +62,9 @@ namespace trview
 
     std::unique_ptr<Control> RouteWindow::create_left_panel(const Device& device)
     {
-        auto left_panel = std::make_unique<StackPanel>(Point(), Size(200, window().size().height), Colours::LeftPanel, Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto left_panel = std::make_unique<StackPanel>(Size(200, window().size().height), Colours::LeftPanel, Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
 
-        auto buttons = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(0, 0), StackPanel::Direction::Horizontal);
+        auto buttons = std::make_unique<StackPanel>(Size(200, 20), Colours::LeftPanel, Size(0, 0), StackPanel::Direction::Horizontal);
 
         _colour = buttons->add_child(std::make_unique<Dropdown>(Point(), Size(20, 20)));
         _colour->set_text_colour(Colour::Green);
@@ -158,7 +158,7 @@ namespace trview
     std::unique_ptr<Control> RouteWindow::create_right_panel()
     {
         const float panel_width = 270;
-        auto right_panel = std::make_unique<StackPanel>(Point(), Size(panel_width, window().size().height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto right_panel = std::make_unique<StackPanel>(Size(panel_width, window().size().height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
         right_panel->set_margin(Size(0, 8));
 
         auto group_box = std::make_unique<GroupBox>(Point(), Size(panel_width, 140), Colours::ItemDetails, Colours::DetailsBorder, L"Waypoint Details");

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -134,7 +134,7 @@ namespace trview
         auto _buttons = left_panel->add_child(std::move(buttons));
 
         // List box to show the waypoints in the route.
-        auto waypoints = std::make_unique<Listbox>(Point(), Size(200, window().size().height - _buttons->size().height), Colours::LeftPanel);
+        auto waypoints = std::make_unique<Listbox>(Size(200, window().size().height - _buttons->size().height), Colours::LeftPanel);
         waypoints->set_enable_sorting(false);
         waypoints->set_columns(
             {

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -91,7 +91,7 @@ namespace trview
             on_colour_changed(new_colour);
         };
 
-        auto import = buttons->add_child(std::make_unique<Button>(Point(), Size(90, 20), L"Import"));
+        auto import = buttons->add_child(std::make_unique<Button>(Size(90, 20), L"Import"));
         _token_store += import->on_click += [&]()
         {
             OPENFILENAME ofn;
@@ -111,7 +111,7 @@ namespace trview
                 on_route_import(trview::to_utf8(ofn.lpstrFile));
             }
         };
-        auto export_button = buttons->add_child(std::make_unique<Button>(Point(), Size(90, 20), L"Export"));
+        auto export_button = buttons->add_child(std::make_unique<Button>(Size(90, 20), L"Export"));
         _token_store += export_button->on_click += [&]()
         {
             OPENFILENAME ofn;
@@ -194,7 +194,7 @@ namespace trview
         };
         _stats = details_panel->add_child(std::move(stats_box));
 
-        auto delete_button = details_panel->add_child(std::make_unique<Button>(Point(), Size(panel_width - 20, 20), L"Delete Waypoint"));
+        auto delete_button = details_panel->add_child(std::make_unique<Button>(Size(panel_width - 20, 20), L"Delete Waypoint"));
         _token_store += delete_button->on_click += [&]()
         {
             if (_route && _selected_index < _route->waypoints())

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -161,7 +161,7 @@ namespace trview
         auto right_panel = std::make_unique<StackPanel>(Size(panel_width, window().size().height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
         right_panel->set_margin(Size(0, 8));
 
-        auto group_box = std::make_unique<GroupBox>(Point(), Size(panel_width, 140), Colours::ItemDetails, Colours::DetailsBorder, L"Waypoint Details");
+        auto group_box = std::make_unique<GroupBox>(Size(panel_width, 140), Colours::ItemDetails, Colours::DetailsBorder, L"Waypoint Details");
 
         auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(panel_width - 20, 120), Colours::ItemDetails, Size(0, 8), StackPanel::Direction::Vertical, SizeMode::Manual);
 
@@ -207,12 +207,12 @@ namespace trview
         right_panel->add_child(std::move(group_box));
 
         // Notes area.
-        auto notes_box = std::make_unique<GroupBox>(Point(), Size(panel_width, window().size().height - 140), Colours::Notes, Colours::DetailsBorder, L"Notes");
+        auto notes_box = std::make_unique<GroupBox>(Size(panel_width, window().size().height - 140), Colours::Notes, Colours::DetailsBorder, L"Notes");
 
         auto notes_area = std::make_unique<TextArea>(Point(10, 21), Size(panel_width - 20, notes_box->size().height - 41), Colours::NotesTextArea, Colour(1.0f, 1.0f, 1.0f));
         _notes_area = notes_box->add_child(std::move(notes_area));
 
-        right_panel->add_child(std::make_unique<ui::Window>(Point(), Size(panel_width, 5), Colours::Notes));
+        right_panel->add_child(std::make_unique<ui::Window>(Size(panel_width, 5), Colours::Notes));
         right_panel->add_child(std::move(notes_box));
 
         _token_store += _notes_area->on_text_changed += [&](const std::wstring& text)

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -50,13 +50,13 @@ namespace trview
     {
         using namespace ui;
 
-        auto left_panel = std::make_unique<ui::StackPanel>(Point(), Size(200, window().size().height), Colours::LeftPanel, Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto left_panel = std::make_unique<ui::StackPanel>(Size(200, window().size().height), Colours::LeftPanel, Size(0, 3), StackPanel::Direction::Vertical, SizeMode::Manual);
         left_panel->set_margin(Size(0, 3));
 
         // Control modes:.
-        auto controls_box = std::make_unique<StackPanel>(Point(), Size(200, 50), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto controls_box = std::make_unique<StackPanel>(Size(200, 50), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Vertical, SizeMode::Manual);
         controls_box->set_margin(Size(2, 2));
-        auto controls = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        auto controls = std::make_unique<StackPanel>(Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
         controls->set_margin(Size(2, 2));
         auto track_room = std::make_unique<Checkbox>(Colours::LeftPanel, L"Track Room");
         _token_store += track_room->on_state_changed += [this](bool value)
@@ -81,7 +81,7 @@ namespace trview
         add_expander(*controls);
 
         // Command filter:
-        auto controls_row2 = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 0), StackPanel::Direction::Horizontal, SizeMode::Manual);
+        auto controls_row2 = std::make_unique<StackPanel>(Size(200, 20), Colours::LeftPanel, Size(2, 0), StackPanel::Direction::Horizontal, SizeMode::Manual);
         controls_row2->set_margin(Size(2, 0));
 
         auto command_filter = std::make_unique<Dropdown>(Point(), Size(186, 20));
@@ -139,7 +139,7 @@ namespace trview
     {
         using namespace ui;
         const float panel_width = 270;
-        auto right_panel = std::make_unique<StackPanel>(Point(), Size(panel_width, window().size().height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto right_panel = std::make_unique<StackPanel>(Size(panel_width, window().size().height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
         auto group_box = std::make_unique<GroupBox>(Point(), Size(panel_width, 190), Colours::ItemDetails, Colours::DetailsBorder, L"Trigger Details");
 
         auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(panel_width - 20, 160), Colours::ItemDetails, Size(0, 16), StackPanel::Direction::Vertical, SizeMode::Manual);

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -58,7 +58,7 @@ namespace trview
         controls_box->set_margin(Size(2, 2));
         auto controls = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
         controls->set_margin(Size(2, 2));
-        auto track_room = std::make_unique<Checkbox>(Point(), Size(16, 16), Colours::LeftPanel, L"Track Room");
+        auto track_room = std::make_unique<Checkbox>(Size(16, 16), Colours::LeftPanel, L"Track Room");
         _token_store += track_room->on_state_changed += [this](bool value)
         {
             set_track_room(value);
@@ -69,7 +69,7 @@ namespace trview
         // Spacing between checkboxes.
         controls->add_child(std::make_unique<ui::Window>(Point(), Size(5, 20), Colours::LeftPanel));
 
-        auto sync_trigger = std::make_unique<Checkbox>(Point(), Size(16, 16), Colours::LeftPanel, L"Sync Trigger");
+        auto sync_trigger = std::make_unique<Checkbox>(Size(16, 16), Colours::LeftPanel, L"Sync Trigger");
         sync_trigger->set_state(_sync_trigger);
         _token_store += sync_trigger->on_state_changed += [this](bool value) { set_sync_trigger(value); };
         controls->add_child(std::move(sync_trigger));
@@ -157,7 +157,7 @@ namespace trview
         stats_list->set_show_highlight(false);
         _stats_list = details_panel->add_child(std::move(stats_list));
 
-        auto button = details_panel->add_child(std::make_unique<Button>(Point(), Size(panel_width - 20, 20), L"Add to Route"));
+        auto button = details_panel->add_child(std::make_unique<Button>(Size(panel_width - 20, 20), L"Add to Route"));
         _token_store += button->on_click += [&]()
         {
             if (_selected_trigger.has_value())

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -67,7 +67,7 @@ namespace trview
         _track_room_checkbox = controls->add_child(std::move(track_room));
 
         // Spacing between checkboxes.
-        controls->add_child(std::make_unique<ui::Window>(Point(), Size(5, 20), Colours::LeftPanel));
+        controls->add_child(std::make_unique<ui::Window>(Size(5, 20), Colours::LeftPanel));
 
         auto sync_trigger = std::make_unique<Checkbox>(Colours::LeftPanel, L"Sync Trigger");
         sync_trigger->set_state(_sync_trigger);
@@ -75,7 +75,7 @@ namespace trview
         controls->add_child(std::move(sync_trigger));
 
         // Space out the button
-        controls->add_child(std::make_unique<ui::Window>(Point(), Size(5, 20), Colours::LeftPanel));
+        controls->add_child(std::make_unique<ui::Window>(Size(5, 20), Colours::LeftPanel));
 
         // Add the expander button at this point.
         add_expander(*controls);
@@ -140,7 +140,7 @@ namespace trview
         using namespace ui;
         const float panel_width = 270;
         auto right_panel = std::make_unique<StackPanel>(Size(panel_width, window().size().height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
-        auto group_box = std::make_unique<GroupBox>(Point(), Size(panel_width, 190), Colours::ItemDetails, Colours::DetailsBorder, L"Trigger Details");
+        auto group_box = std::make_unique<GroupBox>(Size(panel_width, 190), Colours::ItemDetails, Colours::DetailsBorder, L"Trigger Details");
 
         auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(panel_width - 20, 160), Colours::ItemDetails, Size(0, 16), StackPanel::Direction::Vertical, SizeMode::Manual);
 
@@ -168,14 +168,14 @@ namespace trview
 
         group_box->add_child(std::move(details_panel));
 
-        right_panel->add_child(std::make_unique<ui::Window>(Point(), Size(panel_width, 8), Colours::ItemDetails));
+        right_panel->add_child(std::make_unique<ui::Window>(Size(panel_width, 8), Colours::ItemDetails));
         right_panel->add_child(std::move(group_box));
 
         // Spacer element.
-        right_panel->add_child(std::make_unique<ui::Window>(Point(), Size(panel_width, 5), Colours::Triggers));
+        right_panel->add_child(std::make_unique<ui::Window>(Size(panel_width, 5), Colours::Triggers));
 
         // Add the trigger details group box.
-        auto command_group_box = std::make_unique<GroupBox>(Point(), Size(panel_width, 200), Colours::Triggers, Colours::DetailsBorder, L"Commands");
+        auto command_group_box = std::make_unique<GroupBox>(Size(panel_width, 200), Colours::Triggers, Colours::DetailsBorder, L"Commands");
 
         auto command_list = std::make_unique<Listbox>(Point(10, 21), Size(panel_width - 20, 160), Colours::Triggers);
         command_list->set_columns(

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -84,7 +84,7 @@ namespace trview
         auto controls_row2 = std::make_unique<StackPanel>(Size(200, 20), Colours::LeftPanel, Size(2, 0), StackPanel::Direction::Horizontal, SizeMode::Manual);
         controls_row2->set_margin(Size(2, 0));
 
-        auto command_filter = std::make_unique<Dropdown>(Point(), Size(186, 20));
+        auto command_filter = std::make_unique<Dropdown>(Size(186, 20));
         command_filter->set_values({L"All"});
         command_filter->set_dropdown_scope(_ui.get());
         command_filter->set_selected_value(L"All");

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -58,7 +58,7 @@ namespace trview
         controls_box->set_margin(Size(2, 2));
         auto controls = std::make_unique<StackPanel>(Point(), Size(200, 20), Colours::LeftPanel, Size(2, 2), StackPanel::Direction::Horizontal, SizeMode::Manual);
         controls->set_margin(Size(2, 2));
-        auto track_room = std::make_unique<Checkbox>(Size(16, 16), Colours::LeftPanel, L"Track Room");
+        auto track_room = std::make_unique<Checkbox>(Colours::LeftPanel, L"Track Room");
         _token_store += track_room->on_state_changed += [this](bool value)
         {
             set_track_room(value);
@@ -69,7 +69,7 @@ namespace trview
         // Spacing between checkboxes.
         controls->add_child(std::make_unique<ui::Window>(Point(), Size(5, 20), Colours::LeftPanel));
 
-        auto sync_trigger = std::make_unique<Checkbox>(Size(16, 16), Colours::LeftPanel, L"Sync Trigger");
+        auto sync_trigger = std::make_unique<Checkbox>(Colours::LeftPanel, L"Sync Trigger");
         sync_trigger->set_state(_sync_trigger);
         _token_store += sync_trigger->on_state_changed += [this](bool value) { set_sync_trigger(value); };
         controls->add_child(std::move(sync_trigger));

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -108,7 +108,7 @@ namespace trview
         controls_box->add_child(std::move(controls_row2));
         left_panel->add_child(std::move(controls_box));
 
-        auto triggers_list = std::make_unique<Listbox>(Point(), Size(200, window().size().height - controls_box_bottom), Colours::LeftPanel);
+        auto triggers_list = std::make_unique<Listbox>(Size(200, window().size().height - controls_box_bottom), Colours::LeftPanel);
         triggers_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 30 },
@@ -145,7 +145,7 @@ namespace trview
         auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(panel_width - 20, 160), Colours::ItemDetails, Size(0, 16), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Add some information about the selected item.
-        auto stats_list = std::make_unique<Listbox>(Point(), Size(panel_width - 20, 120), Colours::ItemDetails);
+        auto stats_list = std::make_unique<Listbox>(Size(panel_width - 20, 120), Colours::ItemDetails);
         stats_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"Name", 100 },

--- a/trview.ui.tests/CheckboxTests.cpp
+++ b/trview.ui.tests/CheckboxTests.cpp
@@ -8,7 +8,7 @@ using namespace trview::ui;
 /// is called rather than the user clicking on the control.
 TEST(Checkbox, StateChangeEventNotRaised)
 {
-    Checkbox checkbox(Point(), Size(20, 20));
+    Checkbox checkbox;
     bool raised = false;
     auto token = checkbox.on_state_changed += [&](bool)
     {
@@ -24,7 +24,7 @@ TEST(Checkbox, StateChangeEventNotRaised)
 /// Tests that the state change event is raised when the user clicks on the control.
 TEST(Checkbox, StateChangeEventRaised)
 {
-    Checkbox checkbox(Point(), Size(20, 20));
+    Checkbox checkbox;
 
     bool raised = false;
     uint32_t times = 0;
@@ -47,7 +47,7 @@ TEST(Checkbox, StateChangeEventRaised)
 /// an event each time the state changes.
 TEST(Checkbox, StateChangeCycle)
 {
-    Checkbox checkbox(Point(), Size(20, 20));
+    Checkbox checkbox;
 
     std::vector<bool> states;
     auto token = checkbox.on_state_changed += [&states](bool state)

--- a/trview.ui/Button.cpp
+++ b/trview.ui/Button.cpp
@@ -15,7 +15,7 @@ namespace trview
         Button::Button(Point position, Size size, graphics::Texture up_image, graphics::Texture down_image)
             : Window(position, size, Colour::Transparent), _up_image(up_image), _down_image(down_image), _text(nullptr)
         {
-            auto image = std::make_unique<Image>(Point(), size);
+            auto image = std::make_unique<Image>(size);
             image->set_texture(up_image);
             add_child(std::move(image));
         }

--- a/trview.ui/Button.cpp
+++ b/trview.ui/Button.cpp
@@ -32,6 +32,11 @@ namespace trview
         {
         }
 
+        Button::Button(const Size& size)
+            : Button(Point(), size)
+        {
+        }
+
         bool Button::mouse_down(const Point&)
         {
             return true;

--- a/trview.ui/Button.cpp
+++ b/trview.ui/Button.cpp
@@ -37,6 +37,16 @@ namespace trview
         {
         }
 
+        Button::Button(const Size& size, const std::wstring& text)
+            : Button(Point(), size, text)
+        {
+        }
+
+        Button::Button(const Size& size, graphics::Texture up_image, graphics::Texture down_image)
+            : Button(Point(), size, up_image, down_image)
+        {
+        }
+
         bool Button::mouse_down(const Point&)
         {
             return true;

--- a/trview.ui/Button.h
+++ b/trview.ui/Button.h
@@ -39,6 +39,10 @@ namespace trview
             /// @param size The size of the new element.
             Button(Point position, Size size);
 
+            /// Creates a new button.
+            /// @param size The size of the new element.
+            explicit Button(const Size& size);
+
             /// Destructor for the button.
             virtual ~Button() = default;
 

--- a/trview.ui/Button.h
+++ b/trview.ui/Button.h
@@ -43,6 +43,17 @@ namespace trview
             /// @param size The size of the new element.
             explicit Button(const Size& size);
 
+            /// Creates a new button with a label.
+            /// @param size The size of the new element.
+            /// @param text The text to display on the button.
+            Button(const Size& size, const std::wstring& text);
+
+            /// Creates a new button with provided textures.
+            /// @param size The size of the new element.
+            /// @param up_image The texture to use when the button is in the up state.
+            /// @param down_image The texture to use when the button is in the down state.
+            Button(const Size& size, graphics::Texture up_image, graphics::Texture down_image);
+
             /// Destructor for the button.
             virtual ~Button() = default;
 

--- a/trview.ui/Checkbox.cpp
+++ b/trview.ui/Checkbox.cpp
@@ -12,6 +12,11 @@ namespace trview
             const Colour bg_colour { Colour(0.2f, 0.2f, 0.2f) };
         }
 
+        Checkbox::Checkbox(const Size& size)
+            : Checkbox(Point(), size)
+        {
+        }
+
         Checkbox::Checkbox(const Point& position, const Size& size)
             : StackPanel(position, size, Colour::Transparent, Size(), Direction::Horizontal)
         {

--- a/trview.ui/Checkbox.cpp
+++ b/trview.ui/Checkbox.cpp
@@ -36,7 +36,7 @@ namespace trview
 
             add_child(std::make_unique<Window>(Size(3, default_size.height), background_colour));
 
-            auto label = std::make_unique<Label>(Point(), Size(1, 1), background_colour, label_text, 8, TextAlignment::Left, ParagraphAlignment::Centre, SizeMode::Auto);
+            auto label = std::make_unique<Label>(Size(1, 1), background_colour, label_text, 8, TextAlignment::Left, ParagraphAlignment::Centre, SizeMode::Auto);
             label->set_vertical_alignment(Align::Centre);
             _label = add_child(std::move(label));
         }
@@ -45,7 +45,7 @@ namespace trview
         {
             auto outer = std::make_unique<Window>(size, Colour(0.6f, 0.6f, 0.6f));
             outer->add_child(std::make_unique<Window>(Point(1, 1), size - Size(2, 2), bg_colour));
-            _check = outer->add_child(std::make_unique<Label>(Point(), size - Size(2, 2), Colour::Transparent, L"", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
+            _check = outer->add_child(std::make_unique<Label>(size - Size(2, 2), Colour::Transparent, L"", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
             add_child(std::move(outer));
         }
 

--- a/trview.ui/Checkbox.cpp
+++ b/trview.ui/Checkbox.cpp
@@ -10,30 +10,31 @@ namespace trview
         namespace
         {
             const Colour bg_colour { Colour(0.2f, 0.2f, 0.2f) };
+            const Size default_size{ 16, 16 };
         }
 
-        Checkbox::Checkbox(const Size& size)
-            : Checkbox(Point(), size)
+        Checkbox::Checkbox()
+            : Checkbox(Point())
         {
         }
 
-        Checkbox::Checkbox(const Point& position, const Size& size)
-            : StackPanel(position, size, Colour::Transparent, Size(), Direction::Horizontal)
+        Checkbox::Checkbox(const Point& position)
+            : StackPanel(position, default_size, Colour::Transparent, Size(), Direction::Horizontal)
         {
-            create_image(size, Colour(1.0f, 0.5f, 0.5f, 0.5f));
+            create_image(default_size, Colour(1.0f, 0.5f, 0.5f, 0.5f));
         }
 
-        Checkbox::Checkbox(const Point& position, const Size& size, const std::wstring& label_text)
-            : Checkbox(position, size, Colour(1.0f, 0.5f, 0.5f, 0.5f), label_text)
+        Checkbox::Checkbox(const Point& position, const std::wstring& label_text)
+            : Checkbox(position, Colour(1.0f, 0.5f, 0.5f, 0.5f), label_text)
         {
         }
 
-        Checkbox::Checkbox(const Point& position, const Size& size, const Colour& background_colour, const std::wstring& label_text)
-            : StackPanel(position, size, Colour::Transparent, Size(), Direction::Horizontal)
+        Checkbox::Checkbox(const Point& position, const Colour& background_colour, const std::wstring& label_text)
+            : StackPanel(position, default_size, Colour::Transparent, Size(), Direction::Horizontal)
         {
-            create_image(size, background_colour);
+            create_image(default_size, background_colour);
 
-            add_child(std::make_unique<Window>(Point(), Size(3, size.height), background_colour));
+            add_child(std::make_unique<Window>(Point(), Size(3, default_size.height), background_colour));
 
             auto label = std::make_unique<Label>(Point(), Size(1, 1), background_colour, label_text, 8, TextAlignment::Left, ParagraphAlignment::Centre, SizeMode::Auto);
             label->set_vertical_alignment(Align::Centre);
@@ -46,6 +47,11 @@ namespace trview
             outer->add_child(std::make_unique<Window>(Point(1, 1), size - Size(2, 2), bg_colour));
             _check = outer->add_child(std::make_unique<Label>(Point(), size - Size(2, 2), Colour::Transparent, L"", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
             add_child(std::move(outer));
+        }
+
+        Checkbox::Checkbox(const Colour& background_colour, const std::wstring& label_text)
+            : Checkbox(Point(), background_colour, label_text)
+        {
         }
 
         bool Checkbox::mouse_down(const Point&)

--- a/trview.ui/Checkbox.cpp
+++ b/trview.ui/Checkbox.cpp
@@ -34,7 +34,7 @@ namespace trview
         {
             create_image(default_size, background_colour);
 
-            add_child(std::make_unique<Window>(Point(), Size(3, default_size.height), background_colour));
+            add_child(std::make_unique<Window>(Size(3, default_size.height), background_colour));
 
             auto label = std::make_unique<Label>(Point(), Size(1, 1), background_colour, label_text, 8, TextAlignment::Left, ParagraphAlignment::Centre, SizeMode::Auto);
             label->set_vertical_alignment(Align::Centre);
@@ -43,7 +43,7 @@ namespace trview
 
         void Checkbox::create_image(const Size& size, const Colour& colour)
         {
-            auto outer = std::make_unique<Window>(Point(), size, Colour(0.6f, 0.6f, 0.6f));
+            auto outer = std::make_unique<Window>(size, Colour(0.6f, 0.6f, 0.6f));
             outer->add_child(std::make_unique<Window>(Point(1, 1), size - Size(2, 2), bg_colour));
             _check = outer->add_child(std::make_unique<Label>(Point(), size - Size(2, 2), Colour::Transparent, L"", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
             add_child(std::move(outer));

--- a/trview.ui/Checkbox.h
+++ b/trview.ui/Checkbox.h
@@ -16,26 +16,27 @@ namespace trview
         {
         public:
             /// Creates a checkbox.
-            /// @param size The size of the checkbox.
-            explicit Checkbox(const Size& size);
+            explicit Checkbox();
 
             /// Creates a checkbox.
             /// @param position The position of the checkbox.
-            /// @param size The size of the checkbox.
-            Checkbox(const Point& position, const Size& size);
+            Checkbox(const Point& position);
 
             /// Creates a checkox with an associated label.
             /// @param position The position of the checkbox.
-            /// @param size The size of the checkbox.
             /// @param label_text The text for the associated label.
-            Checkbox(const Point& position, const Size& size, const std::wstring& label_text);
+            Checkbox(const Point& position, const std::wstring& label_text);
 
             /// Creates a checkox with an associated label.
             /// @param position The position of the checkbox.
-            /// @param size The size of the checkbox.
             /// @param background_colour Background colour of the label.
             /// @param label_text The text for the associated label.
-            Checkbox(const Point& position, const Size& size, const Colour& background_colour, const std::wstring& label_text);
+            Checkbox(const Point& position, const Colour& background_colour, const std::wstring& label_text);
+
+            /// Creates a checkbox with an associated label.
+            /// @param background_colour Background colour of the label.
+            /// @param label_text The text for the associated label.
+            Checkbox(const Colour& background_colour, const std::wstring& label_text);
 
             /// Destructor for the checkbox.
             virtual ~Checkbox() = default;

--- a/trview.ui/Checkbox.h
+++ b/trview.ui/Checkbox.h
@@ -16,6 +16,10 @@ namespace trview
         {
         public:
             /// Creates a checkbox.
+            /// @param size The size of the checkbox.
+            explicit Checkbox(const Size& size);
+
+            /// Creates a checkbox.
             /// @param position The position of the checkbox.
             /// @param size The size of the checkbox.
             Checkbox(const Point& position, const Size& size);

--- a/trview.ui/Dropdown.cpp
+++ b/trview.ui/Dropdown.cpp
@@ -24,6 +24,11 @@ namespace trview
             };
         }
 
+        Dropdown::Dropdown(const Size& size)
+            : Dropdown(Point(), size)
+        {
+        }
+
         void Dropdown::set_dropdown_scope(ui::Control* scope)
         {
             auto dropdown = std::make_unique<Listbox>(Point(), Size(size().width, size().height * _values.size()), Colour(0.25f, 0.25f, 0.25f));

--- a/trview.ui/Dropdown.cpp
+++ b/trview.ui/Dropdown.cpp
@@ -31,7 +31,7 @@ namespace trview
 
         void Dropdown::set_dropdown_scope(ui::Control* scope)
         {
-            auto dropdown = std::make_unique<Listbox>(Point(), Size(size().width, size().height * _values.size()), Colour(0.25f, 0.25f, 0.25f));
+            auto dropdown = std::make_unique<Listbox>(Size(size().width, size().height * _values.size()), Colour(0.25f, 0.25f, 0.25f));
             dropdown->set_z(-1);
             dropdown->set_visible(false);
             dropdown->set_columns(

--- a/trview.ui/Dropdown.h
+++ b/trview.ui/Dropdown.h
@@ -26,7 +26,11 @@ namespace trview
             /// Create a new dropdown box.
             /// @param position The position of the control.
             /// @param size The size of the control.
-            explicit Dropdown(const Point& position, const Size& size);
+            Dropdown(const Point& position, const Size& size);
+
+            /// Create a new dropdown box.
+            /// @param size The size of the control.
+            explicit Dropdown(const Size& size);
 
             /// Destructor for Dropdown.
             virtual ~Dropdown() = default;

--- a/trview.ui/GroupBox.cpp
+++ b/trview.ui/GroupBox.cpp
@@ -5,6 +5,11 @@ namespace trview
 {
     namespace ui
     {
+        GroupBox::GroupBox(const Size& size, const Colour& background_colour, const Colour& border_colour, const std::wstring& text)
+            : GroupBox(Point(), size, background_colour, border_colour, text)
+        {
+        }
+
         GroupBox::GroupBox(const Point& point, const Size& size, const Colour& background_colour, const Colour& border_colour, const std::wstring& text)
             : Window(point, size, background_colour), _border_colour(border_colour)
         {

--- a/trview.ui/GroupBox.h
+++ b/trview.ui/GroupBox.h
@@ -11,6 +11,7 @@ namespace trview
         class GroupBox : public Window
         {
         public:
+            GroupBox(const Size& size, const Colour& background_colour, const Colour& border_colour, const std::wstring& text);
             GroupBox(const Point& point, const Size& size, const Colour& background_colour, const Colour& border_colour, const std::wstring& text);
             std::wstring title() const;
             void set_title(const std::wstring& title);

--- a/trview.ui/Image.cpp
+++ b/trview.ui/Image.cpp
@@ -4,6 +4,11 @@ namespace trview
 {
     namespace ui
     {
+        Image::Image(const Size& size)
+            : Image(Point(), size)
+        {
+        }
+
         Image::Image(Point position, Size size)
             : Window(position, size, Colour(0.0f, 0.0f, 0.0f, 0.0f))
         {

--- a/trview.ui/Image.h
+++ b/trview.ui/Image.h
@@ -10,7 +10,9 @@ namespace trview
         class Image : public Window
         {
         public:
-            explicit Image(Point position, Size size);
+            explicit Image(const Size& size);
+
+            Image(Point position, Size size);
 
             virtual ~Image() = default;
 

--- a/trview.ui/Label.cpp
+++ b/trview.ui/Label.cpp
@@ -4,6 +4,11 @@ namespace trview
 {
     namespace ui
     {
+        Label::Label(Size size, Colour background_colour, std::wstring text, int text_size, graphics::TextAlignment text_alignment, graphics::ParagraphAlignment paragraph_alignment, SizeMode mode)
+            : Label(Point(), size, background_colour, text, text_size, text_alignment, paragraph_alignment, mode)
+        {
+        }
+
         Label::Label(Point position, Size size, Colour background_colour, std::wstring text, int text_size, graphics::TextAlignment text_alignment, graphics::ParagraphAlignment paragraph_alignment, SizeMode mode)
             : Window(position, size, background_colour), _text(text), _text_size(text_size), _text_alignment(text_alignment), _paragraph_alignment(paragraph_alignment), _size_mode(mode), _text_colour(1.0f, 1.0f, 1.0f, 1.0f)
         {

--- a/trview.ui/Label.h
+++ b/trview.ui/Label.h
@@ -17,6 +17,14 @@ namespace trview
         class Label : public Window
         {
         public:
+            Label(Size size,
+                Colour background_colour,
+                std::wstring text,
+                int text_size,
+                graphics::TextAlignment text_alignment = graphics::TextAlignment::Left,
+                graphics::ParagraphAlignment paragraph_alignment = graphics::ParagraphAlignment::Near,
+                SizeMode mode = SizeMode::Manual);
+
             Label(Point position, 
                 Size size, 
                 Colour background_colour, 

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -8,6 +8,11 @@ namespace trview
 {
     namespace ui
     {
+        Listbox::Listbox(const Size& size, const Colour& background_colour)
+            : Listbox(Point(), size, background_colour)
+        {
+        }
+
         Listbox::Listbox(const Point& position, const Size& size, const Colour& background_colour)
             : StackPanel(position, size, background_colour, Size(), Direction::Vertical, SizeMode::Manual)
         {

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -269,7 +269,7 @@ namespace trview
             auto headers_element = std::make_unique<StackPanel>(Point(), size(), background_colour(), Size(), Direction::Horizontal);
             for (const auto column : _columns)
             {
-                auto header_element = std::make_unique<Button>(Point(), Size(column.width(), 20), column.name());
+                auto header_element = std::make_unique<Button>(Size(column.width(), 20), column.name());
                 header_element->set_text_background_colour(background_colour());
                 _token_store += header_element->on_click += [this, column]()
                 {

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -88,7 +88,7 @@ namespace trview
 
                 if (_show_scrollbar)
                 {
-                    auto rows_scrollbar = std::make_unique<Scrollbar>(Point(), Size(scrollbar_width, remaining_height), background_colour());
+                    auto rows_scrollbar = std::make_unique<Scrollbar>(Size(scrollbar_width, remaining_height), background_colour());
                     _token_store += rows_scrollbar->on_scroll += [&](float value)
                     {
                         scroll_to(value * _items.size());

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -76,9 +76,9 @@ namespace trview
             }
             else
             {
-                auto rows_container = std::make_unique<StackPanel>(Point(), Size(size().width, remaining_height), background_colour(), Size(), Direction::Horizontal, SizeMode::Manual);
+                auto rows_container = std::make_unique<StackPanel>(Size(size().width, remaining_height), background_colour(), Size(), Direction::Horizontal, SizeMode::Manual);
 
-                auto rows_element = std::make_unique<StackPanel>(Point(), Size(size().width - scrollbar_width, remaining_height), background_colour(), Size(), Direction::Vertical, SizeMode::Manual);
+                auto rows_element = std::make_unique<StackPanel>(Size(size().width - scrollbar_width, remaining_height), background_colour(), Size(), Direction::Vertical, SizeMode::Manual);
                 _rows_element = rows_container->add_child(std::move(rows_element));
 
                 if (_show_scrollbar)
@@ -266,7 +266,7 @@ namespace trview
                 return;
             }
 
-            auto headers_element = std::make_unique<StackPanel>(Point(), size(), background_colour(), Size(), Direction::Horizontal);
+            auto headers_element = std::make_unique<StackPanel>(size(), background_colour(), Size(), Direction::Horizontal);
             for (const auto column : _columns)
             {
                 auto header_element = std::make_unique<Button>(Size(column.width(), 20), column.name());

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -298,7 +298,7 @@ namespace trview
             }
 
             // Add the spacer to make the scrollbar look ok.
-            headers_element->add_child(std::make_unique<Window>(Point(), Size(10, 20), background_colour()));
+            headers_element->add_child(std::make_unique<Window>(Size(10, 20), background_colour()));
             _headers_element = add_child(std::move(headers_element));
         }
 

--- a/trview.ui/Listbox.h
+++ b/trview.ui/Listbox.h
@@ -131,6 +131,11 @@ namespace trview
             };
 
             /// Create a new Listbox.
+            /// @param size The size of the listbox.
+            /// @param background_colour The background colour for the list box.
+            Listbox(const Size& size, const Colour& background_colour);
+
+            /// Create a new Listbox.
             /// @param position The position of the listbox.
             /// @param size The size of the listbox.
             /// @param background_colour The background colour for the list box.

--- a/trview.ui/ListboxRow.cpp
+++ b/trview.ui/ListboxRow.cpp
@@ -12,7 +12,7 @@ namespace trview
 
             for (const auto& column : columns)
             {
-                auto button = std::make_unique<Button>(Point(), Size(column.width(), 20), L" ");
+                auto button = std::make_unique<Button>(Size(column.width(), 20), L" ");
                 _token_store += button->on_click += [this]
                 {
                     if (_item.has_value())

--- a/trview.ui/NumericUpDown.cpp
+++ b/trview.ui/NumericUpDown.cpp
@@ -10,6 +10,11 @@ namespace trview
 {
     namespace ui
     {
+        NumericUpDown::NumericUpDown(Size size, Colour background_colour, graphics::Texture up_texture, graphics::Texture down_texture, int32_t minimum, int32_t maximum)
+            : NumericUpDown(Point(), size, background_colour, up_texture, down_texture, minimum, maximum)
+        {
+        }
+
         NumericUpDown::NumericUpDown(Point point, Size size, Colour background_colour, graphics::Texture up_texture, graphics::Texture down_texture, int32_t minimum, int32_t maximum)
             : Window(point, size, background_colour), _minimum(minimum), _maximum(maximum)
         {

--- a/trview.ui/NumericUpDown.cpp
+++ b/trview.ui/NumericUpDown.cpp
@@ -13,7 +13,7 @@ namespace trview
         NumericUpDown::NumericUpDown(Point point, Size size, Colour background_colour, graphics::Texture up_texture, graphics::Texture down_texture, int32_t minimum, int32_t maximum)
             : Window(point, size, background_colour), _minimum(minimum), _maximum(maximum)
         {
-            auto label = std::make_unique<Label>(Point(), Size(size.width - 16, size.height), background_colour, L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
+            auto label = std::make_unique<Label>(Size(size.width - 16, size.height), background_colour, L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
             auto up = std::make_unique<Button>(Point(size.width - 16, 0), Size(16, size.height / 2), up_texture, up_texture);
             auto down = std::make_unique<Button>(Point(size.width - 16, size.height / 2), Size(16, size.height / 2), down_texture, down_texture);
 

--- a/trview.ui/NumericUpDown.h
+++ b/trview.ui/NumericUpDown.h
@@ -14,6 +14,14 @@ namespace trview
         {
         public:
             NumericUpDown(
+                Size size,
+                Colour background_colour,
+                graphics::Texture up_texture,
+                graphics::Texture down_texture,
+                int32_t minimum,
+                int32_t maximum);
+
+            NumericUpDown(
                 Point point, 
                 Size size, 
                 Colour background_colour, 

--- a/trview.ui/Scrollbar.cpp
+++ b/trview.ui/Scrollbar.cpp
@@ -4,6 +4,11 @@ namespace trview
 {
     namespace ui
     {
+        Scrollbar::Scrollbar(const Size& size, const Colour& background_colour)
+            : Scrollbar(Point(), size, background_colour)
+        {
+        }
+
         Scrollbar::Scrollbar(const Point& position, const Size& size, const Colour& background_colour)
             : Window(position, size, background_colour)
         {

--- a/trview.ui/Scrollbar.cpp
+++ b/trview.ui/Scrollbar.cpp
@@ -12,7 +12,7 @@ namespace trview
         Scrollbar::Scrollbar(const Point& position, const Size& size, const Colour& background_colour)
             : Window(position, size, background_colour)
         {
-            _blob = add_child(std::make_unique<Window>(Point(), Size(size.width, 10), Colour(1.0f, 0.15f, 0.15f, 0.15f)));
+            _blob = add_child(std::make_unique<Window>(Size(size.width, 10), Colour(1.0f, 0.15f, 0.15f, 0.15f)));
         }
 
         void Scrollbar::set_range(float range_start, float range_end, float maximum)

--- a/trview.ui/Scrollbar.h
+++ b/trview.ui/Scrollbar.h
@@ -14,6 +14,11 @@ namespace trview
         {
         public:
             /// Create a new scrollbar.
+            /// @param size The size of the new scrollbar.
+            /// @param background_colour The background colour of the scrollbar.
+            Scrollbar(const Size& size, const Colour& background_colour);
+
+            /// Create a new scrollbar.
             /// @param position The position for the scrollbar.
             /// @param size The size of the new scrollbar.
             /// @param background_colour The background colour of the scrollbar.

--- a/trview.ui/StackPanel.cpp
+++ b/trview.ui/StackPanel.cpp
@@ -5,6 +5,11 @@ namespace trview
 {
     namespace ui
     {
+        StackPanel::StackPanel(Size size, Colour colour, Size padding, Direction direction, SizeMode size_mode)
+            : StackPanel(Point(), size, colour, padding, direction, size_mode)
+        {
+        }
+
         StackPanel::StackPanel(Point position, Size size, Colour colour, Size padding, Direction direction, SizeMode size_mode)
             : Window(position, size, colour), _padding(padding), _direction(direction), _size_mode(size_mode)
         {

--- a/trview.ui/StackPanel.h
+++ b/trview.ui/StackPanel.h
@@ -25,6 +25,14 @@ namespace trview
             };
 
             /// Creates a new StackPanel instance.
+            /// @param size The initial size of the stack panel.
+            /// @param colour The background colour of the stack panel.
+            /// @param padding The amount of padding to place between each element.
+            /// @param direction The direction in which to stack elements. Defaults to Vertical.
+            /// @param size_mode Whether or not to resize the panel automatically.
+            StackPanel(Size size, Colour colour, Size padding = Size(), Direction direction = Direction::Vertical, SizeMode size_mode = SizeMode::Auto);
+
+            /// Creates a new StackPanel instance.
             /// @param position The position of the stack panel inside the parent control.
             /// @param size The initial size of the stack panel.
             /// @param colour The background colour of the stack panel.

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -16,7 +16,7 @@ namespace trview
         {
             _area = add_child(std::make_unique<StackPanel>(size, background_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual));
             _area->set_margin(Size(1, 1));
-            _cursor = add_child(std::make_unique<Window>(Point(), Size(1, 14), text_colour));
+            _cursor = add_child(std::make_unique<Window>(Size(1, 14), text_colour));
             _cursor->set_visible(focused());
             set_handles_input(true);
         }

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace ui
     {
-        TextArea::TextArea(const Size& size, const Colour& background_colour, const Colour& text_colour, graphics::TextAlignment text_alignment = graphics::TextAlignment::Left)
+        TextArea::TextArea(const Size& size, const Colour& background_colour, const Colour& text_colour, graphics::TextAlignment text_alignment)
             : TextArea(Point(), size, background_colour, text_colour, text_alignment)
         {
         }

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -281,7 +281,7 @@ namespace trview
 
         void TextArea::add_line(std::wstring text, bool raise_event)
         {
-            _lines.push_back(_area->add_child(std::make_unique<Label>(Point(), Size(size().width, 14), background_colour(), text, 8, _alignment, graphics::ParagraphAlignment::Near, SizeMode::Manual)));
+            _lines.push_back(_area->add_child(std::make_unique<Label>(Size(size().width, 14), background_colour(), text, 8, _alignment, graphics::ParagraphAlignment::Near, SizeMode::Manual)));
             if (raise_event)
             {
                 notify_text_updated();

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -9,7 +9,7 @@ namespace trview
         TextArea::TextArea(const Point& position, const Size& size, const Colour& background_colour, const Colour& text_colour, graphics::TextAlignment text_alignment)
             : Window(position, size, background_colour), _text_colour(text_colour), _alignment(text_alignment)
         {
-            _area = add_child(std::make_unique<StackPanel>(Point(), size, background_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual));
+            _area = add_child(std::make_unique<StackPanel>(size, background_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual));
             _area->set_margin(Size(1, 1));
             _cursor = add_child(std::make_unique<Window>(Point(), Size(1, 14), text_colour));
             _cursor->set_visible(focused());

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -6,6 +6,11 @@ namespace trview
 {
     namespace ui
     {
+        TextArea::TextArea(const Size& size, const Colour& background_colour, const Colour& text_colour, graphics::TextAlignment text_alignment = graphics::TextAlignment::Left)
+            : TextArea(Point(), size, background_colour, text_colour, text_alignment)
+        {
+        }
+
         TextArea::TextArea(const Point& position, const Size& size, const Colour& background_colour, const Colour& text_colour, graphics::TextAlignment text_alignment)
             : Window(position, size, background_colour), _text_colour(text_colour), _alignment(text_alignment)
         {

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -20,6 +20,13 @@ namespace trview
             };
 
             /// Create a text area.
+            /// @param size The size of the control.
+            /// @param background_colour The background colour of the text area.
+            /// @param text_colour The text colour for the text area.
+            /// @param text_alignment The text alignment of the label.
+            TextArea(const Size& size, const Colour& background_colour, const Colour& text_colour, graphics::TextAlignment text_alignment = graphics::TextAlignment::Left);
+
+            /// Create a text area.
             /// @param position The position to place the control.
             /// @param size The size of the control.
             /// @param background_colour The background colour of the text area.

--- a/trview.ui/Window.cpp
+++ b/trview.ui/Window.cpp
@@ -4,7 +4,12 @@ namespace trview
 {
     namespace ui
     {
-        Window::Window(Point point, Size size, Colour background_colour)
+        Window::Window(const Size& size, const Colour& background_colour)
+            : Window(Point(), size, background_colour)
+        {
+        }
+
+        Window::Window(const Point& point, const Size& size, const Colour& background_colour)
             : Control(point, size), _background_colour(background_colour)
         {
         }

--- a/trview.ui/Window.h
+++ b/trview.ui/Window.h
@@ -11,7 +11,9 @@ namespace trview
         class Window : public Control
         {
         public:
-            explicit Window(Point position, Size size, Colour background_colour);
+            Window(const Size& size, const Colour& background_colour);
+
+            explicit Window(const Point& position, const Size& size, const Colour& background_colour);
 
             virtual ~Window() = default;
 


### PR DESCRIPTION
Most of the time the UI elements are created with a default position and then are arranged by the containing control (StackPanel etc). This adds a constructor that doesn't take a position, to make the calling code a little simpler and remove a lot of pointless Point constructor calls.
Issue: #595 