### PR TITLE
Load AI entities in TR4 and TR5

### DIFF
--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -875,6 +875,21 @@ namespace trlevel
         if (_version >= LevelVersion::Tomb4)
         {
             std::vector<tr4_ai_object> ai_objects = read_vector<uint32_t, tr4_ai_object>(file);
+            std::transform(ai_objects.begin(), ai_objects.end(), std::back_inserter(_entities),
+                [](const auto& ai_object)
+                {
+                    tr2_entity entity {};
+                    entity.TypeID = ai_object.type_id;
+                    entity.Room = ai_object.room;
+                    entity.x = ai_object.x;
+                    entity.y = ai_object.y;
+                    entity.z = ai_object.z;
+                    entity.Angle = ai_object.angle;
+                    entity.Intensity1 = 0;
+                    entity.Intensity2 = ai_object.ocb;
+                    entity.Flags = ai_object.flags;
+                    return entity;
+                });
         }
 
         if (_version < LevelVersion::Tomb4)

--- a/trview/resources/type_names.txt
+++ b/trview/resources/type_names.txt
@@ -2944,6 +2944,15 @@
 				"id": 402,
 				"name": "AI Follow"
 			}, {
+				"id": 404,
+				"name": "AI X1"
+			}, {
+				"id": 405,
+				"name": "AI X2"
+			}, {
+				"id": 406,
+				"name": "Lara Start Pos"
+			}, {
 				"id": 408,
 				"name": "Trigger triggerer"
 			}, {
@@ -3674,6 +3683,15 @@
 			}, {
 				"id": 383,
 				"name": "AIPatrol2"
+			}, {
+				"id": 384,
+				"name": "AI X1"
+			}, {
+				"id": 385,
+				"name": "AI X2"
+			}, {
+				"id": 386,
+				"name": "Lara Start Pos"
 			}, {
 				"id": 387,
 				"name": "Teleporter"


### PR DESCRIPTION
AI objects are stored separately from regular entities starting in TR4. 
Load them and append them to the list of entities so they can be seen in the item window.
Also add the new text strings for a few of the new AI object types.
Closes #655 