### PR TITLE
Set focus to main window when child window closes

### DIFF
--- a/trview.app/Windows/CollapsiblePanel.cpp
+++ b/trview.app/Windows/CollapsiblePanel.cpp
@@ -70,7 +70,7 @@ namespace trview
 
     CollapsiblePanel::CollapsiblePanel(Device& device, const IShaderStorage& shader_storage, const FontFactory& font_factory, const Window& parent, const std::wstring& window_class, const std::wstring& title, const Size& size)
         : MessageHandler(create_window(parent, window_class, title, size)), _window_resizer(window()), _device_window(device.create_for_window(window())),
-        _ui_renderer(std::make_unique<render::Renderer>(device, shader_storage, font_factory, window().size()))
+        _ui_renderer(std::make_unique<render::Renderer>(device, shader_storage, font_factory, window().size())), _parent(parent)
     {
         _token_store += _window_resizer.on_resize += [=]()
         {
@@ -103,6 +103,7 @@ namespace trview
         if (message == WM_CLOSE)
         {
             on_window_closed();
+            SetFocus(_parent);
         }
         else if (message == WM_GETMINMAXINFO)
         {

--- a/trview.app/Windows/CollapsiblePanel.h
+++ b/trview.app/Windows/CollapsiblePanel.h
@@ -89,6 +89,7 @@ namespace trview
         std::unique_ptr<ui::Control> create_divider();
         void register_change_detection(ui::Control* control);
 
+        Window _parent;
         std::unique_ptr<graphics::DeviceWindow> _device_window;
         std::unique_ptr<ui::render::Renderer>   _ui_renderer;
         ui::StackPanel* _panels;


### PR DESCRIPTION
Sometimes closing the child window would make a different application be the focus window - usually after a file open dialog was used.
Set the focus to be the main window when we get the close message in the child window.
Bug: #622