### PR TITLE
Hide measure label when behind camera

### DIFF
--- a/trview.app/Tools/Measure.cpp
+++ b/trview.app/Tools/Measure.cpp
@@ -59,6 +59,18 @@ namespace trview
         using namespace DirectX::SimpleMath;
 
         auto to = _end.value() - _start.value();
+        auto halfway = Vector3::Lerp(_start.value(), _end.value(), 0.5f);
+
+        auto from_camera = halfway - camera.position();
+        from_camera.Normalize();
+        if (camera.forward().Dot(from_camera) < 0)
+        {
+            on_visible(false);
+            return;
+        }
+
+        on_visible(true);
+
         const auto scale = Matrix::CreateScale(0.05f);
         const auto view_projection = camera.view_projection();
 
@@ -75,7 +87,7 @@ namespace trview
         auto wvp = scale * Matrix::CreateTranslation(_end.value()) * view_projection;
         _mesh->render(context, wvp, texture_storage, Color(1.0f, 1.0f, 1.0f));
 
-        auto halfway = Vector3::Lerp(_start.value(), _end.value(), 0.5f);
+        
         const auto window_size = camera.view_size();
 
         Vector3 point = XMVector3Project(halfway, 0, 0, window_size.width, window_size.height, 0, 1.0f, camera.projection(), camera.view(), Matrix::Identity);

--- a/trview.app/Tools/Measure.cpp
+++ b/trview.app/Tools/Measure.cpp
@@ -87,7 +87,6 @@ namespace trview
         auto wvp = scale * Matrix::CreateTranslation(_end.value()) * view_projection;
         _mesh->render(context, wvp, texture_storage, Color(1.0f, 1.0f, 1.0f));
 
-        
         const auto window_size = camera.view_size();
 
         Vector3 point = XMVector3Project(halfway, 0, 0, window_size.width, window_size.height, 0, 1.0f, camera.projection(), camera.view(), Matrix::Identity);

--- a/trview.app/Windows/CollapsiblePanel.cpp
+++ b/trview.app/Windows/CollapsiblePanel.cpp
@@ -107,7 +107,7 @@ namespace trview
         }
         else if (message == WM_GETMINMAXINFO)
         {
-            RECT rect{ 0, 0, static_cast<LONG>(_ui->size().width), _initial_size.height };
+            RECT rect{ 0, 0, static_cast<LONG>(_ui->size().width), static_cast<LONG>(_initial_size.height) };
             AdjustWindowRect(&rect, window_style, FALSE);
 
             MINMAXINFO* info = reinterpret_cast<MINMAXINFO*>(lParam);


### PR DESCRIPTION
Don't render the measure label when it is behind the camera.
Previously it was being projected back on to the screen even though it was behind the camera.
Now does a dot product to check.
Closes #647 