### PR TITLE
Add ability to click links in text areas

### DIFF
--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -33,6 +33,8 @@ namespace trview
             bool     process_mouse_down(Control* control, const Point& position);
             void     process_mouse_up();
             bool     process_mouse_up(Control* control, const Point& position);
+            void     process_mouse_click();
+            bool     process_mouse_click(Control* control, const Point& position);
             void     process_mouse_scroll(int16_t delta);
             bool     process_mouse_scroll(Control* control, const Point& position, int16_t delta);
             void     process_key_down(uint16_t key, bool control_pressed, bool shift_pressed);

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -1,7 +1,9 @@
+#define NOMINMAX
 #include "TextArea.h"
 #include "Label.h"
 #include <sstream>
 #include <queue>
+#include <Windows.h>
 
 namespace trview
 {
@@ -106,6 +108,35 @@ namespace trview
 
             output = selected_text();
             delete_selection();
+            return true;
+        }
+
+        bool TextArea::clicked(Point position)
+        {
+            if (_lines.empty() || _line_structure.empty())
+            {
+                return true;
+            }
+
+            // In case the dragging had started already, clear it.
+            _dragging = false;
+
+            auto point = visual_to_logical(position_to_visual(position));
+            auto& line = _text[point.line];
+            if (!std::isspace(line[point.position]))
+            {
+                auto rstart = std::find_if(std::make_reverse_iterator(line.begin() + point.position), line.rend(), std::isspace);
+                auto diff = -(rstart - line.rend());
+                auto start = line.begin() + diff;
+                auto end = std::find_if(line.begin() + point.position, line.end(), std::isspace);
+                auto link = std::wstring(start, end);
+
+                if (link.find(L"http://") == 0 || link.find(L"www.") == 0)
+                {
+                    ShellExecute(0, 0, link.c_str(), 0, 0, SW_SHOW);
+                }
+            }
+
             return true;
         }
 

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -120,6 +120,7 @@ namespace trview
 
             // In case the dragging had started already, clear it.
             _dragging = false;
+            _selection_end = _selection_start;
 
             auto point = visual_to_logical(position_to_visual(position));
             auto& line = _text[point.line];
@@ -408,6 +409,7 @@ namespace trview
 
             _dragging = true;
             _selection_start = visual_to_logical(position_to_visual(position));
+            _selection_end = _selection_start;
             return true;
         }
 

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -124,7 +124,7 @@ namespace trview
 
             auto point = visual_to_logical(position_to_visual(position));
             auto link = word_at_cursor(point);
-            if (link.find(L"http://") == 0 || link.find(L"www.") == 0)
+            if (link.find(L"http://") == 0 || link.find(L"https://") == 0 || link.find(L"www.") == 0)
             {
                 ShellExecute(0, 0, link.c_str(), 0, 0, SW_SHOW);
             }
@@ -292,7 +292,7 @@ namespace trview
                 case 0xA:
                 {
                     auto word = word_at_cursor(_logical_cursor);
-                    if (word.find(L"http://") == 0 || word.find(L"www.") == 0)
+                    if (word.find(L"http://") == 0 || word.find(L"https://") == 0 || word.find(L"www.") == 0)
                     {
                         ShellExecute(0, 0, word.c_str(), 0, 0, SW_SHOW);
                     }

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -123,6 +123,16 @@ namespace trview
             _selection_end = _selection_start;
 
             auto point = visual_to_logical(position_to_visual(position));
+            auto link = word_at_cursor(point);
+            if (link.find(L"http://") == 0 || link.find(L"www.") == 0)
+            {
+                ShellExecute(0, 0, link.c_str(), 0, 0, SW_SHOW);
+            }
+            return true;
+        }
+
+        std::wstring TextArea::word_at_cursor(CursorPoint point) const
+        {
             auto& line = _text[point.line];
             if (!std::isspace(line[point.position]))
             {
@@ -130,15 +140,9 @@ namespace trview
                 auto diff = -(rstart - line.rend());
                 auto start = line.begin() + diff;
                 auto end = std::find_if(line.begin() + point.position, line.end(), std::isspace);
-                auto link = std::wstring(start, end);
-
-                if (link.find(L"http://") == 0 || link.find(L"www.") == 0)
-                {
-                    ShellExecute(0, 0, link.c_str(), 0, 0, SW_SHOW);
-                }
+                return std::wstring(start, end);
             }
-
-            return true;
+            return std::wstring();
         }
 
         void TextArea::update_structure()
@@ -281,6 +285,16 @@ namespace trview
                     if (_mode == Mode::SingleLine)
                     {
                         on_tab(text());
+                    }
+                    return true;
+                }
+                // \n (ctrl + enter)
+                case 0xA:
+                {
+                    auto word = word_at_cursor(_logical_cursor);
+                    if (word.find(L"http://") == 0 || word.find(L"www.") == 0)
+                    {
+                        ShellExecute(0, 0, word.c_str(), 0, 0, SW_SHOW);
                     }
                     return true;
                 }

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -122,6 +122,7 @@ namespace trview
             void delete_selection();
             bool any_text_selected() const;
             std::wstring selected_text() const;
+            std::wstring word_at_cursor(CursorPoint point) const;
 
             StackPanel*         _area;
             std::vector<Label*> _lines;

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -67,6 +67,7 @@ namespace trview
             virtual bool move(Point position) override;
             virtual bool copy(std::wstring& output) override;
             virtual bool cut(std::wstring& output) override;
+            virtual bool clicked(Point position) override;
         private:
             struct LineEntry
             {


### PR DESCRIPTION
Add clicking on links in text areas. Anything that starts with `http://`, `https://` or `www.` will count as a clickable link.
Links can also be clicked by pressing ctrl + enter when the cursor is over a link.
Closes #684 