### PR TITLE
Code cleanup of TextArea

### DIFF
--- a/trview.common/Strings.cpp
+++ b/trview.common/Strings.cpp
@@ -36,4 +36,9 @@ namespace trview
         const auto result = stream.str();
         return std::wstring(result.rbegin(), result.rend());
     }
+
+    bool is_link(const std::wstring& text)
+    {
+        return text.find(L"http://") == 0 || text.find(L"https://") == 0 || text.find(L"www.") == 0;
+    }
 }

--- a/trview.common/Strings.h
+++ b/trview.common/Strings.h
@@ -23,4 +23,9 @@ namespace trview
     /// @param value The value to convert.
     /// @returns The converted string.
     std::wstring format_binary(uint16_t value);
+
+    /// Check whether text is a link.
+    /// @param value The value to check.
+    /// @returns Whether it is a link.
+    bool is_link(const std::wstring& text);
 }

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -120,7 +120,7 @@ namespace trview
 
             auto point = visual_to_logical(position_to_visual(position));
             auto link = word_at_cursor(point);
-            if (link.find(L"http://") == 0 || link.find(L"https://") == 0 || link.find(L"www.") == 0)
+            if (is_link(link))
             {
                 ShellExecute(0, 0, link.c_str(), 0, 0, SW_SHOW);
             }
@@ -288,7 +288,7 @@ namespace trview
                 case 0xA:
                 {
                     auto word = word_at_cursor(_logical_cursor);
-                    if (word.find(L"http://") == 0 || word.find(L"https://") == 0 || word.find(L"www.") == 0)
+                    if (is_link(word))
                     {
                         ShellExecute(0, 0, word.c_str(), 0, 0, SW_SHOW);
                     }

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -175,7 +175,6 @@ namespace trview
                             ++split_length;
                         }
 
-                        // Hackery with the index - might need to be fixed.
                         line_label->set_text(line.substr(0, split_length));
                         _line_structure.push_back({ index, character_count, split_length });
                         lines_to_process.push(line.substr(split_length));
@@ -306,8 +305,9 @@ namespace trview
                     }
                     break;
                 }
-                // Copy, Undo, Redo, Cut, Paste
+                // Copy, Ctrl + E, Undo, Redo, Cut, Paste
                 case 0x3:
+                case 0x5:
                 case 0x7:
                 case 0x1a:
                 case 0x16:

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -76,22 +76,51 @@ namespace trview
                 uint32_t length;
             };
 
-            struct CursorPoint
+            struct LogicalPosition
             {
                 uint32_t line{ 0u };
                 uint32_t position{ 0u };
 
-                bool operator==(const CursorPoint& other) const
+                bool operator==(const LogicalPosition& other) const
                 {
                     return line == other.line && position == other.position;
                 }
 
-                bool operator!=(const CursorPoint& other) const 
+                bool operator!=(const LogicalPosition& other) const
                 {
                     return !(*this == other);
                 }
 
-                bool operator<(const CursorPoint& other) const
+                bool operator<(const LogicalPosition& other) const
+                {
+                    if (line < other.line)
+                    {
+                        return true;
+                    }
+                    if (line == other.line)
+                    {
+                        return position < other.position;
+                    }
+                    return false;
+                }
+            };
+
+            struct VisualPosition
+            {
+                uint32_t line{ 0u };
+                uint32_t position{ 0u };
+
+                bool operator==(const VisualPosition& other) const
+                {
+                    return line == other.line && position == other.position;
+                }
+
+                bool operator!=(const VisualPosition& other) const
+                {
+                    return !(*this == other);
+                }
+
+                bool operator<(const VisualPosition& other) const
                 {
                     if (line < other.line)
                     {
@@ -113,16 +142,16 @@ namespace trview
             uint32_t find_nearest_index(uint32_t line, float x) const;
             void new_line();
             void clear_highlight();
-            void highlight(CursorPoint start, CursorPoint end);
+            void highlight(LogicalPosition start, LogicalPosition end);
             void move_to_earliest_highlight();
             void move_to_latest_highlight();
-            CursorPoint logical_to_visual(CursorPoint point) const;
-            CursorPoint visual_to_logical(CursorPoint point) const;
-            CursorPoint position_to_visual(const Point& position) const;
+            VisualPosition logical_to_visual(LogicalPosition point) const;
+            LogicalPosition visual_to_logical(VisualPosition point) const;
+            VisualPosition position_to_visual(const Point& position) const;
             void delete_selection();
             bool any_text_selected() const;
             std::wstring selected_text() const;
-            std::wstring word_at_cursor(CursorPoint point) const;
+            std::wstring word_at_cursor(LogicalPosition point) const;
 
             StackPanel*         _area;
             std::vector<Label*> _lines;
@@ -133,13 +162,13 @@ namespace trview
             graphics::TextAlignment _alignment{ graphics::TextAlignment::Left };
             std::vector<std::wstring> _text;
             std::vector<LineEntry>    _line_structure;
-            CursorPoint               _visual_cursor{ 0u, 0u };
-            CursorPoint               _logical_cursor{ 0u, 0u };
+            VisualPosition _visual_cursor{ 0u, 0u };
+            LogicalPosition _logical_cursor{ 0u, 0u };
             // The first pin point of the selection. Not necessarily earlier in the text.
-            CursorPoint               _selection_start;
+            LogicalPosition _selection_start;
             // The second pin point of the selection. Not necessarily later in the text.
-            CursorPoint               _selection_end;
-            bool                      _dragging{ false };
+            LogicalPosition _selection_end;
+            bool _dragging{ false };
         };
     }
 }

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -138,7 +138,7 @@ namespace trview
             void update_structure();
             void update_cursor();
             void notify_text_updated();
-            void move_visual_cursor_position(uint32_t line, uint32_t position);
+            void move_visual_cursor_position(VisualPosition position);
             uint32_t find_nearest_index(uint32_t line, float x) const;
             void new_line();
             void clear_highlight();

--- a/trview.ui/stdafx.h
+++ b/trview.ui/stdafx.h
@@ -6,3 +6,5 @@
 #include <queue>
 #include <Windows.h>
 #include <iterator>
+
+#include <trview.common/Strings.h>


### PR DESCRIPTION
Clean up text area a little.
Add visual and logical cursor classes to stop them getting mixed up.
Closes #685 