### PR TITLE
Use TrackMouseEvent to test if the window is under the cursor

### DIFF
--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -14,7 +14,7 @@ using namespace trview::ui;
 namespace trview
 {
     ViewerUI::ViewerUI(const Window& window, const graphics::Device& device, const graphics::IShaderStorage& shader_storage, const graphics::FontFactory& font_factory, const ITextureStorage& texture_storage)
-        : _mouse(window, std::make_unique<input::WindowTester>()), _window(window), _keyboard(window)
+        : _mouse(window, std::make_unique<input::WindowTester>(window)), _window(window), _keyboard(window)
     {
         _control = std::make_unique<ui::Window>(window.size(), Colour::Transparent);
 

--- a/trview.input.tests/MouseTests.cpp
+++ b/trview.input.tests/MouseTests.cpp
@@ -12,7 +12,7 @@ using testing::_;
 class MockWindowTester final : public IWindowTester
 {
 public:
-    MOCK_CONST_METHOD0(window_under_cursor, Window());
+    MOCK_CONST_METHOD0(is_window_under_cursor, bool());
     MOCK_CONST_METHOD1(screen_width, int(bool));
     MOCK_CONST_METHOD1(screen_height, int(bool));
 };
@@ -26,8 +26,8 @@ TEST(Mouse, MouseDownEventRaised)
 
     auto window = create_test_window(L"TRViewInputTests");
     auto mockTester = std::make_unique<MockWindowTester>();
-    EXPECT_CALL(*mockTester, window_under_cursor())
-        .WillRepeatedly(Return(window));
+    EXPECT_CALL(*mockTester, is_window_under_cursor())
+        .WillRepeatedly(Return(true));
 
     Mouse mouse(window, std::move(mockTester));
 
@@ -58,8 +58,8 @@ TEST(Mouse, MouseUpEventRaised)
 
     auto window = create_test_window(L"TRViewInputTests");
     auto mockTester = std::make_unique<MockWindowTester>();
-    EXPECT_CALL(*mockTester, window_under_cursor())
-        .WillRepeatedly(Return(window));
+    EXPECT_CALL(*mockTester, is_window_under_cursor())
+        .WillRepeatedly(Return(true));
     Mouse mouse(window, std::move(mockTester));
 
     auto token = mouse.mouse_up +=
@@ -89,8 +89,8 @@ TEST(Mouse, MouseWheelEventRaised)
 
     auto window = create_test_window(L"TRViewInputTests");
     auto mockTester = std::make_unique<MockWindowTester>();
-    EXPECT_CALL(*mockTester, window_under_cursor())
-        .WillRepeatedly(Return(window));
+    EXPECT_CALL(*mockTester, is_window_under_cursor())
+        .WillRepeatedly(Return(true));
     Mouse mouse(window, std::move(mockTester));
 
     auto token = mouse.mouse_wheel +=
@@ -115,8 +115,8 @@ TEST(Mouse, MouseMoveEventRaised)
 
     auto window = create_test_window(L"TRViewInputTests");
     auto mockTester = std::make_unique<MockWindowTester>();
-    EXPECT_CALL(*mockTester, window_under_cursor())
-        .WillRepeatedly(Return(window));
+    EXPECT_CALL(*mockTester, is_window_under_cursor())
+        .WillRepeatedly(Return(true));
     Mouse mouse(window, std::move(mockTester));
 
     auto token = mouse.mouse_move +=
@@ -151,7 +151,7 @@ TEST(Mouse, MousePositionCorrect)
 {
     auto window = create_test_window(L"TRViewInputTests");
     auto mockTester = std::make_unique<MockWindowTester>();
-    EXPECT_CALL(*mockTester, window_under_cursor()).WillRepeatedly(Return(window));
+    EXPECT_CALL(*mockTester, is_window_under_cursor()).WillRepeatedly(Return(true));
     EXPECT_CALL(*mockTester, screen_width(_)).WillRepeatedly(Return(1000));
     EXPECT_CALL(*mockTester, screen_height(_)).WillRepeatedly(Return(1000));
     Mouse mouse(window, std::move(mockTester));

--- a/trview.input.tests/WindowTesterTests.cpp
+++ b/trview.input.tests/WindowTesterTests.cpp
@@ -1,0 +1,28 @@
+#include "gtest/gtest.h"
+#include <trview.input/WindowTester.h>
+#include <trview.tests.common/Window.h>
+
+using namespace trview::tests;
+using namespace trview::input;
+
+/// Tests that the tester notices when the mouse enters the area.
+TEST(WindowTester, MouseMoveDetected)
+{
+    auto tester = WindowTester(create_test_window(L"WindowTesterTests"));
+
+    ASSERT_FALSE(tester.is_window_under_cursor());
+    tester.process_message(WM_MOUSEMOVE, 0, 0);
+    ASSERT_TRUE(tester.is_window_under_cursor());
+}
+
+/// Tests that the tester notices when the mouse leaves the area.
+TEST(WindowTester, MouseExitDetected)
+{
+    auto tester = WindowTester(create_test_window(L"WindowTesterTests"));
+
+    ASSERT_FALSE(tester.is_window_under_cursor());
+    tester.process_message(WM_MOUSEMOVE, 0, 0);
+    ASSERT_TRUE(tester.is_window_under_cursor());
+    tester.process_message(WM_MOUSELEAVE, 0, 0);
+    ASSERT_FALSE(tester.is_window_under_cursor());
+}

--- a/trview.input.tests/trview.input.tests.vcxproj
+++ b/trview.input.tests/trview.input.tests.vcxproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ClCompile Include="KeyboardTests.cpp" />
     <ClCompile Include="MouseTests.cpp" />
+    <ClCompile Include="WindowTesterTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\trview.input\trview.input.vcxproj">

--- a/trview.input.tests/trview.input.tests.vcxproj.filters
+++ b/trview.input.tests/trview.input.tests.vcxproj.filters
@@ -5,6 +5,7 @@
     <ClCompile Include="MouseTests.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest\gtest-all.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc" />
+    <ClCompile Include="WindowTesterTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/trview.input/IWindowTester.h
+++ b/trview.input/IWindowTester.h
@@ -11,8 +11,8 @@ namespace trview
         {
             virtual ~IWindowTester() = 0;
 
-            /// Gets the window that is currently under the cursor.
-            virtual Window window_under_cursor() const = 0;
+            /// Is the window currently under the cursor?
+            virtual bool is_window_under_cursor() const = 0;
 
             /// Gets the screen width - or the virtual screen width if on remote desktop.
             /// @param rdp Whether to check the remote screen size.

--- a/trview.input/Mouse.cpp
+++ b/trview.input/Mouse.cpp
@@ -33,8 +33,7 @@ namespace trview
 
         void Mouse::update_button(Button button, USHORT flags, USHORT down_mask, USHORT up_mask, DWORD& last_down)
         {
-            auto active_window = _window_tester->window_under_cursor();
-            if (active_window == window() && flags & down_mask)
+            if (_window_tester->is_window_under_cursor() && flags & down_mask)
             {
                 last_down = GetTickCount();
                 mouse_down(button);

--- a/trview.input/WindowTester.cpp
+++ b/trview.input/WindowTester.cpp
@@ -5,9 +5,14 @@ namespace trview
 {
     namespace input
     {
-        Window WindowTester::window_under_cursor() const
+        WindowTester::WindowTester(const Window& window)
+            : MessageHandler(window)
         {
-            return trview::window_under_cursor();
+        }
+
+        bool WindowTester::is_window_under_cursor() const
+        {
+            return _mouse_in_window;
         }
 
         int WindowTester::screen_width(bool rdp) const
@@ -18,6 +23,22 @@ namespace trview
         int WindowTester::screen_height(bool rdp) const
         {
             return GetSystemMetrics(rdp ? SM_CYVIRTUALSCREEN : SM_CYSCREEN);
+        }
+
+        void WindowTester::process_message(UINT message, WPARAM wParam, LPARAM lParam)
+        {
+            if (message == WM_MOUSEMOVE && !_mouse_in_window)
+            {
+                _mouse_in_window = true;
+                TRACKMOUSEEVENT track = { sizeof(track) };
+                track.dwFlags = TME_LEAVE;
+                track.hwndTrack = window();
+                TrackMouseEvent(&track);
+            }
+            else if (message == WM_MOUSELEAVE)
+            {
+                _mouse_in_window = false;
+            }
         }
     }
 }

--- a/trview.input/WindowTester.h
+++ b/trview.input/WindowTester.h
@@ -1,18 +1,23 @@
 #pragma once
 
+#include <trview.common/MessageHandler.h>
 #include "IWindowTester.h"
 
 namespace trview
 {
     namespace input
     {
-        class WindowTester final : public IWindowTester
+        class WindowTester final : public MessageHandler, public IWindowTester
         {
         public:
+            explicit WindowTester(const Window& window);
             virtual ~WindowTester() = default;
-            virtual Window window_under_cursor() const override;
+            virtual bool is_window_under_cursor() const override;
             virtual int screen_width(bool rdp) const override;
             virtual int screen_height(bool rdp) const override;
+            virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        private:
+            bool _mouse_in_window{ false };
         };
     }
 }

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -15,7 +15,7 @@ namespace trview
         }
 
         Input::Input(const trview::Window& window, Control& control)
-            : _mouse(window, std::make_unique<input::WindowTester>()), _keyboard(window), _window(window), _control(control)
+            : _mouse(window, std::make_unique<input::WindowTester>(window)), _keyboard(window), _window(window), _control(control)
         {
             register_events();
         }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -35,7 +35,7 @@ namespace trview
 
     Viewer::Viewer(const Window& window)
         : _window(window), _camera(window.size()), _free_camera(window.size()),
-        _timer(default_time_source()), _keyboard(window), _mouse(window, std::make_unique<input::WindowTester>()), _level_switcher(window),
+        _timer(default_time_source()), _keyboard(window), _mouse(window, std::make_unique<input::WindowTester>(window)), _level_switcher(window),
         _window_resizer(window), _recent_files(window), _file_dropper(window), _alternate_group_toggler(window),
         _view_menu(window), _update_checker(window), _menu_detector(window)
     {


### PR DESCRIPTION
Instead of checking which window is under the cursor (which is apparently quite expensive) use `TrackMouseEvent` to be notified when the mouse leaves the client area. This removes the performance issue.
Bug: #604