### PR TITLE
Reset windows and route before loading the Viewer

### DIFF
--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -176,8 +176,6 @@ namespace trview
         _level = _level_source(std::move(new_level));
         _level->set_filename(filename);
 
-        _viewer->open(_level.get());
-
         _items_windows->set_items(_level->items());
         _items_windows->set_triggers(_level->triggers());
         _triggers_windows->set_items(_level->items());
@@ -188,6 +186,8 @@ namespace trview
         _route_window->set_items(_level->items());
         _route_window->set_triggers(_level->triggers());
         _route_window->set_rooms(_level->rooms());
+
+        _viewer->open(_level.get());
 
         _route->clear();
         _route_window->set_route(_route.get());

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -186,11 +186,10 @@ namespace trview
         _route_window->set_items(_level->items());
         _route_window->set_triggers(_level->triggers());
         _route_window->set_rooms(_level->rooms());
-
-        _viewer->open(_level.get());
-
         _route->clear();
         _route_window->set_route(_route.get());
+
+        _viewer->open(_level.get());
         _viewer->set_route(_route);
     }
 


### PR DESCRIPTION
The `Viewer` was being loaded before the various windows had received the updated items/triggers/etc lists. This meant that when the `Viewer` fired some events they were causing the windows to reference data that had been deleted.
The real problem is probably just storing raw pointers instead of a smart pointer or some kind of non-heap data structure, but that will need bigger changes. For now just move the `Viewer` load after resetting the windows and route.
Added a test to enforce this. It's a bit prescriptive, but it's better than nothing until I can go back and make everything a bit better.
Closes #749 