### PR TITLE
Only render trigger selection when triggers are visible

### DIFF
--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -246,7 +246,7 @@ namespace trview
             _selection_renderer->render(device, camera, *_texture_storage, *_selected_item, Item_Outline);
         }
 
-        if (_selected_trigger)
+        if (_show_triggers && _selected_trigger)
         {
             _selection_renderer->render(device, camera, *_texture_storage, *_selected_trigger, Trigger_Outline);
         }


### PR DESCRIPTION
If the user toggles off rendering of triggers, stop rendering the outline.
Closes #701