### PR TITLE
 Clear the selected trigger in the windows when the level changes

### DIFF
--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -1,0 +1,33 @@
+#include <trview.app/Windows/RoomsWindowManager.h>
+#include <trview.app/Elements/Types.h>
+#include <trview.app/Mocks/Windows/IRoomsWindow.h>
+#include <trview.common/Mocks/Windows/IShortcuts.h>
+#include <trview.app/Mocks/Geometry/IMesh.h>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace trview::tests;
+
+TEST(RoomsWindowManager, SetTriggersClearsSelectedTrigger)
+{
+    Event<> shortcut_handler;
+    auto shortcuts = std::make_shared<MockShortcuts>();
+    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
+    auto mock_window = std::make_shared<MockRoomsWindow>();
+    EXPECT_CALL(*mock_window, set_triggers).Times(3);
+    EXPECT_CALL(*mock_window, clear_selected_trigger).Times(2);
+    RoomsWindowManager manager(create_test_window(L"RoomsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+
+    auto created_window = manager.create_window().lock();
+    ASSERT_NE(created_window, nullptr);
+    ASSERT_EQ(created_window, mock_window);
+
+    auto trigger1 = std::make_unique<Trigger>(100, 55, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
+    manager.set_triggers({ trigger1.get() });
+
+    ASSERT_EQ(manager.selected_trigger(), nullptr);
+    manager.set_selected_trigger(trigger1.get());
+    ASSERT_EQ(manager.selected_trigger(), trigger1.get());
+    manager.set_triggers({});
+    ASSERT_EQ(manager.selected_trigger(), nullptr);
+}

--- a/trview.app.tests/RoomsWindowTests.cpp
+++ b/trview.app.tests/RoomsWindowTests.cpp
@@ -1,0 +1,127 @@
+#include <trview.app/Windows/RoomsWindow.h>
+#include <trview.ui.render/Mocks/IRenderer.h>
+#include <trview.ui/Button.h>
+#include <trview.ui/Listbox.h>
+#include <trview.app/Elements/Types.h>
+#include <trview.graphics/mocks/IDeviceWindow.h>
+#include <trview.app/Mocks/Geometry/IMesh.h>
+#include <trview.ui.render/Mocks/IMapRenderer.h>
+#include <trview.app/Mocks/Elements/ILevel.h>
+#include <trlevel/Mocks/ILevel.h>
+#include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
+#include <trview.app/Mocks/Graphics/IMeshStorage.h>
+
+using namespace trview;
+using namespace trview::tests;
+using namespace trview::graphics;
+using namespace trview::graphics::mocks;
+using namespace trview::ui::render::mocks;
+using namespace trview::mocks;
+
+TEST(RoomsWindow, ClearSelectedTriggerClearsSelection)
+{
+    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
+    auto renderer_ptr = std::move(renderer_ptr_source);
+    RoomsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, 
+        [&](auto) { return std::make_unique<MockMapRenderer>(); }, create_test_window(L"RoomsWindowTests"));
+
+    std::optional<Trigger*> raised_trigger;
+    auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+
+    auto [trlevel_ptr, trlevel] = create_mock<trlevel::mocks::MockLevel>();
+    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto [texture_storage_ptr, texture_storage] = create_mock<MockLevelTextureStorage>();
+    auto [mesh_storage_ptr, mesh_storage] = create_mock<MockMeshStorage>();
+    trlevel::tr3_room tr_room{};
+
+    auto room = std::make_unique<Room>(
+        [](auto, auto, auto, auto, auto) { return std::make_unique<MockMesh>(); },
+        trlevel, tr_room, texture_storage, mesh_storage, 0, level);
+
+    auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {  } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
+    room->add_trigger(trigger1.get());
+
+    window.set_rooms({ room.get() });
+    window.set_triggers({ trigger1.get() });
+
+    auto list = window.root_control()->find<ui::Listbox>(RoomsWindow::Names::rooms_listbox);
+    ASSERT_NE(list, nullptr);
+
+    auto row = list->find<ui::Control>(ui::Listbox::Names::row_name_format + "0");
+    ASSERT_NE(row, nullptr);
+
+    auto cell = row->find<ui::Button>(ui::Listbox::Row::Names::cell_name_format + "#");
+    ASSERT_NE(cell, nullptr);
+    cell->clicked(Point());
+
+    auto triggers_list = window.root_control()->find<ui::Listbox>(RoomsWindow::Names::triggers_listbox);
+    ASSERT_NE(triggers_list, nullptr);
+
+    auto triggers_row = triggers_list->find<ui::Control>(ui::Listbox::Names::row_name_format + "0");
+    ASSERT_NE(triggers_row, nullptr);
+
+    auto triggers_cell = triggers_row->find<ui::Button>(ui::Listbox::Row::Names::cell_name_format + "#");
+    ASSERT_NE(triggers_cell, nullptr);
+
+    ASSERT_FALSE(triggers_list->selected_item().has_value());
+
+    triggers_cell->clicked(Point());
+    ASSERT_TRUE(triggers_list->selected_item().has_value());
+
+    window.clear_selected_trigger();
+    ASSERT_FALSE(triggers_list->selected_item().has_value());
+}
+
+TEST(RoomsWindow, SetTriggersClearsSelection)
+{
+    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
+    auto renderer_ptr = std::move(renderer_ptr_source);
+    RoomsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); },
+        [&](auto) { return std::make_unique<MockMapRenderer>(); }, create_test_window(L"RoomsWindowTests"));
+
+    std::optional<Trigger*> raised_trigger;
+    auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+
+    auto [trlevel_ptr, trlevel] = create_mock<trlevel::mocks::MockLevel>();
+    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto [texture_storage_ptr, texture_storage] = create_mock<MockLevelTextureStorage>();
+    auto [mesh_storage_ptr, mesh_storage] = create_mock<MockMeshStorage>();
+    trlevel::tr3_room tr_room{};
+
+    auto room = std::make_unique<Room>(
+        [](auto, auto, auto, auto, auto) { return std::make_unique<MockMesh>(); },
+        trlevel, tr_room, texture_storage, mesh_storage, 0, level);
+
+    auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {  } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
+    room->add_trigger(trigger1.get());
+
+    window.set_rooms({ room.get() });
+    window.set_triggers({ trigger1.get() });
+
+    auto list = window.root_control()->find<ui::Listbox>(RoomsWindow::Names::rooms_listbox);
+    ASSERT_NE(list, nullptr);
+
+    auto row = list->find<ui::Control>(ui::Listbox::Names::row_name_format + "0");
+    ASSERT_NE(row, nullptr);
+
+    auto cell = row->find<ui::Button>(ui::Listbox::Row::Names::cell_name_format + "#");
+    ASSERT_NE(cell, nullptr);
+    cell->clicked(Point());
+
+    auto triggers_list = window.root_control()->find<ui::Listbox>(RoomsWindow::Names::triggers_listbox);
+    ASSERT_NE(triggers_list, nullptr);
+
+    auto triggers_row = triggers_list->find<ui::Control>(ui::Listbox::Names::row_name_format + "0");
+    ASSERT_NE(triggers_row, nullptr);
+
+    auto triggers_cell = triggers_row->find<ui::Button>(ui::Listbox::Row::Names::cell_name_format + "#");
+    ASSERT_NE(triggers_cell, nullptr);
+
+    ASSERT_FALSE(triggers_list->selected_item().has_value());
+
+    triggers_cell->clicked(Point());
+    ASSERT_TRUE(triggers_list->selected_item().has_value());
+
+    window.set_triggers({});
+    ASSERT_FALSE(triggers_list->selected_item().has_value());
+}

--- a/trview.app.tests/TriggersWindowManagerTests.cpp
+++ b/trview.app.tests/TriggersWindowManagerTests.cpp
@@ -177,6 +177,30 @@ TEST(TriggersWindowManager, SetTriggersSetsTriggersOnWindows)
     manager.set_triggers({ trigger1.get(), trigger2.get() });
 }
 
+TEST(TriggersWindowManager, SetTriggersClearsSelectedTrigger)
+{
+    Event<> shortcut_handler;
+    auto shortcuts = std::make_shared<MockShortcuts>();
+    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
+    auto mock_window = std::make_shared<MockTriggersWindow>();
+    EXPECT_CALL(*mock_window, set_triggers).Times(3);
+    EXPECT_CALL(*mock_window, clear_selected_trigger).Times(2);
+    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+
+    auto created_window = manager.create_window().lock();
+    ASSERT_NE(created_window, nullptr);
+    ASSERT_EQ(created_window, mock_window);
+
+    auto trigger1 = std::make_unique<Trigger>(100, 55, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
+    manager.set_triggers({ trigger1.get() });
+
+    ASSERT_EQ(manager.selected_trigger(), nullptr);
+    manager.set_selected_trigger(trigger1.get());
+    ASSERT_EQ(manager.selected_trigger(), trigger1.get());
+    manager.set_triggers({});
+    ASSERT_EQ(manager.selected_trigger(), nullptr);
+}
+
 TEST(TriggersWindowManager, SetTriggerVisibilityUpdatesWindows)
 {
     Event<> shortcut_handler;

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -34,6 +34,8 @@
     <ClCompile Include="Menus\MenuDetectorTests.cpp" />
     <ClCompile Include="OrbitCameraTests.cpp" />
     <ClCompile Include="RecentFilesTests.cpp" />
+    <ClCompile Include="RoomsWindowManagerTests.cpp" />
+    <ClCompile Include="RoomsWindowTests.cpp" />
     <ClCompile Include="SettingsWindowTests.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -56,6 +56,12 @@
       <Filter>Windows</Filter>
     </ClCompile>
     <ClCompile Include="ApplicationTests.cpp" />
+    <ClCompile Include="RoomsWindowManagerTests.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
+    <ClCompile Include="RoomsWindowTests.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -45,7 +45,7 @@ namespace trview
         const ILevelTextureStorage& texture_storage,
         const IMeshStorage& mesh_storage,
         uint32_t index,
-        Level& parent_level)
+        ILevel& parent_level)
         : _info { room.info.x, 0, room.info.z, room.info.yBottom, room.info.yTop }, 
         _alternate_room(room.alternate_room),
         _alternate_group(room.alternate_group),

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -29,7 +29,7 @@ namespace trview
     struct ICamera;
     class Mesh;
     class TransparencyBuffer;
-    class Level;
+    struct ILevel;
 
     class Room
     {
@@ -56,7 +56,7 @@ namespace trview
             const ILevelTextureStorage& texture_storage,
             const IMeshStorage& mesh_storage,
             uint32_t index,
-            Level& parent_level);
+            ILevel& parent_level);
 
         Room(const Room&) = delete;
         Room& operator=(const Room&) = delete;
@@ -202,6 +202,6 @@ namespace trview
 
         std::unordered_map<uint32_t, Trigger*> _triggers;
         uint16_t _flags{ 0 };
-        Level& _level;
+        ILevel& _level;
     };
 }

--- a/trview.app/Mocks/Windows/IRoomsWindow.h
+++ b/trview.app/Mocks/Windows/IRoomsWindow.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <trview.app/Windows/IRoomsWindow.h>
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockRoomsWindow : public IRoomsWindow
+        {
+            virtual ~MockRoomsWindow() = default;
+            MOCK_METHOD(void, clear_selected_trigger, ());
+            MOCK_METHOD(void, render, (bool));
+            MOCK_METHOD(void, set_current_room, (uint32_t));
+            MOCK_METHOD(void, set_items, (const std::vector<Item>&));
+            MOCK_METHOD(void, set_rooms, (const std::vector<Room*>&));
+            MOCK_METHOD(void, set_selected_item, (const Item&));;
+            MOCK_METHOD(void, set_selected_trigger, (const Trigger* const));
+            MOCK_METHOD(void, set_triggers, (const std::vector<Trigger*>&));
+        };
+    }
+}

--- a/trview.app/Mocks/Windows/IRoomsWindowManager.h
+++ b/trview.app/Mocks/Windows/IRoomsWindowManager.h
@@ -16,7 +16,7 @@ namespace trview
             MOCK_METHOD(void, set_selected_item, (const Item&));
             MOCK_METHOD(void, set_selected_trigger, (const Trigger* const ));
             MOCK_METHOD(void, set_triggers, (const std::vector<Trigger*>&));
-            MOCK_METHOD(void, create_window, ());
+            MOCK_METHOD(std::weak_ptr<IRoomsWindow>, create_window, ());
         };
     }
 }

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -26,6 +26,9 @@ namespace trview
         /// Event raised when the window is closed.
         Event<> on_window_closed;
 
+        /// Clear the selected trigger.
+        virtual void clear_selected_trigger() = 0;
+
         /// Render the window.
         /// @param vsync Whether to use vsync or not.
         virtual void render(bool vsync) = 0;

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -45,6 +45,6 @@ namespace trview
         virtual void set_triggers(const std::vector<Trigger*>& triggers) = 0;
 
         /// Create a new rooms window.
-        virtual void create_window() = 0;
+        virtual std::weak_ptr<IRoomsWindow> create_window() = 0;
     };
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -50,6 +50,9 @@ namespace trview
         }
     }
 
+    const std::string RoomsWindow::Names::rooms_listbox{ "Rooms" };
+    const std::string RoomsWindow::Names::triggers_listbox{ "Triggers" };
+
     RoomsWindow::RoomsWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const ui::render::IMapRenderer::Source& map_renderer_source, const Window& parent)
         : CollapsiblePanel(device_window_source, renderer_source(Size(630, 680)), parent, L"trview.rooms", L"Rooms", Size(630, 680)), _map_renderer(map_renderer_source(Size(341, 341)))
     {
@@ -190,6 +193,7 @@ namespace trview
         using namespace ui;
 
         auto rooms_list = std::make_unique<Listbox>(Size(250, window().size().height - _controls->size().height), Colours::LeftPanel);
+        rooms_list->set_name(Names::rooms_listbox);
         rooms_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 40 },
@@ -257,6 +261,7 @@ namespace trview
 
         auto group_box = std::make_unique<GroupBox>(Size(190, 140), Colours::ItemDetails, Colours::DetailsBorder, L"Triggers");
         auto triggers_list = std::make_unique<Listbox>(Size(180, 140 - 21), Colours::LeftPanel);
+        triggers_list->set_name(Names::triggers_listbox);
         triggers_list->set_columns(
             {
                 { Listbox::Column::Type::Number, L"#", 30 },
@@ -330,6 +335,7 @@ namespace trview
 
     void RoomsWindow::set_triggers(const std::vector<Trigger*>& triggers)
     {
+        _selected_trigger.reset();
         _triggers_list->set_items({});
         _all_triggers = triggers;
     }
@@ -337,8 +343,12 @@ namespace trview
     void RoomsWindow::render_minimap()
     {
         _map_renderer->render(false);
-        auto map_size = _map_renderer->texture().size();
-
+        auto texture = _map_renderer->texture();
+        if (!texture.has_content())
+        {
+            return;
+        }
+        auto map_size = texture.size();
         _minimap->set_texture(_map_renderer->texture());
         _minimap->set_size(map_size);
         _minimap->set_position(Point((341 - map_size.width) / 2.0f, (341 - map_size.height) / 2.0f));
@@ -524,5 +534,11 @@ namespace trview
     void RoomsWindow::render(bool vsync)
     {
         CollapsiblePanel::render(vsync);
+    }
+
+    void RoomsWindow::clear_selected_trigger()
+    {
+        _selected_trigger.reset();
+        _triggers_list->clear_selection();
     }
 }

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -18,6 +18,12 @@ namespace trview
     class RoomsWindow final : public IRoomsWindow, public CollapsiblePanel
     {
     public:
+        struct Names
+        {
+            static const std::string rooms_listbox;
+            static const std::string triggers_listbox;
+        };
+
         /// Create a rooms window as a child of the specified window.
         /// @param device The graphics device
         /// @param renderer_source The function to call to get a renderer.
@@ -26,6 +32,8 @@ namespace trview
 
         /// Destructor for rooms window
         virtual ~RoomsWindow() = default;
+
+        virtual void clear_selected_trigger() override;
 
         virtual void render(bool vsync) override;
 

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -38,6 +38,11 @@ namespace trview
         }
     }
 
+    const Trigger* RoomsWindowManager::selected_trigger() const
+    {
+        return _selected_trigger.value_or(nullptr);
+    }
+
     void RoomsWindowManager::set_items(const std::vector<Item>& items)
     {
         _all_items = items;
@@ -86,13 +91,15 @@ namespace trview
     void RoomsWindowManager::set_triggers(const std::vector<Trigger*>& triggers)
     {
         _all_triggers = triggers;
+        _selected_trigger.reset();
         for (auto& window : _windows)
         {
+            window->clear_selected_trigger();
             window->set_triggers(_all_triggers);
         }
     }
 
-    void RoomsWindowManager::create_window()
+    std::weak_ptr<IRoomsWindow> RoomsWindowManager::create_window()
     {
         auto rooms_window = _rooms_window_source(window());
         rooms_window->on_room_selected += on_room_selected;
@@ -110,5 +117,6 @@ namespace trview
         rooms_window->set_current_room(_current_room);
 
         _windows.push_back(rooms_window);
+        return rooms_window;
     }
 }

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -40,6 +40,9 @@ namespace trview
         /// @param vsync Whether to use vsync.
         virtual void render(bool vsync) override;
 
+        /// Get the currently selected trigger.
+        const Trigger* selected_trigger() const;
+
         /// Set the items in the current level.
         virtual void set_items(const std::vector<Item>& items) override;
 
@@ -64,7 +67,7 @@ namespace trview
         virtual void set_triggers(const std::vector<Trigger*>& triggers) override;
 
         /// Create a new rooms window.
-        virtual void create_window() override;
+        virtual std::weak_ptr<IRoomsWindow> create_window() override;
     private:
         std::vector<std::shared_ptr<IRoomsWindow>> _windows;
         std::vector<std::weak_ptr<IRoomsWindow>> _closing_windows;

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -220,6 +220,9 @@ namespace trview
         _all_triggers = triggers;
         populate_triggers(triggers);
 
+        _command_list->set_items({});
+        _stats_list->set_items({});
+
         // Populate command filter dropdown.
         _selected_commands.clear();
         std::set<TriggerCommandType> command_set;
@@ -246,6 +249,7 @@ namespace trview
     void TriggersWindow::clear_selected_trigger()
     {
         _selected_trigger.reset();
+        _triggers_list->clear_selection();
         _stats_list->set_items({});
         _command_list->set_items({});
     }

--- a/trview.app/Windows/TriggersWindowManager.cpp
+++ b/trview.app/Windows/TriggersWindowManager.cpp
@@ -60,6 +60,11 @@ namespace trview
         return triggers_window;
     }
 
+    const Trigger* TriggersWindowManager::selected_trigger() const
+    {
+        return _selected_trigger.value_or(nullptr);
+    }
+
     void TriggersWindowManager::set_items(const std::vector<Item>& items)
     {
         _items = items;
@@ -72,6 +77,7 @@ namespace trview
     void TriggersWindowManager::set_triggers(const std::vector<Trigger*>& triggers)
     {
         _triggers = triggers;
+        _selected_trigger.reset();
         for (auto& window : _windows)
         {
             window->clear_selected_trigger();

--- a/trview.app/Windows/TriggersWindowManager.h
+++ b/trview.app/Windows/TriggersWindowManager.h
@@ -34,6 +34,9 @@ namespace trview
         /// @param vsync Whether to use vsync.
         virtual void render(bool vsync) override;
 
+        /// Get the currently selected trigger.
+        const Trigger* selected_trigger() const;
+
         /// Set the items to use in the windows.
         /// @param items The items in the level.
         virtual void set_items(const std::vector<Item>& items) override;

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -220,6 +220,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\UI\IViewerUI.h" />
     <ClInclude Include="Mocks\Windows\IItemsWindow.h" />
     <ClInclude Include="Mocks\Windows\IItemsWindowManager.h" />
+    <ClInclude Include="Mocks\Windows\IRoomsWindow.h" />
     <ClInclude Include="Mocks\Windows\IRoomsWindowManager.h" />
     <ClInclude Include="Mocks\Windows\IRouteWindowManager.h" />
     <ClInclude Include="Mocks\Windows\ITriggersWindow.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -746,6 +746,9 @@
     <ClInclude Include="Settings\di.hpp">
       <Filter>Settings</Filter>
     </ClInclude>
+    <ClInclude Include="Mocks\Windows\IRoomsWindow.h">
+      <Filter>Mocks\Windows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.ui.render/Mocks/IMapRenderer.h
+++ b/trview.ui.render/Mocks/IMapRenderer.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "../IMapRenderer.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        namespace render
+        {
+            namespace mocks
+            {
+                struct MockMapRenderer : public IMapRenderer
+                {
+                    virtual ~MockMapRenderer() = default;
+                    MOCK_METHOD(void, render, (bool));
+                    MOCK_METHOD(void, load, (const trview::Room*));
+                    MOCK_METHOD(std::uint16_t, area, (), (const));
+                    MOCK_METHOD(std::shared_ptr<Sector>, sector_at, (const Point&), (const));
+                    MOCK_METHOD(std::shared_ptr<Sector>, sector_at_cursor, (), (const));
+                    MOCK_METHOD(bool, cursor_is_over_control, (), (const));
+                    MOCK_METHOD(void, set_cursor_position, (const Point&));
+                    MOCK_METHOD(bool, loaded, (), (const));
+                    MOCK_METHOD(void, set_window_size, (const Size&));
+                    MOCK_METHOD(void, set_visible, (bool));
+                    MOCK_METHOD(void, clear_highlight, ());
+                    MOCK_METHOD(void, set_highlight, (uint16_t, uint16_t));
+                    MOCK_METHOD(graphics::Texture, texture, (), (const));
+                    MOCK_METHOD(Point, first, (), (const));
+                };
+            }
+        }
+    }
+}
+

--- a/trview.ui.render/trview.ui.render.vcxproj
+++ b/trview.ui.render/trview.ui.render.vcxproj
@@ -27,6 +27,7 @@
     <ClInclude Include="IRenderer.h" />
     <ClInclude Include="LabelNode.h" />
     <ClInclude Include="MapRenderer.h" />
+    <ClInclude Include="Mocks\IMapRenderer.h" />
     <ClInclude Include="Mocks\IRenderer.h" />
     <ClInclude Include="Renderer.h" />
     <ClInclude Include="RenderNode.h" />

--- a/trview.ui.render/trview.ui.render.vcxproj.filters
+++ b/trview.ui.render/trview.ui.render.vcxproj.filters
@@ -30,6 +30,9 @@
     </ClInclude>
     <ClInclude Include="di.h" />
     <ClInclude Include="di.hpp" />
+    <ClInclude Include="Mocks\IMapRenderer.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Renderer.cpp" />

--- a/trview.ui/Listbox.cpp
+++ b/trview.ui/Listbox.cpp
@@ -65,6 +65,13 @@ namespace trview
             generate_rows();
             populate_rows();
 
+            if (_selected_item.has_value() &&
+                std::find_if(_items.begin(), _items.end(), [this](const auto& l) { return identity_equal(l, _selected_item.value()); }) == _items.end())
+            {
+                _selected_item.reset();
+                highlight_item();
+            }
+
             // Scroll to the highlighted item (if present in the list).
             if (_show_highlight && _selected_item.has_value())
             {


### PR DESCRIPTION
When the level changes go through all windows that store the selected trigger and clear the selection. This stops them referring to triggers that no longer exist.
Add tests for this in `TriggersWindowManager` and `RoomsWindowManager`. Only tests for this specific fix are added for `RoomsWindowManager` - they will be added separately as they would be too big for this change.
Closes #751