### PR TITLE
Ignore minimap hovering when minimap is not visible

### DIFF
--- a/trview.ui.render/MapRenderer.cpp
+++ b/trview.ui.render/MapRenderer.cpp
@@ -214,6 +214,10 @@ namespace trview
             std::shared_ptr<Sector> 
             MapRenderer::sector_at_cursor() const
             {
+                if (!_visible)
+                {
+                    return nullptr;
+                }
                 return sector_at(_cursor);
             }
 


### PR DESCRIPTION
If the minimap is not visible, don't raise events.
Closes #643