### PR TITLE
Move conversion of tr4_ai_object to trview.app Level

### DIFF
--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -79,6 +79,15 @@ namespace trlevel
         // Returns: The floor data.
         virtual std::vector<std::uint16_t> get_floor_data_all() const = 0;
 
+        /// Get the number of ai objects in the level.
+        /// Returns: The number of ai objects.
+        virtual uint32_t num_ai_objects() const = 0;
+
+        // Get the ai object at the specified index.
+        // index: The index of the ai object to get.
+        // Returns: The ai object.
+        virtual tr4_ai_object get_ai_object(uint32_t index) const = 0;
+
         // Get the number of entities in the level.
         // Returns: The number of entities.
         virtual uint32_t num_entities() const = 0;

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -487,6 +487,16 @@ namespace trlevel
         return _floor_data;
     }
 
+    uint32_t Level::num_ai_objects() const
+    {
+        return static_cast<uint32_t>(_ai_objects.size());
+    }
+
+    tr4_ai_object Level::get_ai_object(uint32_t index) const
+    {
+        return _ai_objects[index];
+    }
+
     uint32_t Level::num_entities() const
     {
         return static_cast<uint32_t>(_entities.size());
@@ -874,23 +884,7 @@ namespace trlevel
 
         if (_version >= LevelVersion::Tomb4)
         {
-            std::vector<tr4_ai_object> ai_objects = read_vector<uint32_t, tr4_ai_object>(file);
-            std::transform(ai_objects.begin(), ai_objects.end(), std::back_inserter(_entities),
-                [](const auto& ai_object)
-                {
-                    tr2_entity entity {};
-                    entity.TypeID = ai_object.type_id;
-                    entity.Room = ai_object.room;
-                    entity.x = ai_object.x;
-                    entity.y = ai_object.y;
-                    entity.z = ai_object.z;
-                    // Loses some of the angle, but not important at the moment.
-                    entity.Angle = static_cast<int16_t>(ai_object.angle);
-                    entity.Intensity1 = 0;
-                    entity.Intensity2 = ai_object.ocb;
-                    entity.Flags = ai_object.flags;
-                    return entity;
-                });
+            _ai_objects = read_vector<uint32_t, tr4_ai_object>(file);
         }
 
         if (_version < LevelVersion::Tomb4)

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -85,9 +85,12 @@ namespace trlevel
         // Returns: The floor data.
         virtual std::vector<std::uint16_t> get_floor_data_all() const override; 
 
+        virtual uint32_t num_ai_objects() const override;
+        virtual tr4_ai_object get_ai_object(uint32_t index) const override;
+
         // Get the number of entities in the level.
         // Returns: The number of entities.
-        virtual uint32_t num_entities() const override;
+        virtual uint32_t num_entities() const override;        
 
         // Get the entity at the specified index.
         // index: The index of the entity to get.
@@ -187,6 +190,7 @@ namespace trlevel
         std::vector<tr_model>          _models;
         std::vector<tr2_entity>        _entities;
         std::unordered_map<uint32_t, tr_staticmesh> _static_meshes;
+        std::vector<tr4_ai_object>     _ai_objects;
 
         uint16_t _lara_type{ 0u };
         uint16_t _weather_type{ 0u };

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -90,7 +90,7 @@ namespace trlevel
 
         // Get the number of entities in the level.
         // Returns: The number of entities.
-        virtual uint32_t num_entities() const override;        
+        virtual uint32_t num_entities() const override;
 
         // Get the entity at the specified index.
         // index: The index of the entity to get.

--- a/trlevel/Mocks/ILevel.h
+++ b/trlevel/Mocks/ILevel.h
@@ -24,6 +24,8 @@ namespace trlevel
             MOCK_METHOD(uint32_t, num_floor_data, (), (const, override));
             MOCK_METHOD(uint16_t, get_floor_data, (uint32_t), (const, override));
             MOCK_METHOD(std::vector<uint16_t>, get_floor_data_all, (), (const, override));
+            MOCK_METHOD(uint32_t, num_ai_objects, (), (const, override));
+            MOCK_METHOD(tr4_ai_object, get_ai_object, (uint32_t), (const, override));
             MOCK_METHOD(uint32_t, num_entities, (), (const, override));
             MOCK_METHOD(tr2_entity, get_entity, (uint32_t), (const, override));
             MOCK_METHOD(uint32_t, num_models, (), (const, override));

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -550,6 +550,11 @@ namespace trlevel
         int16_t ocb;
         uint16_t flags;     // Activation mask, bitwise-shifted left by 1
         int32_t angle;
+
+        DirectX::SimpleMath::Vector3 position() const
+        {
+            return DirectX::SimpleMath::Vector3(x / Scale_X, y / Scale_Y, z / Scale_Z);
+        }
     };
 
 #pragma pack(pop)

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -9,6 +9,7 @@
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
 #include <trview.app/Mocks/Graphics/ISelectionRenderer.h>
 #include <trview.app/Mocks/Elements/ITypeNameLookup.h>
+#include <trview.app/Mocks/Elements/IEntity.h>
 
 using namespace trview;
 using namespace trview::mocks;
@@ -41,5 +42,6 @@ TEST(Level, LoadTypeNames)
     Level level(std::make_shared<MockDevice>(), std::make_shared<MockShaderStorage>(), std::move(mock_level),
         std::make_unique<MockLevelTextureStorage>(), std::make_unique<MockMeshStorage>(), std::make_unique<MockTransparencyBuffer>(),
         std::make_unique<MockSelectionRenderer>(), mock_type_name_lookup, [](auto, auto, auto, auto, auto) {return std::make_unique<MockMesh>(); },
-        [](auto, auto) { return std::make_unique<MockMesh>(); });
+        [](auto, auto) { return std::make_unique<MockMesh>(); }, [](auto&&, auto&&, auto&&, auto&&) { return std::make_shared<MockEntity>(); },
+        [](auto&&, auto&&, auto&&, auto&) { return std::make_shared<MockEntity>(); });
 }

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -45,3 +45,41 @@ TEST(Level, LoadTypeNames)
         [](auto, auto) { return std::make_unique<MockMesh>(); }, [](auto&&, auto&&, auto&&, auto&&) { return std::make_shared<MockEntity>(); },
         [](auto&&, auto&&, auto&&, auto&) { return std::make_shared<MockEntity>(); });
 }
+
+TEST(Level, LoadFromEntitySources)
+{
+    tr2_entity entity;
+    entity.Room = 0;
+    entity.TypeID = 123;
+
+    tr4_ai_object ai_object{};
+
+    auto mock_level = std::make_unique<testing::NiceMock<MockLevel>>();
+    EXPECT_CALL(*mock_level, get_version).WillRepeatedly(Return(LevelVersion::Tomb4));
+    EXPECT_CALL(*mock_level, num_rooms()).WillRepeatedly(Return(1));
+    EXPECT_CALL(*mock_level, num_entities()).WillRepeatedly(Return(1));
+    EXPECT_CALL(*mock_level, get_entity(0)).WillRepeatedly(Return(entity));
+    EXPECT_CALL(*mock_level, num_ai_objects()).WillRepeatedly(Return(1));
+    EXPECT_CALL(*mock_level, get_ai_object(0)).WillRepeatedly(Return(ai_object));
+
+    uint32_t entity_source_called = 0;
+    uint32_t ai_source_called = 0;
+
+    Level level(std::make_shared<MockDevice>(), std::make_shared<MockShaderStorage>(), std::move(mock_level),
+        std::make_unique<MockLevelTextureStorage>(), std::make_unique<MockMeshStorage>(), std::make_unique<MockTransparencyBuffer>(),
+        std::make_unique<MockSelectionRenderer>(), std::make_shared<MockTypeNameLookup>(), [](auto, auto, auto, auto, auto) {return std::make_unique<MockMesh>(); },
+        [](auto, auto) { return std::make_unique<MockMesh>(); }, 
+        [&](auto&&, auto&&, auto&&, auto&&) 
+        { 
+            ++entity_source_called;
+            return std::make_shared<MockEntity>(); 
+        },
+        [&](auto&&, auto&&, auto&&, auto&) 
+        { 
+            ++ai_source_called;
+            return std::make_shared<MockEntity>(); 
+        });
+
+    ASSERT_EQ(entity_source_called, 1);
+    ASSERT_EQ(ai_source_called, 1);
+}

--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -27,7 +27,8 @@ namespace trview
     {
     }
 
-    Entity::Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint32_t room, uint32_t index, uint32_t type_id, const Vector3& position, int32_t angle, int32_t ocb)
+    Entity::Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint32_t room, uint32_t index, uint32_t type_id,
+        const Vector3& position, int32_t angle, int32_t ocb)
         : _room(room), _index(index)
     {
         // Extract the meshes required from the model.

--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -27,7 +27,7 @@ namespace trview
     {
     }
 
-    Entity::Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint32_t room, uint32_t index, uint32_t type_id, const Vector3& position, uint16_t angle, int32_t ocb)
+    Entity::Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint32_t room, uint32_t index, uint32_t type_id, const Vector3& position, int32_t angle, int32_t ocb)
         : _room(room), _index(index)
     {
         // Extract the meshes required from the model.

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -9,6 +9,7 @@
 #include <trview.app/Geometry/PickResult.h>
 #include <trview.app/Geometry/IRenderable.h>
 #include <trview.app/Geometry/IMesh.h>
+#include "IEntity.h"
 
 namespace trlevel
 {
@@ -25,20 +26,20 @@ namespace trview
     struct ICamera;
     class TransparencyBuffer;
 
-    class Entity : public IRenderable
+    class Entity : public IEntity
     {
     public:
         explicit Entity(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, uint32_t index);
         explicit Entity(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, uint32_t index);
         virtual ~Entity() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
-        uint16_t room() const;
+        virtual uint16_t room() const override;
         uint32_t index() const;
 
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
 
-        PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const;
-        DirectX::BoundingBox bounding_box() const;
+        virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
+        virtual DirectX::BoundingBox bounding_box() const override;
 
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -43,7 +43,7 @@ namespace trview
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;
     private:
-        Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint32_t room, uint32_t index, uint32_t type_id, const DirectX::SimpleMath::Vector3& position, uint16_t angle, int32_t ocb);
+        Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint32_t room, uint32_t index, uint32_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb);
 
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -26,7 +26,7 @@ namespace trview
     struct ICamera;
     class TransparencyBuffer;
 
-    class Entity : public IEntity
+    class Entity final : public IEntity
     {
     public:
         explicit Entity(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, uint32_t index);

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -28,7 +28,8 @@ namespace trview
     class Entity : public IRenderable
     {
     public:
-        explicit Entity(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& room, const IMeshStorage& mesh_storage, uint32_t index);
+        explicit Entity(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, uint32_t index);
+        explicit Entity(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, uint32_t index);
         virtual ~Entity() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         uint16_t room() const;
@@ -42,6 +43,8 @@ namespace trview
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;
     private:
+        Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint32_t room, uint32_t index, uint32_t type_id, const DirectX::SimpleMath::Vector3& position, uint16_t angle, int32_t ocb);
+
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);
         void generate_bounding_box();

--- a/trview.app/Elements/IEntity.cpp
+++ b/trview.app/Elements/IEntity.cpp
@@ -1,0 +1,8 @@
+#include "IEntity.h"
+
+namespace trview
+{
+    IEntity::~IEntity()
+    {
+    }
+}

--- a/trview.app/Elements/IEntity.h
+++ b/trview.app/Elements/IEntity.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+#include <external/DirectXTK/Inc/SimpleMath.h>
+#include <trlevel/ILevel.h>
+#include <trlevel/trtypes.h>
+#include <trview.app/Geometry/IRenderable.h>
+#include <trview.app/Geometry/PickResult.h>
+#include <trview.app/Graphics/IMeshStorage.h>
+
+namespace trview
+{
+    struct IEntity : public IRenderable
+    {
+        using EntitySource =
+            std::function<std::shared_ptr<IEntity> (const trlevel::ILevel&, const trlevel::tr2_entity&, uint32_t, const IMeshStorage&)>;
+        using AiSource =
+            std::function<std::shared_ptr<IEntity>(const trlevel::ILevel&, const trlevel::tr4_ai_object&, uint32_t, const IMeshStorage&)>;
+
+        virtual ~IEntity() = 0;
+        virtual uint16_t room() const = 0;
+        virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
+        virtual DirectX::BoundingBox bounding_box() const = 0;
+    };
+}

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -28,7 +28,7 @@ namespace trview
         const IMesh::Source& mesh_source,
         const IMesh::TransparentSource& mesh_transparent_source,
         const IEntity::EntitySource& entity_source,
-        const IEntity::AiSource ai_source)
+        const IEntity::AiSource& ai_source)
         : _device(device), _version(level->get_version()), _texture_storage(std::move(level_texture_storage)),
         _mesh_storage(std::move(mesh_storage)), _transparency(std::move(transparency_buffer)),
         _selection_renderer(std::move(selection_renderer))

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -396,8 +396,21 @@ namespace trview
             }
 
             // Item for item information.
-            _items.emplace_back(i, level_entity.Room, level_entity.TypeID, type_names.lookup_type_name(_version, level_entity.TypeID), version() >= trlevel::LevelVersion::Tomb4 ? level_entity.Intensity2 : 0, level_entity.Flags, relevant_triggers, level_entity.position());
+            _items.emplace_back(i, level_entity.Room, level_entity.TypeID, type_names.lookup_type_name(_version, level_entity.TypeID), version() >= trlevel::LevelVersion::Tomb4 ? level_entity.Intensity2 : 0, level_entity.Flags, relevant_triggers, level_entity.position());        }
+
+        const uint32_t num_ai_objects = level.num_ai_objects();
+        for (uint32_t i = 0; i < num_ai_objects; ++i)
+        {
+            auto ai_object = level.get_ai_object(i);
+
+            auto entity = std::make_unique<Entity>(mesh_source, level, ai_object, *_mesh_storage.get(), i);
+            _rooms[entity->room()]->add_entity(entity.get());
+            _entities.push_back(std::move(entity));
+
+            _items.push_back(Item(num_entities + i, ai_object.room, ai_object.type_id, type_names.lookup_type_name(_version, ai_object.type_id), ai_object.ocb, ai_object.flags, {},
+                ai_object.position()));
         }
+        
     }
 
     void Level::regenerate_neighbours()

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -396,21 +396,21 @@ namespace trview
             }
 
             // Item for item information.
-            _items.emplace_back(i, level_entity.Room, level_entity.TypeID, type_names.lookup_type_name(_version, level_entity.TypeID), version() >= trlevel::LevelVersion::Tomb4 ? level_entity.Intensity2 : 0, level_entity.Flags, relevant_triggers, level_entity.position());        }
+            _items.emplace_back(i, level_entity.Room, level_entity.TypeID, type_names.lookup_type_name(_version, level_entity.TypeID), version() >= trlevel::LevelVersion::Tomb4 ? level_entity.Intensity2 : 0, level_entity.Flags, relevant_triggers, level_entity.position());        
+        }
 
         const uint32_t num_ai_objects = level.num_ai_objects();
         for (uint32_t i = 0; i < num_ai_objects; ++i)
         {
             auto ai_object = level.get_ai_object(i);
 
-            auto entity = std::make_unique<Entity>(mesh_source, level, ai_object, *_mesh_storage.get(), i);
+            auto entity = std::make_unique<Entity>(mesh_source, level, ai_object, *_mesh_storage.get(), num_entities + i);
             _rooms[entity->room()]->add_entity(entity.get());
             _entities.push_back(std::move(entity));
 
             _items.push_back(Item(num_entities + i, ai_object.room, ai_object.type_id, type_names.lookup_type_name(_version, ai_object.type_id), ai_object.ocb, ai_object.flags, {},
                 ai_object.position()));
         }
-        
     }
 
     void Level::regenerate_neighbours()

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -41,7 +41,9 @@ namespace trview
             std::unique_ptr<ISelectionRenderer> selection_renderer,
             const std::shared_ptr<ITypeNameLookup>& type_names,
             const IMesh::Source& mesh_source,
-            const IMesh::TransparentSource& mesh_transparent_source);
+            const IMesh::TransparentSource& mesh_transparent_source,
+            const IEntity::EntitySource& entity_source,
+            const IEntity::AiSource ai_source);
         ~Level();
 
         // Temporary, for the room info and texture window.
@@ -135,7 +137,7 @@ namespace trview
     private:
         void generate_rooms(const trlevel::ILevel& level, const IMesh::Source& mesh_source);
         void generate_triggers(const IMesh::TransparentSource& mesh_transparent_source);
-        void generate_entities(const trlevel::ILevel& level, const ITypeNameLookup& type_names, const IMesh::Source& mesh_source);
+        void generate_entities(const trlevel::ILevel& level, const ITypeNameLookup& type_names, const IEntity::EntitySource& entity_source, const IEntity::AiSource& ai_source);
         void regenerate_neighbours();
         void generate_neighbours(std::set<uint16_t>& results, uint16_t selected_room, int32_t max_depth);
 
@@ -176,7 +178,7 @@ namespace trview
         std::shared_ptr<graphics::IDevice> _device;
         std::vector<std::unique_ptr<Room>>   _rooms;
         std::vector<std::unique_ptr<Trigger>> _triggers;
-        std::vector<std::unique_ptr<Entity>> _entities;
+        std::vector<std::shared_ptr<IEntity>> _entities;
         std::vector<Item> _items;
 
         graphics::IShader*          _vertex_shader;
@@ -188,7 +190,7 @@ namespace trview
         std::set<RoomHighlightMode> _room_highlight_modes;
         
         uint16_t           _selected_room{ 0u };
-        Entity*            _selected_item{ nullptr };
+        std::weak_ptr<IEntity> _selected_item;
         Trigger*           _selected_trigger{ nullptr };
         uint32_t           _neighbour_depth{ 1 };
         std::set<uint16_t> _neighbours;

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -43,7 +43,7 @@ namespace trview
             const IMesh::Source& mesh_source,
             const IMesh::TransparentSource& mesh_transparent_source,
             const IEntity::EntitySource& entity_source,
-            const IEntity::AiSource ai_source);
+            const IEntity::AiSource& ai_source);
         ~Level();
 
         // Temporary, for the room info and texture window.

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -289,7 +289,7 @@ namespace trview
         });
     }
 
-    void Room::add_entity(Entity* entity)
+    void Room::add_entity(IEntity* entity)
     {
         _entities.push_back(entity);
     }

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -25,7 +25,7 @@ namespace trview
 {
     struct ILevelTextureStorage;
     struct IMeshStorage;
-    class Entity;
+    struct IEntity;
     struct ICamera;
     class Mesh;
     class TransparencyBuffer;
@@ -81,7 +81,7 @@ namespace trview
 
         // Add the specified entity to the room.
         // Entity: The entity to add.
-        void add_entity(Entity* entity);
+        void add_entity(IEntity* entity);
 
         /// Add the specified trigger to the room.
         /// @paramt trigger The trigger to add.
@@ -188,7 +188,7 @@ namespace trview
 
         DirectX::BoundingBox  _bounding_box;
 
-        std::vector<Entity*> _entities;
+        std::vector<IEntity*> _entities;
 
         // Maps a sector to its sector ID 
         std::vector<std::shared_ptr<Sector>> _sectors; 

--- a/trview.app/Elements/di.hpp
+++ b/trview.app/Elements/di.hpp
@@ -20,6 +20,22 @@ namespace trview
                     Resource type_list = get_resource_memory(IDR_TYPE_NAMES, L"TEXT");
                     return std::make_shared<TypeNameLookup>(std::string(type_list.data, type_list.data + type_list.size));
                 }),
+            di::bind<IEntity::EntitySource>.to(
+                [](const auto& injector) -> IEntity::EntitySource
+                {
+                    return [&](auto&& level, auto&& entity, auto&& index, auto&& mesh_storage)
+                    {
+                        return std::make_shared<Entity>(injector.create<IMesh::Source>(), level, entity, mesh_storage, index);
+                    };
+                }),
+            di::bind<IEntity::AiSource>.to(
+                [](const auto& injector) -> IEntity::AiSource
+                {
+                    return [&](auto&& level, auto&& ai_object, auto&& index, auto&& mesh_storage)
+                    {
+                        return std::make_shared<Entity>(injector.create<IMesh::Source>(), level, ai_object, mesh_storage, index);
+                    };
+                }),
             di::bind<ILevel::Source>.to(
                 [](const auto& injector) -> ILevel::Source
                 {
@@ -37,7 +53,9 @@ namespace trview
                             injector.create<std::unique_ptr<ISelectionRenderer>>(),
                             injector.create<std::shared_ptr<ITypeNameLookup>>(),
                             injector.create<IMesh::Source>(),
-                            injector.create<IMesh::TransparentSource>());
+                            injector.create<IMesh::TransparentSource>(),
+                            injector.create<IEntity::EntitySource>(),
+                            injector.create<IEntity::AiSource>());
                     };
                 })
         );

--- a/trview.app/Geometry/di.hpp
+++ b/trview.app/Geometry/di.hpp
@@ -27,7 +27,7 @@ namespace trview
                     };
                 }),
             di::bind<IMesh::TransparentSource>.to(
-                [](const auto& injector) -> IMesh::TransparentSource
+                [](auto&&) -> IMesh::TransparentSource
                 {
                     return [&](auto&& transparent_triangles, auto&& collision_triangles)
                     {

--- a/trview.app/Mocks/Elements/IEntity.h
+++ b/trview.app/Mocks/Elements/IEntity.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <trview.app/Elements/IEntity.h>
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockEntity : public IEntity
+        {
+            virtual ~MockEntity() = default;
+            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&));
+            MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&));
+            MOCK_METHOD(bool, visible, (), (const));
+            MOCK_METHOD(void, set_visible, (bool));
+            MOCK_METHOD(uint16_t, room, (), (const));
+            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const));
+            MOCK_METHOD(DirectX::BoundingBox, bounding_box, (), (const));
+        };
+    }
+}

--- a/trview.app/Mocks/Elements/IEntity.h
+++ b/trview.app/Mocks/Elements/IEntity.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockEntity : public IEntity
+        struct MockEntity final : public IEntity
         {
             virtual ~MockEntity() = default;
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&));

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -37,6 +37,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Camera\ICamera.cpp" />
     <ClCompile Include="Camera\OrbitCamera.cpp" />
     <ClCompile Include="Elements\Entity.cpp" />
+    <ClCompile Include="Elements\IEntity.cpp" />
     <ClCompile Include="Elements\Item.cpp" />
     <ClCompile Include="Elements\ITypeNameLookup.cpp" />
     <ClCompile Include="Elements\ILevel.cpp" />
@@ -146,6 +147,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Elements\di.h" />
     <ClInclude Include="Elements\di.hpp" />
     <ClInclude Include="Elements\Entity.h" />
+    <ClInclude Include="Elements\IEntity.h" />
     <ClInclude Include="Elements\ILevel.h" />
     <ClInclude Include="Elements\Item.h" />
     <ClInclude Include="Elements\ITypeNameLookup.h" />
@@ -199,6 +201,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Menus\RecentFiles.h" />
     <ClInclude Include="Menus\UpdateChecker.h" />
     <ClInclude Include="Menus\ViewMenu.h" />
+    <ClInclude Include="Mocks\Elements\IEntity.h" />
     <ClInclude Include="Mocks\Elements\ILevel.h" />
     <ClInclude Include="Mocks\Elements\ITypeNameLookup.h" />
     <ClInclude Include="Mocks\Geometry\IMesh.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -295,6 +295,9 @@
     <ClCompile Include="Graphics\ISectorHighlight.cpp">
       <Filter>Graphics</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\IEntity.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -748,6 +751,12 @@
     </ClInclude>
     <ClInclude Include="Mocks\Windows\IRoomsWindow.h">
       <Filter>Mocks\Windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\IEntity.h">
+      <Filter>Elements</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\Elements\IEntity.h">
+      <Filter>Mocks\Elements</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Take conversion of tr4_ai_object out of the `trlevel` project - just expose `ai_objects`. Convert them to `trview.app` `Entity` when the level is loaded.
Convert creation of entities to use DI for testing.
Add a test for this.
Closes #724 