### PR TITLE
Add room relative coordinates to route window

### DIFF
--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -167,11 +167,11 @@ namespace trview
 
         auto stats_box = std::make_unique<Listbox>(Size(panel_width - 20, 80), Colours::ItemDetails);
         stats_box->set_show_headers(false);
-        stats_box->set_show_scrollbar(false);
+        stats_box->set_show_scrollbar(true);
         stats_box->set_columns(
             {
                 { Listbox::Column::Type::String, L"Name", 100 },
-                { Listbox::Column::Type::String, L"Value", 150 }
+                { Listbox::Column::Type::String, L"Value", 140 }
             });
         _token_store += stats_box->on_item_selected += [&](const auto&)
         {
@@ -376,9 +376,23 @@ namespace trview
         _delete_waypoint->set_visible(true);
 
         const auto& waypoint = _route->waypoint(index);
+
+        auto get_room_pos = [&waypoint, this]() 
+        {
+            if (waypoint.room() < _all_rooms.size())
+            {
+                const auto info = _all_rooms[waypoint.room()]->info();
+                DirectX::SimpleMath::Vector3 top_left = DirectX::SimpleMath::Vector3(info.x, info.yTop, info.z) / trlevel::Scale_X;
+                return waypoint.position() - top_left;
+            }
+            return waypoint.position();
+        };
+
         std::vector<Listbox::Item> stats;
         stats.push_back(make_item(L"Type", waypoint_type_to_string(waypoint.type())));
         stats.push_back(make_item(L"Position", pos_to_string(waypoint.position())));
+        stats.push_back(make_item(L"Room", std::to_wstring(waypoint.room())));
+        stats.push_back(make_item(L"Room Position", pos_to_string(get_room_pos())));
 
         _selected_type = waypoint.type();
         _selected_index = index;
@@ -398,7 +412,7 @@ namespace trview
             else if (waypoint.type() == Waypoint::Type::Trigger)
             {
                 std::wstring type = L"Invalid trigger";
-                if (waypoint.index() < _all_items.size())
+                if (waypoint.index() < _all_triggers.size())
                 {
                     type = trigger_type_name(_all_triggers[waypoint.index()]->type());
                 }
@@ -441,6 +455,11 @@ namespace trview
     void RouteWindow::set_items(const std::vector<Item>& items)
     {
         _all_items = items;
+    }
+
+    void RouteWindow::set_rooms(const std::vector<Room*>& rooms)
+    {
+        _all_rooms = rooms;
     }
 
     /// Set the triggers in the level.

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -8,6 +8,7 @@
 #include <trview.common/Event.h>
 #include <trview.app/Routing/Waypoint.h>
 #include <trview.app/Elements/Item.h>
+#include <trview.app/Elements/Room.h>
 #include <trview.graphics/FontFactory.h>
 
 namespace trview
@@ -60,6 +61,8 @@ namespace trview
         /// @param items The items to show.
         void set_items(const std::vector<Item>& items);
 
+        void set_rooms(const std::vector<Room*>& rooms);
+
         /// Set the triggers in the level.
         /// @param triggers The triggers.
         void set_triggers(const std::vector<Trigger*>& triggers);
@@ -78,6 +81,7 @@ namespace trview
         ui::Button* _clear_save;
         Route* _route{ nullptr };
         std::vector<Item> _all_items;
+        std::vector<Room*> _all_rooms;
         std::vector<Trigger*> _all_triggers;
         Waypoint::Type _selected_type{ Waypoint::Type::Position };
         uint32_t       _selected_index{ 0u };

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -38,6 +38,7 @@ namespace trview
         _token_store += _route_window->on_window_closed += [&]() { _closing = true; };
 
         _route_window->set_items(_all_items);
+        _route_window->set_rooms(_all_rooms);
         _route_window->set_triggers(_all_triggers);
         if (_route)
         {
@@ -76,6 +77,15 @@ namespace trview
         if (_route_window)
         {
             _route_window->set_items(items);
+        }
+    }
+
+    void RouteWindowManager::set_rooms(const std::vector<Room*>& rooms)
+    {
+        _all_rooms = rooms;
+        if (_route_window)
+        {
+            _route_window->set_rooms(rooms);
         }
     }
 

--- a/trview.app/Windows/RouteWindowManager.h
+++ b/trview.app/Windows/RouteWindowManager.h
@@ -40,6 +40,8 @@ namespace trview
         /// @param items The items to show.
         void set_items(const std::vector<Item>& items);
 
+        void set_rooms(const std::vector<Room*>& rooms);
+
         /// Set the triggers in the level.
         /// @param triggers The triggers.
         void set_triggers(const std::vector<Trigger*>& triggers);
@@ -75,6 +77,7 @@ namespace trview
         bool _closing{ false };
         Route* _route{ nullptr };
         std::vector<Item> _all_items;
+        std::vector<Room*> _all_rooms;
         std::vector<Trigger*> _all_triggers;
         uint32_t _selected_waypoint{ 0u };
     };

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -574,6 +574,7 @@ namespace trview
         _triggers_windows->set_triggers(_level->triggers());
         _route_window_manager->set_items(_level->items());
         _route_window_manager->set_triggers(_level->triggers());
+        _route_window_manager->set_rooms(_level->rooms());
         _rooms_windows->set_items(_level->items());
         _rooms_windows->set_triggers(_level->triggers());
         _rooms_windows->set_rooms(_level->rooms());


### PR DESCRIPTION
Add coordinates of the waypoint relative to the room, as well as the room number.
Add scrollbar to the waypoint stats box as there can be too many now if it is on a trigger or an item.
Closes #726