### PR TITLE
Allow attaching saves to route waypoints

### DIFF
--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -245,6 +245,17 @@ namespace trview
         }
     }
 
+    std::string to_base64(const std::vector<uint8_t>& bytes)
+    {
+        DWORD required_length = 0;
+        CryptBinaryToString(&bytes[0], static_cast<DWORD>(bytes.size()), CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, nullptr, &required_length);
+
+        std::vector<wchar_t> output_string(required_length);
+        CryptBinaryToString(&bytes[0], static_cast<DWORD>(bytes.size()), CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, &output_string[0], &required_length);
+
+        return to_utf8(std::wstring(&output_string[0]));
+    }
+
     void export_route(const Route& route, const std::string& filename)
     {
         try
@@ -269,6 +280,12 @@ namespace trview
                 waypoint_json["room"] = waypoint.room();
                 waypoint_json["index"] = waypoint.index();
                 waypoint_json["notes"] = to_utf8(waypoint.notes());
+
+                auto data = waypoint.save_file();
+                if (!data.empty())
+                {
+                    waypoint_json["save"] = to_base64(data);
+                }
 
                 waypoints.push_back(waypoint_json);
             }

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -38,6 +38,11 @@ namespace trview
 
         std::string to_base64(const std::vector<uint8_t>& bytes)
         {
+            if (bytes.empty())
+            {
+                return std::string();
+            }
+
             DWORD required_length = 0;
             CryptBinaryToString(&bytes[0], static_cast<DWORD>(bytes.size()), CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, nullptr, &required_length);
 

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -298,15 +298,13 @@ namespace trview
                 auto pos = waypoint.position();
                 pos_string << pos.x << "," << pos.y << "," << pos.z;
                 waypoint_json["position"] = pos_string.str();
-
                 waypoint_json["room"] = waypoint.room();
                 waypoint_json["index"] = waypoint.index();
                 waypoint_json["notes"] = to_utf8(waypoint.notes());
 
-                auto data = waypoint.save_file();
-                if (!data.empty())
+                if (waypoint.has_save())
                 {
-                    waypoint_json["save"] = to_base64(data);
+                    waypoint_json["save"] = to_base64(waypoint.save_file());
                 }
 
                 waypoints.push_back(waypoint_json);

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -276,7 +276,7 @@ namespace trview
                 auto pos = waypoint.position();
                 pos_string << pos.x << "," << pos.y << "," << pos.z;
                 waypoint_json["position"] = pos_string.str();
-                
+
                 waypoint_json["room"] = waypoint.room();
                 waypoint_json["index"] = waypoint.index();
                 waypoint_json["notes"] = to_utf8(waypoint.notes());

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -66,6 +66,11 @@ namespace trview
         return _notes;
     }
 
+    std::vector<uint8_t> Waypoint::save_file() const
+    {
+        return _save_data;
+    }
+
     void Waypoint::set_notes(const std::wstring& notes)
     {
         _notes = notes;
@@ -76,7 +81,7 @@ namespace trview
         _route_colour = colour;
     }
 
-    void Waypoint::set_save_file(const std::string& data)
+    void Waypoint::set_save_file(const std::vector<uint8_t>& data)
     {
         _save_data = data;
     }

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -76,6 +76,11 @@ namespace trview
         _route_colour = colour;
     }
 
+    void Waypoint::set_save_file(const std::string& data)
+    {
+        _save_data = data;
+    }
+
     Waypoint::Type waypoint_type_from_string(const std::string& value)
     {
         if (value == "Trigger")

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -51,6 +51,11 @@ namespace trview
         return _type;
     }
 
+    bool Waypoint::has_save() const
+    {
+        return !_save_data.empty();
+    }
+
     uint32_t Waypoint::index() const
     {
         return _index;

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -68,6 +68,8 @@ namespace trview
         /// Get any notes associated with the waypoint.
         std::wstring notes() const;
 
+        std::vector<uint8_t> save_file() const;
+
         /// Set the notes associated with the waypoint.
         /// @param notes The notes to save.
         void set_notes(const std::wstring& notes);
@@ -76,10 +78,10 @@ namespace trview
         /// @param colour The colour of the route.
         void set_route_colour(const Colour& colour);
 
-        void set_save_file(const std::string& data);
+        void set_save_file(const std::vector<uint8_t>& data);
     private:
         std::wstring                 _notes;
-        std::string                  _save_data;
+        std::vector<uint8_t>         _save_data;
         DirectX::SimpleMath::Vector3 _position;
         Mesh*                        _mesh;
         Type                         _type;

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -59,6 +59,9 @@ namespace trview
         /// Get the type of the waypoint.
         Type type() const;
 
+        /// Get whether the waypoint has an attached save file.
+        bool has_save() const;
+
         /// Gets the index of the entity or trigger that the waypoint refers to.
         uint32_t index() const;
 
@@ -68,6 +71,7 @@ namespace trview
         /// Get any notes associated with the waypoint.
         std::wstring notes() const;
 
+        /// Get the contents of the attached save file.
         std::vector<uint8_t> save_file() const;
 
         /// Set the notes associated with the waypoint.
@@ -78,6 +82,7 @@ namespace trview
         /// @param colour The colour of the route.
         void set_route_colour(const Colour& colour);
 
+        /// Set the contents of the attached save file.
         void set_save_file(const std::vector<uint8_t>& data);
     private:
         std::wstring                 _notes;

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -75,8 +75,11 @@ namespace trview
         /// Set the route colour for the waypoint blob.
         /// @param colour The colour of the route.
         void set_route_colour(const Colour& colour);
+
+        void set_save_file(const std::string& data);
     private:
         std::wstring                 _notes;
+        std::string                  _save_data;
         DirectX::SimpleMath::Vector3 _position;
         Mesh*                        _mesh;
         Type                         _type;

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -195,8 +195,30 @@ namespace trview
         _stats = details_panel->add_child(std::move(stats_box));
 
         auto save_area = details_panel->add_child(std::make_unique<StackPanel>(Size(panel_width - 20, 20), Colours::ItemDetails, Size(), StackPanel::Direction::Horizontal, SizeMode::Manual));
+
         auto attach_save = save_area->add_child(std::make_unique<Button>(Size(panel_width - 40, 20), L"Attach Save..."));
+        _token_store += attach_save->on_click += [&]()
+        {
+            OPENFILENAME ofn;
+            memset(&ofn, 0, sizeof(ofn));
+
+            wchar_t path[MAX_PATH];
+            memset(&path, 0, sizeof(path));
+
+            ofn.lStructSize = sizeof(ofn);
+            ofn.lpstrFilter = L"Savegame File\0*.*\0";
+            ofn.nMaxFile = MAX_PATH;
+            ofn.lpstrTitle = L"Select Save";
+            ofn.Flags = OFN_FILEMUSTEXIST;
+            ofn.lpstrFile = path;
+            if (GetOpenFileName(&ofn))
+            {
+                on_save_attached(trview::to_utf8(ofn.lpstrFile));
+            }
+        };
+
         auto clear_save = save_area->add_child(std::make_unique<Button>(Size(20, 20), L"X"));
+        _token_store += clear_save->on_click += [&]() { on_save_cleared(); };
 
         auto delete_button = details_panel->add_child(std::make_unique<Button>(Size(panel_width - 20, 20), L"Delete Waypoint"));
         _token_store += delete_button->on_click += [&]()

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -205,7 +205,7 @@ namespace trview
                 return;
             }
 
-            if (_route->waypoint(_selected_index).save_file().empty())
+            if (!_route->waypoint(_selected_index).has_save())
             {
                 OPENFILENAME ofn;
                 memset(&ofn, 0, sizeof(ofn));
@@ -279,6 +279,17 @@ namespace trview
         _clear_save = save_area->add_child(std::make_unique<Button>(Size(20, 20), L"X"));
         _token_store += _clear_save->on_click += [&]()
         {
+            if (!(_route && _selected_index < _route->waypoints()))
+            {
+                return;
+            }
+
+            auto& waypoint = _route->waypoint(_selected_index);
+            if (waypoint.has_save())
+            {
+                waypoint.set_save_file({});
+                _select_save->set_text(L"Attach Save...");
+            }
         };
 
         _delete_waypoint = details_panel->add_child(std::make_unique<Button>(Size(panel_width - 20, 20), L"Delete Waypoint"));

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -232,15 +232,7 @@ namespace trview
                     {
                         std::vector<uint8_t> bytes(static_cast<uint32_t>(length));
                         infile.read(reinterpret_cast<char*>(&bytes[0]), length);
-
-                        DWORD required_length = 0;
-                        CryptBinaryToString(&bytes[0], static_cast<DWORD>(length), CRYPT_STRING_BASE64, nullptr, &required_length);
-
-                        std::vector<wchar_t> output_string(required_length);
-                        CryptBinaryToString(&bytes[0], static_cast<DWORD>(length), CRYPT_STRING_BASE64, &output_string[0], &required_length);
-
-                        auto final_string = trview::to_utf8(std::wstring(&output_string[0]));
-                        _route->waypoint(_selected_index).set_save_file(final_string);
+                        _route->waypoint(_selected_index).set_save_file(bytes);
                     }
                 }
                 catch(...)

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -161,9 +161,9 @@ namespace trview
         auto right_panel = std::make_unique<StackPanel>(Size(panel_width, window().size().height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
         right_panel->set_margin(Size(0, 8));
 
-        auto group_box = std::make_unique<GroupBox>(Size(panel_width, 140), Colours::ItemDetails, Colours::DetailsBorder, L"Waypoint Details");
+        auto group_box = std::make_unique<GroupBox>(Size(panel_width, 160), Colours::ItemDetails, Colours::DetailsBorder, L"Waypoint Details");
 
-        auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(panel_width - 20, 120), Colours::ItemDetails, Size(0, 8), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(panel_width - 20, 140), Colours::ItemDetails, Size(0, 8), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         auto stats_box = std::make_unique<Listbox>(Point(10, 21), Size(panel_width - 20, 80), Colours::ItemDetails);
         stats_box->set_show_headers(false);
@@ -194,6 +194,10 @@ namespace trview
         };
         _stats = details_panel->add_child(std::move(stats_box));
 
+        auto save_area = details_panel->add_child(std::make_unique<StackPanel>(Size(panel_width - 20, 20), Colours::ItemDetails, Size(), StackPanel::Direction::Horizontal, SizeMode::Manual));
+        auto attach_save = save_area->add_child(std::make_unique<Button>(Size(panel_width - 40, 20), L"Attach Save..."));
+        auto clear_save = save_area->add_child(std::make_unique<Button>(Size(20, 20), L"X"));
+
         auto delete_button = details_panel->add_child(std::make_unique<Button>(Size(panel_width - 20, 20), L"Delete Waypoint"));
         _token_store += delete_button->on_click += [&]()
         {
@@ -207,7 +211,7 @@ namespace trview
         right_panel->add_child(std::move(group_box));
 
         // Notes area.
-        auto notes_box = std::make_unique<GroupBox>(Size(panel_width, window().size().height - 140), Colours::Notes, Colours::DetailsBorder, L"Notes");
+        auto notes_box = std::make_unique<GroupBox>(Size(panel_width, window().size().height - 160), Colours::Notes, Colours::DetailsBorder, L"Notes");
 
         auto notes_area = std::make_unique<TextArea>(Point(10, 21), Size(panel_width - 20, notes_box->size().height - 41), Colours::NotesTextArea, Colour(1.0f, 1.0f, 1.0f));
         _notes_area = notes_box->add_child(std::move(notes_area));

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -241,6 +241,7 @@ namespace trview
                     }
                     catch (...)
                     {
+                        MessageBox(window(), L"Failed to attach save", L"Error", MB_OK);
                     }
                 }
             }
@@ -271,6 +272,7 @@ namespace trview
                     }
                     catch (...)
                     {
+                        MessageBox(window(), L"Failed to export save", L"Error", MB_OK);
                     }
                 }
             }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -197,8 +197,8 @@ namespace trview
 
         auto save_area = details_panel->add_child(std::make_unique<StackPanel>(Size(panel_width - 20, 20), Colours::ItemDetails, Size(), StackPanel::Direction::Horizontal, SizeMode::Manual));
 
-        auto attach_save = save_area->add_child(std::make_unique<Button>(Size(panel_width - 40, 20), L"Attach Save..."));
-        _token_store += attach_save->on_click += [&, attach_save]()
+        _select_save = save_area->add_child(std::make_unique<Button>(Size(panel_width - 40, 20), L"Attach Save..."));
+        _token_store += _select_save->on_click += [&]()
         {
             if (!(_route && _selected_index < _route->waypoints()))
             {
@@ -236,7 +236,7 @@ namespace trview
                             infile.read(reinterpret_cast<char*>(&bytes[0]), length);
                             _route->waypoint(_selected_index).set_save_file(bytes);
 
-                            attach_save->set_text(L"SAVEGAME.0");
+                            _select_save->set_text(L"SAVEGAME.0");
                         }
                     }
                     catch (...)
@@ -276,19 +276,23 @@ namespace trview
             }
         };
 
-        auto clear_save = save_area->add_child(std::make_unique<Button>(Size(20, 20), L"X"));
-        _token_store += clear_save->on_click += [&]()
+        _clear_save = save_area->add_child(std::make_unique<Button>(Size(20, 20), L"X"));
+        _token_store += _clear_save->on_click += [&]()
         {
         };
 
-        auto delete_button = details_panel->add_child(std::make_unique<Button>(Size(panel_width - 20, 20), L"Delete Waypoint"));
-        _token_store += delete_button->on_click += [&]()
+        _delete_waypoint = details_panel->add_child(std::make_unique<Button>(Size(panel_width - 20, 20), L"Delete Waypoint"));
+        _token_store += _delete_waypoint->on_click += [&]()
         {
             if (_route && _selected_index < _route->waypoints())
             {
                 on_waypoint_deleted(_selected_index);
             }
         };
+
+        _select_save->set_visible(false);
+        _clear_save->set_visible(false);
+        _delete_waypoint->set_visible(false);
 
         group_box->add_child(std::move(details_panel));
         right_panel->add_child(std::move(group_box));
@@ -348,8 +352,15 @@ namespace trview
         {
             _stats->set_items({});
             _notes_area->set_text(L"");
+            _select_save->set_visible(false);
+            _clear_save->set_visible(false);
+            _delete_waypoint->set_visible(false);
             return;
         }
+
+        _select_save->set_visible(true);
+        _clear_save->set_visible(true);
+        _delete_waypoint->set_visible(true);
 
         const auto& waypoint = _route->waypoint(index);
         std::vector<Listbox::Item> stats;
@@ -385,6 +396,15 @@ namespace trview
         _stats->set_items(stats);
 
         _notes_area->set_text(waypoint.notes());
+
+        if (waypoint.has_save())
+        {
+            _select_save->set_text(L"SAVEGAME.0");
+        }
+        else
+        {
+            _select_save->set_text(L"Attach Save...");
+        }
     }
 
     void RouteWindow::select_waypoint(uint32_t index)

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -51,12 +51,6 @@ namespace trview
         /// Event raised when a waypoint is deleted.
         Event<uint32_t> on_waypoint_deleted;
 
-        /// Event raised when a save file is attached.
-        Event<std::string> on_save_attached;
-
-        /// Event raised when a save file is cleared.
-        Event<> on_save_cleared;
-
         /// Select the specified waypoint.
         /// @param index The index of the waypoint to select.
         void select_waypoint(uint32_t index);

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -51,6 +51,12 @@ namespace trview
         /// Event raised when a waypoint is deleted.
         Event<uint32_t> on_waypoint_deleted;
 
+        /// Event raised when a save file is attached.
+        Event<std::string> on_save_attached;
+
+        /// Event raised when a save file is cleared.
+        Event<> on_save_cleared;
+
         /// Select the specified waypoint.
         /// @param index The index of the waypoint to select.
         void select_waypoint(uint32_t index);

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -72,6 +72,9 @@ namespace trview
         ui::Listbox* _waypoints;
         ui::Listbox* _stats;
         ui::TextArea* _notes_area;
+        ui::Button* _select_save;
+        ui::Button* _delete_waypoint;
+        ui::Button* _clear_save;
         Route* _route{ nullptr };
         std::vector<Item> _all_items;
         std::vector<Trigger*> _all_triggers;

--- a/trview/trview.vcxproj
+++ b/trview/trview.vcxproj
@@ -95,7 +95,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;winhttp.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;winhttp.lib;version.lib;Crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(SolutionDir);</AdditionalIncludeDirectories>
@@ -117,7 +117,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;winhttp.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;winhttp.lib;version.lib;Crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(SolutionDir);</AdditionalIncludeDirectories>
@@ -143,7 +143,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;winhttp.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;winhttp.lib;version.lib;Crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(SolutionDir);</AdditionalIncludeDirectories>
@@ -169,7 +169,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;winhttp.lib;version.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;winhttp.lib;version.lib;Crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(SolutionDir);</AdditionalIncludeDirectories>


### PR DESCRIPTION
Allow user to attach a save to a waypoint.
The save is listed in the route window and can be exported.
The save is embedded as base64 in the route file when the route is exported.
Issue: #615 