### PR TITLE
Give Group Box a built-in child area

### DIFF
--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -1,5 +1,6 @@
 #define NOMINMAX
 #include "Sector.h"
+#include <stdexcept>
 
 namespace trview
 {

--- a/trview.app/UI/CameraControls.cpp
+++ b/trview.app/UI/CameraControls.cpp
@@ -14,21 +14,21 @@ namespace trview
 
         auto camera_window = std::make_unique<GroupBox>(Size(150, 92), Colour::Transparent, Colour::Grey, L"Camera");
 
-        auto reset_camera = std::make_unique<Button>(Point(12, 20), Size(16, 16));
+        auto reset_camera = std::make_unique<Button>(Size(16, 16));
         reset_camera->on_click += on_reset;
 
-        auto reset_camera_label = std::make_unique<Label>(Point(30, 20), Size(40, 16), Colour::Transparent, L"Reset", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Centre);
+        auto reset_camera_label = std::make_unique<Label>(Point(20, 0), Size(40, 16), Colour::Transparent, L"Reset", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Centre);
 
-        auto orbit_camera = std::make_unique<Checkbox>(Point(86, 20), Colour::Transparent, L"Orbit");
+        auto orbit_camera = std::make_unique<Checkbox>(Point(74, 0), Colour::Transparent, L"Orbit");
         _token_store += orbit_camera->on_state_changed += [&](auto) { change_mode(CameraMode::Orbit); };
 
-        auto free_camera = std::make_unique<Checkbox>(Point(12, 42), Colour::Transparent, L"Free");
+        auto free_camera = std::make_unique<Checkbox>(Point(0, 21), Colour::Transparent, L"Free");
         _token_store += free_camera->on_state_changed += [&](auto) { change_mode(CameraMode::Free); };
 
-        auto axis_camera = std::make_unique<Checkbox>(Point(86, 42), Colour::Transparent, L"Axis");
+        auto axis_camera = std::make_unique<Checkbox>(Point(74, 21), Colour::Transparent, L"Axis");
         _token_store += axis_camera->on_state_changed += [&](auto) { change_mode(CameraMode::Axis); };
 
-        auto ortho = std::make_unique<Checkbox>(Point(12, 64), Colour::Transparent, L"Ortho");
+        auto ortho = std::make_unique<Checkbox>(Point(0, 43), Colour::Transparent, L"Ortho");
         _token_store += ortho->on_state_changed += [&](auto ortho_enabled) { change_projection(ortho_enabled ? ProjectionMode::Orthographic : ProjectionMode::Perspective); };
 
         camera_window->add_child(std::move(reset_camera));

--- a/trview.app/UI/GoTo.cpp
+++ b/trview.app/UI/GoTo.cpp
@@ -9,8 +9,8 @@ namespace trview
     namespace
     {
         const float WindowWidth = 87.0f;
-        const float WindowHeight = 50.0f;
-        const float Width = 50.0f;
+        const float WindowHeight = 60.0f;
+        const float Width = 57.0f;
         const float Height = 20.0f;
     }
 
@@ -34,7 +34,6 @@ namespace trview
             L"Go to Room");
 
         auto text_area = std::make_unique<TextArea>(
-            Point((WindowWidth - 10) / 2.0f - Width / 2.0f, (WindowHeight) / 2.0f - Height / 2.0f + 2),
             Size(Width, Height),
             Colour(1.0f, 0.2f, 0.2f, 0.2f),
             Colour::White,

--- a/trview.app/UI/RoomNavigator.cpp
+++ b/trview.app/UI/RoomNavigator.cpp
@@ -16,23 +16,23 @@ namespace trview
     {
         using namespace ui;
 
-        auto rooms_groups = std::make_unique<GroupBox>(Size(150, 90), Colour::Transparent, Colour::Grey, L"Room");
+        auto rooms_groups = std::make_unique<GroupBox>(Size(150, 100), Colour::Transparent, Colour::Grey, L"Room");
 
-        auto room_controls = std::make_unique<StackPanel>(Point(4, 12), Size(140, 30), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
+        auto room_controls = std::make_unique<StackPanel>(Size(130, 30), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
         _current = room_controls->add_child(std::make_unique<NumericUpDown>(Size(50, 20), Colour::Transparent, texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 0));
         _current->on_value_changed += on_room_selected;
 
-        room_controls->add_child(std::make_unique<Label>(Size(40, 20), Colour::Transparent, L"of", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
+        room_controls->add_child(std::make_unique<Label>(Size(30, 20), Colour::Transparent, L"of", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
         _max = room_controls->add_child(std::make_unique<Label>(Size(50, 20), Colour::Transparent, L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
         rooms_groups->add_child(std::move(room_controls));
 
-        auto listbox = std::make_unique<Listbox>(Point(4, 36), Size(140, 80), Colour::Transparent);
+        auto listbox = std::make_unique<Listbox>(Point(0, 25), Size(130, 80), Colour::Transparent);
         listbox->set_show_scrollbar(false);
         listbox->set_show_headers(false);
         listbox->set_columns(
             {
                 { Listbox::Column::Type::String, L"Name", 50 },
-                { Listbox::Column::Type::String, L"Value", 90 }
+                { Listbox::Column::Type::String, L"Value", 80 }
             });
         _listbox = rooms_groups->add_child(std::move(listbox));
         parent.add_child(std::move(rooms_groups));

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -20,11 +20,11 @@ namespace trview
         using namespace ui;
 
         auto rooms_groups = std::make_unique<GroupBox>(Size(150, 130), Colour::Transparent, Colour::Grey, L"View Options");
-        auto highlight = std::make_unique<Checkbox>(Point(12, 20), Colour::Transparent, L"Highlight");
-        auto triggers = std::make_unique<Checkbox>(Point(86, 20), Colour::Transparent, L"Triggers");
+        auto highlight = std::make_unique<Checkbox>(Colour::Transparent, L"Highlight");
+        auto triggers = std::make_unique<Checkbox>(Point(74, 0), Colour::Transparent, L"Triggers");
         triggers->set_state(true);
-        auto hidden_geometry = std::make_unique<Checkbox>(Point(12, 45), Colour::Transparent, L"Geometry");
-        auto water = std::make_unique<Checkbox>(Point(86, 45), Colour::Transparent, L"Water");
+        auto hidden_geometry = std::make_unique<Checkbox>(Point(0, 24), Colour::Transparent, L"Geometry");
+        auto water = std::make_unique<Checkbox>(Point(74, 24), Colour::Transparent, L"Water");
         water->set_state(true);
 
         highlight->on_state_changed += on_highlight;
@@ -32,10 +32,10 @@ namespace trview
         hidden_geometry->on_state_changed += on_show_hidden_geometry;
         water->on_state_changed += on_show_water;
 
-        auto enabled = std::make_unique<Checkbox>(Point(12, 70), Colour::Transparent, L"Depth");
+        auto enabled = std::make_unique<Checkbox>(Point(0, 49), Colour::Transparent, L"Depth");
         enabled->on_state_changed += on_depth_enabled;
 
-        auto depth = std::make_unique<NumericUpDown>(Point(86, 70), Size(50, 20), Colour::Transparent, texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 20);
+        auto depth = std::make_unique<NumericUpDown>(Point(75, 49), Size(50, 20), Colour::Transparent, texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 20);
         depth->set_value(1);
         depth->on_value_changed += on_depth_changed;
 
@@ -52,14 +52,14 @@ namespace trview
 
         // Add two methods of controlling flipmaps:
         // The TR1-3 method:
-        auto tr1_3_panel = std::make_unique<ui::Window>(Point(12, 96), panel_size, Colour::Transparent);
+        auto tr1_3_panel = std::make_unique<ui::Window>(Point(0, 75), panel_size, Colour::Transparent);
         auto flip = std::make_unique<Checkbox>(Colour::Transparent, L"Flip");
         flip->on_state_changed += on_flip;
         _flip = tr1_3_panel->add_child(std::move(flip));
         _tr1_3_panel = rooms_groups->add_child(std::move(tr1_3_panel));
 
         // The TR4-5 method:
-        auto tr4_5_panel = std::make_unique<ui::Window>(Point(12, 96), panel_size, Colour::Transparent);
+        auto tr4_5_panel = std::make_unique<ui::Window>(Point(0, 75), panel_size, Colour::Transparent);
         auto alternate_groups = std::make_unique<StackPanel>(Size(140, 16), Colour::Transparent, Size(), StackPanel::Direction::Horizontal, SizeMode::Manual);
         _alternate_groups = tr4_5_panel->add_child(std::move(alternate_groups));
         tr4_5_panel->set_visible(false);

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -160,7 +160,7 @@ namespace trview
         auto right_panel = std::make_unique<StackPanel>(Size(200, height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
         auto group_box = std::make_unique<GroupBox>(Size(200, 220), Colours::ItemDetails, Colours::DetailsBorder, L"Item Details");
 
-        auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(180, 210), Colours::ItemDetails, Size(0, 8), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto details_panel = std::make_unique<StackPanel>(Size(180, 210), Colours::ItemDetails, Size(0, 8), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Add some information about the selected item.
         auto stats_list = std::make_unique<Listbox>(Size(180, 160), Colours::ItemDetails);
@@ -195,7 +195,7 @@ namespace trview
         // Add the trigger details group box.
         auto trigger_group_box = std::make_unique<GroupBox>(Size(200, 170), Colours::Triggers, Colours::DetailsBorder, L"Triggered By");
 
-        auto trigger_list = std::make_unique<Listbox>(Point(10, 21), Size(190, 130), Colours::Triggers);
+        auto trigger_list = std::make_unique<Listbox>(Size(190, 130), Colours::Triggers);
         trigger_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 25 },

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -214,7 +214,7 @@ namespace trview
         using namespace ui;
 
         auto group_box = std::make_unique<GroupBox>(Size(190, 140), Colours::ItemDetails, Colours::DetailsBorder, L"Neighbours");
-        auto neighbours_list = std::make_unique<Listbox>(Point(10, 21), Size(180, 140 - 21), Colours::LeftPanel);
+        auto neighbours_list = std::make_unique<Listbox>(Size(180, 140 - 21), Colours::LeftPanel);
         neighbours_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 170 }
@@ -235,7 +235,7 @@ namespace trview
         using namespace ui;
 
         auto group_box = std::make_unique<GroupBox>(Size(190, 150), Colours::ItemDetails, Colours::DetailsBorder, L"Items");
-        auto items_list = std::make_unique<Listbox>(Point(10, 21), Size(180, 150 - 21), Colours::LeftPanel);
+        auto items_list = std::make_unique<Listbox>(Size(180, 150 - 21), Colours::LeftPanel);
         items_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 30 },
@@ -256,7 +256,7 @@ namespace trview
         using namespace ui;
 
         auto group_box = std::make_unique<GroupBox>(Size(190, 140), Colours::ItemDetails, Colours::DetailsBorder, L"Triggers");
-        auto triggers_list = std::make_unique<Listbox>(Point(10, 21), Size(180, 140 - 21), Colours::LeftPanel);
+        auto triggers_list = std::make_unique<Listbox>(Size(180, 140 - 21), Colours::LeftPanel);
         triggers_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 30 },
@@ -418,7 +418,7 @@ namespace trview
         upper_panel->set_margin(Size(5, 5));
 
         auto minimap_group = std::make_unique<GroupBox>(Size(370, 370), Colours::Triggers, Colours::DetailsBorder, L"Minimap");
-        _minimap = minimap_group->add_child(std::make_unique<ui::Image>(Point(10, 21), Size(341, 341)));
+        _minimap = minimap_group->add_child(std::make_unique<ui::Image>(Size(341, 341)));
         _map_tooltip = std::make_unique<Tooltip>(*minimap_group);
         upper_panel->add_child(std::move(minimap_group));
 
@@ -432,7 +432,7 @@ namespace trview
 
         auto lower_left = std::make_unique<StackPanel>(Size(190, 300), Colours::ItemDetails, Size(0, 2), StackPanel::Direction::Vertical, SizeMode::Manual);
         auto room_stats = std::make_unique<GroupBox>(Size(190, 150), Colours::ItemDetails, Colours::DetailsBorder, L"Room Details");
-        _stats_box = room_stats->add_child(std::make_unique<Listbox>(Point(10, 21), Size(180, 150), Colours::LeftPanel));
+        _stats_box = room_stats->add_child(std::make_unique<Listbox>(Size(180, 150), Colours::LeftPanel));
         _stats_box->set_columns(
             {
                 { Listbox::Column::Type::String, L"Name", 100 },

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -164,9 +164,9 @@ namespace trview
 
         auto group_box = std::make_unique<GroupBox>(Size(panel_width, 160), Colours::ItemDetails, Colours::DetailsBorder, L"Waypoint Details");
 
-        auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(panel_width - 20, 140), Colours::ItemDetails, Size(0, 8), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto details_panel = std::make_unique<StackPanel>(Size(panel_width - 20, 140), Colours::ItemDetails, Size(0, 8), StackPanel::Direction::Vertical, SizeMode::Manual);
 
-        auto stats_box = std::make_unique<Listbox>(Point(10, 21), Size(panel_width - 20, 80), Colours::ItemDetails);
+        auto stats_box = std::make_unique<Listbox>(Size(panel_width - 20, 80), Colours::ItemDetails);
         stats_box->set_show_headers(false);
         stats_box->set_show_scrollbar(false);
         stats_box->set_columns(
@@ -313,7 +313,7 @@ namespace trview
         // Notes area.
         auto notes_box = std::make_unique<GroupBox>(Size(panel_width, window().size().height - 160), Colours::Notes, Colours::DetailsBorder, L"Notes");
 
-        auto notes_area = std::make_unique<TextArea>(Point(10, 21), Size(panel_width - 20, notes_box->size().height - 41), Colours::NotesTextArea, Colour(1.0f, 1.0f, 1.0f));
+        auto notes_area = std::make_unique<TextArea>(Size(panel_width - 20, notes_box->size().height - 41), Colours::NotesTextArea, Colour(1.0f, 1.0f, 1.0f));
         _notes_area = notes_box->add_child(std::move(notes_area));
 
         right_panel->add_child(std::make_unique<ui::Window>(Size(panel_width, 5), Colours::Notes));

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -142,7 +142,7 @@ namespace trview
         auto right_panel = std::make_unique<StackPanel>(Size(panel_width, window().size().height), Colours::ItemDetails, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
         auto group_box = std::make_unique<GroupBox>(Size(panel_width, 190), Colours::ItemDetails, Colours::DetailsBorder, L"Trigger Details");
 
-        auto details_panel = std::make_unique<StackPanel>(Point(10, 21), Size(panel_width - 20, 160), Colours::ItemDetails, Size(0, 16), StackPanel::Direction::Vertical, SizeMode::Manual);
+        auto details_panel = std::make_unique<StackPanel>(Size(panel_width - 20, 160), Colours::ItemDetails, Size(0, 16), StackPanel::Direction::Vertical, SizeMode::Manual);
 
         // Add some information about the selected item.
         auto stats_list = std::make_unique<Listbox>(Size(panel_width - 20, 120), Colours::ItemDetails);
@@ -177,7 +177,7 @@ namespace trview
         // Add the trigger details group box.
         auto command_group_box = std::make_unique<GroupBox>(Size(panel_width, 200), Colours::Triggers, Colours::DetailsBorder, L"Commands");
 
-        auto command_list = std::make_unique<Listbox>(Point(10, 21), Size(panel_width - 20, 160), Colours::Triggers);
+        auto command_list = std::make_unique<Listbox>(Size(panel_width - 20, 160), Colours::Triggers);
         command_list->set_columns(
             {
                 { Listbox::Column::Type::String, L"Type", 80 },

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -246,10 +246,21 @@ namespace trview
             on_invalidate();
         }
 
-        void Control::remove_child(Control* child_element)
+        std::unique_ptr<Control> Control::remove_child(Control* child_element)
         {
-            _child_elements.erase(std::remove_if(_child_elements.begin(), _child_elements.end(), [&](const auto& element) { return element.get() == child_element; }), _child_elements.end());
-            on_hierarchy_changed();
+            std::unique_ptr<Control> child;
+            for (auto i = 0u; i < _child_elements.size(); ++i)
+            {
+                auto& element = _child_elements[i];
+                if (element.get() == child_element)
+                {
+                    child = std::move(element);
+                    _child_elements.erase(_child_elements.begin() + i);
+                    on_hierarchy_changed();
+                    break;
+                }
+            }
+            return child;
         }
 
         void Control::set_input_query(IInputQuery* query)

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -151,7 +151,7 @@ namespace trview
 
             /// Remove the specified child element.
             /// @param child_element The element to remove.
-            void remove_child(Control* child_element);
+            std::unique_ptr<Control> remove_child(Control* child_element);
 
             /// Event raised when a child is added.
             Event<Control*> on_add_child;

--- a/trview.ui/GroupBox.cpp
+++ b/trview.ui/GroupBox.cpp
@@ -33,6 +33,9 @@ namespace trview
                 _top_right->set_position(_label->position() + Point(new_size.width + 1, 5));
                 _top_right->set_size(Size(this->size().width - _top_right->position().x - 1, 2));
             };
+
+            // Inner area.
+            _area = add_child(std::make_unique<Window>(Point(10, 21), size - Size(10, 21), background_colour));
         }
 
         std::wstring GroupBox::title() const
@@ -43,6 +46,17 @@ namespace trview
         void GroupBox::set_title(const std::wstring& title)
         {
             _label->set_text(title);
+        }
+
+        void GroupBox::inner_add_child(Control* child_element)
+        {
+            if (_area == nullptr)
+            {
+                return;
+            }
+
+            auto child = remove_child(child_element);
+            _area->add_child(std::move(child));
         }
     }
 }

--- a/trview.ui/GroupBox.h
+++ b/trview.ui/GroupBox.h
@@ -15,10 +15,13 @@ namespace trview
             GroupBox(const Point& point, const Size& size, const Colour& background_colour, const Colour& border_colour, const std::wstring& text);
             std::wstring title() const;
             void set_title(const std::wstring& title);
+        protected:
+            virtual void inner_add_child(Control* child_element) override;
         private:
             Colour _border_colour;
             Window* _top_right;
             Label* _label;
+            Control* _area{ nullptr };
         };
     }
 }


### PR DESCRIPTION
This means that the users of the `GroupBox` don't have to put the first control at 10, 21 all the time.
Update all the places where `GroupBox` is used to that effect.
Closes #648 