### PR TITLE
Tweaks for background colour dialog

### DIFF
--- a/trview.app/Menus/ViewMenu.cpp
+++ b/trview.app/Menus/ViewMenu.cpp
@@ -138,12 +138,16 @@ namespace trview
                 static DWORD rgb;
                 static COLORREF custColours[16];
                 CHOOSECOLOR cc;
+                static COLORREF defaultColours[16];
+                defaultColours[0] = 0x663300;
 
                 ZeroMemory(&cc, sizeof(cc));
                 cc.lStructSize = sizeof(cc);
                 cc.rgbResult = rgb;
                 cc.Flags = CC_ANYCOLOR | CC_RGBINIT | CC_FULLOPEN;
                 cc.lpCustColors = custColours;
+                cc.hwndOwner = window();
+                cc.lpCustColors = defaultColours;
 
                 if (ChooseColor(&cc) == TRUE)
                 {


### PR DESCRIPTION
Make the dialog a child of the main viewer window.
Add the default background to the default colours.
Closes #646