### PR TITLE
Orthographic mode

### DIFF
--- a/trview.app/Camera/Camera.cpp
+++ b/trview.app/Camera/Camera.cpp
@@ -63,6 +63,12 @@ namespace trview
         _target_rotation_yaw = rotation;
     }
 
+    void Camera::set_projection_mode(ProjectionMode mode)
+    {
+        _projection_mode = mode;
+        calculate_projection_matrix();
+    }
+
     void Camera::set_rotation_pitch(float rotation)
     {
         _rotation_pitch = std::max(-DirectX::XM_PIDIV2, std::min(rotation, DirectX::XM_PIDIV2));
@@ -153,9 +159,22 @@ namespace trview
     void Camera::calculate_projection_matrix()
     {
         using namespace DirectX;
-        float aspect_ratio = _view_size.width / _view_size.height;
-        _projection = XMMatrixPerspectiveFovRH(XM_PIDIV4, aspect_ratio, 0.1f, 10000.0f);
-        _projection_lh = XMMatrixPerspectiveFovLH(XM_PIDIV4, aspect_ratio, 0.1f, 10000.0f);
+
+        if (_projection_mode == ProjectionMode::Perspective)
+        {
+            float aspect_ratio = _view_size.width / _view_size.height;
+            _projection = XMMatrixPerspectiveFovRH(XM_PIDIV4, aspect_ratio, 0.1f, 10000.0f);
+            _projection_lh = XMMatrixPerspectiveFovLH(XM_PIDIV4, aspect_ratio, 0.1f, 10000.0f);
+        }
+        else if (_projection_mode == ProjectionMode::Orthographic)
+        {
+            auto width = 30;
+            auto height = width * (_view_size.height / _view_size.width);
+
+            _projection = XMMatrixOrthographicRH(width, height, 0.1f, 10000.0f);
+            _projection_lh = XMMatrixOrthographicLH(width, height, 0.1f, 10000.0f);
+        }
+
         _view_projection = _view * _projection;
         calculate_bounding_frustum();
     }

--- a/trview.app/Camera/Camera.cpp
+++ b/trview.app/Camera/Camera.cpp
@@ -41,6 +41,13 @@ namespace trview
         return _position;
     }
 
+    Vector3 Camera::rendering_position() const
+    {
+        return _projection_mode == ProjectionMode::Orthographic
+            ? _position - _forward * 100
+            : _position;
+    }
+
     const Matrix& Camera::projection() const
     {
         return _projection;
@@ -74,6 +81,7 @@ namespace trview
     void Camera::set_projection_mode(ProjectionMode mode)
     {
         _projection_mode = mode;
+        calculate_view_matrix();
         calculate_projection_matrix();
     }
 
@@ -211,8 +219,8 @@ namespace trview
         if (_projection_mode == ProjectionMode::Orthographic)
         {
             // Scale the position back so that the level doesn't get clipped near the camera.
-            _view = XMMatrixLookAtRH(_position - _forward * 100, _position + _forward, _up);
-            _view_lh = XMMatrixLookAtLH(_position - _forward * 100, _position + _forward, _up);
+            _view = XMMatrixLookAtRH(rendering_position(), _position + _forward, _up);
+            _view_lh = XMMatrixLookAtLH(rendering_position(), _position + _forward, _up);
         }
         else
         {

--- a/trview.app/Camera/Camera.cpp
+++ b/trview.app/Camera/Camera.cpp
@@ -80,6 +80,15 @@ namespace trview
 
     void Camera::set_projection_mode(ProjectionMode mode)
     {
+        if (mode == ProjectionMode::Perspective && _projection_mode == ProjectionMode::Orthographic)
+        {
+            _zoom = _ortho_size;
+        }
+        else if (mode == ProjectionMode::Orthographic && _projection_mode == ProjectionMode::Perspective)
+        {
+            _ortho_size = _zoom;
+        }
+
         _projection_mode = mode;
         calculate_view_matrix();
         calculate_projection_matrix();

--- a/trview.app/Camera/Camera.cpp
+++ b/trview.app/Camera/Camera.cpp
@@ -111,7 +111,7 @@ namespace trview
     {
         if (_projection_mode == ProjectionMode::Orthographic)
         {
-            _ortho_size = std::min(std::max(zoom, 1.0f), 100.0f);
+            _ortho_size = std::min(std::max(zoom, 1.0f), 200.0f);
             calculate_projection_matrix();
         }
         else

--- a/trview.app/Camera/Camera.cpp
+++ b/trview.app/Camera/Camera.cpp
@@ -208,8 +208,17 @@ namespace trview
 
     void Camera::calculate_view_matrix()
     {
-        _view = XMMatrixLookAtRH(_position, _position + _forward, _up);
-        _view_lh = XMMatrixLookAtLH(_position, _position + _forward, _up);
+        if (_projection_mode == ProjectionMode::Orthographic)
+        {
+            // Scale the position back so that the level doesn't get clipped near the camera.
+            _view = XMMatrixLookAtRH(_position - _forward * 100, _position + _forward, _up);
+            _view_lh = XMMatrixLookAtLH(_position - _forward * 100, _position + _forward, _up);
+        }
+        else
+        {
+            _view = XMMatrixLookAtRH(_position, _position + _forward, _up);
+            _view_lh = XMMatrixLookAtLH(_position, _position + _forward, _up);
+        }
         _view_projection = _view * _projection;
         calculate_bounding_frustum();
     }

--- a/trview.app/Camera/Camera.h
+++ b/trview.app/Camera/Camera.h
@@ -25,6 +25,7 @@ namespace trview
         virtual float rotation_yaw() const override;
         virtual void rotate_to_pitch(float rotation) override;
         virtual void rotate_to_yaw(float rotation) override;
+        virtual void set_projection_mode(ProjectionMode mode) override;
         virtual void set_rotation_pitch(float rotation) override;
         virtual void set_rotation_yaw(float rotation) override;
         virtual void set_view_size(const Size& size) override;
@@ -41,7 +42,7 @@ namespace trview
         void calculate_bounding_frustum();
         
         /// Calculate the projection matrix based on the viewport size.
-        virtual void calculate_projection_matrix();
+        void calculate_projection_matrix();
 
         /// Calculate the view matrix based on the forward, up and rotation fields.
         void calculate_view_matrix();
@@ -67,5 +68,6 @@ namespace trview
         DirectX::BoundingFrustum _bounding_frustum;
         std::optional<float> _target_rotation_yaw;
         std::optional<float> _target_rotation_pitch;
+        ProjectionMode _projection_mode{ ProjectionMode::Perspective };
     };
 }

--- a/trview.app/Camera/Camera.h
+++ b/trview.app/Camera/Camera.h
@@ -64,6 +64,9 @@ namespace trview
         DirectX::SimpleMath::Vector3 _up;
         float _rotation_yaw{ default_yaw };
         float _rotation_pitch{ default_pitch };
+        float _zoom{ default_zoom };
+        ProjectionMode _projection_mode{ ProjectionMode::Perspective };
+    private:
         Size _view_size;
         DirectX::SimpleMath::Matrix _view;
         DirectX::SimpleMath::Matrix _view_lh;
@@ -73,8 +76,6 @@ namespace trview
         DirectX::BoundingFrustum _bounding_frustum;
         std::optional<float> _target_rotation_yaw;
         std::optional<float> _target_rotation_pitch;
-        ProjectionMode _projection_mode{ ProjectionMode::Perspective };
         float _ortho_size{ 10.0f };
-        float _zoom{ default_zoom };
     };
 }

--- a/trview.app/Camera/Camera.h
+++ b/trview.app/Camera/Camera.h
@@ -41,7 +41,7 @@ namespace trview
         void calculate_bounding_frustum();
         
         /// Calculate the projection matrix based on the viewport size.
-        void calculate_projection_matrix();
+        virtual void calculate_projection_matrix();
 
         /// Calculate the view matrix based on the forward, up and rotation fields.
         void calculate_view_matrix();
@@ -58,7 +58,6 @@ namespace trview
         DirectX::SimpleMath::Vector3 _up;
         float _rotation_yaw{ default_yaw };
         float _rotation_pitch{ default_pitch };
-    private:
         Size _view_size;
         DirectX::SimpleMath::Matrix _view;
         DirectX::SimpleMath::Matrix _view_lh;

--- a/trview.app/Camera/Camera.h
+++ b/trview.app/Camera/Camera.h
@@ -21,6 +21,7 @@ namespace trview
         virtual const DirectX::BoundingFrustum& frustum() const override;
         virtual DirectX::SimpleMath::Vector3 position() const override;
         virtual const DirectX::SimpleMath::Matrix& projection() const override;
+        virtual ProjectionMode projection_mode() const override;
         virtual float rotation_pitch() const override;
         virtual float rotation_yaw() const override;
         virtual void rotate_to_pitch(float rotation) override;
@@ -29,11 +30,13 @@ namespace trview
         virtual void set_rotation_pitch(float rotation) override;
         virtual void set_rotation_yaw(float rotation) override;
         virtual void set_view_size(const Size& size) override;
+        virtual void set_zoom(float zoom) override;
         virtual DirectX::SimpleMath::Vector3 up() const override;
         virtual void update(float elapsed) override;
         virtual const DirectX::SimpleMath::Matrix& view() const override;
         virtual const DirectX::SimpleMath::Matrix& view_projection() const override;
         virtual const Size& view_size() const override;
+        virtual float zoom() const override;
 
         /// Event raised when the view of the camera has changed.
         Event<> on_view_changed;
@@ -53,6 +56,7 @@ namespace trview
 
         const float default_pitch = -0.78539f;
         const float default_yaw = 0.0f;
+        const float default_zoom = 8.0f;
 
         DirectX::SimpleMath::Vector3 _position;
         DirectX::SimpleMath::Vector3 _forward;
@@ -69,5 +73,7 @@ namespace trview
         std::optional<float> _target_rotation_yaw;
         std::optional<float> _target_rotation_pitch;
         ProjectionMode _projection_mode{ ProjectionMode::Perspective };
+        float _ortho_size{ 10.0f };
+        float _zoom{ default_zoom };
     };
 }

--- a/trview.app/Camera/Camera.h
+++ b/trview.app/Camera/Camera.h
@@ -20,6 +20,7 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 forward() const override;
         virtual const DirectX::BoundingFrustum& frustum() const override;
         virtual DirectX::SimpleMath::Vector3 position() const override;
+        virtual DirectX::SimpleMath::Vector3 rendering_position() const override;
         virtual const DirectX::SimpleMath::Matrix& projection() const override;
         virtual ProjectionMode projection_mode() const override;
         virtual float rotation_pitch() const override;

--- a/trview.app/Camera/FreeCamera.cpp
+++ b/trview.app/Camera/FreeCamera.cpp
@@ -32,12 +32,32 @@ namespace trview
     void FreeCamera::set_alignment(Alignment alignment)
     {
         _alignment = alignment;
+        calculate_projection_matrix();
     }
 
     void FreeCamera::set_position(const Vector3& position)
     {
         _position = position;
         calculate_view_matrix();
+    }
+
+    void FreeCamera::calculate_projection_matrix()
+    {
+        if (_alignment != Alignment::Axis)
+        {
+            Camera::calculate_projection_matrix();
+            return;
+        }
+
+        using namespace DirectX;
+
+        auto width = 10;
+        auto height = 10.0f * (_view_size.height / _view_size.width);
+
+        _projection = XMMatrixOrthographicRH(width, height, 0.1f, 10000.0f);
+        _projection_lh = XMMatrixOrthographicLH(width, height, 0.1f, 10000.0f);
+        _view_projection = _view * _projection;
+        calculate_bounding_frustum();
     }
 
     void FreeCamera::update_vectors()

--- a/trview.app/Camera/FreeCamera.cpp
+++ b/trview.app/Camera/FreeCamera.cpp
@@ -41,25 +41,6 @@ namespace trview
         calculate_view_matrix();
     }
 
-    void FreeCamera::calculate_projection_matrix()
-    {
-        if (_alignment != Alignment::Axis)
-        {
-            Camera::calculate_projection_matrix();
-            return;
-        }
-
-        using namespace DirectX;
-
-        auto width = 10;
-        auto height = 10.0f * (_view_size.height / _view_size.width);
-
-        _projection = XMMatrixOrthographicRH(width, height, 0.1f, 10000.0f);
-        _projection_lh = XMMatrixOrthographicLH(width, height, 0.1f, 10000.0f);
-        _view_projection = _view * _projection;
-        calculate_bounding_frustum();
-    }
-
     void FreeCamera::update_vectors()
     {
         const auto rotation = Matrix::CreateFromYawPitchRoll(_rotation_yaw, _rotation_pitch, 0);

--- a/trview.app/Camera/FreeCamera.cpp
+++ b/trview.app/Camera/FreeCamera.cpp
@@ -13,14 +13,22 @@ namespace trview
 
     void FreeCamera::move(const Vector3& movement)
     {
-        if (_alignment == Alignment::Camera)
+        if (_projection_mode == ProjectionMode::Orthographic)
         {
             auto rotate = Matrix::CreateFromYawPitchRoll(_rotation_yaw, _rotation_pitch, 0);
-            _position += Vector3(0, movement.y, 0) + Vector3::Transform(Vector3(movement.x, 0, movement.z), rotate);
+            _position += Vector3::Transform(Vector3(movement.x, -movement.z, 0), rotate);
         }
-        else if (_alignment == Alignment::Axis)
+        else
         {
-            _position += movement;
+            if (_alignment == Alignment::Camera)
+            {
+                auto rotate = Matrix::CreateFromYawPitchRoll(_rotation_yaw, _rotation_pitch, 0);
+                _position += Vector3(0, movement.y, 0) + Vector3::Transform(Vector3(movement.x, 0, movement.z), rotate);
+            }
+            else if (_alignment == Alignment::Axis)
+            {
+                _position += movement;
+            }
         }
 
         if (movement.LengthSquared() > 0)

--- a/trview.app/Camera/FreeCamera.h
+++ b/trview.app/Camera/FreeCamera.h
@@ -39,6 +39,7 @@ namespace trview
         /// @param position The new camera position.
         void set_position(const DirectX::SimpleMath::Vector3& position);
     protected:
+        virtual void calculate_projection_matrix() override;
         virtual void update_vectors() override;
     private:
         Alignment _alignment{ Alignment::Axis };

--- a/trview.app/Camera/FreeCamera.h
+++ b/trview.app/Camera/FreeCamera.h
@@ -39,7 +39,6 @@ namespace trview
         /// @param position The new camera position.
         void set_position(const DirectX::SimpleMath::Vector3& position);
     protected:
-        virtual void calculate_projection_matrix() override;
         virtual void update_vectors() override;
     private:
         Alignment _alignment{ Alignment::Axis };

--- a/trview.app/Camera/ICamera.h
+++ b/trview.app/Camera/ICamera.h
@@ -30,6 +30,10 @@ namespace trview
         /// @returns The projection matrix.
         virtual const DirectX::SimpleMath::Matrix& projection() const = 0;
 
+        /// Gets the current projection mode for the camera.
+        /// @returns The projection mode.
+        virtual ProjectionMode projection_mode() const = 0;
+
         /// Gets the pitch rotation of the camera in radians.
         /// @returns The pitch rotation.
         virtual float rotation_pitch() const = 0;
@@ -62,6 +66,10 @@ namespace trview
         /// @param size The new size of the viewport.
         virtual void set_view_size(const Size& size) = 0;
 
+        /// Sets the zoom for the camera.
+        /// @param zoom The zoom level.
+        virtual void set_zoom(float zoom) = 0;
+
         /// Gets the direction that the camera considers to be 'up'.
         /// @returns The up direction.
         virtual DirectX::SimpleMath::Vector3 up() const = 0;
@@ -81,5 +89,9 @@ namespace trview
         /// Gets the current size of the viewport for the camera.
         /// @returns The viewport size.
         virtual const Size& view_size() const = 0;
+
+        /// Gets the zoom level.
+        /// @returns The zoom level.
+        virtual float zoom() const = 0;
     };
 }

--- a/trview.app/Camera/ICamera.h
+++ b/trview.app/Camera/ICamera.h
@@ -26,6 +26,10 @@ namespace trview
         /// @returns The position of the camera.
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
 
+        /// Gets the position that the camera is rendering from, after adjusting for projection mode for example.
+        /// @returns The position from which the camera is rendering.
+        virtual DirectX::SimpleMath::Vector3 rendering_position() const = 0;
+
         /// Gets the current projection matrix for the camera.
         /// @returns The projection matrix.
         virtual const DirectX::SimpleMath::Matrix& projection() const = 0;

--- a/trview.app/Camera/ICamera.h
+++ b/trview.app/Camera/ICamera.h
@@ -4,6 +4,7 @@
 
 #include <SimpleMath.h>
 #include <trview.common/Size.h>
+#include "ProjectionMode.h"
 
 namespace trview
 {
@@ -44,6 +45,10 @@ namespace trview
         /// Rotate to the specified yaw.
         /// @param rotation The angle to rotate to.
         virtual void rotate_to_yaw(float rotation) = 0;
+
+        /// Set the projection mode of the camera.
+        /// @param mode The new projection mode.
+        virtual void set_projection_mode(ProjectionMode mode) = 0;
 
         /// Set the pitch rotation of the camera.
         /// @param rotation The rotation around the right vector in radians.

--- a/trview.app/Camera/OrbitCamera.cpp
+++ b/trview.app/Camera/OrbitCamera.cpp
@@ -1,15 +1,8 @@
 #include "OrbitCamera.h"
-#include <algorithm>
 
 namespace trview
 {
     using namespace DirectX::SimpleMath;
-
-    namespace
-    {
-        const float max_zoom = 100.0f;
-        const float min_zoom = 0.1f;
-    }
 
     OrbitCamera::OrbitCamera(const Size& size)
         : Camera(size)
@@ -29,20 +22,9 @@ namespace trview
         update_vectors();
     }
 
-    void OrbitCamera::set_zoom(float zoom)
-    {
-        _zoom = std::min(std::max(zoom, min_zoom), max_zoom);
-        update_vectors();
-    }
-
     const Vector3& OrbitCamera::target() const
     {
         return _target;
-    }
-
-    float OrbitCamera::zoom() const
-    {
-        return _zoom;
     }
 
     void OrbitCamera::update_vectors()

--- a/trview.app/Camera/OrbitCamera.h
+++ b/trview.app/Camera/OrbitCamera.h
@@ -24,23 +24,12 @@ namespace trview
         /// @param target The position that the camera will orbit around.
         void set_target(const DirectX::SimpleMath::Vector3& target);
 
-        /// Set the distance from the orbit target.
-        /// @param zoom The distance from the orbit target.
-        void set_zoom(float zoom);
-
         /// Get the current orbit target.
         /// @returns The orbit target.
         const DirectX::SimpleMath::Vector3& target() const;
-
-        /// Get the current distance from the orbit target.
-        /// @returns The distance from the orbit target.
-        float zoom() const;
     protected:
         virtual void update_vectors() override;
     private:
-        const float default_zoom = 8.0f;
-
         DirectX::SimpleMath::Vector3 _target;
-        float _zoom{ default_zoom };
     };
 }

--- a/trview.app/Camera/ProjectionMode.h
+++ b/trview.app/Camera/ProjectionMode.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace trview
+{
+    enum class ProjectionMode
+    {
+        Perspective,
+        Orthographic
+    };
+}

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -217,7 +217,7 @@ namespace trview
         if (_regenerate_transparency)
         {
             // Sort the accumulated transparent triangles farthest to nearest.
-            _transparency->sort(camera.position());
+            _transparency->sort(camera.rendering_position());
         }
 
         _regenerate_transparency = false;

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -255,7 +255,7 @@ namespace trview
 
         auto in_view = [&](const Room& room)
         {
-            return true || frustum.Contains(room.bounding_box()) != DirectX::DISJOINT;
+            return camera.projection_mode() == ProjectionMode::Orthographic || frustum.Contains(room.bounding_box()) != DirectX::DISJOINT;
         };
     
         bool highlight = highlight_mode_enabled(RoomHighlightMode::Highlight);

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -255,7 +255,7 @@ namespace trview
 
         auto in_view = [&](const Room& room)
         {
-            return frustum.Contains(room.bounding_box()) != DirectX::DISJOINT;
+            return true || frustum.Contains(room.bounding_box()) != DirectX::DISJOINT;
         };
     
         bool highlight = highlight_mode_enabled(RoomHighlightMode::Highlight);

--- a/trview.app/Geometry/Picking.cpp
+++ b/trview.app/Geometry/Picking.cpp
@@ -12,7 +12,7 @@ namespace trview
 {
     void Picking::pick(const Window& window, const ICamera& camera)
     {
-        const Vector3 position = camera.position();
+        Vector3 position = camera.position();
         const auto world = Matrix::CreateTranslation(position);
         const auto projection = camera.projection();
         const auto view = camera.view();
@@ -22,6 +22,9 @@ namespace trview
         Vector3 direction = XMVector3Unproject(Vector3(mouse_pos.x, mouse_pos.y, 1), 0, 0,
             window_size.width, window_size.height, 0, 1.0f, projection, view, world);
         direction.Normalize();
+
+        position += XMVector3Unproject(Vector3(mouse_pos.x, mouse_pos.y, 0.1f), 0, 0,
+            window_size.width, window_size.height, 0.1f, 10000.0f, projection, view, world);
 
         // Call the registered pickers.
         PickInfo info{ camera.view_size(), mouse_pos, position, direction };

--- a/trview.app/Graphics/SelectionRenderer.cpp
+++ b/trview.app/Graphics/SelectionRenderer.cpp
@@ -133,7 +133,7 @@ namespace trview
             // Also render the transparent parts of the meshes, again with black.
             _transparency->reset();
             selected_item.get_transparent_triangles(*_transparency, camera, Color(0.0f, 0.0f, 0.0f));
-            _transparency->sort(camera.position());
+            _transparency->sort(camera.rendering_position());
             _transparency->render(context, camera, texture_storage, true);
         }
 

--- a/trview.app/UI/CameraControls.cpp
+++ b/trview.app/UI/CameraControls.cpp
@@ -12,7 +12,7 @@ namespace trview
     {
         using namespace ui;
 
-        auto camera_window = std::make_unique<GroupBox>(Size(150, 72), Colour::Transparent, Colour::Grey, L"Camera");
+        auto camera_window = std::make_unique<GroupBox>(Size(150, 102), Colour::Transparent, Colour::Grey, L"Camera");
 
         auto reset_camera = std::make_unique<Button>(Point(12, 20), Size(16, 16));
         reset_camera->on_click += on_reset;
@@ -28,11 +28,15 @@ namespace trview
         auto axis_camera = std::make_unique<Checkbox>(Point(86, 42), Colour::Transparent, L"Axis");
         _token_store += axis_camera->on_state_changed += [&](auto) { change_mode(CameraMode::Axis); };
 
+        auto ortho = std::make_unique<Checkbox>(Point(12, 64), Colour::Transparent, L"Ortho");
+        _token_store += ortho->on_state_changed += [&](auto ortho_enabled) { change_projection(ortho_enabled ? ProjectionMode::Orthographic : ProjectionMode::Perspective); };
+
         camera_window->add_child(std::move(reset_camera));
         camera_window->add_child(std::move(reset_camera_label));
         _orbit = camera_window->add_child(std::move(orbit_camera));
         _free = camera_window->add_child(std::move(free_camera));
         _axis = camera_window->add_child(std::move(axis_camera));
+        _ortho = camera_window->add_child(std::move(ortho));
 
         parent.add_child(std::move(camera_window));
     }
@@ -45,6 +49,12 @@ namespace trview
         on_mode_selected(mode);
     }
 
+    void CameraControls::change_projection(ProjectionMode mode)
+    {
+        set_projection_mode(mode);
+        on_projection_mode_selected(mode);
+    }
+
     // Set the current camera mode. This will not raise the on_mode_selected event.
     // mode: The camera mode to change to.
     void CameraControls::set_mode(CameraMode mode)
@@ -52,5 +62,10 @@ namespace trview
         _orbit->set_state(mode == CameraMode::Orbit);
         _free->set_state(mode == CameraMode::Free);
         _axis->set_state(mode == CameraMode::Axis);
+    }
+
+    void CameraControls::set_projection_mode(ProjectionMode mode)
+    {
+        _ortho->set_state(mode == ProjectionMode::Orthographic);
     }
 }

--- a/trview.app/UI/CameraControls.cpp
+++ b/trview.app/UI/CameraControls.cpp
@@ -12,7 +12,7 @@ namespace trview
     {
         using namespace ui;
 
-        auto camera_window = std::make_unique<GroupBox>(Size(150, 102), Colour::Transparent, Colour::Grey, L"Camera");
+        auto camera_window = std::make_unique<GroupBox>(Size(150, 92), Colour::Transparent, Colour::Grey, L"Camera");
 
         auto reset_camera = std::make_unique<Button>(Point(12, 20), Size(16, 16));
         reset_camera->on_click += on_reset;

--- a/trview.app/UI/CameraControls.h
+++ b/trview.app/UI/CameraControls.h
@@ -9,6 +9,7 @@
 #include <trview.common/Event.h>
 #include <trview.common/TokenStore.h>
 #include <trview.app/Camera/CameraMode.h>
+#include <trview.app/Camera/ProjectionMode.h>
 
 namespace trview
 {
@@ -32,6 +33,11 @@ namespace trview
         /// @remarks This event is not raised by the set_mode function.
         Event<CameraMode> on_mode_selected;
 
+        /// Event raised when the camera projection mode has been selected by the user. The newly selected
+        /// projection mode is passed as a parameter when the event is raised.
+        /// @remarks This is event is not raised by the set_projection_mode function.
+        Event<ProjectionMode> on_projection_mode_selected;
+
         /// Event raised when the user clicks the reset button.
         Event<> on_reset;
 
@@ -39,15 +45,26 @@ namespace trview
         /// @param mode The camera mode to change to.
         /// @remarks This will not raise the on_mode_selected event.
         void set_mode(CameraMode mode);
+
+        /// Set the current camera projection mode. This will not raise the on_projection_mode_selected event
+        /// @param mode The projection mode to change to.
+        /// @remarks This will not raise the on_projection_mode_selected event.
+        void set_projection_mode(ProjectionMode mode);
     private:
         /// Set the current camera mode.
         /// @param mode The new camera mode.
-        /// @remarks This will raise the on_mode_selected_event.
+        /// @remarks This will raise the on_mode_selected event.
         void change_mode(CameraMode mode);
+
+        /// Set the current camera projection mode.
+        /// @param mode The new camera projection mode.
+        /// @remakrs This will raise the on_projection_mode_selected event
+        void change_projection(ProjectionMode mode);
 
         ui::Checkbox* _orbit;
         ui::Checkbox* _free;
         ui::Checkbox* _axis;
+        ui::Checkbox* _ortho;
         TokenStore _token_store;
     };
 }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -244,6 +244,7 @@ namespace trview
         _camera_controls = std::make_unique<CameraControls>(parent);
         _camera_controls->on_reset += on_camera_reset;
         _camera_controls->on_mode_selected += on_camera_mode;
+        _camera_controls->on_projection_mode_selected += on_camera_projection_mode;
     }
 
     void ViewerUI::render(const graphics::Device& device)
@@ -280,6 +281,11 @@ namespace trview
     void ViewerUI::set_camera_mode(CameraMode mode)
     {
         _camera_controls->set_mode(mode);
+    }
+
+    void ViewerUI::set_camera_projection_mode(ProjectionMode mode)
+    {
+        _camera_controls->set_projection_mode(mode);
     }
 
     void ViewerUI::set_depth_enabled(bool value)

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -74,6 +74,9 @@ namespace trview
         /// Event raised when the camera mode is set.
         Event<CameraMode> on_camera_mode;
 
+        /// Event raised when the camera projection mode is set.
+        Event<ProjectionMode> on_camera_projection_mode;
+
         /// Event raised when the camera is reset.
         Event<> on_camera_reset;
 
@@ -153,6 +156,10 @@ namespace trview
         /// Set the camera mode.
         /// @param mode The current camera mode.
         void set_camera_mode(CameraMode mode);
+
+        /// Set the camera projection mode.
+        /// @param mode The current camera projection mode.
+        void set_camera_projection_mode(ProjectionMode mode);
 
         /// Set whether depth is enabled.
         /// @param value Whether depth is enabled.

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -88,6 +88,7 @@
     <ClInclude Include="Camera\FreeCamera.h" />
     <ClInclude Include="Camera\ICamera.h" />
     <ClInclude Include="Camera\OrbitCamera.h" />
+    <ClInclude Include="Camera\ProjectionMode.h" />
     <ClInclude Include="Elements\Entity.h" />
     <ClInclude Include="Elements\Item.h" />
     <ClInclude Include="Elements\ITypeNameLookup.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -387,6 +387,9 @@
     <ClInclude Include="Menus\MenuDetector.h">
       <Filter>Menus</Filter>
     </ClInclude>
+    <ClInclude Include="Camera\ProjectionMode.h">
+      <Filter>Camera</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -926,6 +926,14 @@ namespace trview
                     _level->on_camera_moved();
                 }
             }
+            else if (_free_camera.projection_mode() == ProjectionMode::Orthographic)
+            {
+                _free_camera.set_zoom(_free_camera.zoom() + zoom);
+                if (_level)
+                {
+                    _level->on_camera_moved();
+                }
+            }
         };
 
         _token_store += _camera_input.on_pan += [&](bool vertical, float x, float y)

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -133,6 +133,7 @@ namespace trview
         _token_store += _ui->on_depth_level_changed += [&](int32_t value) { if (_level) { _level->set_neighbour_depth(value); } };
         _token_store += _ui->on_camera_reset += [&]() { _camera.reset(); };
         _token_store += _ui->on_camera_mode += [&](CameraMode mode) { set_camera_mode(mode); };
+        _token_store += _ui->on_camera_projection_mode += [&](ProjectionMode mode) { set_camera_projection_mode(mode); };
         _token_store += _ui->on_camera_sensitivity += [&](float value) { _settings.camera_sensitivity = value; };
         _token_store += _ui->on_camera_movement_speed += [&](float value) { _settings.camera_movement_speed = value; };
         _token_store += _ui->on_sector_hover += [&](const std::shared_ptr<Sector>& sector)
@@ -751,6 +752,14 @@ namespace trview
 
         _camera_mode = camera_mode;
         _ui->set_camera_mode(camera_mode);
+        _scene_changed = true;
+    }
+
+    void Viewer::set_camera_projection_mode(ProjectionMode projection_mode)
+    {
+        _free_camera.set_projection_mode(projection_mode);
+        _camera.set_projection_mode(projection_mode);
+        _ui->set_camera_projection_mode(projection_mode);
         _scene_changed = true;
     }
 

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -947,20 +947,28 @@ namespace trview
 
             using namespace DirectX::SimpleMath;
 
-            if (vertical)
+            if (camera.projection_mode() == ProjectionMode::Perspective)
             {
-                _target += 0.05f * Vector3::Up * y * (_settings.invert_vertical_pan ? -1.0f : 1.0f);
+                if (vertical)
+                {
+                    _target += 0.05f * Vector3::Up * y * (_settings.invert_vertical_pan ? -1.0f : 1.0f);
+                }
+                else
+                {
+                    // Rotate forward and right by the camera yaw...
+                    const auto rotation = Matrix::CreateRotationY(camera.rotation_yaw());
+                    const auto forward = Vector3::Transform(Vector3::Forward, rotation);
+                    const auto right = Vector3::Transform(Vector3::Right, rotation);
+
+                    // Add them on to the position.
+                    const auto movement = 0.05f * (forward * -y + right * -x);
+                    _target += movement;
+                }
             }
             else
             {
-                // Rotate forward and right by the camera yaw...
-                const auto rotation = Matrix::CreateRotationY(camera.rotation_yaw());
-                const auto forward = Vector3::Transform(Vector3::Forward, rotation);
-                const auto right = Vector3::Transform(Vector3::Right, rotation);
-
-                // Add them on to the position.
-                const auto movement = 0.05f * (forward * -y + right * -x);
-                _target += movement;
+                auto rotate = Matrix::CreateFromYawPitchRoll(camera.rotation_yaw(), camera.rotation_pitch(), 0);
+                _target += 0.05f * Vector3::Transform(Vector3(-x, y * (_settings.invert_vertical_pan ? -1.0f : 1.0f), 0), rotate);
             }
 
             if (_level)

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -97,6 +97,7 @@ namespace trview
         const ICamera& current_camera() const;
         ICamera& current_camera();
         void set_camera_mode(CameraMode camera_mode);
+        void set_camera_projection_mode(ProjectionMode projection_mode);
         void set_alternate_mode(bool enabled);
         void set_alternate_group(uint16_t group, bool enabled);
         bool alternate_group(uint16_t group) const;


### PR DESCRIPTION
Add orthographic projection mode to the camera. The user can turn it on by toggling the checkbox on the camera controls UI.
Issue: #576 