### PR TITLE
Clear focus when checkbox toggled

### DIFF
--- a/trview.ui/Checkbox.cpp
+++ b/trview.ui/Checkbox.cpp
@@ -68,6 +68,7 @@ namespace trview
         {
             set_state(!_state);
             on_state_changed(_state);
+            on_focus_clear_requested();
             return true;
         }
 


### PR DESCRIPTION
This allows the user to use the keyboard immediately as the UI is no longer taking input - this happens when clicking free mode.
Bug: #597