### PR TITLE
Add camera acceleration

### DIFF
--- a/trview.app.tests/FreeCameraTests.cpp
+++ b/trview.app.tests/FreeCameraTests.cpp
@@ -18,7 +18,7 @@ TEST(FreeCamera, Alignment)
     const auto current_position = camera.position();
     ASSERT_EQ(Vector3::Zero, camera.position());
 
-    camera.move(Vector3(0, 1, 0));
+    camera.move(Vector3(0, 1, 0), 1);
 
     // Check that the camera has moved up.
     const auto new_position = camera.position();

--- a/trview.app.tests/SettingsWindowTests.cpp
+++ b/trview.app.tests/SettingsWindowTests.cpp
@@ -1,0 +1,526 @@
+#include <trview.app/UI/SettingsWindow.h>
+#include <trview.ui/StackPanel.h>
+#include <trview.ui/Button.h>
+#include <trview.ui/Checkbox.h>
+#include <trview.ui/Slider.h>
+
+using namespace trview;
+using namespace trview::ui;
+
+TEST(SettingsWindow, SetVSyncUpdatesCheckbox)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto checkbox = host.find<Checkbox>("VSync");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    std::optional<bool> received_value;
+    auto token = window.on_vsync += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    window.set_vsync(true);
+    ASSERT_TRUE(checkbox->state());
+    ASSERT_FALSE(received_value.has_value());
+}
+
+TEST(SettingsWindow, ClickingVSyncRaisesEvent)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    std::optional<bool> received_value;
+    auto token = window.on_vsync += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    auto checkbox = host.find<Checkbox>("VSync");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    checkbox->clicked(Point());
+    ASSERT_EQ(received_value.has_value(), true);
+    ASSERT_TRUE(received_value.value());
+}
+
+TEST(SettingsWindow, SetGoToLaraUpdatesCheckbox)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto checkbox = host.find<Checkbox>("GoToLara");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    std::optional<bool> received_value;
+    auto token = window.on_go_to_lara += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    window.set_go_to_lara(true);
+    ASSERT_TRUE(checkbox->state());
+    ASSERT_FALSE(received_value.has_value());
+}
+
+TEST(SettingsWindow, ClickingGoToLaraRaisesEvent)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    std::optional<bool> received_value;
+    auto token = window.on_go_to_lara += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    auto checkbox = host.find<Checkbox>("GoToLara");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    checkbox->clicked(Point());
+    ASSERT_EQ(received_value.has_value(), true);
+    ASSERT_TRUE(received_value.value());
+}
+
+TEST(SettingsWindow, SetInvertMapControlsUpdatesCheckbox)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto checkbox = host.find<Checkbox>("InvertMapControls");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    std::optional<bool> received_value;
+    auto token = window.on_invert_map_controls += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    window.set_invert_map_controls(true);
+    ASSERT_TRUE(checkbox->state());
+    ASSERT_FALSE(received_value.has_value());
+}
+
+TEST(SettingsWindow, ClickingInvertMapControlsRaisesEvent)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    std::optional<bool> received_value;
+    auto token = window.on_invert_map_controls += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    auto checkbox = host.find<Checkbox>("InvertMapControls");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    checkbox->clicked(Point());
+    ASSERT_EQ(received_value.has_value(), true);
+    ASSERT_TRUE(received_value.value());
+}
+
+TEST(SettingsWindow, SetItemsWindowOnStartupUpdatesCheckbox)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto checkbox = host.find<Checkbox>("ItemsStartup");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    std::optional<bool> received_value;
+    auto token = window.on_items_startup += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    window.set_items_startup(true);
+    ASSERT_TRUE(checkbox->state());
+    ASSERT_FALSE(received_value.has_value());
+}
+
+TEST(SettingsWindow, ClickingItemsWindowOnStartupRaisesEvent)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    std::optional<bool> received_value;
+    auto token = window.on_items_startup += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    auto checkbox = host.find<Checkbox>("ItemsStartup");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    checkbox->clicked(Point());
+    ASSERT_EQ(received_value.has_value(), true);
+    ASSERT_TRUE(received_value.value());
+}
+
+TEST(SettingsWindow, SetTriggersWindowOnStartupUpdatesCheckbox)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto checkbox = host.find<Checkbox>("TriggersStartup");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    std::optional<bool> received_value;
+    auto token = window.on_triggers_startup += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    window.set_triggers_startup(true);
+    ASSERT_TRUE(checkbox->state());
+    ASSERT_FALSE(received_value.has_value());
+}
+
+TEST(SettingsWindow, ClickingTriggersWindowOnStartupRaisesEvent)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    std::optional<bool> received_value;
+    auto token = window.on_triggers_startup += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    auto checkbox = host.find<Checkbox>("TriggersStartup");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    checkbox->clicked(Point());
+    ASSERT_EQ(received_value.has_value(), true);
+    ASSERT_TRUE(received_value.value());
+}
+
+TEST(SettingsWindow, SetRoomsWindowOnStartupUpdatesCheckbox)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto checkbox = host.find<Checkbox>("RoomsStartup");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    std::optional<bool> received_value;
+    auto token = window.on_rooms_startup += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    window.set_rooms_startup(true);
+    ASSERT_TRUE(checkbox->state());
+    ASSERT_FALSE(received_value.has_value());
+}
+
+TEST(SettingsWindow, ClickingRoomsWindowOnStartupRaisesEvent)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    std::optional<bool> received_value;
+    auto token = window.on_rooms_startup += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    auto checkbox = host.find<Checkbox>("RoomsStartup");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    checkbox->clicked(Point());
+    ASSERT_EQ(received_value.has_value(), true);
+    ASSERT_TRUE(received_value.value());
+}
+
+TEST(SettingsWindow, SetOrbitUpdatesCheckbox)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto checkbox = host.find<Checkbox>("AutoOrbit");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    std::optional<bool> received_value;
+    auto token = window.on_auto_orbit += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    window.set_auto_orbit(true);
+    ASSERT_TRUE(checkbox->state());
+    ASSERT_FALSE(received_value.has_value());
+}
+
+TEST(SettingsWindow, ClickingOrbitRaisesEvent)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    std::optional<bool> received_value;
+    auto token = window.on_auto_orbit += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    auto checkbox = host.find<Checkbox>("AutoOrbit");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    checkbox->clicked(Point());
+    ASSERT_EQ(received_value.has_value(), true);
+    ASSERT_TRUE(received_value.value());
+}
+
+TEST(SettingsWindow, SetInvertVerticalPanUpdatesCheckbox)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto checkbox = host.find<Checkbox>("InvertVerticalPan");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    std::optional<bool> received_value;
+    auto token = window.on_invert_vertical_pan += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    window.set_invert_vertical_pan(true);
+    ASSERT_TRUE(checkbox->state());
+    ASSERT_FALSE(received_value.has_value());
+}
+
+TEST(SettingsWindow, ClickingInvertVerticalPanRaisesEvent)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    std::optional<bool> received_value;
+    auto token = window.on_invert_vertical_pan += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    auto checkbox = host.find<Checkbox>("InvertVerticalPan");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    checkbox->clicked(Point());
+    ASSERT_EQ(received_value.has_value(), true);
+    ASSERT_TRUE(received_value.value());
+}
+
+TEST(SettingsWindow, SetMovementSpeedUpdatesSlider)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto slider = host.find<Slider>("MovementSpeed");
+    ASSERT_NE(slider, nullptr);
+    ASSERT_EQ(slider->value(), 0.0f);
+
+    std::optional<bool> received_value;
+    auto token = window.on_movement_speed_changed += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    window.set_movement_speed(0.5f);
+    ASSERT_EQ(slider->value(), 0.5f);
+    ASSERT_FALSE(received_value.has_value());
+}
+
+
+TEST(SettingsWindow, ClickingMovementSpeedRaisesEvent)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto slider = host.find<Slider>("MovementSpeed");
+    ASSERT_NE(slider, nullptr);
+    ASSERT_EQ(slider->value(), 0.0f);
+
+    std::optional<float> received_value;
+    auto token = window.on_movement_speed_changed += [&](float value)
+    {
+        received_value = value;
+    };
+
+    slider->clicked(Point(slider->size().width / 2, 0));
+    ASSERT_TRUE(received_value.has_value());
+    ASSERT_EQ(received_value.value(), 0.5f);
+}
+
+TEST(SettingsWindow, SetSensitivitySlider)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto slider = host.find<Slider>("Sensitivity");
+    ASSERT_NE(slider, nullptr);
+    ASSERT_EQ(slider->value(), 0.0f);
+
+    std::optional<bool> received_value;
+    auto token = window.on_sensitivity_changed += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    window.set_sensitivity(0.5f);
+    ASSERT_EQ(slider->value(), 0.5f);
+    ASSERT_FALSE(received_value.has_value());
+}
+
+
+TEST(SettingsWindow, ClickingSensitivityRaisesEvent)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto slider = host.find<Slider>("Sensitivity");
+    ASSERT_NE(slider, nullptr);
+    ASSERT_EQ(slider->value(), 0.0f);
+
+    std::optional<float> received_value;
+    auto token = window.on_sensitivity_changed += [&](float value)
+    {
+        received_value = value;
+    };
+
+    slider->clicked(Point(slider->size().width / 2, 0));
+    ASSERT_TRUE(received_value.has_value());
+    ASSERT_EQ(received_value.value(), 0.5f);
+}
+
+TEST(SettingsWindow, SetAccelerationUpdatesCheckbox)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto checkbox = host.find<Checkbox>("Acceleration");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    std::optional<bool> received_value;
+    auto token = window.on_camera_acceleration += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    window.set_camera_acceleration(true);
+    ASSERT_TRUE(checkbox->state());
+    ASSERT_FALSE(received_value.has_value());
+}
+
+TEST(SettingsWindow, ClickingAccelerationRaisesEvent)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    std::optional<bool> received_value;
+    auto token = window.on_camera_acceleration += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    auto checkbox = host.find<Checkbox>("Acceleration");
+    ASSERT_NE(checkbox, nullptr);
+    ASSERT_FALSE(checkbox->state());
+
+    checkbox->clicked(Point());
+    ASSERT_EQ(received_value.has_value(), true);
+    ASSERT_TRUE(received_value.value());
+}
+
+TEST(SettingsWindow, SetAccelerationRateUpdatesSlider)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto slider = host.find<Slider>("AccelerationRate");
+    ASSERT_NE(slider, nullptr);
+    ASSERT_EQ(slider->value(), 0.0f);
+
+    std::optional<bool> received_value;
+    auto token = window.on_camera_acceleration_rate += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    window.set_camera_acceleration_rate(0.5f);
+    ASSERT_EQ(slider->value(), 0.5f);
+    ASSERT_FALSE(received_value.has_value());
+}
+
+
+TEST(SettingsWindow, ClickingAccelerationRateRaisesEvent)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto slider = host.find<Slider>("AccelerationRate");
+    ASSERT_NE(slider, nullptr);
+    ASSERT_EQ(slider->value(), 0.0f);
+
+    std::optional<float> received_value;
+    auto token = window.on_camera_acceleration_rate += [&](float value)
+    {
+        received_value = value;
+    };
+
+    slider->clicked(Point(slider->size().width / 2, 0));
+    ASSERT_TRUE(received_value.has_value());
+    ASSERT_EQ(received_value.value(), 0.5f);
+}
+
+TEST(SettingsWindow, CloseClosesWindow)
+{
+    StackPanel host(Size(), Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto control = host.find<Control>("SettingsWindow");
+    ASSERT_NE(control, nullptr);
+    ASSERT_FALSE(control->visible());
+
+    window.toggle_visibility();
+    ASSERT_TRUE(control->visible());
+
+    auto close = control->find<Button>("Close");
+    ASSERT_NE(close, nullptr);
+
+    close->clicked(Point());
+    ASSERT_FALSE(control->visible());
+}
+
+TEST(SettingsWindow, WindowIsCentred)
+{
+    auto host_size = Size(3000, 2000);
+    ui::Window host(host_size, Colour::Transparent);
+    SettingsWindow window(host);
+
+    auto control = host.find<Control>("SettingsWindow");
+    ASSERT_NE(control, nullptr);
+
+    auto size = control->size();
+    auto position = control->position();
+
+    auto calculated_size = host_size / 2 - size / 2;
+    ASSERT_EQ(position, Point(calculated_size.width, calculated_size.height));
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -29,6 +29,7 @@
     <ClCompile Include="Menus\MenuDetectorTests.cpp" />
     <ClCompile Include="OrbitCameraTests.cpp" />
     <ClCompile Include="RecentFilesTests.cpp" />
+    <ClCompile Include="SettingsWindowTests.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -30,6 +30,9 @@
       <Filter>Menus</Filter>
     </ClCompile>
     <ClCompile Include="stdafx.cpp" />
+    <ClCompile Include="SettingsWindowTests.cpp">
+      <Filter>UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Camera/FreeCamera.cpp
+++ b/trview.app/Camera/FreeCamera.cpp
@@ -83,7 +83,7 @@ namespace trview
         }
         else
         {
-            _acceleration = std::max(_acceleration + _acceleration_rate * elapsed, _acceleration_maximum);
+            _acceleration = std::min(_acceleration + _acceleration_rate * elapsed, _acceleration_maximum);
         }
     }
 }

--- a/trview.app/Camera/FreeCamera.cpp
+++ b/trview.app/Camera/FreeCamera.cpp
@@ -17,7 +17,7 @@ namespace trview
 
         // Scale the movement by elapsed time to keep it framerate independent - also apply
         // camera movement acceleration if present.
-        auto scaled_movement = movement * elapsed * (1 + _acceleration);
+        auto scaled_movement = movement * elapsed * _acceleration;
 
         if (_projection_mode == ProjectionMode::Orthographic)
         {
@@ -55,15 +55,14 @@ namespace trview
         calculate_view_matrix();
     }
 
-    void FreeCamera::set_acceleration_settings(bool enabled, float rate, float maximum)
+    void FreeCamera::set_acceleration_settings(bool enabled, float rate)
     {
         _acceleration_enabled = enabled;
         _acceleration_rate = rate;
-        _acceleration_maximum = maximum;
 
         if (!_acceleration_enabled)
         {
-            _acceleration = 0.0f;
+            _acceleration = 1.0f;
         }
     }
 
@@ -77,13 +76,17 @@ namespace trview
 
     void FreeCamera::update_acceleration(const Vector3& movement, float elapsed)
     {
-        if (_acceleration_enabled || movement.LengthSquared() == 0)
+        if (!_acceleration_enabled)
+        {
+            _acceleration = 1.0f;
+        }
+        else if (movement.LengthSquared() == 0)
         {
             _acceleration = 0.0f;
         }
         else
         {
-            _acceleration = std::min(_acceleration + _acceleration_rate * elapsed, _acceleration_maximum);
+            _acceleration = std::min(_acceleration + std::max(_acceleration_rate, 0.1f) * elapsed, 1.0f);
         }
     }
 }

--- a/trview.app/Camera/FreeCamera.cpp
+++ b/trview.app/Camera/FreeCamera.cpp
@@ -77,7 +77,7 @@ namespace trview
 
     void FreeCamera::update_acceleration(const Vector3& movement, float elapsed)
     {
-        if (movement.LengthSquared() == 0)
+        if (_acceleration_enabled || movement.LengthSquared() == 0)
         {
             _acceleration = 0.0f;
         }

--- a/trview.app/Camera/FreeCamera.cpp
+++ b/trview.app/Camera/FreeCamera.cpp
@@ -55,6 +55,18 @@ namespace trview
         calculate_view_matrix();
     }
 
+    void FreeCamera::set_acceleration_settings(bool enabled, float rate, float maximum)
+    {
+        _acceleration_enabled = enabled;
+        _acceleration_rate = rate;
+        _acceleration_maximum = maximum;
+
+        if (!_acceleration_enabled)
+        {
+            _acceleration = 0.0f;
+        }
+    }
+
     void FreeCamera::update_vectors()
     {
         const auto rotation = Matrix::CreateFromYawPitchRoll(_rotation_yaw, _rotation_pitch, 0);
@@ -71,7 +83,7 @@ namespace trview
         }
         else
         {
-            _acceleration += 0.5f * elapsed;
+            _acceleration = std::max(_acceleration + _acceleration_rate * elapsed, _acceleration_maximum);
         }
     }
 }

--- a/trview.app/Camera/FreeCamera.h
+++ b/trview.app/Camera/FreeCamera.h
@@ -43,8 +43,7 @@ namespace trview
         /// Set the new acceleration settings.
         /// @param enabled Whether acceleration is on.
         /// @param rate The rate of acceleration.
-        /// @param maximum The maximum speedup factor.
-        void set_acceleration_settings(bool enabled, float rate, float maximum);
+        void set_acceleration_settings(bool enabled, float rate);
     protected:
         virtual void update_vectors() override;
     private:
@@ -54,7 +53,6 @@ namespace trview
 
         bool _acceleration_enabled{ true };
         float _acceleration_rate{ 0.5f };
-        float _acceleration_maximum{ 20.0f };
         float _acceleration{ 0.0f };
     };
 }

--- a/trview.app/Camera/FreeCamera.h
+++ b/trview.app/Camera/FreeCamera.h
@@ -28,8 +28,9 @@ namespace trview
 
         /// Move the camera around the world.
         /// @param movement The axis relative movement vector.
+        /// @param elapsed The elapsed time since the previous update.
         /// @remarks The movement will be applied based on the current alignment mode of the camera.
-        void move(const DirectX::SimpleMath::Vector3& movement);
+        void move(const DirectX::SimpleMath::Vector3& movement, float elapsed);
 
         /// Set the camera alignment. This controls how the camera movement is applied to the current position.
         /// @param alignment The new alignment mode.
@@ -41,6 +42,9 @@ namespace trview
     protected:
         virtual void update_vectors() override;
     private:
+        void update_acceleration(const DirectX::SimpleMath::Vector3& movement, float elapsed);
+
         Alignment _alignment{ Alignment::Axis };
+        float _acceleration{ 0.0f };
     };
 }

--- a/trview.app/Camera/FreeCamera.h
+++ b/trview.app/Camera/FreeCamera.h
@@ -39,12 +39,22 @@ namespace trview
         /// Set the position of the camera in the world.
         /// @param position The new camera position.
         void set_position(const DirectX::SimpleMath::Vector3& position);
+
+        /// Set the new acceleration settings.
+        /// @param enabled Whether acceleration is on.
+        /// @param rate The rate of acceleration.
+        /// @param maximum The maximum speedup factor.
+        void set_acceleration_settings(bool enabled, float rate, float maximum);
     protected:
         virtual void update_vectors() override;
     private:
         void update_acceleration(const DirectX::SimpleMath::Vector3& movement, float elapsed);
 
         Alignment _alignment{ Alignment::Axis };
+
+        bool _acceleration_enabled{ true };
+        float _acceleration_rate{ 0.5f };
+        float _acceleration_maximum{ 20.0f };
         float _acceleration{ 0.0f };
     };
 }

--- a/trview.app/Settings/UserSettings.cpp
+++ b/trview.app/Settings/UserSettings.cpp
@@ -70,18 +70,18 @@ namespace trview
             nlohmann::json json;
             file >> json;
 
-            settings.camera_sensitivity = json["camera"].get<float>();
-            settings.camera_movement_speed = json["movement"].get<float>();
-            settings.vsync = json["vsync"].get<bool>();
-            settings.go_to_lara = json["gotolara"].get<bool>();
-            settings.invert_map_controls = json["invertmapcontrols"].get<bool>();
-            settings.items_startup = json["itemsstartup"].get<bool>();
-            settings.triggers_startup = json["triggersstartup"].get<bool>();
-            settings.auto_orbit = json["autoorbit"].get<bool>();
-            settings.recent_files = json["recent"].get<std::list<std::string>>();
-            settings.invert_vertical_pan = json["invertverticalpan"].get<bool>();
-            settings.background_colour = json["background"].get<uint32_t>();
-            settings.rooms_startup = json["roomsstartup"].get<bool>();
+            read_setting(json, settings.camera_sensitivity, "camera");
+            read_setting(json, settings.camera_movement_speed, "movement");
+            read_setting(json, settings.vsync, "vsync");
+            read_setting(json, settings.go_to_lara, "gotolara");
+            read_setting(json, settings.invert_map_controls, "invertmapcontrols");
+            read_setting(json, settings.items_startup, "itemsstartup");
+            read_setting(json, settings.triggers_startup, "triggersstartup");
+            read_setting(json, settings.auto_orbit, "autoorbit");
+            read_setting(json, settings.recent_files, "recent");
+            read_setting(json, settings.invert_vertical_pan, "invertverticalpan");
+            read_setting(json, settings.background_colour, "background");
+            read_setting(json, settings.rooms_startup, "roomsstartup");
             read_setting(json, settings.camera_acceleration, "cameraacceleration");
             read_setting(json, settings.camera_acceleration_rate, "cameraaccelerationrate");
         }

--- a/trview.app/Settings/UserSettings.cpp
+++ b/trview.app/Settings/UserSettings.cpp
@@ -17,6 +17,15 @@ namespace trview
                 }
             }
         };
+
+        template <typename T>
+        void read_setting(const nlohmann::json& json, T& destination, const std::string& attribute_name)
+        {
+            if (json.count(attribute_name) != 0)
+            {
+                destination = json[attribute_name].get<T>();
+            }
+        }
     }
 
     void UserSettings::add_recent_file(const std::string& file)
@@ -73,6 +82,9 @@ namespace trview
             settings.invert_vertical_pan = json["invertverticalpan"].get<bool>();
             settings.background_colour = json["background"].get<uint32_t>();
             settings.rooms_startup = json["roomsstartup"].get<bool>();
+            read_setting(json, settings.camera_acceleration, "cameraacceleration");
+            read_setting(json, settings.camera_acceleration_maximum, "cameraaccelerationmaximum");
+            read_setting(json, settings.camera_acceleration_rate, "cameraaccelerationrate");
         }
         catch (...)
         {
@@ -114,6 +126,9 @@ namespace trview
             json["invertverticalpan"] = settings.invert_vertical_pan;
             json["background"] = settings.background_colour;
             json["roomsstartup"] = settings.rooms_startup;
+            json["cameraacceleration"] = settings.camera_acceleration;
+            json["cameraaccelerationmaximum"] = settings.camera_acceleration_maximum;
+            json["cameraaccelerationrate"] = settings.camera_acceleration_rate;
 
             std::ofstream file(file_path);
             file << json;

--- a/trview.app/Settings/UserSettings.cpp
+++ b/trview.app/Settings/UserSettings.cpp
@@ -83,7 +83,6 @@ namespace trview
             settings.background_colour = json["background"].get<uint32_t>();
             settings.rooms_startup = json["roomsstartup"].get<bool>();
             read_setting(json, settings.camera_acceleration, "cameraacceleration");
-            read_setting(json, settings.camera_acceleration_maximum, "cameraaccelerationmaximum");
             read_setting(json, settings.camera_acceleration_rate, "cameraaccelerationrate");
         }
         catch (...)
@@ -127,7 +126,6 @@ namespace trview
             json["background"] = settings.background_colour;
             json["roomsstartup"] = settings.rooms_startup;
             json["cameraacceleration"] = settings.camera_acceleration;
-            json["cameraaccelerationmaximum"] = settings.camera_acceleration_maximum;
             json["cameraaccelerationrate"] = settings.camera_acceleration_rate;
 
             std::ofstream file(file_path);

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -21,6 +21,9 @@ namespace trview
         bool                    invert_vertical_pan{ true };
         uint32_t                background_colour = 0x003366;
         bool                    rooms_startup{ false };
+        bool                    camera_acceleration{ true };
+        float                   camera_acceleration_maximum{ 20.0f };
+        float                   camera_acceleration_rate{ 0.5f };
     };
 
     // Load the user settings from the settings file.

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -22,7 +22,6 @@ namespace trview
         uint32_t                background_colour = 0x003366;
         bool                    rooms_startup{ false };
         bool                    camera_acceleration{ true };
-        float                   camera_acceleration_maximum{ 20.0f };
         float                   camera_acceleration_rate{ 0.5f };
     };
 

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -11,7 +11,7 @@ namespace trview
 
         std::list<std::string>  recent_files;
         float                   camera_sensitivity{ 0 };
-        float                   camera_movement_speed{ 0 };
+        float                   camera_movement_speed{ 0.5f };
         bool                    vsync{ true };
         bool                    go_to_lara{ true };
         bool                    invert_map_controls{ false };

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -7,6 +7,7 @@
 #include <trview.ui/Label.h>
 #include <trview.ui/Button.h>
 #include <trview.ui/Slider.h>
+#include <trview.ui/Grid.h>
 
 using namespace trview::ui;
 
@@ -63,33 +64,25 @@ namespace trview
         invert_vertical_pan->on_state_changed += on_invert_vertical_pan;
         _invert_vertical_pan = panel->add_child(std::move(invert_vertical_pan));
 
-        auto camera_panel = std::make_unique<StackPanel>(Size(400, 40), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
-        camera_panel->set_margin(Size(5, 5));
+        auto camera_group = panel->add_child(std::make_unique<GroupBox>(Size(380, 80), Colour::Transparent, Colour::LightGrey, L"Camera Movement"));
+        auto camera_panel = camera_group->add_child(std::make_unique<Grid>(Size(360, 50), Colour::Transparent, 2, 2));
 
-        camera_panel->add_child(std::make_unique<Label>(Size(), Colour::Transparent, L"Sensitivity", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto));
-        _sensitivity = camera_panel->add_child(std::make_unique<Slider>(Point(6, 12), Size(118, 16)));
-        camera_panel->add_child(std::make_unique<Label>(Size(), Colour::Transparent, L"Movement Speed", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto));
-        _movement_speed = camera_panel->add_child(std::make_unique<Slider>(Point(6, 12), Size(118, 16)));
+        auto add_labelled_slider = [&](const std::wstring& text)
+        {
+            auto slider_panel = camera_panel->add_child(std::make_unique<StackPanel>(Size(160, 50), Colour::Transparent, Size(), StackPanel::Direction::Horizontal));
+            slider_panel->add_child(std::make_unique<Label>(Size(), Colour::Transparent, text, 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto));
+            return slider_panel->add_child(std::make_unique<Slider>(Size(100, 16)));
+        };
+
+        _sensitivity = add_labelled_slider(L"Sensitivity");
+        _movement_speed = add_labelled_slider(L"Movement Speed ");
+        _acceleration = camera_panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Acceleration"));
+        _acceleration_rate = add_labelled_slider(L"Acceleration Rate");
 
         _sensitivity->on_value_changed += on_sensitivity_changed;
         _movement_speed->on_value_changed += on_movement_speed_changed;
-
-        panel->add_child(std::move(camera_panel));
-
-        auto camera_acceleration_panel = std::make_unique<StackPanel>(Size(400, 40), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
-        camera_acceleration_panel->set_margin(Size(5, 5));
-
-        _acceleration = camera_acceleration_panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Acceleration"));
-        camera_acceleration_panel->add_child(std::make_unique<Label>(Size(), Colour::Transparent, L"Rate", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto));
-        _acceleration_rate = camera_acceleration_panel->add_child(std::make_unique<Slider>(Point(6, 12), Size(118, 16)));
-        camera_acceleration_panel->add_child(std::make_unique<Label>(Size(), Colour::Transparent, L"Maximum", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto));
-        _acceleration_maximum = camera_acceleration_panel->add_child(std::make_unique<Slider>(Point(6, 12), Size(118, 16)));
-
         _acceleration->on_state_changed += on_camera_acceleration;
         _acceleration_rate->on_value_changed += on_camera_acceleration_rate;
-        _acceleration_maximum->on_value_changed += on_camera_acceleration_maximum;
-
-        panel->add_child(std::move(camera_acceleration_panel));
 
         auto ok = std::make_unique<Button>(Point(), Size(60, 20), L"Close");
         ok->set_horizontal_alignment(Align::Centre);
@@ -150,11 +143,6 @@ namespace trview
     void SettingsWindow::set_camera_acceleration_enabled(bool value)
     {
         _acceleration->set_state(value);
-    }
-
-    void SettingsWindow::set_camera_acceleration_maximum(float value)
-    {
-        _acceleration_maximum->set_value(value);
     }
 
     void SettingsWindow::set_camera_acceleration_rate(float value)

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -127,7 +127,7 @@ namespace trview
         _auto_orbit->set_state(value);
     }
 
-    void SettingsWindow::set_camera_acceleration_enabled(bool value)
+    void SettingsWindow::set_camera_acceleration(bool value)
     {
         _acceleration->set_state(value);
     }

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -18,51 +18,42 @@ namespace trview
         const auto background_colour = Colour(0.5f, 0.0f, 0.0f, 0.0f);
         const auto title_colour = Colour::Black;
 
-        auto window = std::make_unique<StackPanel>(Point(400, 200), Size(400, 300), background_colour, Size());
-        window->set_visible(false);
+        _window = parent.add_child(std::make_unique<StackPanel>(Point(400, 200), Size(400, 300), background_colour, Size()));
+        _window->set_visible(false);
 
         // Create the title bar.
-        auto title_bar = std::make_unique<StackPanel>(Size(400, 20), title_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual);
-        auto title = std::make_unique<Label>(Size(400, 20), title_colour, L"Settings", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre);
+        auto title_bar = _window->add_child(std::make_unique<StackPanel>(Size(400, 20), title_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual));
+        auto title = title_bar->add_child(std::make_unique<Label>(Size(400, 20), title_colour, L"Settings", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre));
         title->set_horizontal_alignment(Align::Centre);
-        title_bar->add_child(std::move(title));
-        window->add_child(std::move(title_bar));
 
         // Create the rest of the window contents.
-        auto panel = std::make_unique<StackPanel>(Size(400, 250), Colour::Transparent , Size(5, 5));
+        auto panel = _window->add_child(std::make_unique<StackPanel>(Size(400, 250), Colour::Transparent , Size(5, 5)));
         panel->set_auto_size_dimension(SizeDimension::Height);
         panel->set_margin(Size(5, 5));
 
-        auto vsync = std::make_unique<Checkbox>(Colour::Transparent, L"Vsync");
-        vsync->on_state_changed += on_vsync;
-        _vsync = panel->add_child(std::move(vsync));
+        _vsync = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Vsync"));
+        _vsync->on_state_changed += on_vsync;
 
-        auto go_to_lara = std::make_unique<Checkbox>(Colour::Transparent, L"Go to Lara");
-        go_to_lara->on_state_changed += on_go_to_lara;
-        _go_to_lara = panel->add_child(std::move(go_to_lara));
+        _go_to_lara = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Go to Lara"));
+        _go_to_lara->on_state_changed += on_go_to_lara;
 
-        auto invert_map_controls = std::make_unique<Checkbox>(Colour::Transparent, L"Invert map controls");
-        invert_map_controls->on_state_changed += on_invert_map_controls;
-        _invert_map_controls = panel->add_child(std::move(invert_map_controls));
+        _invert_map_controls = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Invert map controls"));
+        _invert_map_controls->on_state_changed += on_invert_map_controls;
 
-        auto items_startup = std::make_unique<Checkbox>(Colour::Transparent, L"Open Items Window at startup");
-        items_startup->on_state_changed += on_items_startup;
-        _items_startup = panel->add_child(std::move(items_startup));
+        _items_startup = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Open Items Window at startup"));
+        _items_startup->on_state_changed += on_items_startup;
 
-        auto triggers_startup = std::make_unique<Checkbox>(Colour::Transparent, L"Open Triggers Window at startup");
-        triggers_startup->on_state_changed += on_triggers_startup;
-        _triggers_startup = panel->add_child(std::move(triggers_startup));
+        _triggers_startup = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Open Triggers Window at startup"));
+        _triggers_startup->on_state_changed += on_triggers_startup;
 
         _rooms_startup = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Open Rooms Window at startup"));
         _rooms_startup->on_state_changed += on_rooms_startup;
 
-        auto auto_orbit = std::make_unique<Checkbox>(Colour::Transparent, L"Switch to orbit on selection");
-        auto_orbit->on_state_changed += on_auto_orbit;
-        _auto_orbit = panel->add_child(std::move(auto_orbit));
+        _auto_orbit = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Switch to orbit on selection"));
+        _auto_orbit->on_state_changed += on_auto_orbit;
 
-        auto invert_vertical_pan = std::make_unique<Checkbox>(Colour::Transparent, L"Invert vertical panning");
-        invert_vertical_pan->on_state_changed += on_invert_vertical_pan;
-        _invert_vertical_pan = panel->add_child(std::move(invert_vertical_pan));
+        _invert_vertical_pan = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Invert vertical panning"));
+        _invert_vertical_pan->on_state_changed += on_invert_vertical_pan;
 
         auto camera_group = panel->add_child(std::make_unique<GroupBox>(Size(380, 80), Colour::Transparent, Colour::LightGrey, L"Camera Movement"));
         auto camera_panel = camera_group->add_child(std::make_unique<Grid>(Size(360, 50), Colour::Transparent, 2, 2));
@@ -84,13 +75,9 @@ namespace trview
         _acceleration->on_state_changed += on_camera_acceleration;
         _acceleration_rate->on_value_changed += on_camera_acceleration_rate;
 
-        auto ok = std::make_unique<Button>(Point(), Size(60, 20), L"Close");
+        auto ok = panel->add_child(std::make_unique<Button>(Point(), Size(60, 20), L"Close"));
         ok->set_horizontal_alignment(Align::Centre);
         _token_store += ok->on_click += [&]() { _window->set_visible(!_window->visible()); };
-        panel->add_child(std::move(ok));
-
-        window->add_child(std::move(panel));
-        _window = parent.add_child(std::move(window));
 
         // Register for control resizes on the parent so that the window will always
         // be in the middle of the screen.

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -20,6 +20,7 @@ namespace trview
 
         _window = parent.add_child(std::make_unique<StackPanel>(Point(400, 200), Size(400, 300), background_colour, Size()));
         _window->set_visible(false);
+        _window->set_name("SettingsWindow");
 
         // Create the title bar.
         auto title_bar = _window->add_child(std::make_unique<StackPanel>(Size(400, 20), title_colour, Size(), StackPanel::Direction::Vertical, SizeMode::Manual));
@@ -32,27 +33,35 @@ namespace trview
         panel->set_margin(Size(5, 5));
 
         _vsync = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Vsync"));
+        _vsync->set_name("VSync");
         _vsync->on_state_changed += on_vsync;
 
         _go_to_lara = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Go to Lara"));
+        _go_to_lara->set_name("GoToLara");
         _go_to_lara->on_state_changed += on_go_to_lara;
 
         _invert_map_controls = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Invert map controls"));
+        _invert_map_controls->set_name("InvertMapControls");
         _invert_map_controls->on_state_changed += on_invert_map_controls;
 
         _items_startup = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Open Items Window at startup"));
+        _items_startup->set_name("ItemsStartup");
         _items_startup->on_state_changed += on_items_startup;
 
         _triggers_startup = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Open Triggers Window at startup"));
+        _triggers_startup->set_name("TriggersStartup");
         _triggers_startup->on_state_changed += on_triggers_startup;
 
         _rooms_startup = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Open Rooms Window at startup"));
+        _rooms_startup->set_name("RoomsStartup");
         _rooms_startup->on_state_changed += on_rooms_startup;
 
         _auto_orbit = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Switch to orbit on selection"));
+        _auto_orbit->set_name("AutoOrbit");
         _auto_orbit->on_state_changed += on_auto_orbit;
 
         _invert_vertical_pan = panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Invert vertical panning"));
+        _invert_vertical_pan->set_name("InvertVerticalPan");
         _invert_vertical_pan->on_state_changed += on_invert_vertical_pan;
 
         auto camera_group = panel->add_child(std::make_unique<GroupBox>(Size(380, 80), Colour::Transparent, Colour::LightGrey, L"Camera Movement"));
@@ -66,18 +75,23 @@ namespace trview
         };
 
         _sensitivity = add_labelled_slider(L"Sensitivity");
+        _sensitivity->set_name("Sensitivity");
         _movement_speed = add_labelled_slider(L"Movement Speed ");
+        _movement_speed->set_name("MovementSpeed");
         _acceleration = camera_panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Acceleration"));
+        _acceleration->set_name("Acceleration");
         _acceleration_rate = add_labelled_slider(L"Acceleration Rate");
+        _acceleration_rate->set_name("AccelerationRate");
 
         _sensitivity->on_value_changed += on_sensitivity_changed;
         _movement_speed->on_value_changed += on_movement_speed_changed;
         _acceleration->on_state_changed += on_camera_acceleration;
         _acceleration_rate->on_value_changed += on_camera_acceleration_rate;
 
-        auto ok = panel->add_child(std::make_unique<Button>(Point(), Size(60, 20), L"Close"));
-        ok->set_horizontal_alignment(Align::Centre);
-        _token_store += ok->on_click += [&]() { _window->set_visible(!_window->visible()); };
+        auto close = panel->add_child(std::make_unique<Button>(Point(), Size(60, 20), L"Close"));
+        close->set_horizontal_alignment(Align::Centre);
+        close->set_name("Close");
+        _token_store += close->on_click += [&]() { toggle_visibility(); };
 
         // Register for control resizes on the parent so that the window will always
         // be in the middle of the screen.

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -76,6 +76,21 @@ namespace trview
 
         panel->add_child(std::move(camera_panel));
 
+        auto camera_acceleration_panel = std::make_unique<StackPanel>(Size(400, 40), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
+        camera_acceleration_panel->set_margin(Size(5, 5));
+
+        _acceleration = camera_acceleration_panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Acceleration"));
+        camera_acceleration_panel->add_child(std::make_unique<Label>(Size(), Colour::Transparent, L"Rate", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto));
+        _acceleration_rate = camera_acceleration_panel->add_child(std::make_unique<Slider>(Point(6, 12), Size(118, 16)));
+        camera_acceleration_panel->add_child(std::make_unique<Label>(Size(), Colour::Transparent, L"Maximum", 8, graphics::TextAlignment::Left, graphics::ParagraphAlignment::Near, SizeMode::Auto));
+        _acceleration_maximum = camera_acceleration_panel->add_child(std::make_unique<Slider>(Point(6, 12), Size(118, 16)));
+
+        _acceleration->on_state_changed += on_camera_acceleration;
+        _acceleration_rate->on_value_changed += on_camera_acceleration_rate;
+        _acceleration_maximum->on_value_changed += on_camera_acceleration_maximum;
+
+        panel->add_child(std::move(camera_acceleration_panel));
+
         auto ok = std::make_unique<Button>(Point(), Size(60, 20), L"Close");
         ok->set_horizontal_alignment(Align::Centre);
         _token_store += ok->on_click += [&]() { _window->set_visible(!_window->visible()); };
@@ -130,6 +145,21 @@ namespace trview
     void SettingsWindow::set_auto_orbit(bool value)
     {
         _auto_orbit->set_state(value);
+    }
+
+    void SettingsWindow::set_camera_acceleration_enabled(bool value)
+    {
+        _acceleration->set_state(value);
+    }
+
+    void SettingsWindow::set_camera_acceleration_maximum(float value)
+    {
+        _acceleration_maximum->set_value(value);
+    }
+
+    void SettingsWindow::set_camera_acceleration_rate(float value)
+    {
+        _acceleration_rate->set_value(value);
     }
 
     void SettingsWindow::toggle_visibility()

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -76,16 +76,18 @@ namespace trview
 
         _sensitivity = add_labelled_slider(L"Sensitivity");
         _sensitivity->set_name("Sensitivity");
+        _sensitivity->on_value_changed += on_sensitivity_changed;
+
         _movement_speed = add_labelled_slider(L"Movement Speed ");
         _movement_speed->set_name("MovementSpeed");
+        _movement_speed->on_value_changed += on_movement_speed_changed;
+
         _acceleration = camera_panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Acceleration"));
         _acceleration->set_name("Acceleration");
+        _acceleration->on_state_changed += on_camera_acceleration;
+
         _acceleration_rate = add_labelled_slider(L"Acceleration Rate");
         _acceleration_rate->set_name("AccelerationRate");
-
-        _sensitivity->on_value_changed += on_sensitivity_changed;
-        _movement_speed->on_value_changed += on_movement_speed_changed;
-        _acceleration->on_state_changed += on_camera_acceleration;
         _acceleration_rate->on_value_changed += on_camera_acceleration_rate;
 
         auto close = panel->add_child(std::make_unique<Button>(Point(), Size(60, 20), L"Close"));

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -110,19 +110,19 @@ namespace trview
         /// Toggle the visibility of the settings window.
         void toggle_visibility();
     private:
-        ui::Checkbox* _vsync;
-        ui::Checkbox* _go_to_lara;
-        ui::Checkbox* _invert_map_controls;
-        ui::Checkbox* _items_startup;
-        ui::Checkbox* _triggers_startup;
-        ui::Checkbox* _rooms_startup;
-        ui::Checkbox* _auto_orbit;
-        ui::Slider* _sensitivity;
-        ui::Slider* _movement_speed;
-        ui::Control* _window;
-        ui::Checkbox* _invert_vertical_pan;
-        ui::Checkbox* _acceleration;
-        ui::Slider* _acceleration_rate;
+        ui::Checkbox* _vsync{ nullptr };
+        ui::Checkbox* _go_to_lara{ nullptr };
+        ui::Checkbox* _invert_map_controls{ nullptr };
+        ui::Checkbox* _items_startup{ nullptr };
+        ui::Checkbox* _triggers_startup{ nullptr };
+        ui::Checkbox* _rooms_startup{ nullptr };
+        ui::Checkbox* _auto_orbit{ nullptr };
+        ui::Slider* _sensitivity{ nullptr };
+        ui::Slider* _movement_speed{ nullptr };
+        ui::Control* _window{ nullptr };
+        ui::Checkbox* _invert_vertical_pan{ nullptr };
+        ui::Checkbox* _acceleration{ nullptr };
+        ui::Slider* _acceleration_rate{ nullptr };
         TokenStore _token_store;
     };
 }

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -61,8 +61,6 @@ namespace trview
         Event<bool> on_camera_acceleration;
         Event<float> on_camera_acceleration_rate;
 
-        Event<float> on_camera_acceleration_maximum;
-
         /// Set the new value of the vsync setting. This will not raise the on_vsync event.
         /// @param value The new vsync setting.
         void set_vsync(bool value);
@@ -92,7 +90,6 @@ namespace trview
         void set_auto_orbit(bool value);
 
         void set_camera_acceleration_enabled(bool value);
-        void set_camera_acceleration_maximum(float value);
         void set_camera_acceleration_rate(float value);
 
         /// Set the movement speed slider to specified value.
@@ -126,7 +123,6 @@ namespace trview
         ui::Checkbox* _invert_vertical_pan;
         ui::Checkbox* _acceleration;
         ui::Slider* _acceleration_rate;
-        ui::Slider* _acceleration_maximum;
         TokenStore _token_store;
     };
 }

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -58,6 +58,11 @@ namespace trview
         /// Event raised when the 'Invert vertical pan' setting has been changed. The new setting is passed as the parameter.
         Event<bool> on_invert_vertical_pan;
 
+        Event<bool> on_camera_acceleration;
+        Event<float> on_camera_acceleration_rate;
+
+        Event<float> on_camera_acceleration_maximum;
+
         /// Set the new value of the vsync setting. This will not raise the on_vsync event.
         /// @param value The new vsync setting.
         void set_vsync(bool value);
@@ -85,6 +90,10 @@ namespace trview
         /// Set the new value of the 'Switch to orbit on selection' setting. This will not raise the on_auto_orbit event.
         /// @param value The new 'Switch to orbit on selection' setting.
         void set_auto_orbit(bool value);
+
+        void set_camera_acceleration_enabled(bool value);
+        void set_camera_acceleration_maximum(float value);
+        void set_camera_acceleration_rate(float value);
 
         /// Set the movement speed slider to specified value.
         /// @param value The movement speed between 0 and 1.
@@ -115,6 +124,9 @@ namespace trview
         ui::Slider* _movement_speed;
         ui::Control* _window;
         ui::Checkbox* _invert_vertical_pan;
+        ui::Checkbox* _acceleration;
+        ui::Slider* _acceleration_rate;
+        ui::Slider* _acceleration_maximum;
         TokenStore _token_store;
     };
 }

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -58,7 +58,10 @@ namespace trview
         /// Event raised when the 'Invert vertical pan' setting has been changed. The new setting is passed as the parameter.
         Event<bool> on_invert_vertical_pan;
 
+        /// Event raised when the 'camera acceleration' setting has been changed. The new setting is passed as the parameter.
         Event<bool> on_camera_acceleration;
+
+        /// Event raised when the 'camera acceleration rate' setting has been changed. The new setting is passed as the parameter.
         Event<float> on_camera_acceleration_rate;
 
         /// Set the new value of the vsync setting. This will not raise the on_vsync event.
@@ -89,7 +92,12 @@ namespace trview
         /// @param value The new 'Switch to orbit on selection' setting.
         void set_auto_orbit(bool value);
 
-        void set_camera_acceleration_enabled(bool value);
+        /// Set the new value of the 'camera acceleration' setting. This will not raise the on_camera_acceleration event.
+        /// @param value The new 'camera acceleration' setting.
+        void set_camera_acceleration(bool value);
+
+        /// Set the new value of the 'camera acceleration rate' setting. This will not raise the on_camera_acceleration_rate event.
+        /// @param value The new 'camera acceleration rate' setting.
         void set_camera_acceleration_rate(float value);
 
         /// Set the movement speed slider to specified value.

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -139,10 +139,26 @@ namespace trview
             _settings.invert_vertical_pan = value;
             on_settings(_settings);
         };
-        _settings_window->on_sensitivity_changed += on_camera_sensitivity;
-        _settings_window->on_movement_speed_changed += on_camera_movement_speed;
-        _settings_window->on_camera_acceleration += on_camera_acceleration;
-        _settings_window->on_camera_acceleration_rate += on_camera_acceleration_rate;
+        _token_store += _settings_window->on_sensitivity_changed += [&](float value)
+        {
+            _settings.camera_sensitivity = value;
+            on_settings(_settings);
+        };
+        _token_store += _settings_window->on_movement_speed_changed += [&](float value)
+        {
+            _settings.camera_movement_speed = value;
+            on_settings(_settings);
+        };
+        _token_store += _settings_window->on_camera_acceleration += [&](bool value)
+        {
+            _settings.camera_acceleration = value;
+            on_settings(_settings);
+        };
+        _token_store += _settings_window->on_camera_acceleration_rate += [&](float value)
+        {
+            _settings.camera_acceleration_rate = value;
+            on_settings(_settings);
+        };
 
         _camera_position = std::make_unique<CameraPosition>(*_control);
         _camera_position->on_position_changed += on_camera_position;
@@ -263,29 +279,9 @@ namespace trview
         _view_options->set_alternate_groups(groups);
     }
 
-    void ViewerUI::set_camera_acceleration(bool value)
-    {
-        _settings_window->set_camera_acceleration(value);
-    }
-    
-    void ViewerUI::set_camera_acceleration_rate(float value)
-    {
-        _settings_window->set_camera_acceleration_rate(value);
-    }
-
-    void ViewerUI::set_camera_movement_speed(float value)
-    {
-        _settings_window->set_movement_speed(value);
-    }
-
     void ViewerUI::set_camera_position(const DirectX::SimpleMath::Vector3& position)
     {
         _camera_position->set_position(position);
-    }
-
-    void ViewerUI::set_camera_sensitivity(float value)
-    {
-        _settings_window->set_sensitivity(value);
     }
 
     void ViewerUI::set_camera_mode(CameraMode mode)
@@ -390,6 +386,8 @@ namespace trview
         _settings_window->set_rooms_startup(settings.rooms_startup);
         _settings_window->set_vsync(settings.vsync);
         _settings_window->set_invert_vertical_pan(settings.invert_vertical_pan);
+        _settings_window->set_movement_speed(settings.camera_movement_speed);
+        _settings_window->set_sensitivity(settings.camera_sensitivity);
         _settings_window->set_camera_acceleration(settings.camera_acceleration);
         _settings_window->set_camera_acceleration_rate(settings.camera_acceleration_rate);
     }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -141,8 +141,8 @@ namespace trview
         };
         _settings_window->on_sensitivity_changed += on_camera_sensitivity;
         _settings_window->on_movement_speed_changed += on_camera_movement_speed;
-        _settings_window->on_camera_acceleration += on_camera_acceleration_enabled;
-        _settings_window->on_camera_acceleration_rate += on_camera_acceleration_rate_changed;
+        _settings_window->on_camera_acceleration += on_camera_acceleration;
+        _settings_window->on_camera_acceleration_rate += on_camera_acceleration_rate;
 
         _camera_position = std::make_unique<CameraPosition>(*_control);
         _camera_position->on_position_changed += on_camera_position;
@@ -263,9 +263,9 @@ namespace trview
         _view_options->set_alternate_groups(groups);
     }
 
-    void ViewerUI::set_camera_acceleration_enabled(bool value)
+    void ViewerUI::set_camera_acceleration(bool value)
     {
-        _settings_window->set_camera_acceleration_enabled(value);
+        _settings_window->set_camera_acceleration(value);
     }
     
     void ViewerUI::set_camera_acceleration_rate(float value)
@@ -390,7 +390,7 @@ namespace trview
         _settings_window->set_rooms_startup(settings.rooms_startup);
         _settings_window->set_vsync(settings.vsync);
         _settings_window->set_invert_vertical_pan(settings.invert_vertical_pan);
-        _settings_window->set_camera_acceleration_enabled(settings.camera_acceleration);
+        _settings_window->set_camera_acceleration(settings.camera_acceleration);
         _settings_window->set_camera_acceleration_rate(settings.camera_acceleration_rate);
     }
 

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -143,7 +143,6 @@ namespace trview
         _settings_window->on_movement_speed_changed += on_camera_movement_speed;
         _settings_window->on_camera_acceleration += on_camera_acceleration_enabled;
         _settings_window->on_camera_acceleration_rate += on_camera_acceleration_rate_changed;
-        _settings_window->on_camera_acceleration_maximum += on_camera_acceleration_maximum_changed;
 
         _camera_position = std::make_unique<CameraPosition>(*_control);
         _camera_position->on_position_changed += on_camera_position;
@@ -267,11 +266,6 @@ namespace trview
     void ViewerUI::set_camera_acceleration_enabled(bool value)
     {
         _settings_window->set_camera_acceleration_enabled(value);
-    }
-
-    void ViewerUI::set_camera_acceleration_maximum(float value)
-    {
-        _settings_window->set_camera_acceleration_maximum(value);
     }
     
     void ViewerUI::set_camera_acceleration_rate(float value)
@@ -398,7 +392,6 @@ namespace trview
         _settings_window->set_invert_vertical_pan(settings.invert_vertical_pan);
         _settings_window->set_camera_acceleration_enabled(settings.camera_acceleration);
         _settings_window->set_camera_acceleration_rate(settings.camera_acceleration_rate);
-        _settings_window->set_camera_acceleration_maximum(settings.camera_acceleration_maximum);
     }
 
     void ViewerUI::set_selected_room(Room* room)

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -141,6 +141,9 @@ namespace trview
         };
         _settings_window->on_sensitivity_changed += on_camera_sensitivity;
         _settings_window->on_movement_speed_changed += on_camera_movement_speed;
+        _settings_window->on_camera_acceleration += on_camera_acceleration_enabled;
+        _settings_window->on_camera_acceleration_rate += on_camera_acceleration_rate_changed;
+        _settings_window->on_camera_acceleration_maximum += on_camera_acceleration_maximum_changed;
 
         _camera_position = std::make_unique<CameraPosition>(*_control);
         _camera_position->on_position_changed += on_camera_position;
@@ -261,6 +264,21 @@ namespace trview
         _view_options->set_alternate_groups(groups);
     }
 
+    void ViewerUI::set_camera_acceleration_enabled(bool value)
+    {
+        _settings_window->set_camera_acceleration_enabled(value);
+    }
+
+    void ViewerUI::set_camera_acceleration_maximum(float value)
+    {
+        _settings_window->set_camera_acceleration_maximum(value);
+    }
+    
+    void ViewerUI::set_camera_acceleration_rate(float value)
+    {
+        _settings_window->set_camera_acceleration_rate(value);
+    }
+
     void ViewerUI::set_camera_movement_speed(float value)
     {
         _settings_window->set_movement_speed(value);
@@ -378,6 +396,9 @@ namespace trview
         _settings_window->set_rooms_startup(settings.rooms_startup);
         _settings_window->set_vsync(settings.vsync);
         _settings_window->set_invert_vertical_pan(settings.invert_vertical_pan);
+        _settings_window->set_camera_acceleration_enabled(settings.camera_acceleration);
+        _settings_window->set_camera_acceleration_rate(settings.camera_acceleration_rate);
+        _settings_window->set_camera_acceleration_maximum(settings.camera_acceleration_maximum);
     }
 
     void ViewerUI::set_selected_room(Room* room)

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -74,8 +74,11 @@ namespace trview
         /// Event raised when an alternate group is toggled.
         Event<uint32_t, bool> on_alternate_group;
 
-        Event<bool> on_camera_acceleration_enabled;
-        Event<float> on_camera_acceleration_rate_changed;
+        /// Event raised when camera acceleration setting is changed.
+        Event<bool> on_camera_acceleration;
+
+        /// Event raised when camera acceleration rate is changed.
+        Event<float> on_camera_acceleration_rate;
 
         /// Event raised when the camera mode is set.
         Event<CameraMode> on_camera_mode;
@@ -150,7 +153,12 @@ namespace trview
         /// @param groups The alternate groups for the level.
         void set_alternate_groups(const std::set<uint32_t>& groups);
 
-        void set_camera_acceleration_enabled(bool value);
+        /// Set whether camera acceleration is enabled.
+        /// @param value Whether camera acceleration is enabled.
+        void set_camera_acceleration(bool value);
+
+        /// Set the camera acceleration rate.
+        /// @param value The acceleration rate.
         void set_camera_acceleration_rate(float value);
 
         /// Set the camera movement speed.

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -74,12 +74,6 @@ namespace trview
         /// Event raised when an alternate group is toggled.
         Event<uint32_t, bool> on_alternate_group;
 
-        /// Event raised when camera acceleration setting is changed.
-        Event<bool> on_camera_acceleration;
-
-        /// Event raised when camera acceleration rate is changed.
-        Event<float> on_camera_acceleration_rate;
-
         /// Event raised when the camera mode is set.
         Event<CameraMode> on_camera_mode;
 
@@ -88,12 +82,6 @@ namespace trview
 
         /// Event raised when the camera is reset.
         Event<> on_camera_reset;
-
-        /// Event raised when the camera sensitivity is changed.
-        Event<float> on_camera_sensitivity;
-
-        /// Event raised when the camera movement speed is changed.
-        Event<float> on_camera_movement_speed;
 
         /// Event raised when the depth level changes.
         Event<int32_t> on_depth_level_changed;
@@ -153,25 +141,9 @@ namespace trview
         /// @param groups The alternate groups for the level.
         void set_alternate_groups(const std::set<uint32_t>& groups);
 
-        /// Set whether camera acceleration is enabled.
-        /// @param value Whether camera acceleration is enabled.
-        void set_camera_acceleration(bool value);
-
-        /// Set the camera acceleration rate.
-        /// @param value The acceleration rate.
-        void set_camera_acceleration_rate(float value);
-
-        /// Set the camera movement speed.
-        /// @param value The camera movement speed.
-        void set_camera_movement_speed(float value);
-
         /// Set the current camera position.
         /// @param position The camera position.
         void set_camera_position(const DirectX::SimpleMath::Vector3& position);
-
-        /// Set the sensitivity of the camera.
-        /// @param value The camera sensitivity.
-        void set_camera_sensitivity(float value);
 
         /// Set the camera mode.
         /// @param mode The current camera mode.

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -76,7 +76,6 @@ namespace trview
 
         Event<bool> on_camera_acceleration_enabled;
         Event<float> on_camera_acceleration_rate_changed;
-        Event<float> on_camera_acceleration_maximum_changed;
 
         /// Event raised when the camera mode is set.
         Event<CameraMode> on_camera_mode;
@@ -152,7 +151,6 @@ namespace trview
         void set_alternate_groups(const std::set<uint32_t>& groups);
 
         void set_camera_acceleration_enabled(bool value);
-        void set_camera_acceleration_maximum(float value);
         void set_camera_acceleration_rate(float value);
 
         /// Set the camera movement speed.

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -74,6 +74,10 @@ namespace trview
         /// Event raised when an alternate group is toggled.
         Event<uint32_t, bool> on_alternate_group;
 
+        Event<bool> on_camera_acceleration_enabled;
+        Event<float> on_camera_acceleration_rate_changed;
+        Event<float> on_camera_acceleration_maximum_changed;
+
         /// Event raised when the camera mode is set.
         Event<CameraMode> on_camera_mode;
 
@@ -146,6 +150,10 @@ namespace trview
         /// Set the alternate groups for the level.
         /// @param groups The alternate groups for the level.
         void set_alternate_groups(const std::set<uint32_t>& groups);
+
+        void set_camera_acceleration_enabled(bool value);
+        void set_camera_acceleration_maximum(float value);
+        void set_camera_acceleration_rate(float value);
 
         /// Set the camera movement speed.
         /// @param value The camera movement speed.

--- a/trview.ui/Slider.cpp
+++ b/trview.ui/Slider.cpp
@@ -34,6 +34,11 @@ namespace trview
         {
         }
 
+        float Slider::value() const
+        {
+            return _value;
+        }
+
         void Slider::set_value(float value)
         {
             _value = value;
@@ -53,7 +58,7 @@ namespace trview
 
         bool Slider::clicked(Point position)
         {
-            set_blob_position(position);
+            set_blob_position(position, true);
             return true;
         }
 
@@ -61,28 +66,31 @@ namespace trview
         {
             if (_input_query && _input_query->focus_control() == this)
             {
-                set_blob_position(position);
+                set_blob_position(position, true);
                 return true;
             }
             return false;
         }
 
-        void Slider::set_blob_position(float percentage)
+        void Slider::set_blob_position(float percentage, bool raise_event)
         {
             const float SliderSize = size().width - BlobWidth * 2;
             const float x = BlobWidth + percentage * SliderSize - BlobWidth * 0.5f;
 
             const auto pos = _blob->position();
             _blob->set_position(Point(x, pos.y));
-            on_value_changed(percentage);
+            if (raise_event)
+            {
+                on_value_changed(percentage);
+            }
             on_invalidate();
         }
 
-        void Slider::set_blob_position(Point position)
+        void Slider::set_blob_position(Point position, bool raise_event)
         {
             const float SliderSize = size().width - BlobWidth * 2;
             const float percentage = std::min(1.0f, std::max(0.0f, (position.x - BlobWidth) / SliderSize));
-            set_blob_position(percentage);
+            set_blob_position(percentage, raise_event);
         }
     }
 }

--- a/trview.ui/Slider.cpp
+++ b/trview.ui/Slider.cpp
@@ -29,6 +29,11 @@ namespace trview
             set_blob_position(Point(0, 0));
         }
 
+        Slider::Slider(const Size& size)
+            : Slider(Point(), size)
+        {
+        }
+
         void Slider::set_value(float value)
         {
             _value = value;

--- a/trview.ui/Slider.h
+++ b/trview.ui/Slider.h
@@ -16,16 +16,17 @@ namespace trview
 
             Event<float> on_value_changed;
 
+            float value() const;
             void set_value(float value);
             virtual bool mouse_down(const Point& position) override;
             virtual bool mouse_up(const Point& position) override;
             virtual bool clicked(Point position) override;
             virtual bool move(Point position) override;
         private:
-            void set_blob_position(Point position);
-            void set_blob_position(float percentage);
+            void set_blob_position(Point position, bool raise_event = false);
+            void set_blob_position(float percentage, bool raise_event = false);
 
-            float _value{ 0.5f };
+            float _value{ 0.0f };
             ui::Control* _blob;
         };
     }

--- a/trview.ui/Slider.h
+++ b/trview.ui/Slider.h
@@ -11,6 +11,7 @@ namespace trview
         {
         public:
             Slider(Point position, Size size);
+            explicit Slider(const Size& size);
             virtual ~Slider() = default;
 
             Event<float> on_value_changed;

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -37,7 +37,7 @@ namespace trview
         _update_checker.check_for_updates();
 
         _settings = load_user_settings();
-        _free_camera.set_acceleration_settings(_settings.camera_acceleration, _settings.camera_acceleration_rate, _settings.camera_acceleration_maximum);
+        apply_acceleration_settings();
 
         Resource type_list = get_resource_memory(IDR_TYPE_NAMES, L"TEXT");
         _type_name_lookup = std::make_unique<TypeNameLookup>(std::string(type_list.data, type_list.data + type_list.size));
@@ -142,6 +142,21 @@ namespace trview
         _token_store += _ui->on_camera_projection_mode += [&](ProjectionMode mode) { set_camera_projection_mode(mode); };
         _token_store += _ui->on_camera_sensitivity += [&](float value) { _settings.camera_sensitivity = value; };
         _token_store += _ui->on_camera_movement_speed += [&](float value) { _settings.camera_movement_speed = value; };
+        _token_store += _ui->on_camera_acceleration_enabled += [&](bool value)
+        {
+            _settings.camera_acceleration = value;
+            apply_acceleration_settings();
+        };
+        _token_store += _ui->on_camera_acceleration_rate_changed += [&](float value)
+        {
+            _settings.camera_acceleration_rate = value;
+            apply_acceleration_settings();
+        };
+        _token_store += _ui->on_camera_acceleration_maximum_changed += [&](float value)
+        {
+            _settings.camera_acceleration_maximum = value;
+            apply_acceleration_settings();
+        };
         _token_store += _ui->on_sector_hover += [&](const std::shared_ptr<Sector>& sector)
         {
             if (_level)
@@ -196,6 +211,9 @@ namespace trview
         _ui->set_camera_mode(CameraMode::Orbit);
         _ui->set_camera_sensitivity(_settings.camera_sensitivity);
         _ui->set_camera_movement_speed(_settings.camera_movement_speed == 0 ? _CAMERA_MOVEMENT_SPEED_DEFAULT : _settings.camera_movement_speed);
+        _ui->set_camera_acceleration_enabled(_settings.camera_acceleration);
+        _ui->set_camera_acceleration_rate(_settings.camera_acceleration_rate);
+        _ui->set_camera_acceleration_maximum(_settings.camera_acceleration_maximum);
 
         _measure = std::make_unique<Measure>(_device);
         _compass = std::make_unique<Compass>(_device, *_shader_storage);
@@ -1143,5 +1161,10 @@ namespace trview
             viewer->open(*std::next(settings.recent_files.begin(), index - 1));
         }
         return 0;
+    }
+
+    void Viewer::apply_acceleration_settings()
+    {
+        _free_camera.set_acceleration_settings(_settings.camera_acceleration, _settings.camera_acceleration_rate, _settings.camera_acceleration_maximum);
     }
 }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -25,7 +25,6 @@ namespace trview
     namespace
     {
         const float _CAMERA_MOVEMENT_SPEED_MULTIPLIER = 23.0f;
-        const float _CAMERA_MOVEMENT_SPEED_DEFAULT = 0.5f;
     }
 
     Viewer::Viewer(const Window& window)
@@ -140,18 +139,6 @@ namespace trview
         _token_store += _ui->on_camera_reset += [&]() { _camera.reset(); };
         _token_store += _ui->on_camera_mode += [&](CameraMode mode) { set_camera_mode(mode); };
         _token_store += _ui->on_camera_projection_mode += [&](ProjectionMode mode) { set_camera_projection_mode(mode); };
-        _token_store += _ui->on_camera_sensitivity += [&](float value) { _settings.camera_sensitivity = value; };
-        _token_store += _ui->on_camera_movement_speed += [&](float value) { _settings.camera_movement_speed = value; };
-        _token_store += _ui->on_camera_acceleration += [&](bool value)
-        {
-            _settings.camera_acceleration = value;
-            apply_acceleration_settings();
-        };
-        _token_store += _ui->on_camera_acceleration_rate += [&](float value)
-        {
-            _settings.camera_acceleration_rate = value;
-            apply_acceleration_settings();
-        };
         _token_store += _ui->on_sector_hover += [&](const std::shared_ptr<Sector>& sector)
         {
             if (_level)
@@ -180,7 +167,11 @@ namespace trview
             stored_pick.type = PickResult::Type::Room;
             add_recent_orbit(stored_pick);
         };
-        _token_store += _ui->on_settings += [&](auto settings) { _settings = settings; };
+        _token_store += _ui->on_settings += [&](auto settings)
+        {
+            _settings = settings;
+            apply_acceleration_settings();
+        };
         _token_store += _ui->on_tool_selected += [&](auto tool) { _active_tool = tool; _measure->reset(); };
         _token_store += _ui->on_camera_position += [&](const auto& position)
         {
@@ -202,12 +193,7 @@ namespace trview
         };
 
         _ui->set_settings(_settings);
-
         _ui->set_camera_mode(CameraMode::Orbit);
-        _ui->set_camera_sensitivity(_settings.camera_sensitivity);
-        _ui->set_camera_movement_speed(_settings.camera_movement_speed == 0 ? _CAMERA_MOVEMENT_SPEED_DEFAULT : _settings.camera_movement_speed);
-        _ui->set_camera_acceleration(_settings.camera_acceleration);
-        _ui->set_camera_acceleration_rate(_settings.camera_acceleration_rate);
 
         _measure = std::make_unique<Measure>(_device);
         _compass = std::make_unique<Compass>(_device, *_shader_storage);

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -37,6 +37,7 @@ namespace trview
         _update_checker.check_for_updates();
 
         _settings = load_user_settings();
+        _free_camera.set_acceleration_settings(_settings.camera_acceleration, _settings.camera_acceleration_rate, _settings.camera_acceleration_maximum);
 
         Resource type_list = get_resource_memory(IDR_TYPE_NAMES, L"TEXT");
         _type_name_lookup = std::make_unique<TypeNameLookup>(std::string(type_list.data, type_list.data + type_list.size));

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -1159,6 +1159,6 @@ namespace trview
 
     void Viewer::apply_acceleration_settings()
     {
-        _free_camera.set_acceleration_settings(_settings.camera_acceleration, _settings.camera_acceleration_rate, _settings.camera_movement_speed);
+        _free_camera.set_acceleration_settings(_settings.camera_acceleration, _settings.camera_acceleration_rate);
     }
 }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -152,11 +152,6 @@ namespace trview
             _settings.camera_acceleration_rate = value;
             apply_acceleration_settings();
         };
-        _token_store += _ui->on_camera_acceleration_maximum_changed += [&](float value)
-        {
-            _settings.camera_acceleration_maximum = value;
-            apply_acceleration_settings();
-        };
         _token_store += _ui->on_sector_hover += [&](const std::shared_ptr<Sector>& sector)
         {
             if (_level)
@@ -213,7 +208,6 @@ namespace trview
         _ui->set_camera_movement_speed(_settings.camera_movement_speed == 0 ? _CAMERA_MOVEMENT_SPEED_DEFAULT : _settings.camera_movement_speed);
         _ui->set_camera_acceleration_enabled(_settings.camera_acceleration);
         _ui->set_camera_acceleration_rate(_settings.camera_acceleration_rate);
-        _ui->set_camera_acceleration_maximum(_settings.camera_acceleration_maximum);
 
         _measure = std::make_unique<Measure>(_device);
         _compass = std::make_unique<Compass>(_device, *_shader_storage);
@@ -1165,6 +1159,6 @@ namespace trview
 
     void Viewer::apply_acceleration_settings()
     {
-        _free_camera.set_acceleration_settings(_settings.camera_acceleration, _settings.camera_acceleration_rate, _settings.camera_acceleration_maximum);
+        _free_camera.set_acceleration_settings(_settings.camera_acceleration, _settings.camera_acceleration_rate, _settings.camera_movement_speed);
     }
 }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -142,12 +142,12 @@ namespace trview
         _token_store += _ui->on_camera_projection_mode += [&](ProjectionMode mode) { set_camera_projection_mode(mode); };
         _token_store += _ui->on_camera_sensitivity += [&](float value) { _settings.camera_sensitivity = value; };
         _token_store += _ui->on_camera_movement_speed += [&](float value) { _settings.camera_movement_speed = value; };
-        _token_store += _ui->on_camera_acceleration_enabled += [&](bool value)
+        _token_store += _ui->on_camera_acceleration += [&](bool value)
         {
             _settings.camera_acceleration = value;
             apply_acceleration_settings();
         };
-        _token_store += _ui->on_camera_acceleration_rate_changed += [&](float value)
+        _token_store += _ui->on_camera_acceleration_rate += [&](float value)
         {
             _settings.camera_acceleration_rate = value;
             apply_acceleration_settings();
@@ -206,7 +206,7 @@ namespace trview
         _ui->set_camera_mode(CameraMode::Orbit);
         _ui->set_camera_sensitivity(_settings.camera_sensitivity);
         _ui->set_camera_movement_speed(_settings.camera_movement_speed == 0 ? _CAMERA_MOVEMENT_SPEED_DEFAULT : _settings.camera_movement_speed);
-        _ui->set_camera_acceleration_enabled(_settings.camera_acceleration);
+        _ui->set_camera_acceleration(_settings.camera_acceleration);
         _ui->set_camera_acceleration_rate(_settings.camera_acceleration_rate);
 
         _measure = std::make_unique<Measure>(_device);

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -520,7 +520,7 @@ namespace trview
         if (_camera_mode == CameraMode::Free || _camera_mode == CameraMode::Axis)
         {
             const float Speed = std::max(0.01f, _settings.camera_movement_speed) * _CAMERA_MOVEMENT_SPEED_MULTIPLIER;
-            _free_camera.move(_camera_input.movement() * _timer.elapsed() * Speed);
+            _free_camera.move(_camera_input.movement() * Speed, _timer.elapsed());
 
             if (_level)
             {

--- a/trview/Viewer.h
+++ b/trview/Viewer.h
@@ -125,6 +125,8 @@ namespace trview
         static int lua_open(lua_State* state);
         static int lua_open_recent(lua_State* state);
 
+        void apply_acceleration_settings();
+
         graphics::Device _device;
         Shortcuts _shortcuts;
         std::unique_ptr<graphics::DeviceWindow> _main_window;


### PR DESCRIPTION
Add camera acceleration functionality. When enabled the camera movement in free mode will accelerate up until the maximum configured movement speed.
User can configure these settings in the settings window.
Added unit tests for `SettingsWindow`, which found a bug in `Slider` where value changed event was being raised on non-human sets of the value.
Updated the json reading code to not throw when a value is missing.
Removed special handling of camera speed and sensitivity in the viewer UI.
Closes #579 