### PR TITLE
Create Grid control and use it in View Options and Camera Settings

### DIFF
--- a/trview.app/UI/CameraControls.cpp
+++ b/trview.app/UI/CameraControls.cpp
@@ -14,10 +14,7 @@ namespace trview
         using namespace ui;
 
         auto camera_window = parent.add_child(std::make_unique<GroupBox>(Size(150, 92), Colour::Transparent, Colour::Grey, L"Camera"));
-
-#if 1
-        // Use the new grid control.
-        auto grid = camera_window->add_child(std::make_unique<Grid>(Size(150, 92), Colour::Transparent, Grid::InsertOrder::Column));
+        auto grid = camera_window->add_child(std::make_unique<Grid>(Size(150, 63), Colour::Transparent, Grid::InsertOrder::Column, 2, 3));
 
         // Make a button with a label next to it, until this kind of control exists.
         auto create_labelled_button = [](Event<>& on_click, const std::wstring& text)
@@ -42,32 +39,6 @@ namespace trview
 
         _ortho = grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Ortho"));
         _token_store += _ortho->on_state_changed += [&](auto ortho_enabled) { change_projection(ortho_enabled ? ProjectionMode::Orthographic : ProjectionMode::Perspective); };
-#else
-
-        auto reset_camera = std::make_unique<Button>(Size(16, 16));
-        reset_camera->on_click += on_reset;
-
-        auto reset_camera_label = std::make_unique<Label>(Point(20, 0), Size(40, 16), Colour::Transparent, L"Reset", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Centre);
-
-        auto orbit_camera = std::make_unique<Checkbox>(Point(74, 0), Colour::Transparent, L"Orbit");
-        _token_store += orbit_camera->on_state_changed += [&](auto) { change_mode(CameraMode::Orbit); };
-
-        auto free_camera = std::make_unique<Checkbox>(Point(0, 21), Colour::Transparent, L"Free");
-        _token_store += free_camera->on_state_changed += [&](auto) { change_mode(CameraMode::Free); };
-
-        auto axis_camera = std::make_unique<Checkbox>(Point(74, 21), Colour::Transparent, L"Axis");
-        _token_store += axis_camera->on_state_changed += [&](auto) { change_mode(CameraMode::Axis); };
-
-        auto ortho = std::make_unique<Checkbox>(Point(0, 43), Colour::Transparent, L"Ortho");
-        _token_store += ortho->on_state_changed += [&](auto ortho_enabled) { change_projection(ortho_enabled ? ProjectionMode::Orthographic : ProjectionMode::Perspective); };
-
-        camera_window->add_child(std::move(reset_camera));
-        camera_window->add_child(std::move(reset_camera_label));
-        _orbit = camera_window->add_child(std::move(orbit_camera));
-        _free = camera_window->add_child(std::move(free_camera));
-        _axis = camera_window->add_child(std::move(axis_camera));
-        _ortho = camera_window->add_child(std::move(ortho));
-#endif
     }
 
     // Set the current camera mode and raise the on_mode_selected event.

--- a/trview.app/UI/CameraControls.cpp
+++ b/trview.app/UI/CameraControls.cpp
@@ -5,6 +5,7 @@
 #include <trview.ui/Button.h>
 #include <trview.ui/Slider.h>
 #include <trview.ui/Label.h>
+#include <trview.ui/Grid.h>
 
 namespace trview
 {
@@ -13,6 +14,9 @@ namespace trview
         using namespace ui;
 
         auto camera_window = std::make_unique<GroupBox>(Size(150, 92), Colour::Transparent, Colour::Grey, L"Camera");
+
+        // Use the new grid control.
+        auto grid = std::make_unique<Grid>(Grid::InsertOrder::Column);
 
         auto reset_camera = std::make_unique<Button>(Size(16, 16));
         reset_camera->on_click += on_reset;

--- a/trview.app/UI/CameraControls.cpp
+++ b/trview.app/UI/CameraControls.cpp
@@ -13,7 +13,7 @@ namespace trview
     {
         using namespace ui;
 
-        auto camera_window = std::make_unique<GroupBox>(Size(150, 92), Colour::Transparent, Colour::Grey, L"Camera");
+        auto camera_window = parent.add_child(std::make_unique<GroupBox>(Size(150, 92), Colour::Transparent, Colour::Grey, L"Camera"));
 
 #if 1
         // Use the new grid control.
@@ -68,8 +68,6 @@ namespace trview
         _axis = camera_window->add_child(std::move(axis_camera));
         _ortho = camera_window->add_child(std::move(ortho));
 #endif
-
-        parent.add_child(std::move(camera_window));
     }
 
     // Set the current camera mode and raise the on_mode_selected event.

--- a/trview.app/UI/CameraControls.cpp
+++ b/trview.app/UI/CameraControls.cpp
@@ -15,8 +15,34 @@ namespace trview
 
         auto camera_window = std::make_unique<GroupBox>(Size(150, 92), Colour::Transparent, Colour::Grey, L"Camera");
 
+#if 1
         // Use the new grid control.
-        auto grid = std::make_unique<Grid>(Grid::InsertOrder::Column);
+        auto grid = camera_window->add_child(std::make_unique<Grid>(Size(150, 92), Colour::Transparent, Grid::InsertOrder::Column));
+
+        // Make a button with a label next to it, until this kind of control exists.
+        auto create_labelled_button = [](Event<>& on_click, const std::wstring& text)
+        {
+            auto panel = std::make_unique<StackPanel>(Size(16, 16), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
+            auto button = panel->add_child(std::make_unique<Button>(Size(16, 16)));
+            button->on_click += on_click;
+            panel->add_child(std::make_unique<Label>(Size(40, 16), Colour::Transparent, text, 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Centre));
+            return std::move(panel);
+        };
+
+        grid->add_child(create_labelled_button(on_reset, L"Reset"));
+
+        _orbit = grid->add_child(std::make_unique<Checkbox>(Point(74, 0), Colour::Transparent, L"Orbit"));
+        _token_store += _orbit->on_state_changed += [&](auto) { change_mode(CameraMode::Orbit); };
+
+        _free = grid->add_child(std::make_unique<Checkbox>(Point(0, 21), Colour::Transparent, L"Free"));
+        _token_store += _free->on_state_changed += [&](auto) { change_mode(CameraMode::Free); };
+
+        _axis = grid->add_child(std::make_unique<Checkbox>(Point(74, 21), Colour::Transparent, L"Axis"));
+        _token_store += _axis->on_state_changed += [&](auto) { change_mode(CameraMode::Axis); };
+
+        _ortho = grid->add_child(std::make_unique<Checkbox>(Point(0, 43), Colour::Transparent, L"Ortho"));
+        _token_store += _ortho->on_state_changed += [&](auto ortho_enabled) { change_projection(ortho_enabled ? ProjectionMode::Orthographic : ProjectionMode::Perspective); };
+#else
 
         auto reset_camera = std::make_unique<Button>(Size(16, 16));
         reset_camera->on_click += on_reset;
@@ -41,6 +67,7 @@ namespace trview
         _free = camera_window->add_child(std::move(free_camera));
         _axis = camera_window->add_child(std::move(axis_camera));
         _ortho = camera_window->add_child(std::move(ortho));
+#endif
 
         parent.add_child(std::move(camera_window));
     }

--- a/trview.app/UI/CameraControls.cpp
+++ b/trview.app/UI/CameraControls.cpp
@@ -14,7 +14,7 @@ namespace trview
         using namespace ui;
 
         auto camera_window = parent.add_child(std::make_unique<GroupBox>(Size(150, 92), Colour::Transparent, Colour::Grey, L"Camera"));
-        auto grid = camera_window->add_child(std::make_unique<Grid>(Size(150, 63), Colour::Transparent, Grid::InsertOrder::Column, 2, 3));
+        auto grid = camera_window->add_child(std::make_unique<Grid>(Size(150, 63), Colour::Transparent, 2, 3));
 
         // Make a button with a label next to it, until this kind of control exists.
         auto create_labelled_button = [](Event<>& on_click, const std::wstring& text)

--- a/trview.app/UI/CameraControls.cpp
+++ b/trview.app/UI/CameraControls.cpp
@@ -22,7 +22,7 @@ namespace trview
         // Make a button with a label next to it, until this kind of control exists.
         auto create_labelled_button = [](Event<>& on_click, const std::wstring& text)
         {
-            auto panel = std::make_unique<StackPanel>(Size(16, 16), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
+            auto panel = std::make_unique<StackPanel>(Size(56, 16), Colour::Transparent, Size(), StackPanel::Direction::Horizontal, SizeMode::Manual);
             auto button = panel->add_child(std::make_unique<Button>(Size(16, 16)));
             button->on_click += on_click;
             panel->add_child(std::make_unique<Label>(Size(40, 16), Colour::Transparent, text, 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Centre));
@@ -31,16 +31,16 @@ namespace trview
 
         grid->add_child(create_labelled_button(on_reset, L"Reset"));
 
-        _orbit = grid->add_child(std::make_unique<Checkbox>(Point(74, 0), Colour::Transparent, L"Orbit"));
+        _orbit = grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Orbit"));
         _token_store += _orbit->on_state_changed += [&](auto) { change_mode(CameraMode::Orbit); };
 
-        _free = grid->add_child(std::make_unique<Checkbox>(Point(0, 21), Colour::Transparent, L"Free"));
+        _free = grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Free"));
         _token_store += _free->on_state_changed += [&](auto) { change_mode(CameraMode::Free); };
 
-        _axis = grid->add_child(std::make_unique<Checkbox>(Point(74, 21), Colour::Transparent, L"Axis"));
+        _axis = grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Axis"));
         _token_store += _axis->on_state_changed += [&](auto) { change_mode(CameraMode::Axis); };
 
-        _ortho = grid->add_child(std::make_unique<Checkbox>(Point(0, 43), Colour::Transparent, L"Ortho"));
+        _ortho = grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Ortho"));
         _token_store += _ortho->on_state_changed += [&](auto ortho_enabled) { change_projection(ortho_enabled ? ProjectionMode::Orthographic : ProjectionMode::Perspective); };
 #else
 

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -5,6 +5,7 @@
 #include <trview.ui/Checkbox.h>
 #include <trview.ui/StackPanel.h>
 #include <trview.ui/NumericUpDown.h>
+#include <trview.ui/Grid.h>
 #include <trview.app/Graphics/ITextureStorage.h>
 
 namespace trview
@@ -19,53 +20,40 @@ namespace trview
     {
         using namespace ui;
 
-        auto rooms_groups = std::make_unique<GroupBox>(Size(150, 130), Colour::Transparent, Colour::Grey, L"View Options");
-        auto highlight = std::make_unique<Checkbox>(Colour::Transparent, L"Highlight");
-        auto triggers = std::make_unique<Checkbox>(Point(74, 0), Colour::Transparent, L"Triggers");
-        triggers->set_state(true);
-        auto hidden_geometry = std::make_unique<Checkbox>(Point(0, 24), Colour::Transparent, L"Geometry");
-        auto water = std::make_unique<Checkbox>(Point(74, 24), Colour::Transparent, L"Water");
-        water->set_state(true);
+        auto rooms_group = parent.add_child(std::make_unique<GroupBox>(Size(150, 130), Colour::Transparent, Colour::Grey, L"View Options"));
+        auto rooms_area = rooms_group->add_child(std::make_unique<StackPanel>(Size(150, 130), Colour::Transparent));
+        auto rooms_grid = rooms_area->add_child(std::make_unique<Grid>(Size(150, 70), Colour::Transparent, Grid::InsertOrder::Column, 2, 3));
 
-        highlight->on_state_changed += on_highlight;
-        triggers->on_state_changed += on_show_triggers;
-        hidden_geometry->on_state_changed += on_show_hidden_geometry;
-        water->on_state_changed += on_show_water;
+        _highlight = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Highlight"));
+        _highlight->on_state_changed += on_highlight;
 
-        auto enabled = std::make_unique<Checkbox>(Point(0, 49), Colour::Transparent, L"Depth");
-        enabled->on_state_changed += on_depth_enabled;
+        _triggers = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Triggers"));
+        _triggers->set_state(true);
+        _triggers->on_state_changed += on_show_triggers;
 
-        auto depth = std::make_unique<NumericUpDown>(Point(75, 49), Size(50, 20), Colour::Transparent, texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 20);
-        depth->set_value(1);
-        depth->on_value_changed += on_depth_changed;
+        _hidden_geometry = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Geometry"));
+        _hidden_geometry->on_state_changed += on_show_hidden_geometry;
 
-        _enabled = rooms_groups->add_child(std::move(enabled));
-        _depth = rooms_groups->add_child(std::move(depth));
+        _water = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Water"));
+        _water->set_state(true);
+        _water->on_state_changed += on_show_water;
 
-        _highlight = rooms_groups->add_child(std::move(highlight));
-        _triggers = rooms_groups->add_child(std::move(triggers));
-        _hidden_geometry = rooms_groups->add_child(std::move(hidden_geometry));
-        _water = rooms_groups->add_child(std::move(water));
+        _enabled = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Depth"));
+        _enabled->on_state_changed += on_depth_enabled;
 
-        // Shared panel size.
+        _depth = rooms_grid->add_child(std::make_unique<NumericUpDown>(Size(50, 20), Colour::Transparent, texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 20));
+        _depth->set_value(1);
+        _depth->on_value_changed += on_depth_changed;
+        
         const auto panel_size = Size(140, 20);
+        auto flip_panel = rooms_area->add_child(std::make_unique<ui::Window>(panel_size, Colour::Transparent));
+        _tr1_3_panel = flip_panel->add_child(std::make_unique<ui::Window>(panel_size, Colour::Transparent));
+        _flip = _tr1_3_panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Flip"));
+        _flip->on_state_changed += on_flip;
 
-        // Add two methods of controlling flipmaps:
-        // The TR1-3 method:
-        auto tr1_3_panel = std::make_unique<ui::Window>(Point(0, 75), panel_size, Colour::Transparent);
-        auto flip = std::make_unique<Checkbox>(Colour::Transparent, L"Flip");
-        flip->on_state_changed += on_flip;
-        _flip = tr1_3_panel->add_child(std::move(flip));
-        _tr1_3_panel = rooms_groups->add_child(std::move(tr1_3_panel));
-
-        // The TR4-5 method:
-        auto tr4_5_panel = std::make_unique<ui::Window>(Point(0, 75), panel_size, Colour::Transparent);
-        auto alternate_groups = std::make_unique<StackPanel>(Size(140, 16), Colour::Transparent, Size(), StackPanel::Direction::Horizontal, SizeMode::Manual);
-        _alternate_groups = tr4_5_panel->add_child(std::move(alternate_groups));
-        tr4_5_panel->set_visible(false);
-        _tr4_5_panel = rooms_groups->add_child(std::move(tr4_5_panel));
-
-        parent.add_child(std::move(rooms_groups));
+        _tr4_5_panel = flip_panel->add_child(std::make_unique<ui::Window>(panel_size, Colour::Transparent));
+        _alternate_groups = _tr4_5_panel->add_child(std::make_unique<StackPanel>(Size(140, 16), Colour::Transparent, Size(), StackPanel::Direction::Horizontal, SizeMode::Manual));
+        _tr4_5_panel->set_visible(false);
     }
 
     void ViewOptions::set_alternate_group(uint32_t value, bool enabled)

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -22,7 +22,7 @@ namespace trview
 
         auto rooms_group = parent.add_child(std::make_unique<GroupBox>(Size(150, 130), Colour::Transparent, Colour::Grey, L"View Options"));
         auto rooms_area = rooms_group->add_child(std::make_unique<StackPanel>(Size(150, 130), Colour::Transparent));
-        auto rooms_grid = rooms_area->add_child(std::make_unique<Grid>(Size(150, 70), Colour::Transparent, Grid::InsertOrder::Column, 2, 3));
+        auto rooms_grid = rooms_area->add_child(std::make_unique<Grid>(Size(150, 70), Colour::Transparent, 2, 3));
 
         _highlight = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Highlight"));
         _highlight->on_state_changed += on_highlight;

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -218,7 +218,7 @@ namespace trview
     void ViewerUI::generate_tool_window(const ITextureStorage& texture_storage)
     {
         // This is the main tool window on the side of the screen.
-        auto tool_window = std::make_unique<StackPanel>(Size(150.0f, 348.0f), Colour(0.5f, 0.0f, 0.0f, 0.0f), Size(5, 5));
+        auto tool_window = _control->add_child(std::make_unique<StackPanel>(Size(150.0f, 348.0f), Colour(0.5f, 0.0f, 0.0f, 0.0f), Size(5, 5)));
         tool_window->set_margin(Size(5, 5));
 
         _view_options = std::make_unique<ViewOptions>(*tool_window, texture_storage);
@@ -231,12 +231,10 @@ namespace trview
         _view_options->on_flip += on_flip;
         _view_options->on_alternate_group += on_alternate_group;
 
-        _room_navigator = std::make_unique<RoomNavigator>(*tool_window.get(), texture_storage);
+        _room_navigator = std::make_unique<RoomNavigator>(*tool_window, texture_storage);
         _room_navigator->on_room_selected += on_select_room;
 
         initialise_camera_controls(*tool_window);
-
-        _control->add_child(std::move(tool_window));
     }
 
     void ViewerUI::initialise_camera_controls(ui::Control& parent)

--- a/trview.common/Point.cpp
+++ b/trview.common/Point.cpp
@@ -29,6 +29,11 @@ namespace trview
         return *this;
     }
 
+    bool Point::operator==(const Point& other) const
+    {
+        return x == other.x && y == other.y;
+    }
+
     bool Point::is_between(const Point& first, const Point& second) const
     {
         return x >= first.x && y >= first.y 

--- a/trview.common/Point.h
+++ b/trview.common/Point.h
@@ -11,6 +11,7 @@ namespace trview
         Point operator -(const Point& other) const;
         Point operator +(const Point& other) const;
         Point& operator +=(const Point& other);
+        bool operator==(const Point& other) const;
 
         bool is_between(const Point& first, const Point& second) const;
 

--- a/trview.ui.tests/GridTests.cpp
+++ b/trview.ui.tests/GridTests.cpp
@@ -1,0 +1,25 @@
+#include "gtest/gtest.h"
+#include <trview.ui/Grid.h>
+
+using namespace trview;
+using namespace trview::ui;
+
+/// Tests that controls are placed correctly when added to the grid.
+TEST(Grid, ControlsPositionedCorrectly)
+{
+    Grid grid(Size(100, 200), Colour::Transparent, 2, 2);
+
+    auto x1y1 = grid.add_child(std::make_unique<Window>(Size(10, 10), Colour::Transparent));
+    auto x2y1 = grid.add_child(std::make_unique<Window>(Size(10, 10), Colour::Transparent));
+    auto x1y2 = grid.add_child(std::make_unique<Window>(Size(10, 10), Colour::Transparent));
+    auto x2y2 = grid.add_child(std::make_unique<Window>(Size(10, 10), Colour::Transparent));
+
+    ASSERT_EQ(x1y1->absolute_position(), Point(0, 0));
+    ASSERT_EQ(x1y1->position(), Point());
+    ASSERT_EQ(x2y1->absolute_position(), Point(50, 0));
+    ASSERT_EQ(x2y1->position(), Point());
+    ASSERT_EQ(x1y2->absolute_position(), Point(0, 100));
+    ASSERT_EQ(x1y2->position(), Point());
+    ASSERT_EQ(x2y2->absolute_position(), Point(50, 100));
+    ASSERT_EQ(x2y2->position(), Point());
+}

--- a/trview.ui.tests/trview.ui.tests.vcxproj
+++ b/trview.ui.tests/trview.ui.tests.vcxproj
@@ -148,6 +148,7 @@
   <ItemGroup>
     <ClCompile Include="ButtonTests.cpp" />
     <ClCompile Include="CheckboxTests.cpp" />
+    <ClCompile Include="GridTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\trview.ui\trview.ui.vcxproj">

--- a/trview.ui.tests/trview.ui.tests.vcxproj.filters
+++ b/trview.ui.tests/trview.ui.tests.vcxproj.filters
@@ -5,6 +5,7 @@
     <ClCompile Include="CheckboxTests.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest\gtest-all.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc" />
+    <ClCompile Include="GridTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/trview.ui/Grid.cpp
+++ b/trview.ui/Grid.cpp
@@ -12,13 +12,11 @@ namespace trview
 
         void Grid::inner_add_child(Control* child_element)
         {
-            // Take the newly added child element, add it to the 'grid'
             if (!_grid)
             {
                 return;
             }
 
-            // Add the cell to the grid
             auto cell = _grid->add_child(std::make_unique<Window>(Size(static_cast<int>(size().width / _columns), static_cast<int>(size().height / _rows)), background_colour()));
 
             // Calculate the coordinates based on cell index.

--- a/trview.ui/Grid.cpp
+++ b/trview.ui/Grid.cpp
@@ -4,8 +4,8 @@ namespace trview
 {
     namespace ui
     {
-        Grid::Grid(const Size& size, const Colour& background_colour, InsertOrder insert_order, uint32_t columns, uint32_t rows)
-            : Window(size, background_colour), _insert_order(insert_order), _columns(columns), _rows(rows)
+        Grid::Grid(const Size& size, const Colour& background_colour, uint32_t columns, uint32_t rows)
+            : Window(size, background_colour), _columns(columns), _rows(rows)
         {
             _grid = add_child(std::make_unique<Window>(size, background_colour));
         }

--- a/trview.ui/Grid.cpp
+++ b/trview.ui/Grid.cpp
@@ -13,7 +13,7 @@ namespace trview
         void Grid::inner_add_child(Control* child_element)
         {
             // Take the newly added child element, add it to the 'grid'
-            if (!_grid || std::find(_cells.begin(), _cells.end(), child_element) != _cells.end())
+            if (!_grid)
             {
                 return;
             }
@@ -21,20 +21,18 @@ namespace trview
             const int Columns = 2;
             const int Rows = 3;
 
-            auto cell = std::make_unique<Window>(Size(size().width / Columns, size().height / Rows), background_colour());
+            // Add the cell to the grid
+            auto cell = _grid->add_child(std::make_unique<Window>(Size(static_cast<int>(size().width / Columns), static_cast<int>(size().height / Rows)), background_colour()));
 
             // Calculate the coordinates based on cell index.
             auto y = std::floor(_cells.size() / Columns);
             auto x = _cells.size() - Columns * y;
             cell->set_position(Point((size().width / Columns) * x, (size().height / Rows) * y));
 
-            _cells.push_back(cell.get());
+            _cells.push_back(cell);
 
             // Transfer the new element into the cell.
             cell->add_child(remove_child(child_element));
-
-            // Add the cell to the grid.
-            add_child(std::move(cell));
         }
     }
 }

--- a/trview.ui/Grid.cpp
+++ b/trview.ui/Grid.cpp
@@ -1,0 +1,12 @@
+#include "Grid.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        Grid::Grid(InsertOrder insert_order)
+            : _insert_order(insert_order)
+        {
+        }
+    }
+}

--- a/trview.ui/Grid.cpp
+++ b/trview.ui/Grid.cpp
@@ -4,8 +4,8 @@ namespace trview
 {
     namespace ui
     {
-        Grid::Grid(InsertOrder insert_order)
-            : _insert_order(insert_order)
+        Grid::Grid(const Size& size, const Colour& background_colour, InsertOrder insert_order)
+            : Window(size, background_colour), _insert_order(insert_order)
         {
         }
     }

--- a/trview.ui/Grid.cpp
+++ b/trview.ui/Grid.cpp
@@ -4,8 +4,8 @@ namespace trview
 {
     namespace ui
     {
-        Grid::Grid(const Size& size, const Colour& background_colour, InsertOrder insert_order)
-            : Window(size, background_colour), _insert_order(insert_order)
+        Grid::Grid(const Size& size, const Colour& background_colour, InsertOrder insert_order, uint32_t columns, uint32_t rows)
+            : Window(size, background_colour), _insert_order(insert_order), _columns(columns), _rows(rows)
         {
             _grid = add_child(std::make_unique<Window>(size, background_colour));
         }
@@ -18,16 +18,13 @@ namespace trview
                 return;
             }
 
-            const int Columns = 2;
-            const int Rows = 3;
-
             // Add the cell to the grid
-            auto cell = _grid->add_child(std::make_unique<Window>(Size(static_cast<int>(size().width / Columns), static_cast<int>(size().height / Rows)), background_colour()));
+            auto cell = _grid->add_child(std::make_unique<Window>(Size(static_cast<int>(size().width / _columns), static_cast<int>(size().height / _rows)), background_colour()));
 
             // Calculate the coordinates based on cell index.
-            auto y = std::floor(_cells.size() / Columns);
-            auto x = _cells.size() - Columns * y;
-            cell->set_position(Point((size().width / Columns) * x, (size().height / Rows) * y));
+            auto y = std::floor(_cells.size() / _columns);
+            auto x = _cells.size() - _columns * y;
+            cell->set_position(Point((size().width / _columns) * x, (size().height / _rows) * y));
 
             _cells.push_back(cell);
 

--- a/trview.ui/Grid.cpp
+++ b/trview.ui/Grid.cpp
@@ -7,6 +7,34 @@ namespace trview
         Grid::Grid(const Size& size, const Colour& background_colour, InsertOrder insert_order)
             : Window(size, background_colour), _insert_order(insert_order)
         {
+            _grid = add_child(std::make_unique<Window>(size, background_colour));
+        }
+
+        void Grid::inner_add_child(Control* child_element)
+        {
+            // Take the newly added child element, add it to the 'grid'
+            if (!_grid || std::find(_cells.begin(), _cells.end(), child_element) != _cells.end())
+            {
+                return;
+            }
+
+            const int Columns = 2;
+            const int Rows = 3;
+
+            auto cell = std::make_unique<Window>(Size(size().width / Columns, size().height / Rows), background_colour());
+
+            // Calculate the coordinates based on cell index.
+            auto y = std::floor(_cells.size() / Columns);
+            auto x = _cells.size() - Columns * y;
+            cell->set_position(Point((size().width / Columns) * x, (size().height / Rows) * y));
+
+            _cells.push_back(cell.get());
+
+            // Transfer the new element into the cell.
+            cell->add_child(remove_child(child_element));
+
+            // Add the cell to the grid.
+            add_child(std::move(cell));
         }
     }
 }

--- a/trview.ui/Grid.h
+++ b/trview.ui/Grid.h
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace trview
+{
+    namespace ui
+    {
+        class Grid final
+        {
+        public:
+            enum class InsertOrder
+            {
+                Column,
+                Row
+            };
+
+            explicit Grid(InsertOrder insert_order);
+        private:
+            InsertOrder _insert_order;
+        };
+    }
+}

--- a/trview.ui/Grid.h
+++ b/trview.ui/Grid.h
@@ -16,12 +16,14 @@ namespace trview
                 Row
             };
 
-            explicit Grid(const Size& size, const Colour& background_colour, InsertOrder insert_order);
+            explicit Grid(const Size& size, const Colour& background_colour, InsertOrder insert_order, uint32_t columns, uint32_t rows);
         protected:
             virtual void inner_add_child(Control* child_element) override;
         private:
             InsertOrder _insert_order;
             Window* _grid { nullptr };
+            uint32_t _rows{ 1 };
+            uint32_t _columns{ 1 };
             std::vector<Window*> _cells;
         };
     }

--- a/trview.ui/Grid.h
+++ b/trview.ui/Grid.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "Window.h"
+
 namespace trview
 {
     namespace ui
     {
-        class Grid final
+        class Grid final : public Window
         {
         public:
             enum class InsertOrder
@@ -13,7 +15,7 @@ namespace trview
                 Row
             };
 
-            explicit Grid(InsertOrder insert_order);
+            explicit Grid(const Size& size, const Colour& background_colour, InsertOrder insert_order);
         private:
             InsertOrder _insert_order;
         };

--- a/trview.ui/Grid.h
+++ b/trview.ui/Grid.h
@@ -10,17 +10,10 @@ namespace trview
         class Grid final : public Window
         {
         public:
-            enum class InsertOrder
-            {
-                Column,
-                Row
-            };
-
-            explicit Grid(const Size& size, const Colour& background_colour, InsertOrder insert_order, uint32_t columns, uint32_t rows);
+            explicit Grid(const Size& size, const Colour& background_colour, uint32_t columns, uint32_t rows);
         protected:
             virtual void inner_add_child(Control* child_element) override;
         private:
-            InsertOrder _insert_order;
             Window* _grid { nullptr };
             uint32_t _rows{ 1 };
             uint32_t _columns{ 1 };

--- a/trview.ui/Grid.h
+++ b/trview.ui/Grid.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <vector>
 #include "Window.h"
 
 namespace trview
@@ -16,8 +17,12 @@ namespace trview
             };
 
             explicit Grid(const Size& size, const Colour& background_colour, InsertOrder insert_order);
+        protected:
+            virtual void inner_add_child(Control* child_element) override;
         private:
             InsertOrder _insert_order;
+            Window* _grid { nullptr };
+            std::vector<Window*> _cells;
         };
     }
 }

--- a/trview.ui/trview.ui.vcxproj
+++ b/trview.ui/trview.ui.vcxproj
@@ -23,6 +23,7 @@
     <ClInclude Include="Button.h" />
     <ClInclude Include="Control.h" />
     <ClInclude Include="Dropdown.h" />
+    <ClInclude Include="Grid.h" />
     <ClInclude Include="GroupBox.h" />
     <ClInclude Include="IFontMeasurer.h" />
     <ClInclude Include="IInputQuery.h" />
@@ -45,6 +46,7 @@
     <ClCompile Include="Button.cpp" />
     <ClCompile Include="Control.cpp" />
     <ClCompile Include="Dropdown.cpp" />
+    <ClCompile Include="Grid.cpp" />
     <ClCompile Include="GroupBox.cpp" />
     <ClCompile Include="IFontMeasurer.cpp" />
     <ClCompile Include="IInputQuery.cpp" />

--- a/trview.ui/trview.ui.vcxproj.filters
+++ b/trview.ui/trview.ui.vcxproj.filters
@@ -62,6 +62,9 @@
       <Filter>Input</Filter>
     </ClInclude>
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="Grid.h">
+      <Filter>Controls\Grid</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Control.cpp">
@@ -125,6 +128,9 @@
       <Filter>Input</Filter>
     </ClCompile>
     <ClCompile Include="stdafx.cpp" />
+    <ClCompile Include="Grid.cpp">
+      <Filter>Controls\Grid</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Types">
@@ -150,6 +156,9 @@
     </Filter>
     <Filter Include="Input">
       <UniqueIdentifier>{4ae4639a-c45d-428e-9104-b6604caaa0cf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Controls\Grid">
+      <UniqueIdentifier>{1106c79a-72c2-4484-9448-0c9d678a06dc}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Create a Grid control that lays out controls in a regular grid.
Use this control in Camera Settings and View Options to cut down on the amount of manual UI coordinate entry.
Add a test for the layout of child elements in the Grid.
Closes #709 