### PR TITLE
Detatch LabelNode when Label is destroyed

### DIFF
--- a/trview.ui.render/LabelNode.cpp
+++ b/trview.ui.render/LabelNode.cpp
@@ -23,11 +23,18 @@ namespace trview
                     };
                 }
                 _label->set_measurer(this);
+                _token_store += _label->on_deleting += [&]()
+                {
+                    _label = nullptr;
+                };
             }
 
             LabelNode::~LabelNode()
             {
-                _label->set_measurer(nullptr);
+                if (_label)
+                {
+                    _label->set_measurer(nullptr);
+                }
             }
 
             Size LabelNode::measure(const std::wstring& text) const
@@ -43,6 +50,11 @@ namespace trview
             void LabelNode::render_self(const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context, graphics::Sprite& sprite)
             {
                 WindowNode::render_self(context, sprite);
+                if (!_label)
+                {
+                    return;
+                }
+
                 const auto size = _label->size();
                 _font->render(context, _label->text(), size.width, size.height, _label->text_colour());
             }
@@ -51,6 +63,11 @@ namespace trview
             // resize the label if the label has been set to auto size mode.
             void LabelNode::generate_font_texture()
             {
+                if (!_label)
+                {
+                    return;
+                }
+
                 if (_label->size_mode() == SizeMode::Auto)
                 {
                     auto new_size = _font->measure(_label->text());

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -142,16 +142,32 @@ namespace trview
 
         void TextArea::set_text(const std::wstring& text)
         {
-            while (!_lines.empty())
-            {
-                remove_line(false);
-            }
-
             std::wstringstream stream(text);
+            std::vector<std::wstring> newlines;
             std::wstring line;
             while (std::getline(stream, line, L'\n'))
             {
-                add_line(line, false);
+                newlines.push_back(line);
+            }
+
+            if (newlines.size() == _lines.size())
+            {
+                for (std::size_t i = 0; i < newlines.size(); ++i)
+                {
+                    _lines[i]->set_text(newlines[i]);
+                }
+            }
+            else
+            {
+                while (!_lines.empty())
+                {
+                    remove_line(false);
+                }
+
+                for (const auto& line : newlines)
+                {
+                    add_line(line, false);
+                }
             }
 
             _cursor_line = _lines.empty() ? 0 : _lines.size() - 1;


### PR DESCRIPTION
LabelNode now listens to when labels are destroyed and will remove the reference to the label and no longer attempt to access it.
This stops a crash to do with the alternate group labels being destroyed.
Also altered TextArea to only add and remove lines if the line count is different - this makes the debug performance way better just because of the tooltip not regenerating all lines all the time.
Bug: #630