### PR TITLE
Allow cycling through orbit positions with - and +

### DIFF
--- a/trview.app/Geometry/PickResult.h
+++ b/trview.app/Geometry/PickResult.h
@@ -25,6 +25,7 @@ namespace trview
         uint32_t                     index{ 0u };
         bool                         stop{ false };
         std::wstring                 text;
+        bool                         override_centre{ false };
     };
 
     /// Convert the pick result to a display string.

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -206,7 +206,7 @@ namespace trview
     bool ViewerUI::is_input_active() const
     {
         const auto focus = _ui_input->focus_control();
-        return focus && focus->visible() && focus->handles_input();
+        return focus && focus->visible(true) && focus->handles_input();
     }
 
     bool ViewerUI::is_cursor_over() const

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -72,8 +72,12 @@ namespace trview
             return _size;
         }
 
-        bool Control::visible() const
+        bool Control::visible(bool check_tree) const
         {
+            if (check_tree && _parent)  
+            {
+                return _parent->visible(true) && _visible;
+            }
             return _visible;
         }
 

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -65,8 +65,9 @@ namespace trview
             /// Gets whether the control and its child controls are visible. Invisible
             /// controls will not be rendered and will not accept input.
             /// To set the visibility state of a control, use set_visible(bool);
+            /// @param check_tree Whether to check up from this control.
             /// @returns Whether the control is visible.
-            bool visible() const;
+            bool visible(bool check_tree = false) const;
 
             /// Sets whether the control and its child controls are visible. Invisible
             /// controls will not be rendered and will not accept input.

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -161,6 +161,7 @@ namespace trview
 
             auto stored_pick = _context_pick;
             stored_pick.override_centre = true;
+            stored_pick.type = PickResult::Type::Room;
             add_recent_orbit(stored_pick);
         };
         _token_store += _ui->on_settings += [&](auto settings) { _settings = settings; };

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -112,6 +112,7 @@ namespace trview
         void add_recent_orbit(const PickResult& pick);
         void select_previous_orbit();
         void select_next_orbit();
+        void select_pick(const PickResult& pick);
 
         graphics::Device _device;
         std::unique_ptr<graphics::DeviceWindow> _main_window;

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -109,6 +109,9 @@ namespace trview
         void set_show_hidden_geometry(bool show);
         void set_show_water(bool show);
         uint32_t room_from_pick(const PickResult& pick) const;
+        void add_recent_orbit(const PickResult& pick);
+        void select_previous_orbit();
+        void select_next_orbit();
 
         graphics::Device _device;
         std::unique_ptr<graphics::DeviceWindow> _main_window;
@@ -166,6 +169,9 @@ namespace trview
 
         UpdateChecker _update_checker;
         std::unique_ptr<ITypeNameLookup> _type_name_lookup;
+
+        std::vector<PickResult> _recent_orbits;
+        std::size_t _recent_orbit_index{ 0u };
     };
 }
 


### PR DESCRIPTION
Record orbit positions when something is orbited (positions, items etc).
User can press - and + to cycle through them.
Closes #641 