### PR TITLE
Stop adding X and Y coordinate value to UVs

### DIFF
--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -895,9 +895,20 @@ namespace trlevel
         {
             std::vector<int16_t> sound_map = read_vector<int16_t>(file, 256);
         }
-        else if (_version < LevelVersion::Tomb5)
+        else if (_version < LevelVersion::Tomb4)
         {
             std::vector<int16_t> sound_map = read_vector<int16_t>(file, 370);
+        }
+        else if (_version == LevelVersion::Tomb4)
+        {
+            if (demo_data.size() == 2048)
+            {
+                std::vector<int16_t> sound_map = read_vector<int16_t>(file, 1024);
+            }
+            else
+            {
+                std::vector<int16_t> sound_map = read_vector<int16_t>(file, 370);
+            }
         }
         else
         {

--- a/trview.app/Graphics/LevelTextureStorage.cpp
+++ b/trview.app/Graphics/LevelTextureStorage.cpp
@@ -52,7 +52,7 @@ namespace trview
     {
         using namespace DirectX::SimpleMath;
         const auto& vert = _object_textures[texture_index].Vertices[uv_index];
-        return Vector2(static_cast<float>(vert.Xpixel + vert.Xcoordinate), static_cast<float>(vert.Ypixel + vert.Ycoordinate)) / 255.0f;
+        return Vector2(static_cast<float>(vert.Xpixel), static_cast<float>(vert.Ypixel)) / 255.0f;
     }
 
     uint32_t LevelTextureStorage::tile(uint32_t texture_index) const


### PR DESCRIPTION
For some reason I was adding the XCoordinate and YCoordinate values on to the UV coordinates for textures. This doesn't normally cause an issue because they tend to be 0, but in the winter level, they were 127. The renderer is set up to clamp UV coordinates, so they were just using the bottom right of the texture, which was a transparent pixel.

Also take fix from @sapper-trle for loading v130 sound maps.

Closes #620