### PR TITLE
Show quicksand flag in rooms window

### DIFF
--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -146,6 +146,9 @@ namespace trview
 
         /// Gets whether this room is a water room.
         bool water() const;
+
+        /// Gets whether this room is a quicksand room.
+        bool quicksand() const;
     private:
         void generate_geometry(trlevel::LevelVersion level_version, const graphics::Device& device, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage);
         void generate_adjacency();
@@ -199,8 +202,7 @@ namespace trview
         AlternateMode        _alternate_mode;
 
         std::unordered_map<uint32_t, Trigger*> _triggers;
-        bool _water{ false };
-        bool _outside{ false };
+        uint16_t _flags{ 0 };
         Level& _level;
     };
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -368,8 +368,18 @@ namespace trview
         stats.push_back(make_item(L"X", std::to_wstring(room.info().x)));
         stats.push_back(make_item(L"Y", std::to_wstring(room.info().yBottom)));
         stats.push_back(make_item(L"Z", std::to_wstring(room.info().z)));
-        stats.push_back(make_item(L"Water", format_bool(room.water())));
-        stats.push_back(make_item(L"Outside", format_bool(room.outside())));
+        if (room.water())
+        {
+            stats.push_back(make_item(L"Water", format_bool(room.water())));
+        }
+        if (room.outside())
+        {
+            stats.push_back(make_item(L"Outside", format_bool(room.outside())));
+        }
+        if (room.quicksand())
+        {
+            stats.push_back(make_item(L"Quicksand", format_bool(room.quicksand())));
+        }
         if (room.alternate_mode() != Room::AlternateMode::None)
         {
             stats.push_back(make_item(L"Alternate", std::to_wstring(room.alternate_room())));


### PR DESCRIPTION
Add the quicksand flag to the rooms window.
This will only show if the room is a TR3 level.
Now only show flags if present.
Changed room to store flags and calculate instead of storing multiple bools.
Closes #388