### PR TITLE
Notify owned windows to resize when the main window is restored

### DIFF
--- a/trview.app.tests/WindowResizerTests.cpp
+++ b/trview.app.tests/WindowResizerTests.cpp
@@ -43,6 +43,41 @@ TEST(WindowResizer, Minimise)
     ASSERT_EQ(1u, times_called);
 }
 
+// Test that sending a minimise message notifies owned windows.
+TEST(WindowResizer, MinimiseNotifiesOwnedWindows)
+{
+    auto parent = create_test_window(L"TRViewWindowResizerTests");
+    WindowResizer resizer(parent);
+
+    uint32_t times_called = 0;
+    auto owned_window = create_test_window(L"TRViewWindowResizerTests-Child", parent);
+    SetWindowSubclass(owned_window, 
+        [](auto, auto message, auto, auto, auto, auto ref_data) -> LRESULT 
+        {
+            if (message == WindowResizer::WM_APP_PARENT_RESTORED)
+            {
+                ++(*reinterpret_cast<uint32_t*>(ref_data));
+            }
+            return 0;
+        }, 1337, reinterpret_cast<DWORD_PTR>(&times_called));
+
+    resizer.process_message(WM_SIZE, SIZE_RESTORED, 0);
+    ASSERT_EQ(1u, times_called);
+}
+
+// Test that sending a app restore message triggers the resize event.
+TEST(WindowResizer, AppRestoreTriggersOnResize)
+{
+    WindowResizer resizer(create_test_window(L"TRViewWindowResizerTests"));
+
+    uint32_t times_called = 0;
+    auto token = resizer.on_resize += [&]() { ++times_called; };
+
+    resizer.process_message(WindowResizer::WM_APP_PARENT_RESTORED, 0, 0);
+
+    ASSERT_EQ(1u, times_called);
+}
+
 // Test that size messages during resize don't trigger the event.
 TEST(WindowResizer, Resizing)
 {

--- a/trview.app/Windows/WindowResizer.h
+++ b/trview.app/Windows/WindowResizer.h
@@ -29,6 +29,8 @@ namespace trview
 
         /// Event that is raised when the window has resized.
         Event<> on_resize;
+
+        static const int32_t WM_APP_PARENT_RESTORED;
     private:
         bool has_size_changed();
 

--- a/trview.tests.common/Window.cpp
+++ b/trview.tests.common/Window.cpp
@@ -9,7 +9,7 @@ namespace trview
             return DefWindowProc(hWnd, message, wParam, lParam);
         }
 
-        Window create_test_window(const std::wstring& name)
+        Window create_test_window(const std::wstring& name, HWND parent)
         {
             HINSTANCE hInstance = GetModuleHandle(nullptr);
 
@@ -28,7 +28,7 @@ namespace trview
             RegisterClassExW(&wcex);
 
             HWND window = CreateWindowW(name.c_str(), name.c_str(), 0,
-                CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, HWND_MESSAGE, nullptr, hInstance, nullptr);
+                CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, parent, nullptr, hInstance, nullptr);
             ShowWindow(window, SW_HIDE);
             UpdateWindow(window);
             return window;

--- a/trview.tests.common/Window.h
+++ b/trview.tests.common/Window.h
@@ -9,6 +9,7 @@ namespace trview
     {
         /// Makes a hidden test window that can be used to pass messages to for tests.
         /// @param name The name to use for the window class and window name.
-        Window create_test_window(const std::wstring& name);
+        /// @param parent The parent window - defaults to HWND_MESSAGE.
+        Window create_test_window(const std::wstring& name, HWND parent = HWND_MESSAGE);
     }
 }


### PR DESCRIPTION
When the main window receives `WM_SIZE` with `SIZE_RESTORED` notify all windows created by the thread that they should resize. This is because they don't seem to get the `WM_SIZE` message, just the main window does.
Closes #729