### PR TITLE
Clear selected entities in trigger and item windows when instructed

### DIFF
--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -52,6 +52,7 @@ namespace trview
 
     void ItemsWindow::clear_selected_item()
     {
+        _selected_item.reset();
         _stats_list->set_items({});
     }
 

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -229,6 +229,9 @@ namespace trview
 
     void TriggersWindow::clear_selected_trigger()
     {
+        _selected_trigger.reset();
+        _stats_list->set_items({});
+        _command_list->set_items({});
     }
 
     void TriggersWindow::populate_triggers(const std::vector<Trigger*>& triggers)


### PR DESCRIPTION
Actually put some code inside the function to clear selected trigger.
This will stop the trigger window trying to access triggers from previous levels.
Also add the same to items window as it references triggers indirectly.
Closes #639
