### PR TITLE
Add read only mode for TextArea

### DIFF
--- a/trview.app/UI/Console.cpp
+++ b/trview.app/UI/Console.cpp
@@ -13,6 +13,8 @@ namespace trview
         _window->set_visible(false);
 
         _log = _window->add_child(std::make_unique<ui::TextArea>(Size(500, 282), Colour(0.0f, 0.0f, 0.0f, 0.0f), Colour::White));
+        _log->set_read_only(true);
+        _token_store += _log->on_tab += [&](auto) { _input->on_focus_requested(); };
 
         _input = _window->add_child(std::make_unique<ui::TextArea>(Point(0, 282), Size(500, 18), Colour(0.75f, 0.0f, 0.0f, 0.0f), Colour::White));
         _input->set_mode(ui::TextArea::Mode::SingleLine);

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -34,6 +34,11 @@ namespace trview
 
         bool TextArea::paste(const std::wstring& text)
         {
+            if (read_only())
+            {
+                return false;
+            }
+
             if (_text.empty())
             {
                 _text.push_back({});
@@ -97,7 +102,7 @@ namespace trview
 
         bool TextArea::cut(std::wstring& output)
         {
-            if (!any_text_selected())
+            if (read_only() || !any_text_selected())
             {
                 return false;
             }
@@ -229,6 +234,11 @@ namespace trview
                 // VK_BACK
                 case 0x8:
                 {
+                    if (read_only())
+                    {
+                        return false;
+                    }
+
                     if (any_text_selected())
                     {
                         delete_selection();
@@ -255,7 +265,7 @@ namespace trview
                 // VK_TAB
                 case 0x9:
                 {
-                    if (_mode == Mode::SingleLine)
+                    if (_mode == Mode::SingleLine || read_only())
                     {
                         on_tab(text());
                     }
@@ -274,6 +284,11 @@ namespace trview
                 // VK_RETURN
                 case 0xD:
                 {
+                    if (read_only())
+                    {
+                        return false;
+                    }
+
                     if (any_text_selected())
                     {
                         delete_selection();
@@ -324,6 +339,11 @@ namespace trview
                 }
                 default:
                 {
+                    if (read_only())
+                    {
+                        return false;
+                    }
+
                     if (any_text_selected())
                     {
                         delete_selection();
@@ -705,6 +725,11 @@ namespace trview
                 // VK_DELETE
                 case 0x2E:
                 {
+                    if (read_only())
+                    {
+                        return false;
+                    }
+
                     if (any_text_selected())
                     {
                         delete_selection();
@@ -963,6 +988,16 @@ namespace trview
                 }
             }
             return output;
+        }
+
+        bool TextArea::read_only() const
+        {
+            return _read_only;
+        }
+
+        void TextArea::set_read_only(bool value)
+        {
+            _read_only = value;
         }
     }
 }

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -68,6 +68,8 @@ namespace trview
             virtual bool copy(std::wstring& output) override;
             virtual bool cut(std::wstring& output) override;
             virtual bool clicked(Point position) override;
+            bool read_only() const;
+            void set_read_only(bool value);
         private:
             struct LineEntry
             {
@@ -169,6 +171,7 @@ namespace trview
             // The second pin point of the selection. Not necessarily later in the text.
             LogicalPosition _selection_end;
             bool _dragging{ false };
+            bool _read_only{ false };
         };
     }
 }


### PR DESCRIPTION
Add a read only mode for text areas.
User can still select, copy, etc but cannot edit the contents of the text area.
`on_tab` will be raised when tab is pressed in a read only multiline text area - normally this is only for single line text areas.
Make the console log a read only text area.
Closes #690