### PR TITLE
Show booleans in rooms window as true/false instead of 1/0

### DIFF
--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -7,6 +7,7 @@
 #include <trview.ui/Checkbox.h>
 #include <trview.ui/GroupBox.h>
 #include <trview.ui/Button.h>
+#include <trview.common/Strings.h>
 
 using namespace trview::graphics;
 
@@ -222,21 +223,6 @@ namespace trview
 
     void ItemsWindow::load_item_details(const Item& item)
     {
-        auto format_bool = [](bool value)
-        {
-            std::wstringstream stream;
-            stream << std::boolalpha << value;
-            return stream.str();
-        };
-
-        auto format_binary = [](uint16_t value)
-        {
-            std::wstringstream stream;
-            stream << std::bitset<5>(value);
-            const auto result = stream.str();
-            return std::wstring(result.rbegin(), result.rend());
-        };
-
         auto make_item = [](const auto& name, const auto& value)
         {
             return Listbox::Item { { { L"Name", name }, { L"Value", value } } };

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -5,6 +5,7 @@
 #include <trview.app/Elements/Room.h>
 #include <trview.app/Elements/Item.h>
 #include <trview.app/Elements/Trigger.h>
+#include <trview.common/Strings.h>
 #include <numeric>
 
 namespace trview
@@ -367,8 +368,8 @@ namespace trview
         stats.push_back(make_item(L"X", std::to_wstring(room.info().x)));
         stats.push_back(make_item(L"Y", std::to_wstring(room.info().yBottom)));
         stats.push_back(make_item(L"Z", std::to_wstring(room.info().z)));
-        stats.push_back(make_item(L"Water", std::to_wstring(room.water())));
-        stats.push_back(make_item(L"Outside", std::to_wstring(room.outside())));
+        stats.push_back(make_item(L"Water", format_bool(room.water())));
+        stats.push_back(make_item(L"Outside", format_bool(room.outside())));
         if (room.alternate_mode() != Room::AlternateMode::None)
         {
             stats.push_back(make_item(L"Alternate", std::to_wstring(room.alternate_room())));

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -10,6 +10,7 @@
 #include <trview.ui/GroupBox.h>
 #include <trview.ui/Dropdown.h>
 #include <trview.ui/Label.h>
+#include <trview.common/Strings.h>
 
 namespace trview
 {
@@ -324,21 +325,6 @@ namespace trview
 
     void TriggersWindow::load_trigger_details(const Trigger& trigger)
     {
-        auto format_bool = [](bool value)
-        {
-            std::wstringstream stream;
-            stream << std::boolalpha << value;
-            return stream.str();
-        };
-
-        auto format_binary = [](uint16_t value)
-        {
-            std::wstringstream stream;
-            stream << std::bitset<5>(value);
-            const auto result = stream.str();
-            return std::wstring(result.rbegin(), result.rend());
-        };
-
         auto make_item = [](const auto& name, const auto& value)
         {
             return Listbox::Item{ { { L"Name", name }, { L"Value", value } } };

--- a/trview.common/Strings.cpp
+++ b/trview.common/Strings.cpp
@@ -1,6 +1,8 @@
 #include "Strings.h"
 #include <vector>
 #include <Windows.h>
+#include <sstream>
+#include <bitset>
 
 namespace trview
 {
@@ -22,5 +24,20 @@ namespace trview
             MultiByteToWideChar(CP_UTF8, 0, value.c_str(), -1, &output[0], output.size());
         }
         return &output[0];
+    }
+
+    std::wstring format_bool(bool value)
+    {
+        std::wstringstream stream;
+        stream << std::boolalpha << value;
+        return stream.str();
+    }
+
+    std::wstring format_binary(uint16_t value)
+    {
+        std::wstringstream stream;
+        stream << std::bitset<5>(value);
+        const auto result = stream.str();
+        return std::wstring(result.rbegin(), result.rend());
     }
 }

--- a/trview.common/Strings.h
+++ b/trview.common/Strings.h
@@ -13,4 +13,14 @@ namespace trview
     /// @param value The utf-8 value to convert.
     /// @returns The converted string.
     std::wstring to_utf16(const std::string& value);
+
+    /// Convert a boolean to true/false.
+    /// @param value The bool to convert.
+    /// @returns The converted string.
+    std::wstring format_bool(bool value);
+
+    /// Convert a value to a binary - only shows 5 bits.
+    /// @param value The value to convert.
+    /// @returns The converted string.
+    std::wstring format_binary(uint16_t value);
 }


### PR DESCRIPTION
Convert booleans to true/false instead of 1/0 in rooms window.
Move the functions to a common place as they are used in a few places.
Move the format_binary function too.
Closes #660