### PR TITLE
Move most of the DI registration into modules

### DIFF
--- a/trlevel/di.h
+++ b/trlevel/di.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace trlevel
+{
+    auto register_module();
+}
+
+#include "di.hpp"

--- a/trlevel/di.h
+++ b/trlevel/di.h
@@ -2,7 +2,7 @@
 
 namespace trlevel
 {
-    auto register_module();
+    auto register_module() noexcept;
 }
 
 #include "di.hpp"

--- a/trlevel/di.hpp
+++ b/trlevel/di.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+#include "LevelLoader.h"
+
+namespace trlevel
+{
+    auto register_module()
+    {
+        using namespace boost;
+        return di::make_injector(
+            di::bind<ILevelLoader>.to<LevelLoader>()
+        );
+    }
+}

--- a/trlevel/di.hpp
+++ b/trlevel/di.hpp
@@ -5,7 +5,7 @@
 
 namespace trlevel
 {
-    auto register_module()
+    auto register_module() noexcept
     {
         using namespace boost;
         return di::make_injector(

--- a/trlevel/trlevel.vcxproj
+++ b/trlevel/trlevel.vcxproj
@@ -159,6 +159,8 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="di.h" />
+    <ClInclude Include="di.hpp" />
     <ClInclude Include="ILevel.h" />
     <ClInclude Include="ILevelLoader.h" />
     <ClInclude Include="Level.h" />

--- a/trlevel/trlevel.vcxproj.filters
+++ b/trlevel/trlevel.vcxproj.filters
@@ -15,6 +15,8 @@
     <ClInclude Include="Mocks\ILevel.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="di.h" />
+    <ClInclude Include="di.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ILevel.cpp" />

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -41,6 +41,7 @@
 #include <trview.graphics/di.h>
 #include <trview.ui.render/di.h>
 #include <trview.input/di.h>
+#include <trview.app/Geometry/di.h>
 #include <trview.app/Graphics/di.h>
 #include <trview.app/Tools/di.h>
 #include <trview.app/Windows/di.h>
@@ -568,6 +569,7 @@ namespace trview
             register_app_windows_module(),
             register_app_tools_module(),
             register_app_graphics_module(),
+            register_app_geometry_module(),
             di::bind<trlevel::ILevelLoader>.to<trlevel::LevelLoader>(),
             di::bind<IUpdateChecker>.to<UpdateChecker>(),
             di::bind<ISettingsLoader>.to<SettingsLoader>(),
@@ -575,7 +577,6 @@ namespace trview
             di::bind<ILevelSwitcher>.to<LevelSwitcher>(),
             di::bind<IRecentFiles>.to<RecentFiles>(),
             di::bind<Window>.to(create_window(instance, command_show)),
-            di::bind<IPicking>.to<Picking>(),
             di::bind<IRoute>.to<Route>(),
             di::bind<IRoute::Source>.to(
                 [](const auto& injector) -> IRoute::Source
@@ -592,29 +593,6 @@ namespace trview
                     Resource type_list = get_resource_memory(IDR_TYPE_NAMES, L"TEXT");
                     return std::make_shared<TypeNameLookup>(std::string(type_list.data, type_list.data + type_list.size));
                 }),
-            di::bind<IMesh::Source>.to(
-                [](const auto& injector) -> IMesh::Source
-                {
-                    return [&](auto&& vertices, auto&& indices, auto&& untextured_indices, auto&& transparent_triangles, auto&& collision_triangles)
-                    {
-                        return std::make_unique<Mesh>(
-                            injector.create<std::shared_ptr<IDevice>>(),
-                            vertices,
-                            indices,
-                            untextured_indices,
-                            transparent_triangles,
-                            collision_triangles);
-                    };
-                }),
-            di::bind<IMesh::TransparentSource>.to(
-                [](const auto& injector) -> IMesh::TransparentSource
-                {
-                    return [&](auto&& transparent_triangles, auto&& collision_triangles)
-                    {
-                        return std::make_unique<Mesh>(transparent_triangles, collision_triangles);
-                    };
-                }),
-            di::bind<ITransparencyBuffer>.to<TransparencyBuffer>(),
             di::bind<ILevel::Source>.to(
                 [](const auto& injector) -> ILevel::Source
                 {

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -46,6 +46,7 @@
 #include <trview.app/Menus/di.h>
 #include <trview.app/Routing/di.h>
 #include <trview.app/Tools/di.h>
+#include <trview.app/UI/di.h>
 #include <trview.app/Windows/di.h>
 
 using namespace DirectX::SimpleMath;
@@ -574,12 +575,12 @@ namespace trview
             register_app_menus_module(),
             register_app_routing_module(),
             register_app_tools_module(),
+            register_app_ui_module(),
             register_app_windows_module(),
             di::bind<trlevel::ILevelLoader>.to<trlevel::LevelLoader>(),
             di::bind<ISettingsLoader>.to<SettingsLoader>(),
             di::bind<Window>.to(create_window(instance, command_show)),
             di::bind<IShortcuts>.to<Shortcuts>(),
-            di::bind<IViewerUI>.to<ViewerUI>(),
             di::bind<IApplication>.to<Application>(),
             di::bind<Application::CommandLine>.to(command_line)
         );

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -39,6 +39,7 @@
 #include <external/boost/di.hpp>
 
 #include <trview.graphics/di.h>
+#include <trview.ui.render/di.h>
 
 using namespace DirectX::SimpleMath;
 
@@ -564,43 +565,10 @@ namespace trview
             );
         };
 
-        auto ui_render_module = [] {
-            using namespace ui::render;
-            using namespace graphics;
-            return di::make_injector(
-                di::bind<IRenderer::Source>.to(
-                    [](const auto& injector) -> IRenderer::Source
-                    {
-                        return [&](auto size)
-                        {
-                            return std::make_unique<Renderer>(
-                                injector.create<std::shared_ptr<IDevice>>(),
-                                injector.create<IRenderTarget::SizeSource>(),
-                                *injector.create<std::shared_ptr<IFontFactory>>(),
-                                size,
-                                injector.create<ISprite::Source>());
-                        };
-                    }),
-                di::bind<ui::render::IMapRenderer::Source>.to(
-                    [](const auto& injector) -> IMapRenderer::Source
-                    {
-                        return [&](auto size)
-                        {
-                            return std::make_unique<MapRenderer>(
-                                injector.create<std::shared_ptr<IDevice>>(),
-                                *injector.create<std::shared_ptr<IFontFactory>>(),
-                                size,
-                                injector.create<ISprite::Source>(),
-                                injector.create<IRenderTarget::SizeSource>());
-                        };
-                    })
-            );
-        };
-
         const auto injector = di::make_injector(
             graphics::register_module(),
             input_module(),
-            ui_render_module(),
+            ui::render::register_module(),
             di::bind<trlevel::ILevelLoader>.to<trlevel::LevelLoader>(),
             di::bind<IUpdateChecker>.to<UpdateChecker>(),
             di::bind<ISettingsLoader>.to<SettingsLoader>(),

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -41,6 +41,7 @@
 #include <trview.graphics/di.h>
 #include <trview.ui.render/di.h>
 #include <trview.input/di.h>
+#include <trview.app/Tools/di.h>
 #include <trview.app/Windows/di.h>
 
 using namespace DirectX::SimpleMath;
@@ -564,6 +565,7 @@ namespace trview
             input::register_module(),
             ui::render::register_module(),
             register_app_windows_module(),
+            register_app_tools_module(),
             di::bind<trlevel::ILevelLoader>.to<trlevel::LevelLoader>(),
             di::bind<IUpdateChecker>.to<UpdateChecker>(),
             di::bind<ISettingsLoader>.to<SettingsLoader>(),
@@ -583,7 +585,6 @@ namespace trview
                 }),
             di::bind<ITextureStorage>.to<TextureStorage>(),
             di::bind<IShortcuts>.to<Shortcuts>(),
-            di::bind<ICompass>.to<Compass>(),
             di::bind<ITypeNameLookup>.to(
                 []()
                 {
@@ -657,7 +658,6 @@ namespace trview
                             injector.create<IMesh::TransparentSource>());
                     };
                 }),
-            di::bind<IMeasure>.to<Measure>(),
             di::bind<IViewerUI>.to<ViewerUI>(),
             di::bind<IApplication>.to<Application>(),
             di::bind<Application::CommandLine>.to(command_line)

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -43,6 +43,7 @@
 #include <trview.input/di.h>
 #include <trview.app/Geometry/di.h>
 #include <trview.app/Graphics/di.h>
+#include <trview.app/Menus/di.h>
 #include <trview.app/Tools/di.h>
 #include <trview.app/Windows/di.h>
 
@@ -566,16 +567,13 @@ namespace trview
             graphics::register_module(),
             input::register_module(),
             ui::render::register_module(),
-            register_app_windows_module(),
-            register_app_tools_module(),
-            register_app_graphics_module(),
             register_app_geometry_module(),
+            register_app_graphics_module(),
+            register_app_menus_module(),
+            register_app_tools_module(),
+            register_app_windows_module(),
             di::bind<trlevel::ILevelLoader>.to<trlevel::LevelLoader>(),
-            di::bind<IUpdateChecker>.to<UpdateChecker>(),
             di::bind<ISettingsLoader>.to<SettingsLoader>(),
-            di::bind<IFileDropper>.to<FileDropper>(),
-            di::bind<ILevelSwitcher>.to<LevelSwitcher>(),
-            di::bind<IRecentFiles>.to<RecentFiles>(),
             di::bind<Window>.to(create_window(instance, command_show)),
             di::bind<IRoute>.to<Route>(),
             di::bind<IRoute::Source>.to(

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -40,6 +40,7 @@
 
 #include <trview.graphics/di.h>
 #include <trview.ui.render/di.h>
+#include <trview.input/di.h>
 
 using namespace DirectX::SimpleMath;
 
@@ -557,17 +558,9 @@ namespace trview
         using namespace boost;
         using namespace graphics;
 
-        auto input_module = [] {
-            using namespace input;
-            return di::make_injector(
-                di::bind<IWindowTester>.to<WindowTester>(),
-                di::bind<IMouse>.to<Mouse>()
-            );
-        };
-
         const auto injector = di::make_injector(
             graphics::register_module(),
-            input_module(),
+            input::register_module(),
             ui::render::register_module(),
             di::bind<trlevel::ILevelLoader>.to<trlevel::LevelLoader>(),
             di::bind<IUpdateChecker>.to<UpdateChecker>(),

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -41,6 +41,7 @@
 #include <trview.graphics/di.h>
 #include <trview.ui.render/di.h>
 #include <trview.input/di.h>
+#include <trview.app/Graphics/di.h>
 #include <trview.app/Tools/di.h>
 #include <trview.app/Windows/di.h>
 
@@ -566,6 +567,7 @@ namespace trview
             ui::render::register_module(),
             register_app_windows_module(),
             register_app_tools_module(),
+            register_app_graphics_module(),
             di::bind<trlevel::ILevelLoader>.to<trlevel::LevelLoader>(),
             di::bind<IUpdateChecker>.to<UpdateChecker>(),
             di::bind<ISettingsLoader>.to<SettingsLoader>(),
@@ -583,35 +585,12 @@ namespace trview
                         return injector.create<std::unique_ptr<IRoute>>();
                     };
                 }),
-            di::bind<ITextureStorage>.to<TextureStorage>(),
             di::bind<IShortcuts>.to<Shortcuts>(),
             di::bind<ITypeNameLookup>.to(
                 []()
                 {
                     Resource type_list = get_resource_memory(IDR_TYPE_NAMES, L"TEXT");
                     return std::make_shared<TypeNameLookup>(std::string(type_list.data, type_list.data + type_list.size));
-                }),
-            di::bind<ILevelTextureStorage::Source>.to(
-                [](const auto& injector) -> ILevelTextureStorage::Source
-                {
-                    return [&](auto&& level)
-                    {
-                        return std::make_unique<LevelTextureStorage>(
-                            injector.create<std::shared_ptr<IDevice>>(),
-                            injector.create<std::unique_ptr<ITextureStorage>>(),
-                            level);
-                    };
-                }),
-            di::bind<IMeshStorage::Source>.to(
-                [](const auto& injector) -> IMeshStorage::Source
-                {
-                    return [&](auto&& level, auto&& level_texture_storage)
-                    {
-                        return std::make_unique<MeshStorage>(
-                            injector.create<IMesh::Source>(),
-                            level,
-                            level_texture_storage);
-                    };
                 }),
             di::bind<IMesh::Source>.to(
                 [](const auto& injector) -> IMesh::Source
@@ -635,8 +614,6 @@ namespace trview
                         return std::make_unique<Mesh>(transparent_triangles, collision_triangles);
                     };
                 }),
-            di::bind<ISelectionRenderer>.to<SelectionRenderer>(),
-            di::bind<ISectorHighlight>.to<SectorHighlight>(),
             di::bind<ITransparencyBuffer>.to<TransparencyBuffer>(),
             di::bind<ILevel::Source>.to(
                 [](const auto& injector) -> ILevel::Source

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -37,6 +37,7 @@
 
 #include <external/boost/di.hpp>
 
+#include <trlevel/di.h>
 #include <trview.graphics/di.h>
 #include <trview.ui.render/di.h>
 #include <trview.input/di.h>
@@ -569,6 +570,7 @@ namespace trview
         const auto injector = di::make_injector(
             graphics::register_module(),
             input::register_module(),
+            trlevel::register_module(),
             ui::render::register_module(),
             register_app_elements_module(),
             register_app_geometry_module(),
@@ -579,7 +581,6 @@ namespace trview
             register_app_tools_module(),
             register_app_ui_module(),
             register_app_windows_module(),
-            di::bind<trlevel::ILevelLoader>.to<trlevel::LevelLoader>(),
             di::bind<Window>.to(create_window(instance, command_show)),
             di::bind<IShortcuts>.to<Shortcuts>(),
             di::bind<IApplication>.to<Application>(),

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -41,6 +41,7 @@
 #include <trview.graphics/di.h>
 #include <trview.ui.render/di.h>
 #include <trview.input/di.h>
+#include <trview.app/Windows/di.h>
 
 using namespace DirectX::SimpleMath;
 
@@ -562,6 +563,7 @@ namespace trview
             graphics::register_module(),
             input::register_module(),
             ui::render::register_module(),
+            register_app_windows_module(),
             di::bind<trlevel::ILevelLoader>.to<trlevel::LevelLoader>(),
             di::bind<IUpdateChecker>.to<UpdateChecker>(),
             di::bind<ISettingsLoader>.to<SettingsLoader>(),
@@ -581,56 +583,6 @@ namespace trview
                 }),
             di::bind<ITextureStorage>.to<TextureStorage>(),
             di::bind<IShortcuts>.to<Shortcuts>(),
-            di::bind<IItemsWindow::Source>.to(
-                [](const auto& injector) -> IItemsWindow::Source
-                {
-                    return [&](auto window)
-                    {
-                        return std::make_shared<ItemsWindow>(
-                            injector.create<IDeviceWindow::Source>(),
-                            injector.create<ui::render::IRenderer::Source>(),
-                            window);
-                    };
-                }),
-            di::bind<IItemsWindowManager>.to<ItemsWindowManager>(),
-            di::bind<ITriggersWindow::Source>.to(
-                [](const auto& injector) -> ITriggersWindow::Source
-                {
-                    return [&](auto window)
-                    {
-                        return std::make_shared<TriggersWindow>(
-                            injector.create<IDeviceWindow::Source>(),
-                            injector.create<ui::render::IRenderer::Source>(),
-                            window);
-                    };
-                }),
-            di::bind<ITriggersWindowManager>.to<TriggersWindowManager>(),
-            di::bind<IRouteWindow::Source>.to(
-                [](const auto& injector) -> IRouteWindow::Source
-                {
-                    return [&](auto window)
-                    {
-                        return std::make_shared<RouteWindow>(
-                            injector.create<IDeviceWindow::Source>(),
-                            injector.create<ui::render::IRenderer::Source>(),
-                            window);
-                    };
-                }
-            ),
-            di::bind<IRouteWindowManager>.to<RouteWindowManager>(),
-            di::bind<IRoomsWindow::Source>.to(
-                [](const auto& injector) -> IRoomsWindow::Source
-                {
-                    return [&](auto window)
-                    {
-                        return std::make_shared<RoomsWindow>(
-                            injector.create<IDeviceWindow::Source>(),
-                            injector.create<ui::render::IRenderer::Source>(),
-                            injector.create<ui::render::IMapRenderer::Source>(),
-                            window);
-                    };
-                }),
-            di::bind<IRoomsWindowManager>.to<RoomsWindowManager>(),
             di::bind<ICompass>.to<Compass>(),
             di::bind<ITypeNameLookup>.to(
                 []()
@@ -707,7 +659,6 @@ namespace trview
                 }),
             di::bind<IMeasure>.to<Measure>(),
             di::bind<IViewerUI>.to<ViewerUI>(),
-            di::bind<IViewer>.to<Viewer>(),
             di::bind<IApplication>.to<Application>(),
             di::bind<Application::CommandLine>.to(command_line)
         );

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -4,36 +4,12 @@
 #include <Shlwapi.h>
 #include <commdlg.h>
 
-#include <trlevel/LevelLoader.h>
-
-#include <trview.app/Geometry/Picking.h>
-#include <trview.app/Graphics/TextureStorage.h>
-#include <trview.app/Settings/SettingsLoader.h>
-#include <trview.app/UI/ViewerUI.h>
-#include <trview.app/Menus/FileDropper.h>
-#include <trview.app/Menus/LevelSwitcher.h>
-#include <trview.app/Menus/UpdateChecker.h>
-#include <trview.app/Menus/RecentFiles.h>
 #include <trview.common/Strings.h>
-#include <trview.graphics/ShaderStorage.h>
-#include <trview.input/WindowTester.h>
-#include <trview.app/Windows/Viewer.h>
-#include <trview.app/Tools/ICompass.h>
-
-#include <trview.app/Windows/ItemsWindowManager.h>
-#include <trview.app/Windows/RoomsWindowManager.h>
-#include <trview.app/Windows/RouteWindowManager.h>
-#include <trview.app/Windows/TriggersWindowManager.h>
-#include <trview.app/Graphics/LevelTextureStorage.h>
-#include <trview.app/Graphics/MeshStorage.h>
-#include <trview.app/Graphics/SelectionRenderer.h>
-#include <trview.app/Graphics/SectorHighlight.h>
 
 #include "Resources/resource.h"
 #include "Resources/DefaultShaders.h"
 #include "Resources/DefaultFonts.h"
 #include "Resources/DefaultTextures.h"
-#include "Elements/TypeNameLookup.h"
 
 #include <external/boost/di.hpp>
 

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -45,6 +45,7 @@
 #include <trview.app/Graphics/di.h>
 #include <trview.app/Menus/di.h>
 #include <trview.app/Routing/di.h>
+#include <trview.app/Settings/di.h>
 #include <trview.app/Tools/di.h>
 #include <trview.app/UI/di.h>
 #include <trview.app/Windows/di.h>
@@ -574,11 +575,11 @@ namespace trview
             register_app_graphics_module(),
             register_app_menus_module(),
             register_app_routing_module(),
+            register_app_settings_module(),
             register_app_tools_module(),
             register_app_ui_module(),
             register_app_windows_module(),
             di::bind<trlevel::ILevelLoader>.to<trlevel::LevelLoader>(),
-            di::bind<ISettingsLoader>.to<SettingsLoader>(),
             di::bind<Window>.to(create_window(instance, command_show)),
             di::bind<IShortcuts>.to<Shortcuts>(),
             di::bind<IApplication>.to<Application>(),

--- a/trview.app/Elements/di.h
+++ b/trview.app/Elements/di.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace trview
+{
+    auto register_app_elements_module();
+}
+
+#include "di.hpp"

--- a/trview.app/Elements/di.h
+++ b/trview.app/Elements/di.h
@@ -2,7 +2,7 @@
 
 namespace trview
 {
-    auto register_app_elements_module();
+    auto register_app_elements_module() noexcept;
 }
 
 #include "di.hpp"

--- a/trview.app/Elements/di.hpp
+++ b/trview.app/Elements/di.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+#include "Level.h"
+#include "TypeNameLookup.h"
+
+#include "Resources/resource.h"
+#include "Resources/ResourceHelper.h"
+
+namespace trview
+{
+    auto register_app_elements_module()
+    {
+        using namespace boost;
+        using namespace graphics;
+        return di::make_injector(
+            di::bind<ITypeNameLookup>.to(
+                []()
+                {
+                    Resource type_list = get_resource_memory(IDR_TYPE_NAMES, L"TEXT");
+                    return std::make_shared<TypeNameLookup>(std::string(type_list.data, type_list.data + type_list.size));
+                }),
+            di::bind<ILevel::Source>.to(
+                [](const auto& injector) -> ILevel::Source
+                {
+                    return [&](auto&& level)
+                    {
+                        auto texture_storage = injector.create<ILevelTextureStorage::Source>()(*level);
+                        auto mesh_storage = injector.create<IMeshStorage::Source>()(*level, *texture_storage);
+                        return std::make_unique<Level>(
+                            injector.create<std::shared_ptr<IDevice>>(),
+                            injector.create<std::shared_ptr<IShaderStorage>>(),
+                            std::move(level),
+                            std::move(texture_storage),
+                            std::move(mesh_storage),
+                            injector.create<std::unique_ptr<ITransparencyBuffer>>(),
+                            injector.create<std::unique_ptr<ISelectionRenderer>>(),
+                            injector.create<std::shared_ptr<ITypeNameLookup>>(),
+                            injector.create<IMesh::Source>(),
+                            injector.create<IMesh::TransparentSource>());
+                    };
+                })
+        );
+    }
+}

--- a/trview.app/Elements/di.hpp
+++ b/trview.app/Elements/di.hpp
@@ -9,7 +9,7 @@
 
 namespace trview
 {
-    auto register_app_elements_module()
+    auto register_app_elements_module() noexcept
     {
         using namespace boost;
         using namespace graphics;

--- a/trview.app/Geometry/di.h
+++ b/trview.app/Geometry/di.h
@@ -2,7 +2,7 @@
 
 namespace trview
 {
-    auto register_app_geometry_module();
+    auto register_app_geometry_module() noexcept;
 }
 
 #include "di.hpp"

--- a/trview.app/Geometry/di.h
+++ b/trview.app/Geometry/di.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace trview
+{
+    auto register_app_geometry_module();
+}
+
+#include "di.hpp"

--- a/trview.app/Geometry/di.hpp
+++ b/trview.app/Geometry/di.hpp
@@ -7,7 +7,7 @@
 
 namespace trview
 {
-    auto register_app_geometry_module()
+    auto register_app_geometry_module() noexcept
     {
         using namespace boost;
         using namespace graphics;

--- a/trview.app/Geometry/di.hpp
+++ b/trview.app/Geometry/di.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+#include "Mesh.h"
+#include "Picking.h"
+#include "TransparencyBuffer.h"
+
+namespace trview
+{
+    auto register_app_geometry_module()
+    {
+        using namespace boost;
+        using namespace graphics;
+        return di::make_injector(
+            di::bind<IMesh::Source>.to(
+                [](const auto& injector) -> IMesh::Source
+                {
+                    return [&](auto&& vertices, auto&& indices, auto&& untextured_indices, auto&& transparent_triangles, auto&& collision_triangles)
+                    {
+                        return std::make_unique<Mesh>(
+                            injector.create<std::shared_ptr<IDevice>>(),
+                            vertices,
+                            indices,
+                            untextured_indices,
+                            transparent_triangles,
+                            collision_triangles);
+                    };
+                }),
+            di::bind<IMesh::TransparentSource>.to(
+                [](const auto& injector) -> IMesh::TransparentSource
+                {
+                    return [&](auto&& transparent_triangles, auto&& collision_triangles)
+                    {
+                        return std::make_unique<Mesh>(transparent_triangles, collision_triangles);
+                    };
+                }),
+            di::bind<IPicking>.to<Picking>(),
+            di::bind<ITransparencyBuffer>.to<TransparencyBuffer>()
+        );
+    }
+}

--- a/trview.app/Graphics/di.h
+++ b/trview.app/Graphics/di.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace trview
+{
+    auto register_app_graphics_module();
+}
+
+#include "di.hpp"

--- a/trview.app/Graphics/di.h
+++ b/trview.app/Graphics/di.h
@@ -2,7 +2,7 @@
 
 namespace trview
 {
-    auto register_app_graphics_module();
+    auto register_app_graphics_module() noexcept;
 }
 
 #include "di.hpp"

--- a/trview.app/Graphics/di.hpp
+++ b/trview.app/Graphics/di.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+#include "LevelTextureStorage.h"
+#include "MeshStorage.h"
+#include "SectorHighlight.h"
+#include "SelectionRenderer.h"
+#include "TextureStorage.h"
+
+namespace trview
+{
+    auto register_app_graphics_module()
+    {
+        using namespace boost;
+        using namespace graphics;
+        return di::make_injector(
+            di::bind<ILevelTextureStorage::Source>.to(
+                [](const auto& injector) -> ILevelTextureStorage::Source
+                {
+                    return [&](auto&& level)
+                    {
+                        return std::make_unique<LevelTextureStorage>(
+                            injector.create<std::shared_ptr<IDevice>>(),
+                            injector.create<std::unique_ptr<ITextureStorage>>(),
+                            level);
+                    };
+                }),
+            di::bind<IMeshStorage::Source>.to(
+                [](const auto& injector) -> IMeshStorage::Source
+                {
+                    return [&](auto&& level, auto&& level_texture_storage)
+                    {
+                        return std::make_unique<MeshStorage>(
+                            injector.create<IMesh::Source>(),
+                            level,
+                            level_texture_storage);
+                    };
+                }),
+            di::bind<ISectorHighlight>.to<SectorHighlight>(),
+            di::bind<ISelectionRenderer>.to<SelectionRenderer>(),
+            di::bind<ITextureStorage>.to<TextureStorage>()
+        );
+    }
+}

--- a/trview.app/Graphics/di.hpp
+++ b/trview.app/Graphics/di.hpp
@@ -9,7 +9,7 @@
 
 namespace trview
 {
-    auto register_app_graphics_module()
+    auto register_app_graphics_module() noexcept
     {
         using namespace boost;
         using namespace graphics;

--- a/trview.app/Menus/di.h
+++ b/trview.app/Menus/di.h
@@ -2,7 +2,7 @@
 
 namespace trview
 {
-    auto register_app_menus_module();
+    auto register_app_menus_module() noexcept;
 }
 
 #include "di.hpp"

--- a/trview.app/Menus/di.h
+++ b/trview.app/Menus/di.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace trview
+{
+    auto register_app_menus_module();
+}
+
+#include "di.hpp"

--- a/trview.app/Menus/di.hpp
+++ b/trview.app/Menus/di.hpp
@@ -8,7 +8,7 @@
 
 namespace trview
 {
-    auto register_app_menus_module()
+    auto register_app_menus_module() noexcept
     {
         using namespace boost;
         return di::make_injector(

--- a/trview.app/Menus/di.hpp
+++ b/trview.app/Menus/di.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+#include "FileDropper.h"
+#include "LevelSwitcher.h"
+#include "RecentFiles.h"
+#include "UpdateChecker.h"
+
+namespace trview
+{
+    auto register_app_menus_module()
+    {
+        using namespace boost;
+        return di::make_injector(
+            di::bind<IUpdateChecker>.to<UpdateChecker>(),
+            di::bind<IFileDropper>.to<FileDropper>(),
+            di::bind<ILevelSwitcher>.to<LevelSwitcher>(),
+            di::bind<IRecentFiles>.to<RecentFiles>()
+        );
+    }
+}

--- a/trview.app/Routing/di.h
+++ b/trview.app/Routing/di.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace trview
+{
+    auto register_app_routing_module();
+}
+
+#include "di.hpp"

--- a/trview.app/Routing/di.h
+++ b/trview.app/Routing/di.h
@@ -2,7 +2,7 @@
 
 namespace trview
 {
-    auto register_app_routing_module();
+    auto register_app_routing_module() noexcept;
 }
 
 #include "di.hpp"

--- a/trview.app/Routing/di.hpp
+++ b/trview.app/Routing/di.hpp
@@ -5,7 +5,7 @@
 
 namespace trview
 {
-    auto register_app_routing_module()
+    auto register_app_routing_module() noexcept
     {
         using namespace boost;
         return di::make_injector(

--- a/trview.app/Routing/di.hpp
+++ b/trview.app/Routing/di.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+#include "Route.h"
+
+namespace trview
+{
+    auto register_app_routing_module()
+    {
+        using namespace boost;
+        return di::make_injector(
+            di::bind<IRoute>.to<Route>(),
+            di::bind<IRoute::Source>.to(
+                [](const auto& injector) -> IRoute::Source
+                {
+                    return [&]()
+                    {
+                        return injector.create<std::unique_ptr<IRoute>>();
+                    };
+                })
+        );
+    }
+}
+

--- a/trview.app/Settings/di.h
+++ b/trview.app/Settings/di.h
@@ -2,7 +2,7 @@
 
 namespace trview
 {
-    auto register_app_settings_module();
+    auto register_app_settings_module() noexcept;
 }
 
 #include "di.hpp"

--- a/trview.app/Settings/di.h
+++ b/trview.app/Settings/di.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace trview
+{
+    auto register_app_settings_module();
+}
+
+#include "di.hpp"

--- a/trview.app/Settings/di.hpp
+++ b/trview.app/Settings/di.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+#include "SettingsLoader.h"
+
+namespace trview
+{
+    auto register_app_settings_module()
+    {
+        using namespace boost;
+        return di::make_injector(
+            di::bind<ISettingsLoader>.to<SettingsLoader>()
+        );
+    }
+}

--- a/trview.app/Settings/di.hpp
+++ b/trview.app/Settings/di.hpp
@@ -5,7 +5,7 @@
 
 namespace trview
 {
-    auto register_app_settings_module()
+    auto register_app_settings_module() noexcept
     {
         using namespace boost;
         return di::make_injector(

--- a/trview.app/Tools/di.h
+++ b/trview.app/Tools/di.h
@@ -2,7 +2,7 @@
 
 namespace trview
 {
-    auto register_app_tools_module();
+    auto register_app_tools_module() noexcept;
 }
 
 #include "di.hpp"

--- a/trview.app/Tools/di.h
+++ b/trview.app/Tools/di.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace trview
+{
+    auto register_app_tools_module();
+}
+
+#include "di.hpp"

--- a/trview.app/Tools/di.hpp
+++ b/trview.app/Tools/di.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+#include "Compass.h"
+#include "Measure.h"
+
+namespace trview
+{
+    auto register_app_tools_module()
+    {
+        using namespace boost;
+        return di::make_injector(
+            di::bind<ICompass>.to<Compass>(),
+            di::bind<IMeasure>.to<Measure>()
+        );
+    }
+}

--- a/trview.app/Tools/di.hpp
+++ b/trview.app/Tools/di.hpp
@@ -6,7 +6,7 @@
 
 namespace trview
 {
-    auto register_app_tools_module()
+    auto register_app_tools_module() noexcept
     {
         using namespace boost;
         return di::make_injector(

--- a/trview.app/UI/di.h
+++ b/trview.app/UI/di.h
@@ -2,7 +2,7 @@
 
 namespace trview
 {
-    auto register_app_ui_module();
+    auto register_app_ui_module() noexcept;
 }
 
 #include "di.hpp"

--- a/trview.app/UI/di.h
+++ b/trview.app/UI/di.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace trview
+{
+    auto register_app_ui_module();
+}
+
+#include "di.hpp"

--- a/trview.app/UI/di.hpp
+++ b/trview.app/UI/di.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+#include "ViewerUI.h"
+
+namespace trview
+{
+    auto register_app_ui_module()
+    {
+        using namespace boost;
+        return di::make_injector(
+            di::bind<IViewerUI>.to<ViewerUI>()
+        );
+    }
+}

--- a/trview.app/UI/di.hpp
+++ b/trview.app/UI/di.hpp
@@ -5,7 +5,7 @@
 
 namespace trview
 {
-    auto register_app_ui_module()
+    auto register_app_ui_module() noexcept
     {
         using namespace boost;
         return di::make_injector(

--- a/trview.app/Windows/di.h
+++ b/trview.app/Windows/di.h
@@ -2,7 +2,7 @@
 
 namespace trview
 {
-    auto register_app_windows_module();
+    auto register_app_windows_module() noexcept;
 }
 
 #include "di.hpp"

--- a/trview.app/Windows/di.h
+++ b/trview.app/Windows/di.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace trview
+{
+    auto register_app_windows_module();
+}
+
+#include "di.hpp"

--- a/trview.app/Windows/di.hpp
+++ b/trview.app/Windows/di.hpp
@@ -10,6 +10,7 @@
 #include "TriggersWindowManager.h"
 #include "RouteWindowManager.h"
 #include "RoomsWindowManager.h"
+#include "Viewer.h"
 
 namespace trview
 {

--- a/trview.app/Windows/di.hpp
+++ b/trview.app/Windows/di.hpp
@@ -13,7 +13,7 @@
 
 namespace trview
 {
-    auto register_app_windows_module()
+    auto register_app_windows_module() noexcept
     {
         using namespace boost;
         using namespace graphics;

--- a/trview.app/Windows/di.hpp
+++ b/trview.app/Windows/di.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+
+#include <trview.graphics/IDeviceWindow.h>
+
+#include "ItemsWindow.h"
+#include "TriggersWindow.h"
+#include "ItemsWindowManager.h"
+#include "TriggersWindowManager.h"
+#include "RouteWindowManager.h"
+#include "RoomsWindowManager.h"
+
+namespace trview
+{
+    auto register_app_windows_module()
+    {
+        using namespace boost;
+        using namespace graphics;
+
+        return di::make_injector(
+            di::bind<IItemsWindow::Source>.to(
+            [](const auto& injector) -> IItemsWindow::Source
+            {
+                return [&](auto window)
+                {
+                    return std::make_shared<ItemsWindow>(
+                        injector.create<IDeviceWindow::Source>(),
+                        injector.create<ui::render::IRenderer::Source>(),
+                        window);
+                };
+            }),
+            di::bind<IItemsWindowManager>.to<ItemsWindowManager>(),
+            di::bind<ITriggersWindow::Source>.to(
+                [](const auto& injector) -> ITriggersWindow::Source
+                {
+                    return [&](auto window)
+                    {
+                        return std::make_shared<TriggersWindow>(
+                            injector.create<IDeviceWindow::Source>(),
+                            injector.create<ui::render::IRenderer::Source>(),
+                            window);
+                    };
+                }),
+            di::bind<ITriggersWindowManager>.to<TriggersWindowManager>(),
+            di::bind<IRouteWindow::Source>.to(
+                [](const auto& injector) -> IRouteWindow::Source
+                {
+                    return [&](auto window)
+                    {
+                        return std::make_shared<RouteWindow>(
+                            injector.create<IDeviceWindow::Source>(),
+                            injector.create<ui::render::IRenderer::Source>(),
+                            window);
+                    };
+                }
+            ),
+            di::bind<IRouteWindowManager>.to<RouteWindowManager>(),
+            di::bind<IRoomsWindow::Source>.to(
+                [](const auto& injector) -> IRoomsWindow::Source
+                {
+                    return [&](auto window)
+                    {
+                        return std::make_shared<RoomsWindow>(
+                            injector.create<IDeviceWindow::Source>(),
+                            injector.create<ui::render::IRenderer::Source>(),
+                            injector.create<ui::render::IMapRenderer::Source>(),
+                            window);
+                    };
+                }),
+            di::bind<IRoomsWindowManager>.to<RoomsWindowManager>(),
+            di::bind<IViewer>.to<Viewer>()
+        );
+    }
+}

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -236,6 +236,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Routing\IRoute.h" />
     <ClInclude Include="Routing\Route.h" />
     <ClInclude Include="Routing\Waypoint.h" />
+    <ClInclude Include="Settings\di.h" />
+    <ClInclude Include="Settings\di.hpp" />
     <ClInclude Include="Settings\ISettingsLoader.h" />
     <ClInclude Include="Settings\SettingsLoader.h" />
     <ClInclude Include="Settings\UserSettings.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -231,6 +231,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Settings\UserSettings.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="Tools\Compass.h" />
+    <ClInclude Include="Tools\di.h" />
+    <ClInclude Include="Tools\di.hpp" />
     <ClInclude Include="Tools\ICompass.h" />
     <ClInclude Include="Tools\IMeasure.h" />
     <ClInclude Include="Tools\Measure.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -184,6 +184,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Graphics\TextureStorage.h" />
     <ClInclude Include="Lua\Lua.h" />
     <ClInclude Include="Menus\AlternateGroupToggler.h" />
+    <ClInclude Include="Menus\di.h" />
+    <ClInclude Include="Menus\di.hpp" />
     <ClInclude Include="Menus\DirectoryListing.h" />
     <ClInclude Include="Menus\FileDropper.h" />
     <ClInclude Include="Menus\IFileDropper.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -248,6 +248,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="UI\ViewerUI.h" />
     <ClInclude Include="UI\ViewOptions.h" />
     <ClInclude Include="Windows\CollapsiblePanel.h" />
+    <ClInclude Include="Windows\di.h" />
+    <ClInclude Include="Windows\di.hpp" />
     <ClInclude Include="Windows\IItemsWindow.h" />
     <ClInclude Include="Windows\IItemsWindowManager.h" />
     <ClInclude Include="Windows\IRoomsWindow.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -155,6 +155,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Elements\Trigger.h" />
     <ClInclude Include="Elements\TypeNameLookup.h" />
     <ClInclude Include="Elements\Types.h" />
+    <ClInclude Include="Geometry\di.h" />
+    <ClInclude Include="Geometry\di.hpp" />
     <ClInclude Include="Geometry\IMesh.h" />
     <ClInclude Include="Geometry\IPicking.h" />
     <ClInclude Include="Geometry\IRenderable.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -168,6 +168,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Geometry\TransparencyBuffer.h" />
     <ClInclude Include="Geometry\TransparentTriangle.h" />
     <ClInclude Include="Geometry\Triangle.h" />
+    <ClInclude Include="Graphics\di.h" />
+    <ClInclude Include="Graphics\di.hpp" />
     <ClInclude Include="Graphics\ILevelTextureStorage.h" />
     <ClInclude Include="Graphics\IMeshStorage.h" />
     <ClInclude Include="Graphics\ISectorHighlight.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -143,6 +143,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Camera\ICamera.h" />
     <ClInclude Include="Camera\OrbitCamera.h" />
     <ClInclude Include="Camera\ProjectionMode.h" />
+    <ClInclude Include="Elements\di.h" />
+    <ClInclude Include="Elements\di.hpp" />
     <ClInclude Include="Elements\Entity.h" />
     <ClInclude Include="Elements\ILevel.h" />
     <ClInclude Include="Elements\Item.h" />
@@ -229,6 +231,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Resources\resource.h" />
     <ClInclude Include="Resources\ResourceHelper.h" />
     <ClInclude Include="Resources\targetver.h" />
+    <ClInclude Include="Routing\di.h" />
+    <ClInclude Include="Routing\di.hpp" />
     <ClInclude Include="Routing\IRoute.h" />
     <ClInclude Include="Routing\Route.h" />
     <ClInclude Include="Routing\Waypoint.h" />
@@ -247,6 +251,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="UI\CameraPosition.h" />
     <ClInclude Include="UI\Console.h" />
     <ClInclude Include="UI\ContextMenu.h" />
+    <ClInclude Include="UI\di.h" />
+    <ClInclude Include="UI\di.hpp" />
     <ClInclude Include="UI\GoTo.h" />
     <ClInclude Include="UI\IViewerUI.h" />
     <ClInclude Include="UI\LevelInfo.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -714,6 +714,12 @@
     <ClInclude Include="Geometry\di.hpp">
       <Filter>Geometry</Filter>
     </ClInclude>
+    <ClInclude Include="Menus\di.h">
+      <Filter>Menus</Filter>
+    </ClInclude>
+    <ClInclude Include="Menus\di.hpp">
+      <Filter>Menus</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -702,6 +702,12 @@
     <ClInclude Include="Tools\di.hpp">
       <Filter>Tools</Filter>
     </ClInclude>
+    <ClInclude Include="Graphics\di.h">
+      <Filter>Graphics</Filter>
+    </ClInclude>
+    <ClInclude Include="Graphics\di.hpp">
+      <Filter>Graphics</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -690,6 +690,12 @@
     <ClInclude Include="Mocks\Graphics\ISectorHighlight.h">
       <Filter>Mocks\Graphics</Filter>
     </ClInclude>
+    <ClInclude Include="Windows\di.h">
+      <Filter>Windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Windows\di.hpp">
+      <Filter>Windows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -708,6 +708,12 @@
     <ClInclude Include="Graphics\di.hpp">
       <Filter>Graphics</Filter>
     </ClInclude>
+    <ClInclude Include="Geometry\di.h">
+      <Filter>Geometry</Filter>
+    </ClInclude>
+    <ClInclude Include="Geometry\di.hpp">
+      <Filter>Geometry</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -740,6 +740,12 @@
     <ClInclude Include="UI\IViewerUI.h">
       <Filter>UI</Filter>
     </ClInclude>
+    <ClInclude Include="Settings\di.h">
+      <Filter>Settings</Filter>
+    </ClInclude>
+    <ClInclude Include="Settings\di.hpp">
+      <Filter>Settings</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -542,7 +542,6 @@
     <ClInclude Include="Mocks\UI\IViewerUI.h">
       <Filter>Mocks\UI</Filter>
     </ClInclude>
-    <ClInclude Include="UI\IViewerUI.h" />
     <ClInclude Include="Elements\ILevel.h">
       <Filter>Elements</Filter>
     </ClInclude>
@@ -719,6 +718,27 @@
     </ClInclude>
     <ClInclude Include="Menus\di.hpp">
       <Filter>Menus</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\di.h">
+      <Filter>Elements</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\di.hpp">
+      <Filter>Elements</Filter>
+    </ClInclude>
+    <ClInclude Include="Routing\di.h">
+      <Filter>Routing</Filter>
+    </ClInclude>
+    <ClInclude Include="Routing\di.hpp">
+      <Filter>Routing</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\di.h">
+      <Filter>UI</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\di.hpp">
+      <Filter>UI</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\IViewerUI.h">
+      <Filter>UI</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -696,6 +696,12 @@
     <ClInclude Include="Windows\di.hpp">
       <Filter>Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Tools\di.h">
+      <Filter>Tools</Filter>
+    </ClInclude>
+    <ClInclude Include="Tools\di.hpp">
+      <Filter>Tools</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.graphics/di.h
+++ b/trview.graphics/di.h
@@ -4,7 +4,7 @@ namespace trview
 {
     namespace graphics
     {
-        auto register_module();
+        auto register_module() noexcept;
     }
 }
 

--- a/trview.graphics/di.h
+++ b/trview.graphics/di.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace trview
+{
+    namespace graphics
+    {
+        auto register_module();
+    }
+}
+
+#include "di.hpp"

--- a/trview.graphics/di.hpp
+++ b/trview.graphics/di.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+#include "Device.h"
+#include "FontFactory.h"
+#include "ShaderStorage.h"
+#include "RenderTarget.h"
+#include "DeviceWindow.h"
+#include "Sprite.h"
+
+namespace trview
+{
+    namespace graphics
+    {
+        auto register_module()
+        {
+            using namespace graphics;
+            using namespace boost;
+
+            return di::make_injector(
+                di::bind<IDevice>.to<Device>(),
+                di::bind<IFontFactory>.to<FontFactory>(),
+                di::bind<IShaderStorage>.to<ShaderStorage>(),
+                di::bind<IRenderTarget::SizeSource>.to(
+                    [](const auto& injector) -> IRenderTarget::SizeSource
+                    {
+                        return [&](auto&& width, auto&& height, auto&& depth_stencil_mode)
+                        {
+                            return std::make_unique<RenderTarget>(
+                                injector.create<std::shared_ptr<IDevice>>(),
+                                width,
+                                height,
+                                depth_stencil_mode);
+                        };
+                    }),
+                di::bind<IRenderTarget::TextureSource>.to(
+                    [](const auto& injector) -> IRenderTarget::TextureSource
+                    {
+                        return [&](auto&& texture, auto&& depth_stencil_mode)
+                        {
+                            return std::make_unique<RenderTarget>(
+                                injector.create<std::shared_ptr<IDevice>>(),
+                                texture,
+                                depth_stencil_mode);
+                        };
+                    }),
+                di::bind<ISprite::Source>.to(
+                    [](const auto& injector) -> ISprite::Source
+                    {
+                        return [&](auto size)
+                        {
+                            return std::make_unique<Sprite>(
+                                injector.create<std::shared_ptr<IDevice>>(),
+                                injector.create<std::shared_ptr<IShaderStorage>>(),
+                                size);
+                        };
+                    }),
+                di::bind<IDeviceWindow::Source>.to(
+                    [](const auto& injector) -> IDeviceWindow::Source
+                    {
+                        return [&](auto&& window)
+                        {
+                            return std::make_unique<DeviceWindow>(
+                                injector.create<std::shared_ptr<IDevice>>(),
+                                injector.create<IRenderTarget::TextureSource>(),
+                                window);
+                        };
+                    })
+            );
+        }
+    }
+}
+

--- a/trview.graphics/di.hpp
+++ b/trview.graphics/di.hpp
@@ -14,7 +14,6 @@ namespace trview
     {
         auto register_module()
         {
-            using namespace graphics;
             using namespace boost;
 
             return di::make_injector(

--- a/trview.graphics/di.hpp
+++ b/trview.graphics/di.hpp
@@ -12,7 +12,7 @@ namespace trview
 {
     namespace graphics
     {
-        auto register_module()
+        auto register_module() noexcept
         {
             using namespace boost;
 

--- a/trview.graphics/trview.graphics.vcxproj
+++ b/trview.graphics/trview.graphics.vcxproj
@@ -22,6 +22,8 @@
     <ClInclude Include="DepthStencil.h" />
     <ClInclude Include="Device.h" />
     <ClInclude Include="DeviceWindow.h" />
+    <ClInclude Include="di.h" />
+    <ClInclude Include="di.hpp" />
     <ClInclude Include="Font.h" />
     <ClInclude Include="FontFactory.h" />
     <ClInclude Include="IDevice.h" />

--- a/trview.graphics/trview.graphics.vcxproj.filters
+++ b/trview.graphics/trview.graphics.vcxproj.filters
@@ -104,6 +104,8 @@
     <ClInclude Include="mocks\IDeviceWindow.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="di.h" />
+    <ClInclude Include="di.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="IShaderStorage.cpp">

--- a/trview.input/di.h
+++ b/trview.input/di.h
@@ -4,7 +4,7 @@ namespace trview
 {
     namespace input
     {
-        auto register_module();
+        auto register_module() noexcept;
     }
 }
 

--- a/trview.input/di.h
+++ b/trview.input/di.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace trview
+{
+    namespace input
+    {
+        auto register_module();
+    }
+}
+
+#include "di.hpp"

--- a/trview.input/di.hpp
+++ b/trview.input/di.hpp
@@ -8,7 +8,7 @@ namespace trview
 {
     namespace input
     {
-        auto register_module()
+        auto register_module() noexcept
         {
             using namespace boost;
             return di::make_injector(

--- a/trview.input/di.hpp
+++ b/trview.input/di.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+#include "WindowTester.h"
+#include "Mouse.h"
+
+namespace trview
+{
+    namespace input
+    {
+        auto register_module()
+        {
+            using namespace boost;
+            return di::make_injector(
+                di::bind<IWindowTester>.to<WindowTester>(),
+                di::bind<IMouse>.to<Mouse>()
+            );
+        }
+    }
+}

--- a/trview.input/trview.input.vcxproj
+++ b/trview.input/trview.input.vcxproj
@@ -32,6 +32,8 @@
     <ClCompile Include="WindowTester.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="di.h" />
+    <ClInclude Include="di.hpp" />
     <ClInclude Include="IMouse.h" />
     <ClInclude Include="IWindowTester.h" />
     <ClInclude Include="Keyboard.h" />

--- a/trview.input/trview.input.vcxproj.filters
+++ b/trview.input/trview.input.vcxproj.filters
@@ -18,6 +18,8 @@
     <ClInclude Include="Mocks\IMouse.h">
       <Filter>Mocks</Filter>
     </ClInclude>
+    <ClInclude Include="di.h" />
+    <ClInclude Include="di.hpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">

--- a/trview.ui.render/di.h
+++ b/trview.ui.render/di.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace trview
+{
+    namespace ui
+    {
+        namespace render
+        {
+            auto register_module();
+        }
+    }
+}
+
+#include "di.hpp"

--- a/trview.ui.render/di.h
+++ b/trview.ui.render/di.h
@@ -6,7 +6,7 @@ namespace trview
     {
         namespace render
         {
-            auto register_module();
+            auto register_module() noexcept;
         }
     }
 }

--- a/trview.ui.render/di.hpp
+++ b/trview.ui.render/di.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+#include "Renderer.h"
+#include "MapRenderer.h"
+#include <trview.graphics/IRenderTarget.h>
+
+namespace trview
+{
+    namespace ui
+    {
+        namespace render
+        {
+            auto register_module()
+            {
+                using namespace ui::render;
+                using namespace graphics;
+                using namespace boost;
+                return di::make_injector(
+                    di::bind<IRenderer::Source>.to(
+                        [](const auto& injector) -> IRenderer::Source
+                        {
+                            return [&](auto size)
+                            {
+                                return std::make_unique<Renderer>(
+                                    injector.create<std::shared_ptr<IDevice>>(),
+                                    injector.create<IRenderTarget::SizeSource>(),
+                                    *injector.create<std::shared_ptr<IFontFactory>>(),
+                                    size,
+                                    injector.create<ISprite::Source>());
+                            };
+                        }),
+                    di::bind<ui::render::IMapRenderer::Source>.to(
+                        [](const auto& injector) -> IMapRenderer::Source
+                        {
+                            return [&](auto size)
+                            {
+                                return std::make_unique<MapRenderer>(
+                                    injector.create<std::shared_ptr<IDevice>>(),
+                                    *injector.create<std::shared_ptr<IFontFactory>>(),
+                                    size,
+                                    injector.create<ISprite::Source>(),
+                                    injector.create<IRenderTarget::SizeSource>());
+                            };
+                        }));
+            }
+        }
+    }
+}

--- a/trview.ui.render/di.hpp
+++ b/trview.ui.render/di.hpp
@@ -11,7 +11,7 @@ namespace trview
     {
         namespace render
         {
-            auto register_module()
+            auto register_module() noexcept
             {
                 using namespace graphics;
                 using namespace boost;

--- a/trview.ui.render/di.hpp
+++ b/trview.ui.render/di.hpp
@@ -13,7 +13,6 @@ namespace trview
         {
             auto register_module()
             {
-                using namespace ui::render;
                 using namespace graphics;
                 using namespace boost;
                 return di::make_injector(

--- a/trview.ui.render/trview.ui.render.vcxproj
+++ b/trview.ui.render/trview.ui.render.vcxproj
@@ -20,6 +20,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ButtonNode.h" />
+    <ClInclude Include="di.h" />
+    <ClInclude Include="di.hpp" />
     <ClInclude Include="ImageNode.h" />
     <ClInclude Include="IMapRenderer.h" />
     <ClInclude Include="IRenderer.h" />

--- a/trview.ui.render/trview.ui.render.vcxproj.filters
+++ b/trview.ui.render/trview.ui.render.vcxproj.filters
@@ -28,6 +28,8 @@
     <ClInclude Include="IMapRenderer.h">
       <Filter>Graphics</Filter>
     </ClInclude>
+    <ClInclude Include="di.h" />
+    <ClInclude Include="di.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Renderer.cpp" />


### PR DESCRIPTION
Split the registration of the application in `Application.cpp` out into different files - in other libraries or in folders in the `trview.app` library. This makes it easier to read/manage.
Common isn't moved yet - it only has one or two items and I couldn't figure out how to move create_window yet. I will move that next time I touch common.
Closes #744