### PR TITLE
Add 'mid waypoints' feature

### DIFF
--- a/trview.app/Camera/Camera.cpp
+++ b/trview.app/Camera/Camera.cpp
@@ -1,4 +1,5 @@
 #include "Camera.h"
+#include <trview.common/Maths.h>
 
 namespace trview
 {
@@ -14,9 +15,6 @@ namespace trview
             return atan2(sin(target - current), cos(target - current));
         }
     }
-
-    const float Pi = 3.1415926535897932384626433832796f;
-    const float Pi2 = 3.1415926535897932384626433832796f * 2.0f;
 
     Camera::Camera(const Size& size)
         : _view_size(size), _forward(Vector3::Forward), _up(Vector3::Down), _position(Vector3::Zero)
@@ -103,7 +101,7 @@ namespace trview
 
     void Camera::set_rotation_yaw(float rotation)
     {
-        _rotation_yaw = rotation - static_cast<int>(rotation / Pi2) * Pi2;
+        _rotation_yaw = rotation - static_cast<int>(rotation / maths::Pi2) * maths::Pi2;
         _target_rotation_pitch.reset();
         _target_rotation_yaw.reset();
         update_vectors();

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -456,6 +456,7 @@ namespace trview
                 final_result.hit = true;
                 final_result.distance = result.distance;
                 final_result.position = result.position;
+                final_result.centroid = result.centroid;
                 final_result.index = result.index;
                 final_result.type = result.type;
             }

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -209,7 +209,7 @@ namespace trview
             render_selected_item(device, camera);
         }
 
-        context->RSSetState(old_state.Get());
+        // context->RSSetState(old_state.Get());
     }
 
     // Render the rooms in the level.

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -44,6 +44,13 @@ namespace trview
         // Create the texture sampler state.
         device.device()->CreateSamplerState(&sampler_desc, &_sampler_state);
 
+        D3D11_RASTERIZER_DESC rasterizer_desc;
+        memset(&rasterizer_desc, 0, sizeof(rasterizer_desc));
+        rasterizer_desc.FillMode = D3D11_FILL_WIREFRAME;
+        rasterizer_desc.CullMode = D3D11_CULL_NONE;
+        rasterizer_desc.DepthClipEnable = true;
+        device.device()->CreateRasterizerState(&rasterizer_desc, &_rasterizer_state);
+
         _texture_storage = std::make_unique<LevelTextureStorage>(device, *level);
         _mesh_storage = std::make_unique<MeshStorage>(device, *level, *_texture_storage.get());
         generate_rooms(device, *level);
@@ -201,6 +208,8 @@ namespace trview
         {
             render_selected_item(device, camera);
         }
+
+        context->RSSetState(old_state.Get());
     }
 
     // Render the rooms in the level.

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -44,13 +44,6 @@ namespace trview
         // Create the texture sampler state.
         device.device()->CreateSamplerState(&sampler_desc, &_sampler_state);
 
-        D3D11_RASTERIZER_DESC rasterizer_desc;
-        memset(&rasterizer_desc, 0, sizeof(rasterizer_desc));
-        rasterizer_desc.FillMode = D3D11_FILL_WIREFRAME;
-        rasterizer_desc.CullMode = D3D11_CULL_NONE;
-        rasterizer_desc.DepthClipEnable = true;
-        device.device()->CreateRasterizerState(&rasterizer_desc, &_rasterizer_state);
-
         _texture_storage = std::make_unique<LevelTextureStorage>(device, *level);
         _mesh_storage = std::make_unique<MeshStorage>(device, *level, *_texture_storage.get());
         generate_rooms(device, *level);
@@ -191,7 +184,6 @@ namespace trview
 
         {
             graphics::RasterizerStateStore rasterizer_store(context);
-
             context->PSSetSamplers(0, 1, &_sampler_state);
             if (_show_wireframe)
             {
@@ -208,8 +200,6 @@ namespace trview
         {
             render_selected_item(device, camera);
         }
-
-        // context->RSSetState(old_state.Get());
     }
 
     // Render the rooms in the level.

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -459,6 +459,7 @@ namespace trview
                 final_result.centroid = result.centroid;
                 final_result.index = result.index;
                 final_result.type = result.type;
+                final_result.triangle = result.triangle;
             }
         };
 

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -141,6 +141,12 @@ namespace trview
                 geometry_result.type = PickResult::Type::Room;
                 geometry_result.index = _index;
                 geometry_result.position = Vector3::Transform(geometry_result.position, _room_offset);
+
+                PickResult centroid_hit = _mesh->pick(
+                    Vector3::Transform(Vector3(std::floor(geometry_result.position.x) + 0.5f, -1000, std::floor(geometry_result.position.z) + 0.5f), room_offset),
+                    Vector3(0, 1, 0));
+                geometry_result.centroid = centroid_hit.hit ? Vector3::Transform(centroid_hit.position, _room_offset) : geometry_result.position;
+
                 pick_results.push_back(geometry_result);
             }
 

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -61,6 +61,8 @@ namespace trview
         _alternate_mode = room.alternate_room != -1 ? AlternateMode::HasAlternate : AlternateMode::None;
 
         _room_offset = Matrix::CreateTranslation(room.info.x / trlevel::Scale_X, 0, room.info.z / trlevel::Scale_Z);
+        _inverted_room_offset = _room_offset.Invert();
+
         generate_sectors(level, room);
         generate_geometry(level.get_version(), device, room, texture_storage);
         generate_adjacency();
@@ -700,9 +702,6 @@ namespace trview
         Vector3 centroid;
         Vector3 ray_direction{ 0, 1, 0 };
 
-        Matrix from_room;
-        _room_offset.Invert(from_room);
-
         if (tri.normal.y)
         {
             centroid = { std::floor(geometry_result.position.x) + 0.5f, geometry_result.position.y, std::floor(geometry_result.position.z) + 0.5f };
@@ -719,7 +718,7 @@ namespace trview
             ray_direction = { 0, 0, -tri.normal.z };
         }
 
-        centroid = Vector3::Transform(centroid, from_room);
+        centroid = Vector3::Transform(centroid, _inverted_room_offset);
         ray_direction.Normalize();
         PickResult centroid_hit = mesh.pick(centroid - ray_direction * 0.5f, ray_direction);
         geometry_result.centroid = centroid_hit.hit ? Vector3::Transform(centroid_hit.position, _room_offset) : geometry_result.position;

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -142,15 +142,11 @@ namespace trview
                 geometry_result.index = _index;
                 geometry_result.position = Vector3::Transform(geometry_result.position, _room_offset);
 
-                Vector3 centroid;
+                auto tri = geometry_result.triangle;
+                Vector3 centroid = tri.v0 + (tri.v2 - tri.v0) * 0.5f;
                 Vector3 ray_direction{ 0, 1, 0 };
 
-                auto tri = geometry_result.triangle;
-                Vector3 ab = tri.v1 - tri.v0;
-                Vector3 bc = tri.v2 - tri.v1;
-                Vector3 ac = tri.v2 - tri.v0;
-
-                // Special handling for walls.
+                // Ray direction handling - Wall:
                 if (tri.normal.y == 0)
                 {
                     if (tri.normal.z == 0) // X wall
@@ -164,32 +160,16 @@ namespace trview
                 }
                 else
                 {
+                    // Surface:
                     ray_direction = -tri.normal;
                     ray_direction.x = 0;
                     ray_direction.z = 0;
-                    ab.y = 0;
-                    bc.y = 0;
-                    ac.y = 0;
-                }
-
-                if (ab.LengthSquared() > bc.LengthSquared() && ab.LengthSquared() > ac.LengthSquared())
-                {
-                    centroid = tri.v0 + (tri.v1 - tri.v0) * 0.5f;
-                }
-                else if (bc.LengthSquared() > ab.LengthSquared() && bc.LengthSquared() > ac.LengthSquared())
-                {
-                    centroid = tri.v1 + (tri.v2 - tri.v1) * 0.5f;
-                }
-                else
-                {
-                    centroid = tri.v0 + (tri.v2 - tri.v0) * 0.5f;
                 }
 
                 ray_direction.Normalize();
-                PickResult centroid_hit = _mesh->pick(centroid - ray_direction, ray_direction);
+                PickResult centroid_hit = _mesh->pick(centroid - ray_direction * 0.1f, ray_direction);
                 geometry_result.centroid = centroid_hit.hit ? Vector3::Transform(centroid_hit.position, _room_offset) : geometry_result.position;
                 geometry_result.triangle = centroid_hit.hit ? centroid_hit.triangle : geometry_result.triangle;
-
                 pick_results.push_back(geometry_result);
             }
 

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -188,6 +188,7 @@ namespace trview
                 ray_direction.Normalize();
                 PickResult centroid_hit = _mesh->pick(centroid - ray_direction, ray_direction);
                 geometry_result.centroid = centroid_hit.hit ? Vector3::Transform(centroid_hit.position, _room_offset) : geometry_result.position;
+                geometry_result.triangle = centroid_hit.hit ? centroid_hit.triangle : geometry_result.triangle;
 
                 pick_results.push_back(geometry_result);
             }

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -137,7 +137,7 @@ namespace trview
             PickResult geometry_result = _mesh->pick(Vector3::Transform(position, room_offset), direction);
             if (geometry_result.hit)
             {
-                add_centroid_to_pick(geometry_result);
+                add_centroid_to_pick(*_mesh, geometry_result);
                 pick_results.push_back(geometry_result);
             }
 
@@ -148,7 +148,7 @@ namespace trview
                 {
                     unmatched_result.type = PickResult::Type::Room;
                     unmatched_result.index = _index;
-                    unmatched_result.position = Vector3::Transform(unmatched_result.position, _room_offset);
+                    add_centroid_to_pick(*_unmatched_mesh, unmatched_result);
                     pick_results.push_back(unmatched_result);
                 }
             }
@@ -689,7 +689,7 @@ namespace trview
         return _sectors; 
     }
 
-    void Room::add_centroid_to_pick(PickResult& geometry_result) const
+    void Room::add_centroid_to_pick(const Mesh& mesh, PickResult& geometry_result) const
     {
         // Transform the position back in to world space. Also mark it as a room pick result.
         geometry_result.type = PickResult::Type::Room;
@@ -721,7 +721,7 @@ namespace trview
         }
 
         ray_direction.Normalize();
-        PickResult centroid_hit = _mesh->pick(centroid - ray_direction * 0.1f, ray_direction);
+        PickResult centroid_hit = mesh.pick(centroid - ray_direction * 0.1f, ray_direction);
         geometry_result.centroid = centroid_hit.hit ? Vector3::Transform(centroid_hit.position, _room_offset) : geometry_result.position;
         geometry_result.triangle = centroid_hit.hit ? centroid_hit.triangle : geometry_result.triangle;
     }

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -177,6 +177,8 @@ namespace trview
             std::vector<uint32_t>& output_indices,
             std::vector<Triangle>& collision_triangles);
 
+        void add_centroid_to_pick(PickResult& geometry_result) const;
+
         RoomInfo                           _info;
         std::set<uint16_t>                 _neighbours;
         uint32_t _index;

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -177,7 +177,7 @@ namespace trview
             std::vector<uint32_t>& output_indices,
             std::vector<Triangle>& collision_triangles);
 
-        void add_centroid_to_pick(PickResult& geometry_result) const;
+        void add_centroid_to_pick(const Mesh& mesh, PickResult& geometry_result) const;
 
         RoomInfo                           _info;
         std::set<uint16_t>                 _neighbours;

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -188,6 +188,7 @@ namespace trview
         std::unique_ptr<Mesh>       _mesh;
         std::unique_ptr<Mesh>       _unmatched_mesh;
         DirectX::SimpleMath::Matrix _room_offset;
+        DirectX::SimpleMath::Matrix _inverted_room_offset;
 
         DirectX::BoundingBox  _bounding_box;
 

--- a/trview.app/Geometry/Mesh.cpp
+++ b/trview.app/Geometry/Mesh.cpp
@@ -200,7 +200,8 @@ namespace trview
         {
             float distance = 0;
             if (direction.Dot(tri.normal) < 0 &&
-                Intersects(position, direction, tri.v0, tri.v1, tri.v2, distance))
+                Intersects(position, direction, tri.v0, tri.v1, tri.v2, distance) &&
+                distance < result.distance)
             {
                 result.hit = true;
                 result.distance = std::min(distance, result.distance);

--- a/trview.app/Geometry/Mesh.cpp
+++ b/trview.app/Geometry/Mesh.cpp
@@ -204,6 +204,7 @@ namespace trview
             {
                 result.hit = true;
                 result.distance = std::min(distance, result.distance);
+                result.triangle = tri;
             }
         }
 

--- a/trview.app/Geometry/PickResult.h
+++ b/trview.app/Geometry/PickResult.h
@@ -21,6 +21,7 @@ namespace trview
         bool                         hit{ false };
         float                        distance{ FLT_MAX };
         DirectX::SimpleMath::Vector3 position;
+        DirectX::SimpleMath::Vector3 centroid;
         Type                         type{ Type::Room };
         uint32_t                     index{ 0u };
         bool                         stop{ false };

--- a/trview.app/Geometry/PickResult.h
+++ b/trview.app/Geometry/PickResult.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <SimpleMath.h>
+#include <trview.app/Geometry/Triangle.h>
 
 namespace trview
 {
@@ -27,6 +28,7 @@ namespace trview
         bool                         stop{ false };
         std::wstring                 text;
         bool                         override_centre{ false };
+        Triangle                     triangle;
     };
 
     /// Convert the pick result to a display string.

--- a/trview.app/Geometry/Triangle.h
+++ b/trview.app/Geometry/Triangle.h
@@ -17,6 +17,6 @@ namespace trview
         DirectX::SimpleMath::Vector3 v0;
         DirectX::SimpleMath::Vector3 v1;
         DirectX::SimpleMath::Vector3 v2;
-        DirectX::SimpleMath::Vector3 normal{ 0, 1, 0 };
+        DirectX::SimpleMath::Vector3 normal{ 0, -1, 0 };
     };
 }

--- a/trview.app/Geometry/Triangle.h
+++ b/trview.app/Geometry/Triangle.h
@@ -4,6 +4,10 @@ namespace trview
 {
     struct Triangle
     {
+        Triangle()
+        {
+        }
+
         Triangle(const DirectX::SimpleMath::Vector3& v0, const DirectX::SimpleMath::Vector3& v1, const DirectX::SimpleMath::Vector3& v2)
             : v0(v0), v1(v1), v2(v2), normal((v2 - v0).Cross(v1 - v0))
         {

--- a/trview.app/Geometry/Triangle.h
+++ b/trview.app/Geometry/Triangle.h
@@ -11,6 +11,7 @@ namespace trview
         Triangle(const DirectX::SimpleMath::Vector3& v0, const DirectX::SimpleMath::Vector3& v1, const DirectX::SimpleMath::Vector3& v2)
             : v0(v0), v1(v1), v2(v2), normal((v2 - v0).Cross(v1 - v0))
         {
+            normal.Normalize();
         }
 
         DirectX::SimpleMath::Vector3 v0;

--- a/trview.app/Geometry/Triangle.h
+++ b/trview.app/Geometry/Triangle.h
@@ -17,6 +17,6 @@ namespace trview
         DirectX::SimpleMath::Vector3 v0;
         DirectX::SimpleMath::Vector3 v1;
         DirectX::SimpleMath::Vector3 v2;
-        DirectX::SimpleMath::Vector3 normal;
+        DirectX::SimpleMath::Vector3 normal{ 0, 1, 0 };
     };
 }

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -2,6 +2,7 @@
 #include <trview.app/Camera/ICamera.h>
 #include <trview.app/Graphics/ILevelTextureStorage.h>
 #include <trview.common/Strings.h>
+#include <trview.common/Maths.h>
 
 using namespace DirectX;
 using namespace DirectX::SimpleMath;
@@ -12,7 +13,6 @@ namespace trview
     {
         const float PoleThickness = 0.05f;
         const float RopeThickness = 0.015f;
-        const float Pi = 3.1415926535897932384626433832796f;
 
         std::vector<uint8_t> from_base64(const std::string& text)
         {
@@ -153,7 +153,7 @@ namespace trview
                 const auto to = next_waypoint - current;
                 const auto matrix = 
                     (to.x == 0 && to.z == 0) 
-                        ? Matrix::CreateRotationX(Pi * 0.5f) * Matrix::CreateTranslation(mid)
+                        ? Matrix::CreateRotationX(maths::Pi * 0.5f) * Matrix::CreateTranslation(mid)
                         : Matrix(DirectX::XMMatrixLookAtRH(mid, next_waypoint, Vector3::Up)).Invert();
                 const auto length = to.Length();
                 const auto to_wvp = Matrix::CreateScale(RopeThickness, RopeThickness, length) * matrix * camera.view_projection();

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -12,6 +12,7 @@ namespace trview
     {
         const float PoleThickness = 0.05f;
         const float RopeThickness = 0.015f;
+        const float Pi = 3.1415926535897932384626433832796f;
 
         std::vector<uint8_t> from_base64(const std::string& text)
         {
@@ -149,8 +150,12 @@ namespace trview
                 const auto current = waypoint.blob_position();
                 const auto next_waypoint = _waypoints[i + 1].blob_position();
                 const auto mid = Vector3::Lerp(current, next_waypoint, 0.5f);
-                const auto matrix = Matrix(DirectX::XMMatrixLookAtRH(mid, next_waypoint, Vector3::Up)).Invert();
-                const auto length = (next_waypoint - current).Length();
+                const auto to = next_waypoint - current;
+                const auto matrix = 
+                    (to.x == 0 && to.z == 0) 
+                        ? Matrix::CreateRotationX(Pi * 0.5f) * Matrix::CreateTranslation(mid)
+                        : Matrix(DirectX::XMMatrixLookAtRH(mid, next_waypoint, Vector3::Up)).Invert();
+                const auto length = to.Length();
                 const auto to_wvp = Matrix::CreateScale(RopeThickness, RopeThickness, length) * matrix * camera.view_projection();
                 _waypoint_mesh->render(device.context(), to_wvp, texture_storage, _colour);
             }

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -49,14 +49,14 @@ namespace trview
     {
     }
 
-    void Route::add(const Vector3& position, uint32_t room)
+    void Route::add(const Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room)
     {
-        add(position, room, Waypoint::Type::Position, 0u);
+        add(position, normal, room, Waypoint::Type::Position, 0u);
     }
 
-    void Route::add(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index)
+    void Route::add(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, Waypoint::Type type, uint32_t type_index)
     {
-        _waypoints.emplace_back(_waypoint_mesh.get(), position, room, type, type_index, _colour);
+        _waypoints.emplace_back(_waypoint_mesh.get(), position, normal, room, type, type_index, _colour);
     }
 
     Colour Route::colour() const
@@ -70,31 +70,31 @@ namespace trview
         _selected_index = 0u;
     }
 
-    void Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index)
+    void Route::insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index)
     {
         if (index >= _waypoints.size())
         {
-            return add(position, room, Waypoint::Type::Position, 0u);
+            return add(position, normal, room, Waypoint::Type::Position, 0u);
         }
-        insert(position, room, index, Waypoint::Type::Position, 0u);
+        insert(position, normal, room, index, Waypoint::Type::Position, 0u);
     }
 
-    uint32_t Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room)
+    uint32_t Route::insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room)
     {
         uint32_t index = next_index();
-        insert(position, room, index);
+        insert(position, normal, room, index);
         return index;
     }
 
-    void Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index)
+    void Route::insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index)
     {
-        _waypoints.insert(_waypoints.begin() + index, Waypoint(_waypoint_mesh.get(), position, room, type, type_index, _colour));
+        _waypoints.insert(_waypoints.begin() + index, Waypoint(_waypoint_mesh.get(), position, normal, room, type, type_index, _colour));
     }
 
-    uint32_t Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index)
+    uint32_t Route::insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, Waypoint::Type type, uint32_t type_index)
     {
         uint32_t index = next_index();
-        insert(position, room, index, type, type_index);
+        insert(position, normal, room, index, type, type_index);
         return index;
     }
 
@@ -146,8 +146,8 @@ namespace trview
             // Should render the in-between line somehow - if there is another point in the list.
             if (i < _waypoints.size() - 1)
             {
-                const auto current = waypoint.position() - Vector3(0, 0.5f + PoleThickness * 0.5f, 0);
-                const auto next_waypoint = _waypoints[i + 1].position() - Vector3(0, 0.5f + PoleThickness * 0.5f, 0);
+                const auto current = waypoint.blob_position();
+                const auto next_waypoint = _waypoints[i + 1].blob_position();
                 const auto mid = Vector3::Lerp(current, next_waypoint, 0.5f);
                 const auto matrix = Matrix(DirectX::XMMatrixLookAtRH(mid, next_waypoint, Vector3::Up)).Invert();
                 const auto length = (next_waypoint - current).Length();
@@ -254,7 +254,7 @@ namespace trview
                 auto index = waypoint["index"].get<int>();
                 auto notes = waypoint["notes"].get<std::string>();
 
-                route->add(position, room, type, index);
+                route->add(position, Vector3(0, -1, 0), room, type, index);
 
                 auto& new_waypoint = route->waypoint(route->waypoints() - 1);
                 new_waypoint.set_notes(to_utf16(notes));

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -23,14 +23,14 @@ namespace trview
         /// Add a new waypoint to the end of the route.
         /// @param position The new waypoint.
         /// @param room The room the waypoint is in.
-        void add(const DirectX::SimpleMath::Vector3& position, uint32_t room);
+        void add(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room);
 
         /// Add a new waypoint to the end of the route.
         /// @param position The position of the waypoint in the world.
         /// @param room The room that waypoint is in.
         /// @param type The type of the waypoint.
         /// @param type_index The index of the referred to entity or trigger.
-        void add(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index);
+        void add(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, Waypoint::Type type, uint32_t type_index);
 
         /// Remove all of the waypoints from the route.
         void clear();
@@ -42,13 +42,13 @@ namespace trview
         /// @param position The new waypoint.
         /// @param room The room that the waypoint is in.
         /// @param index The index in the route list to put the waypoint.
-        void insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index);
+        void insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index);
 
         /// Insert the new waypoint into the route based on the currently selected waypoint.
         /// @param position The new waypoint.
         /// @param room The room that the waypoint is in.
         /// @return The index of the new waypoint.
-        uint32_t insert(const DirectX::SimpleMath::Vector3& position, uint32_t room);
+        uint32_t insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room);
 
         /// Insert a new non-positional waypoint.
         /// @param position The position of the waypoint in the world.
@@ -56,7 +56,7 @@ namespace trview
         /// @param type The type of waypoint.
         /// @param index The index in the route list to put the waypoint.
         /// @param type_index The index of the trigger or entity to reference.
-        void insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index);
+        void insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index);
 
         /// Insert a new non-positional waypoint based on the currently selected waypoint.
         /// @param position The position of the waypoint in the world.
@@ -64,7 +64,7 @@ namespace trview
         /// @param type The type of waypoint.
         /// @param type_index The index of the trigger or entity to reference.
         /// @return The index of the new waypoint.
-        uint32_t insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index);
+        uint32_t insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, Waypoint::Type type, uint32_t type_index);
 
         /// Pick against the waypoints in the route.
         /// @param position The position of the camera.

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -36,6 +36,10 @@ namespace trview
         {
             rotation = Matrix::Identity;
         }
+        else if (_normal == Vector3::Up)
+        {
+            rotation = Matrix::CreateRotationX(Pi);
+        }
 
         // The pole
         auto pole_wvp = Matrix::CreateScale(PoleThickness, 0.5f, PoleThickness) * Matrix::CreateTranslation(0, -0.25f, 0) * rotation * Matrix::CreateTranslation(_position) * camera.view_projection();
@@ -65,6 +69,10 @@ namespace trview
         if (_normal == Vector3::Down)
         {
             rotation = Matrix::Identity;
+        }
+        else if (_normal == Vector3::Up)
+        {
+            rotation = Matrix::CreateRotationX(Pi);
         }
         auto matrix = Matrix::CreateTranslation(-Vector3(0, 0.5f + PoleThickness * 0.5f, 0)) * rotation * Matrix::CreateTranslation(_position);
         return Vector3::Transform(Vector3(), matrix);

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -1,5 +1,6 @@
 #include "Waypoint.h"
 #include <trview.app/Camera/ICamera.h>
+#include <trview.common/Maths.h>
 
 using namespace DirectX::SimpleMath;
 
@@ -27,19 +28,7 @@ namespace trview
         auto light_direction = _position - camera.position();
         light_direction.Normalize();
 
-        const float Pi = 3.1415926535897932384626433832796f;
-
-        Matrix rotation = Matrix(DirectX::XMMatrixLookAtRH(Vector3::Zero, _normal, Vector3::Up)).Invert();
-        rotation = Matrix::CreateRotationX(Pi * 0.5f) * rotation;
-
-        if (_normal == Vector3::Down)
-        {
-            rotation = Matrix::Identity;
-        }
-        else if (_normal == Vector3::Up)
-        {
-            rotation = Matrix::CreateRotationX(Pi);
-        }
+        Matrix rotation = calculate_waypoint_rotation();
 
         // The pole
         auto pole_wvp = Matrix::CreateScale(PoleThickness, 0.5f, PoleThickness) * Matrix::CreateTranslation(0, -0.25f, 0) * rotation * Matrix::CreateTranslation(_position) * camera.view_projection();
@@ -61,10 +50,14 @@ namespace trview
 
     DirectX::SimpleMath::Vector3 Waypoint::blob_position() const
     {
-        const float Pi = 3.1415926535897932384626433832796f;
+        auto matrix = Matrix::CreateTranslation(-Vector3(0, 0.5f + PoleThickness * 0.5f, 0)) * calculate_waypoint_rotation() * Matrix::CreateTranslation(_position);
+        return Vector3::Transform(Vector3(), matrix);
+    }
 
+    Matrix Waypoint::calculate_waypoint_rotation() const
+    {
         Matrix rotation = Matrix(DirectX::XMMatrixLookAtRH(Vector3::Zero, _normal, Vector3::Up)).Invert();
-        rotation = Matrix::CreateRotationX(Pi * 0.5f) * rotation;
+        rotation = Matrix::CreateRotationX(maths::Pi * 0.5f) * rotation;
 
         if (_normal == Vector3::Down)
         {
@@ -72,10 +65,9 @@ namespace trview
         }
         else if (_normal == Vector3::Up)
         {
-            rotation = Matrix::CreateRotationX(Pi);
+            rotation = Matrix::CreateRotationX(maths::Pi);
         }
-        auto matrix = Matrix::CreateTranslation(-Vector3(0, 0.5f + PoleThickness * 0.5f, 0)) * rotation * Matrix::CreateTranslation(_position);
-        return Vector3::Transform(Vector3(), matrix);
+        return rotation;
     }
 
     Waypoint::Type Waypoint::type() const

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -26,7 +26,7 @@ namespace trview
         /// @param mesh The waypoint mesh.
         /// @param position The position of the waypoint in the world.
         /// @param room The room that the waypoint is in.
-        explicit Waypoint(Mesh* mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room);
+        explicit Waypoint(Mesh* mesh, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room);
 
         /// Create a new waypoint.
         /// @param mesh The waypoint mesh.
@@ -35,7 +35,7 @@ namespace trview
         /// @param type The type of waypoint.
         /// @param index The index of the entity or trigger being referenced if this is a non-position type.
         /// @param route_colour The colour of the route.
-        explicit Waypoint(Mesh* mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room, Type type, uint32_t index, const Colour& route_colour);
+        explicit Waypoint(Mesh* mesh, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, Type type, uint32_t index, const Colour& route_colour);
 
         /// Destructor for waypoint.
         virtual ~Waypoint() = default;
@@ -55,6 +55,8 @@ namespace trview
 
         /// Get the position of the waypoint in the 3D view.
         DirectX::SimpleMath::Vector3 position() const;
+
+        DirectX::SimpleMath::Vector3 blob_position() const;
 
         /// Get the type of the waypoint.
         Type type() const;
@@ -91,6 +93,7 @@ namespace trview
         std::wstring                 _notes;
         std::vector<uint8_t>         _save_data;
         DirectX::SimpleMath::Vector3 _position;
+        DirectX::SimpleMath::Vector3 _normal;
         Mesh*                        _mesh;
         Type                         _type;
         uint32_t                     _index;

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -90,6 +90,8 @@ namespace trview
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;
     private:
+        DirectX::SimpleMath::Matrix calculate_waypoint_rotation() const;
+
         std::wstring                 _notes;
         std::vector<uint8_t>         _save_data;
         DirectX::SimpleMath::Vector3 _position;

--- a/trview.app/Tools/Compass.cpp
+++ b/trview.app/Tools/Compass.cpp
@@ -5,6 +5,7 @@
 #include <trview.graphics/IShaderStorage.h>
 #include <trview.graphics/RenderTargetStore.h>
 #include <trview.graphics/ViewportStore.h>
+#include <trview.common/Maths.h>
 
 namespace trview
 {
@@ -14,8 +15,6 @@ namespace trview
 
     namespace
     {
-        const float HalfPi = 1.5707963267948966192313216916398f;
-        const float Pi = 3.1415926535897932384626433832796f;
         const float View_Size = 200;
         const float Nodule_Size = 0.05f;
 
@@ -74,8 +73,8 @@ namespace trview
             const auto scale = Matrix::CreateScale(thickness, 1.0f, thickness);
 
             _mesh->render(context, scale * view_projection, texture_storage, Color(1.0f, 0.0f, 0.0f));
-            _mesh->render(context, scale * Matrix::CreateRotationZ(HalfPi) * view_projection, texture_storage, Color(0.0f, 1.0f, 0.0f));
-            _mesh->render(context, scale * Matrix::CreateRotationX(HalfPi) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
+            _mesh->render(context, scale * Matrix::CreateRotationZ(maths::HalfPi) * view_projection, texture_storage, Color(0.0f, 1.0f, 0.0f));
+            _mesh->render(context, scale * Matrix::CreateRotationX(maths::HalfPi) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
 
             // Nodules for each direction - they can be clicked.
             const auto nodule_scale = Matrix::CreateScale(0.05f);
@@ -157,25 +156,25 @@ namespace trview
         switch (axis)
         {
         case Compass::Axis::Pos_X:
-            yaw = HalfPi;
+            yaw = maths::HalfPi;
             pitch = 0;
             break;
         case Compass::Axis::Pos_Y:
-            pitch = -HalfPi;
+            pitch = -maths::HalfPi;
             break;
         case Compass::Axis::Pos_Z:
             yaw = 0;
             pitch = 0;
             break;
         case Compass::Axis::Neg_X:
-            yaw = -HalfPi;
+            yaw = -maths::HalfPi;
             pitch = 0;
             break;
         case Compass::Axis::Neg_Y:
-            pitch = HalfPi;
+            pitch = maths::HalfPi;
             break;
         case Compass::Axis::Neg_Z:
-            yaw = Pi;
+            yaw = maths::Pi;
             pitch = 0;
             break;
         }

--- a/trview.app/UI/ContextMenu.cpp
+++ b/trview.app/UI/ContextMenu.cpp
@@ -17,6 +17,7 @@ namespace trview
     const std::string ContextMenu::Names::hide_button{ "Hide" };
     const std::string ContextMenu::Names::orbit_button{ "Orbit" };
     const std::string ContextMenu::Names::add_waypoint_button{ "AddWaypoint" };
+    const std::string ContextMenu::Names::add_mid_waypoint_button{ "AddMidWaypoint" };
     const std::string ContextMenu::Names::remove_waypoint_button{ "RemoveWaypoint" };
 
     ContextMenu::ContextMenu(Control& parent)
@@ -30,6 +31,15 @@ namespace trview
         _token_store += button->on_click += [&]()
         {
             on_add_waypoint();
+            set_visible(false);
+        };
+
+        auto mid_button = _menu->add_child(std::make_unique<Button>(Size(100, 24), L"Add Mid Waypoint"));
+        mid_button->set_name(Names::add_mid_waypoint_button);
+        mid_button->set_text_background_colour(Colours::Button);
+        _token_store += mid_button->on_click += [&]()
+        {
+            on_add_mid_waypoint();
             set_visible(false);
         };
 

--- a/trview.app/UI/ContextMenu.h
+++ b/trview.app/UI/ContextMenu.h
@@ -12,6 +12,7 @@ namespace trview
         struct Names
         {
             static const std::string add_waypoint_button;
+            static const std::string add_mid_waypoint_button;
             static const std::string hide_button;
             static const std::string orbit_button;
             static const std::string remove_waypoint_button;
@@ -40,6 +41,10 @@ namespace trview
         /// Event raised when the user has clicked the button to create a new
         /// waypoint for the current route.
         Event<> on_add_waypoint;
+
+        /// Event raised when the user has clicked the button to create a new
+        /// mid waypoint for the current route.
+        Event<> on_add_mid_waypoint;
 
         /// Event raised when the user has clicked the remove waypoint button.
         Event<> on_remove_waypoint;

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -91,6 +91,7 @@ namespace trview
 
         _context_menu = std::make_unique<ContextMenu>(*_control);
         _context_menu->on_add_waypoint += on_add_waypoint;
+        _context_menu->on_add_mid_waypoint += on_add_mid_waypoint;
         _context_menu->on_remove_waypoint += on_remove_waypoint;
         _context_menu->on_orbit_here += on_orbit;
         _context_menu->on_hide += on_hide;

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -65,6 +65,9 @@ namespace trview
         /// Event raised when the add waypoint button is pressed.
         Event<> on_add_waypoint;
 
+        /// Event raised when the add mid waypoint button is pressed.
+        Event<> on_add_mid_waypoint;
+
         /// Event raised when the remove waypoint button is pressed.
         Event<> on_remove_waypoint;
 

--- a/trview.common/Maths.h
+++ b/trview.common/Maths.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace trview
+{
+    namespace maths
+    {
+        const float Pi{ 3.1415926535897932384626433832796f };
+        const float HalfPi{ Pi * 0.5f };
+        const float Pi2{ Pi * 2.0f };
+    }
+}

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -22,6 +22,7 @@
     <ClInclude Include="Colour.h" />
     <ClInclude Include="Event.h" />
     <ClInclude Include="FileLoader.h" />
+    <ClInclude Include="Maths.h" />
     <ClInclude Include="MessageHandler.h" />
     <ClInclude Include="Point.h" />
     <ClInclude Include="Size.h" />

--- a/trview.common/trview.common.vcxproj.filters
+++ b/trview.common/trview.common.vcxproj.filters
@@ -24,6 +24,7 @@
       <Filter>Windows</Filter>
     </ClInclude>
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="Maths.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FileLoader.cpp" />

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -62,7 +62,7 @@ namespace trview
         _token_store += _items_windows->on_trigger_selected += [this](const auto& trigger) { select_trigger(trigger); };
         _token_store += _items_windows->on_add_to_route += [this](const auto& item)
         {
-            uint32_t new_index = _route->insert(item.position(), item.room(), Waypoint::Type::Entity, item.number());
+            uint32_t new_index = _route->insert(item.position(), DirectX::SimpleMath::Vector3(0, -1, 0), item.room(), Waypoint::Type::Entity, item.number());
             _route_window_manager->set_route(_route.get());
             select_waypoint(new_index);
         };
@@ -77,7 +77,7 @@ namespace trview
         _token_store += _triggers_windows->on_trigger_visibility += [this](const auto& trigger, bool state) { set_trigger_visibility(trigger, state); };
         _token_store += _triggers_windows->on_add_to_route += [this](const auto& trigger)
         {
-            uint32_t new_index = _route->insert(trigger->position(), trigger->room(), Waypoint::Type::Trigger, trigger->number());
+            uint32_t new_index = _route->insert(trigger->position(), DirectX::SimpleMath::Vector3(0, -1, 0), trigger->room(), Waypoint::Type::Trigger, trigger->number());
             _route_window_manager->set_route(_route.get());
             select_waypoint(new_index);
         };
@@ -155,7 +155,7 @@ namespace trview
         _token_store += _ui->on_add_waypoint += [&]()
         {
             auto type = _context_pick.type == PickResult::Type::Entity ? Waypoint::Type::Entity : _context_pick.type == PickResult::Type::Trigger ? Waypoint::Type::Trigger : Waypoint::Type::Position;
-            uint32_t new_index = _route->insert(_context_pick.position, room_from_pick(_context_pick), type, _context_pick.index);
+            uint32_t new_index = _route->insert(_context_pick.position, DirectX::SimpleMath::Vector3(0, -1, 0), room_from_pick(_context_pick), type, _context_pick.index);
             _route_window_manager->set_route(_route.get());
             select_waypoint(new_index);
         };
@@ -176,7 +176,7 @@ namespace trview
                 _context_pick.position = _level->triggers()[_context_pick.index]->position();
             }
 
-            uint32_t new_index = _route->insert(_context_pick.position, room_from_pick(_context_pick), type, _context_pick.index);
+            uint32_t new_index = _route->insert(_context_pick.position, _context_pick.triangle.normal, room_from_pick(_context_pick), type, _context_pick.index);
             _route_window_manager->set_route(_route.get());
             select_waypoint(new_index);
         };

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -159,6 +159,27 @@ namespace trview
             _route_window_manager->set_route(_route.get());
             select_waypoint(new_index);
         };
+        _token_store += _ui->on_add_mid_waypoint += [&]()
+        {
+            auto type = _context_pick.type == PickResult::Type::Entity ? Waypoint::Type::Entity : _context_pick.type == PickResult::Type::Trigger ? Waypoint::Type::Trigger : Waypoint::Type::Position;
+
+            if (_context_pick.type == PickResult::Type::Room)
+            {
+                _context_pick.position = _context_pick.centroid;
+            }
+            else if (_context_pick.type == PickResult::Type::Entity)
+            {
+                _context_pick.position = _level->items()[_context_pick.index].position();
+            }
+            else if (_context_pick.type == PickResult::Type::Trigger)
+            {
+                _context_pick.position = _level->triggers()[_context_pick.index]->position();
+            }
+
+            uint32_t new_index = _route->insert(_context_pick.position, room_from_pick(_context_pick), type, _context_pick.index);
+            _route_window_manager->set_route(_route.get());
+            select_waypoint(new_index);
+        };
         _token_store += _ui->on_remove_waypoint += [&]() { remove_waypoint(_context_pick.index); };
         _token_store += _ui->on_hide += [&]()
         {


### PR DESCRIPTION
Add a way of adding a 'mid waypoint' that adds a waypoint at the centre of the 'square' that the pick is in. These can be added from the context menu.
Also add support for adding waypoints to walls and ceilings - the waypoint will align to the normal of the surface, but only if there is no y component.
Move `Pi` to `trview.common` and update usages.
Closes #730 