### PR TITLE
Revert "Stop adding X and Y coordinate value to UVs (#645)"

### DIFF
--- a/trview.app/Graphics/LevelTextureStorage.cpp
+++ b/trview.app/Graphics/LevelTextureStorage.cpp
@@ -52,7 +52,7 @@ namespace trview
     {
         using namespace DirectX::SimpleMath;
         const auto& vert = _object_textures[texture_index].Vertices[uv_index];
-        return Vector2(static_cast<float>(vert.Xpixel), static_cast<float>(vert.Ypixel)) / 255.0f;
+        return Vector2(static_cast<float>(vert.Xpixel + vert.Xcoordinate), static_cast<float>(vert.Ypixel + vert.Ycoordinate)) / 255.0f;
     }
 
     uint32_t LevelTextureStorage::tile(uint32_t texture_index) const


### PR DESCRIPTION
Not adding X/Y coordinate to the UV added seams to regular levels.
This reverts the texture coordinate fix part of commit d6131961690e13783dcbd4b01a9acb9a7e9cdf60.
Reopens #620
