### PR TITLE
Allow user to dismiss the context menu

### DIFF
--- a/trview.app.tests/ContextMenuTests.cpp
+++ b/trview.app.tests/ContextMenuTests.cpp
@@ -130,3 +130,18 @@ TEST(ContextMenu, RemoveWaypointRaised)
     button->clicked(Point());
     ASSERT_TRUE(raised);
 }
+
+TEST(ContextMenu, ShowContextMenu)
+{
+    ui::Window parent(Size(800, 600), Colour::Transparent);
+    ContextMenu menu(parent);
+
+    auto control = menu.control();
+    ASSERT_NE(control, nullptr);
+    ASSERT_FALSE(control->visible());
+    ASSERT_FALSE(menu.visible());
+    
+    menu.set_visible(true);
+    ASSERT_TRUE(menu.visible());
+    ASSERT_TRUE(control->visible());
+}

--- a/trview.app/Camera/CameraInput.cpp
+++ b/trview.app/Camera/CameraInput.cpp
@@ -150,14 +150,14 @@ namespace trview
         on_zoom(scroll / -100.0f);
     }
 
-    void CameraInput::reset()
+    void CameraInput::reset(bool ignore_key_states)
     {
-        _free_forward = GetAsyncKeyState('W') & 0x8000;
-        _free_left = GetAsyncKeyState('A') & 0x8000;
-        _free_right = GetAsyncKeyState('D') & 0x8000;
-        _free_backward = GetAsyncKeyState('S') & 0x8000;
-        _free_up = GetAsyncKeyState('E') & 0x8000;
-        _free_down = GetAsyncKeyState('Q') & 0x8000;
+        _free_forward = ignore_key_states ? false : GetAsyncKeyState('W') & 0x8000;
+        _free_left = ignore_key_states ? false : GetAsyncKeyState('A') & 0x8000;
+        _free_right = ignore_key_states ? false : GetAsyncKeyState('D') & 0x8000;
+        _free_backward = ignore_key_states ? false : GetAsyncKeyState('S') & 0x8000;
+        _free_up = ignore_key_states ? false : GetAsyncKeyState('E') & 0x8000;
+        _free_down = ignore_key_states ? false : GetAsyncKeyState('Q') & 0x8000;
         _rotating = false;
         _panning = false;
         _panning_vertical = false;

--- a/trview.app/Camera/CameraInput.h
+++ b/trview.app/Camera/CameraInput.h
@@ -45,7 +45,8 @@ namespace trview
         void mouse_scroll(int16_t scroll);
 
         /// Reset all input states.
-        void reset();
+        /// @param ignore_key_states Whether to set everything to false regardless of the actual state.
+        void reset(bool ignore_key_states = false);
 
         /// Event raised when the camera needs to be rotated.
         Event<float, float> on_rotate;

--- a/trview.app/UI/ContextMenu.cpp
+++ b/trview.app/UI/ContextMenu.cpp
@@ -73,6 +73,11 @@ namespace trview
         _menu->set_visible(false);
     }
 
+    const ui::Control* ContextMenu::control() const
+    {
+        return _menu;
+    }
+
     void ContextMenu::set_position(const Point& position)
     {
         _menu->set_position(position);
@@ -93,5 +98,10 @@ namespace trview
     {
         _hide_enabled = value;
         _hide_button->set_text_colour(value ? Colours::Enabled : Colours::Disabled);
+    }
+
+    bool ContextMenu::visible() const
+    {
+        return _menu->visible();
     }
 }

--- a/trview.app/UI/ContextMenu.h
+++ b/trview.app/UI/ContextMenu.h
@@ -21,6 +21,10 @@ namespace trview
         /// @param parent The control to add the window to.
         explicit ContextMenu(ui::Control& parent);
 
+        /// Get the root control.
+        /// @returns The root control.
+        const ui::Control* control() const;
+
         /// Set the position of the context menu.
         /// @param position The new position of the menu.
         void set_position(const Point& position);
@@ -36,6 +40,10 @@ namespace trview
         /// Set whether the hide button is enabled or not.
         /// @param value Whether the hide button is enabled or not.
         void set_hide_enabled(bool value);
+
+        /// Get whether the context menu is visible.
+        /// @returns Whether the menu is visible.
+        bool visible() const;
 
         /// Event raised when the user has clicked the button to create a new
         /// waypoint for the current route.

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -483,6 +483,11 @@ namespace trview
         return _view_options->show_wireframe();
     }
 
+    bool ViewerUI::show_context_menu() const
+    {
+        return _context_menu->visible();
+    }
+
     void ViewerUI::toggle_settings_visibility()
     {
         _settings_window->toggle_visibility();

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -277,6 +277,9 @@ namespace trview
         /// Get whether wireframe is visible.
         bool show_wireframe() const;
 
+        /// Get whether the context menu is visible.
+        bool show_context_menu() const;
+
         /// Toggle the visibility of the settings window.
         void toggle_settings_visibility();
 

--- a/trview.input/Mouse.cpp
+++ b/trview.input/Mouse.cpp
@@ -57,7 +57,7 @@ namespace trview
                 update_button(Button::Middle, input.data.mouse.usButtonFlags, RI_MOUSE_MIDDLE_BUTTON_DOWN, RI_MOUSE_MIDDLE_BUTTON_UP, _middle_down);
                 update_button(Button::Right, input.data.mouse.usButtonFlags, RI_MOUSE_RIGHT_BUTTON_DOWN, RI_MOUSE_RIGHT_BUTTON_UP, _right_down);
 
-                if (input.data.mouse.usFlags == MOUSE_MOVE_RELATIVE)
+                if (input.data.mouse.usFlags == MOUSE_MOVE_RELATIVE && (input.data.mouse.lLastX || input.data.mouse.lLastY))
                 {
                     mouse_move(input.data.mouse.lLastX, input.data.mouse.lLastY);
                 }

--- a/trview/Viewer.cpp
+++ b/trview/Viewer.cpp
@@ -422,9 +422,13 @@ namespace trview
 
         _token_store += _keyboard.on_key_down += [&](uint16_t key, bool control, bool)
         {
-            if (!_ui->is_input_active())
+            if (!_ui->is_input_active() && !_ui->show_context_menu())
             {
                 _camera_input.key_down(key, control);
+            }
+            else if (_ui->show_context_menu() && key == VK_ESCAPE)
+            {
+                _ui->set_show_context_menu(false);
             }
         };
 
@@ -438,6 +442,12 @@ namespace trview
             {
                 if (!_ui->is_cursor_over())
                 {
+                    if (_ui->show_context_menu())
+                    {
+                        _ui->set_show_context_menu(false);
+                        return;
+                    }
+
                     _ui->set_show_context_menu(false);
 
                     if (_compass_axis.has_value())
@@ -523,6 +533,7 @@ namespace trview
             {
                 _context_pick = _current_pick;
                 _ui->set_show_context_menu(true);
+                _camera_input.reset(true);
                 _ui->set_remove_waypoint_enabled(_current_pick.type == PickResult::Type::Waypoint);
                 _ui->set_hide_enabled(_current_pick.type == PickResult::Type::Entity || _current_pick.type == PickResult::Type::Trigger);
             }
@@ -950,6 +961,11 @@ namespace trview
                 return;
             }
 
+            if (_ui->show_context_menu())
+            {
+                _ui->set_show_context_menu(false);
+            }
+
             ICamera& camera = current_camera();
             const float low_sensitivity = 200.0f;
             const float high_sensitivity = 25.0f;
@@ -992,6 +1008,11 @@ namespace trview
             if (_ui->is_cursor_over() || _camera_mode != CameraMode::Orbit)
             {
                 return;
+            }
+
+            if (_ui->show_context_menu())
+            {
+                _ui->set_show_context_menu(false);
             }
 
             ICamera& camera = current_camera();


### PR DESCRIPTION
Allow the user to dismiss the context menu without performing an action.
The user can now dismiss the context menu by doing one of the following - previously they had to choose an action:
- Left clicking off the menu
- Moving the camera with the mouse
- Pressing escape
- Right clicking somewhere else (this will make a new context menu in that location)

As part of this change the mouse class to only give mouse move event when there has actually been some movement (relative movement only).
Closes #275