### PR TITLE
Reset camera movement on menu activation

### DIFF
--- a/trview.app.tests/Camera/CameraInputTests.cpp
+++ b/trview.app.tests/Camera/CameraInputTests.cpp
@@ -218,3 +218,17 @@ TEST(CameraInput, PanningVertical)
     ASSERT_EQ(200.0f, std::get<2>(pan_movement.value()));
 }
 
+TEST(CameraInput, Reset)
+{
+    using namespace DirectX::SimpleMath;
+
+    CameraInput subject;
+
+    subject.key_down('W', false);
+    subject.key_down('A', false);
+    ASSERT_NE(Vector3::Zero, subject.movement());
+
+    subject.reset();
+    ASSERT_EQ(Vector3::Zero, subject.movement());
+}
+

--- a/trview.app.tests/FileDropperTests.cpp
+++ b/trview.app.tests/FileDropperTests.cpp
@@ -8,7 +8,7 @@ using namespace trview;
 using namespace trview::tests;
 
 // Tests that sending a dropfile message to the dropper raises the event.
-TEST(FileDroper, DropFile)
+TEST(FileDropper, DropFile)
 {
     FileDropper dropper(create_test_window(L"TRViewFileDropperTests"));
 
@@ -37,7 +37,7 @@ TEST(FileDroper, DropFile)
 }
 
 // Tests that the class enables drag and drop
-TEST(FileDroper, EnableDragDrop)
+TEST(FileDropper, EnableDragDrop)
 {
     Window window = create_test_window(L"TRViewFileDropperTests");
     FileDropper dropper(window);

--- a/trview.app.tests/Menus/MenuDetectorTests.cpp
+++ b/trview.app.tests/Menus/MenuDetectorTests.cpp
@@ -1,0 +1,39 @@
+#include "gtest/gtest.h"
+#include <trview.app/Menus/MenuDetector.h>
+#include <trview.tests.common/Window.h>
+#include <optional>
+
+using namespace trview;
+using namespace trview::tests;
+
+TEST(MenuDetector, OpenMenu)
+{
+    MenuDetector detector(create_test_window(L"MenuDetector"));
+
+    std::optional<bool> value;
+    auto token = detector.on_menu_toggled += [&](bool open)
+    {
+        value = open;
+    };
+
+    detector.process_message(WM_ENTERMENULOOP, 0, 0);
+
+    ASSERT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value());
+}
+
+TEST(MenuDetector, CloseMenu)
+{
+    MenuDetector detector(create_test_window(L"MenuDetector"));
+
+    std::optional<bool> value;
+    auto token = detector.on_menu_toggled += [&](bool open)
+    {
+        value = open;
+    };
+
+    detector.process_message(WM_EXITMENULOOP, 0, 0);
+
+    ASSERT_TRUE(value.has_value());
+    ASSERT_FALSE(value.value());
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -26,6 +26,7 @@
     <ClCompile Include="FileDropperTests.cpp" />
     <ClCompile Include="FreeCameraTests.cpp" />
     <ClCompile Include="Graphics\LevelTextureStorageTests.cpp" />
+    <ClCompile Include="Menus\MenuDetectorTests.cpp" />
     <ClCompile Include="OrbitCameraTests.cpp" />
     <ClCompile Include="RecentFilesTests.cpp" />
     <ClCompile Include="UI\CameraPositionTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -26,6 +26,9 @@
     <ClCompile Include="Elements\LevelTests.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
+    <ClCompile Include="Menus\MenuDetectorTests.cpp">
+      <Filter>Menus</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">
@@ -42,6 +45,9 @@
     </Filter>
     <Filter Include="Elements">
       <UniqueIdentifier>{511e3bad-c463-4037-83d1-c079ea951456}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Menus">
+      <UniqueIdentifier>{1f416bd8-ff05-4720-81cd-5666b82a28e2}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/Camera/CameraInput.cpp
+++ b/trview.app/Camera/CameraInput.cpp
@@ -149,4 +149,17 @@ namespace trview
     {
         on_zoom(scroll / -100.0f);
     }
+
+    void CameraInput::reset()
+    {
+        _free_forward = false;
+        _free_left = false;
+        _free_right = false;
+        _free_backward = false;
+        _free_up = false;
+        _free_down = false;
+        _rotating = false;
+        _panning = false;
+        _panning_vertical = false;
+    }
 }

--- a/trview.app/Camera/CameraInput.cpp
+++ b/trview.app/Camera/CameraInput.cpp
@@ -152,12 +152,12 @@ namespace trview
 
     void CameraInput::reset()
     {
-        _free_forward = GetAsyncKeyState('W');
-        _free_left = GetAsyncKeyState('A');
-        _free_right = GetAsyncKeyState('D');
-        _free_backward = GetAsyncKeyState('S');;
-        _free_up = GetAsyncKeyState('E');
-        _free_down = GetAsyncKeyState('Q');
+        _free_forward = GetAsyncKeyState('W') & 0x8000;
+        _free_left = GetAsyncKeyState('A') & 0x8000;
+        _free_right = GetAsyncKeyState('D') & 0x8000;
+        _free_backward = GetAsyncKeyState('S') & 0x8000;
+        _free_up = GetAsyncKeyState('E') & 0x8000;
+        _free_down = GetAsyncKeyState('Q') & 0x8000;
         _rotating = false;
         _panning = false;
         _panning_vertical = false;

--- a/trview.app/Camera/CameraInput.cpp
+++ b/trview.app/Camera/CameraInput.cpp
@@ -152,12 +152,12 @@ namespace trview
 
     void CameraInput::reset()
     {
-        _free_forward = false;
-        _free_left = false;
-        _free_right = false;
-        _free_backward = false;
-        _free_up = false;
-        _free_down = false;
+        _free_forward = GetAsyncKeyState('W');
+        _free_left = GetAsyncKeyState('A');
+        _free_right = GetAsyncKeyState('D');
+        _free_backward = GetAsyncKeyState('S');;
+        _free_up = GetAsyncKeyState('E');
+        _free_down = GetAsyncKeyState('Q');
         _rotating = false;
         _panning = false;
         _panning_vertical = false;

--- a/trview.app/Camera/CameraInput.h
+++ b/trview.app/Camera/CameraInput.h
@@ -44,6 +44,9 @@ namespace trview
         /// @param scroll The mouse wheel movement.
         void mouse_scroll(int16_t scroll);
 
+        /// Reset all input states.
+        void reset();
+
         /// Event raised when the camera needs to be rotated.
         Event<float, float> on_rotate;
 

--- a/trview.app/Menus/MenuDetector.cpp
+++ b/trview.app/Menus/MenuDetector.cpp
@@ -9,10 +9,13 @@ namespace trview
 
     void MenuDetector::process_message(UINT message, WPARAM wParam, LPARAM lParam) 
     {
-        if (message == WM_MENUSELECT)
+        if (message == WM_ENTERMENULOOP)
         {
-            bool closing = HIWORD(wParam) == 0xffff;
-            on_menu_toggled(!closing);
+            on_menu_toggled(true);
+        }
+        else if (message == WM_EXITMENULOOP)
+        {
+            on_menu_toggled(false);
         }
     }
 }

--- a/trview.app/Menus/MenuDetector.cpp
+++ b/trview.app/Menus/MenuDetector.cpp
@@ -1,0 +1,18 @@
+#include "MenuDetector.h"
+
+namespace trview
+{
+    MenuDetector::MenuDetector(const Window& window)
+        : MessageHandler(window)
+    {
+    }
+
+    void MenuDetector::process_message(UINT message, WPARAM wParam, LPARAM lParam) 
+    {
+        if (message == WM_MENUSELECT)
+        {
+            bool closing = HIWORD(wParam) == 0xffff;
+            on_menu_toggled(!closing);
+        }
+    }
+}

--- a/trview.app/Menus/MenuDetector.h
+++ b/trview.app/Menus/MenuDetector.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <trview.common/Event.h>
+#include <trview.common/MessageHandler.h>
+
+namespace trview
+{
+    class MenuDetector final : public MessageHandler
+    {
+    public:
+        /// Create a new MenuDetector.
+        /// @param window The window that the detector is monitoring.
+        explicit MenuDetector(const Window& window);
+
+        /// Destructor for MenuDetector.
+        virtual ~MenuDetector() = default;
+
+        /// Handles a window message.
+        /// @param message The message that was received.
+        /// @param wParam The WPARAM for the message.
+        /// @param lParam The LPARAM for the message.
+        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+
+        /// Event raised when the menu is toggled on or off.
+        Event<bool> on_menu_toggled;
+    private:
+
+    };
+}

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -52,6 +52,7 @@
     <ClCompile Include="Menus\DirectoryListing.cpp" />
     <ClCompile Include="Menus\FileDropper.cpp" />
     <ClCompile Include="Menus\LevelSwitcher.cpp" />
+    <ClCompile Include="Menus\MenuDetector.cpp" />
     <ClCompile Include="Menus\RecentFiles.cpp" />
     <ClCompile Include="Menus\UpdateChecker.cpp" />
     <ClCompile Include="Menus\ViewMenu.cpp" />
@@ -119,6 +120,7 @@
     <ClInclude Include="Menus\DirectoryListing.h" />
     <ClInclude Include="Menus\FileDropper.h" />
     <ClInclude Include="Menus\LevelSwitcher.h" />
+    <ClInclude Include="Menus\MenuDetector.h" />
     <ClInclude Include="Menus\RecentFiles.h" />
     <ClInclude Include="Menus\UpdateChecker.h" />
     <ClInclude Include="Menus\ViewMenu.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -181,6 +181,9 @@
     <ClCompile Include="Elements\ITypeNameLookup.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
+    <ClCompile Include="Menus\MenuDetector.cpp">
+      <Filter>Menus</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -380,6 +383,9 @@
     </ClInclude>
     <ClInclude Include="Elements\ITypeNameLookup.h">
       <Filter>Elements</Filter>
+    </ClInclude>
+    <ClInclude Include="Menus\MenuDetector.h">
+      <Filter>Menus</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/trview.common/Timer.cpp
+++ b/trview.common/Timer.cpp
@@ -30,6 +30,7 @@ namespace trview
     {
         _elapsed = 0.0f;
         _total = 0.0f;
+        _previous = _time_source();
     }
 
     std::function<float()> default_time_source()

--- a/trview.input/Keyboard.cpp
+++ b/trview.input/Keyboard.cpp
@@ -15,7 +15,7 @@ namespace trview
 
         bool Keyboard::control() const
         {
-            return GetAsyncKeyState(VK_CONTROL);
+            return GetAsyncKeyState(VK_CONTROL) & 0x8000;
         }
 
         void Keyboard::process_message(UINT message, WPARAM wParam, LPARAM)

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -37,7 +37,7 @@ namespace trview
         : _window(window), _camera(window.size()), _free_camera(window.size()),
         _timer(default_time_source()), _keyboard(window), _mouse(window, std::make_unique<input::WindowTester>()), _level_switcher(window),
         _window_resizer(window), _recent_files(window), _file_dropper(window), _alternate_group_toggler(window),
-        _view_menu(window), _update_checker(window)
+        _view_menu(window), _update_checker(window), _menu_detector(window)
     {
         _update_checker.check_for_updates();
 
@@ -318,6 +318,11 @@ namespace trview
                 auto z = _current_pick.position.z - (info.value().z / trlevel::Scale_Z);
                 _ui->set_minimap_highlight(x, z);
             }
+        };
+
+        _token_store += _menu_detector.on_menu_toggled += [&](bool open)
+        {
+            _menu_active = open;
         };
     }
 
@@ -638,6 +643,12 @@ namespace trview
         }
 
         _timer.update();
+
+        // Keep updating the camera, but don't do anything.
+        if (_menu_active)
+        {
+            return;
+        }
 
         update_camera();
 

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -467,7 +467,7 @@ namespace trview
                         return t->room() == sector->room() && t->sector_id() == sector->id();
                     });
 
-                    if (trigger == triggers.end() || GetAsyncKeyState(VK_CONTROL))
+                    if (trigger == triggers.end() || (GetAsyncKeyState(VK_CONTROL) & 0x8000))
                     {
                         if (sector->flags & SectorFlag::Portal)
                         {

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -322,7 +322,8 @@ namespace trview
 
         _token_store += _menu_detector.on_menu_toggled += [&](bool open)
         {
-            _menu_active = open;
+            _timer.reset();
+            _camera_input.reset();
         };
     }
 
@@ -643,13 +644,6 @@ namespace trview
         }
 
         _timer.update();
-
-        // Keep updating the camera, but don't do anything.
-        if (_menu_active)
-        {
-            return;
-        }
-
         update_camera();
 
         if (_mouse_changed || _scene_changed)

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -40,6 +40,7 @@
 #include <trview.app/UI/ViewerUI.h>
 #include <trview.app/Menus/UpdateChecker.h>
 #include <trview.app/Elements/ITypeNameLookup.h>
+#include <trview.app/Menus/MenuDetector.h>
 
 namespace trview
 {
@@ -138,6 +139,8 @@ namespace trview
         ViewMenu _view_menu;
         bool _show_selection{ true };
         SectorHighlight _sector_highlight;
+        MenuDetector _menu_detector;
+        bool _menu_active{ false };
 
         // Tools:
 

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -140,7 +140,6 @@ namespace trview
         bool _show_selection{ true };
         SectorHighlight _sector_highlight;
         MenuDetector _menu_detector;
-        bool _menu_active{ false };
 
         // Tools:
 


### PR DESCRIPTION
When the user activates the menu, reset the timer so the camera doesn't jump and also reset the camera input so that it doesn't keep moving around afterwards.
Bug: #596