### PR TITLE
Adjust pickup height based on OCB value

### DIFF
--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -5,6 +5,7 @@
 #include <trview.app/Camera/ICamera.h>
 #include <trview.app/Geometry/Mesh.h>
 #include <trview.app/Geometry/TransparencyBuffer.h>
+#include <trview.common/Algorithms.h>
 
 #include <trlevel/ILevel.h>
 #include <trlevel/trtypes.h>
@@ -333,9 +334,8 @@ namespace trview
     void Entity::apply_ocb_adjustment(uint32_t ocb)
     {
         using namespace DirectX::SimpleMath;
-        const auto flags = ocb & 0x3F;
-        if (_meshes.size() == 1 &&
-            flags == 0 || flags == 3 || flags == 4 || flags == 7 || flags == 8 || flags == 11)
+        const int flags = ocb & 0x3F;
+        if (_meshes.size() == 1 && equals_any(flags, 0, 3, 4, 7, 11))
         {
             Matrix offset = Matrix::CreateTranslation(0, -_bounding_box.Extents.y, 0);
             _world *= offset;

--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -338,6 +338,9 @@ namespace trview
     {
         using namespace DirectX::SimpleMath;
         const int flags = ocb & 0x3F;
+        // This assumes that pickups only have one mesh, as a general rule (it seems to work most of the time).
+        // Applying OCB adjustment without this test when OCB is 0 makes Lara and other entities move up, which
+        // isn't right.
         if (_meshes.size() == 1 && equals_any(flags, 0, 3, 7, 11))
         {
             Matrix offset = Matrix::CreateTranslation(0, -_bounding_box.Extents.y, 0);

--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -335,7 +335,7 @@ namespace trview
     {
         using namespace DirectX::SimpleMath;
         const int flags = ocb & 0x3F;
-        if (_meshes.size() == 1 && equals_any(flags, 0, 3, 4, 7, 11))
+        if (_meshes.size() == 1 && equals_any(flags, 0, 3, 7, 11))
         {
             Matrix offset = Matrix::CreateTranslation(0, -_bounding_box.Extents.y, 0);
             _world *= offset;

--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -334,7 +334,8 @@ namespace trview
     {
         using namespace DirectX::SimpleMath;
         const auto flags = ocb & 0x3F;
-        if (ocb & 64 && flags == 0 || flags == 3 || flags == 4 || flags == 7 || flags == 8 || flags == 11)
+        if (_meshes.size() == 1 &&
+            flags == 0 || flags == 3 || flags == 4 || flags == 7 || flags == 8 || flags == 11)
         {
             Matrix offset = Matrix::CreateTranslation(0, -_bounding_box.Extents.y, 0);
             _world *= offset;

--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -40,7 +40,12 @@ namespace trview
             _position = entity.position();
         }
 
-        generate_bounding_box(entity.Intensity2);
+        generate_bounding_box();
+
+        if (level.get_version() >= trlevel::LevelVersion::Tomb4)
+        {
+            apply_ocb_adjustment(entity.Intensity2);
+        }
     }
 
     void Entity::load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage)
@@ -285,7 +290,7 @@ namespace trview
         return result;
     }
 
-    void Entity::generate_bounding_box(uint32_t ocb)
+    void Entity::generate_bounding_box()
     {
         using namespace DirectX;
 
@@ -327,8 +332,6 @@ namespace trview
 
         // Create an axis-aligned BB from the points of the oriented ones.
         BoundingBox::CreateFromPoints(_bounding_box, corners.size(), &corners[0], sizeof(Vector3));
-
-        apply_ocb_adjustment(ocb);
     }
 
     void Entity::apply_ocb_adjustment(uint32_t ocb)

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -45,7 +45,7 @@ namespace trview
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);
         void load_sprite(const graphics::Device& device, const trlevel::tr_sprite_sequence& sprite_sequence, const trlevel::ILevel& level, const ILevelTextureStorage& texture_storage);
-        void generate_bounding_box(uint32_t ocb);
+        void generate_bounding_box();
         void apply_ocb_adjustment(uint32_t ocb);
 
         DirectX::SimpleMath::Matrix               _world;

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -45,7 +45,8 @@ namespace trview
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);
         void load_sprite(const graphics::Device& device, const trlevel::tr_sprite_sequence& sprite_sequence, const trlevel::ILevel& level, const ILevelTextureStorage& texture_storage);
-        void generate_bounding_box();
+        void generate_bounding_box(uint32_t ocb);
+        void apply_ocb_adjustment(uint32_t ocb);
 
         DirectX::SimpleMath::Matrix               _world;
         std::vector<Mesh*>                        _meshes;

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -251,8 +251,8 @@ namespace trview
         auto position_text = [&item]()
         {
             std::wstringstream stream;
-            stream.precision(0);
-            stream << item.position().x * trlevel::Scale_X << L", " <<
+            stream << std::fixed << std::setprecision(0) <<
+                item.position().x * trlevel::Scale_X << L", " <<
                 item.position().y * trlevel::Scale_Y << L", " <<
                 item.position().z * trlevel::Scale_Z;
             return stream.str();

--- a/trview.common.tests/AlgorithmsTests.cpp
+++ b/trview.common.tests/AlgorithmsTests.cpp
@@ -1,0 +1,32 @@
+#include "gtest/gtest.h"
+#include <trview.common/Algorithms.h>
+
+using namespace trview;
+
+TEST(equals_any, NotEqualsMany)
+{
+    int value = 15;
+    bool result = trview::equals_any(value, 3, 10, 13);
+    ASSERT_FALSE(result);
+}
+
+TEST(equals_any, EqualsMany)
+{
+    int value = 15;
+    bool result = trview::equals_any(value, 4, 8, 15);
+    ASSERT_TRUE(result);
+}
+
+TEST(equals_any, OneOtherEquals)
+{
+    int value = 15;
+    bool result = trview::equals_any(value, 15);
+    ASSERT_TRUE(result);
+}
+
+TEST(equals_any, OneOtherNotEquals)
+{
+    int value = 15;
+    bool result = trview::equals_any(value, 16);
+    ASSERT_FALSE(result);
+}

--- a/trview.common.tests/trview.common.tests.vcxproj
+++ b/trview.common.tests/trview.common.tests.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="AlgorithmsTests.cpp" />
     <ClCompile Include="EventTests.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="TimerTests.cpp" />

--- a/trview.common.tests/trview.common.tests.vcxproj.filters
+++ b/trview.common.tests/trview.common.tests.vcxproj.filters
@@ -6,6 +6,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest\gtest-all.cc" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc" />
     <ClCompile Include="Main.cpp" />
+    <ClCompile Include="AlgorithmsTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/trview.common/Algorithms.h
+++ b/trview.common/Algorithms.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace trview
+{
+    template < typename T >
+    bool equals_any(T value, T other);
+
+    template < typename T, typename... Args >
+    bool equals_any(T value, T other, Args... set);
+}
+
+#include "Algorithms.hpp"

--- a/trview.common/Algorithms.h
+++ b/trview.common/Algorithms.h
@@ -2,11 +2,11 @@
 
 namespace trview
 {
-    template <typename T>
-    bool equals_any(T value, T other);
+    template <typename T1, typename T2>
+    bool equals_any(T1&& value, T2&& other);
 
-    template <typename T, typename... Args>
-    bool equals_any(T value, T other, Args... set);
+    template <typename T1, typename T2, typename... Args>
+    bool equals_any(T1&& value, T2&& other, Args&&... set);
 }
 
 #include "Algorithms.hpp"

--- a/trview.common/Algorithms.h
+++ b/trview.common/Algorithms.h
@@ -2,10 +2,10 @@
 
 namespace trview
 {
-    template < typename T >
+    template <typename T>
     bool equals_any(T value, T other);
 
-    template < typename T, typename... Args >
+    template <typename T, typename... Args>
     bool equals_any(T value, T other, Args... set);
 }
 

--- a/trview.common/Algorithms.hpp
+++ b/trview.common/Algorithms.hpp
@@ -2,14 +2,14 @@
 
 namespace trview
 {
-    template <typename T>
-    bool equals_any(T value, T other)
+    template <typename T1, typename T2>
+    bool equals_any(T1&& value, T2&& other)
     {
         return value == other;
     }
 
-    template <typename T, typename... Args>
-    bool equals_any(T value, T other, Args... set)
+    template <typename T1, typename T2, typename... Args>
+    bool equals_any(T1&& value, T2&& other, Args&&... set)
     {
         return equals_any(value, other) || equals_any(value, set...);
     }

--- a/trview.common/Algorithms.hpp
+++ b/trview.common/Algorithms.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace trview
+{
+    template <typename T>
+    bool equals_any(T value, T other)
+    {
+        return value == other;
+    }
+
+    template <typename T, typename... Args>
+    bool equals_any(T value, T other, Args... set)
+    {
+        return equals_any(value, other) || equals_any(value, set...);
+    }
+}

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -19,6 +19,8 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Algorithms.h" />
+    <ClInclude Include="Algorithms.hpp" />
     <ClInclude Include="Colour.h" />
     <ClInclude Include="Event.h" />
     <ClInclude Include="FileLoader.h" />

--- a/trview.common/trview.common.vcxproj.filters
+++ b/trview.common/trview.common.vcxproj.filters
@@ -24,6 +24,8 @@
       <Filter>Windows</Filter>
     </ClInclude>
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="Algorithms.h" />
+    <ClInclude Include="Algorithms.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FileLoader.cpp" />


### PR DESCRIPTION
Bump the height of pickup objects up by the y extents of the bounding box if the OCB value is one of several values. Only do this if there's one mesh, because doing this when OCB is 0 also moves Lara etc up, which is wrong.
Also fixed a bug in item position display - it was using scientific notation.

Closes #159 