### PR TITLE
Only trigger click on window activate when client area is clicked

### DIFF
--- a/trview.input/Mouse.cpp
+++ b/trview.input/Mouse.cpp
@@ -106,6 +106,11 @@ namespace trview
             {
                 case WM_MOUSEACTIVATE:
                 {
+                    if (LOWORD(lParam) != HTCLIENT)
+                    {
+                        break;
+                    }
+
                     const auto mouse_message = HIWORD(lParam);
                     if (mouse_message == WM_LBUTTONDOWN)
                     {


### PR DESCRIPTION
Previously it was being triggered even if you clicked on the title bar.
Now only do a mouse event when the client area is activated.
Bug: #606