### PR TITLE
Enable copying route window stats to clipboard and convert clipboard usages to use DI

### DIFF
--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -7,6 +7,7 @@
 #include <trview.graphics/mocks/IDeviceWindow.h>
 #include <trview.ui.render/Mocks/IRenderer.h>
 #include <trview.app/Mocks/Geometry/IMesh.h>
+#include <trview.common/Mocks/Windows/IClipboard.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -19,7 +20,8 @@ TEST(ItemsWindow, AddToRouteEventRaised)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"));
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_add_to_route += [&raised_item](const auto& item) { raised_item = item; };
@@ -44,7 +46,8 @@ TEST(ItemsWindow, ClearSelectedItemClearsSelection)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"));
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
@@ -96,7 +99,8 @@ TEST(ItemsWindow, ItemSelectedNotRaisedWhenSyncItemDisabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"));
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
@@ -129,7 +133,8 @@ TEST(ItemsWindow, ItemSelectedRaisedWhenSyncItemEnabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"));
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
@@ -159,7 +164,8 @@ TEST(ItemsWindow, ItemVisibilityRaised)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"));
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<std::tuple<Item, bool>> raised_item;
     auto token = window.on_item_visibility += [&raised_item](const auto& item, bool state) { raised_item = { item, state }; };
@@ -190,7 +196,8 @@ TEST(ItemsWindow, ItemsListNotFilteredWhenRoomSetAndTrackRoomDisabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"));
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
@@ -221,7 +228,8 @@ TEST(ItemsWindow, ItemsListFilteredWhenRoomSetAndTrackRoomEnabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"));
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
@@ -256,7 +264,8 @@ TEST(ItemsWindow, ItemsListPopulatedOnSet)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"));
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::vector<Item> items
     {
@@ -292,7 +301,8 @@ TEST(ItemsWindow, ItemsListUpdatedWhenFiltered)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"));
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::vector<Item> items
     {
@@ -327,7 +337,8 @@ TEST(ItemsWindow, ItemsListUpdatedWhenNotFiltered)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"));
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::vector<Item> items
     {
@@ -357,7 +368,8 @@ TEST(ItemsWindow, SelectionSurvivesFiltering)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"));
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::vector<Item> items
     {
@@ -390,7 +402,8 @@ TEST(ItemsWindow, TriggersLoadedForItem)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"));
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
+        std::make_shared<MockClipboard>());
 
     auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
@@ -425,7 +438,8 @@ TEST(ItemsWindow, TriggerSelectedEventRaised)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"));
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };

--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -8,11 +8,13 @@
 #include <trview.ui.render/Mocks/IRenderer.h>
 #include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.common/Mocks/Windows/IClipboard.h>
+#include <trview.ui/Mocks/Input/IInput.h>
 
 using namespace trview;
 using namespace trview::tests;
 using namespace trview::graphics;
 using namespace trview::graphics::mocks;
+using namespace trview::ui::mocks;
 using namespace trview::ui::render::mocks;
 using namespace trview::mocks;
 
@@ -20,8 +22,8 @@ TEST(ItemsWindow, AddToRouteEventRaised)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
-        std::make_shared<MockClipboard>());
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); }, 
+        create_test_window(L"ItemsWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_add_to_route += [&raised_item](const auto& item) { raised_item = item; };
@@ -46,8 +48,8 @@ TEST(ItemsWindow, ClearSelectedItemClearsSelection)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
-        std::make_shared<MockClipboard>());
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"ItemsWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
@@ -99,8 +101,8 @@ TEST(ItemsWindow, ItemSelectedNotRaisedWhenSyncItemDisabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
-        std::make_shared<MockClipboard>());
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"ItemsWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
@@ -133,8 +135,8 @@ TEST(ItemsWindow, ItemSelectedRaisedWhenSyncItemEnabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
-        std::make_shared<MockClipboard>());
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"ItemsWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
@@ -164,8 +166,8 @@ TEST(ItemsWindow, ItemVisibilityRaised)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
-        std::make_shared<MockClipboard>());
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"ItemsWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<std::tuple<Item, bool>> raised_item;
     auto token = window.on_item_visibility += [&raised_item](const auto& item, bool state) { raised_item = { item, state }; };
@@ -196,8 +198,8 @@ TEST(ItemsWindow, ItemsListNotFilteredWhenRoomSetAndTrackRoomDisabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
-        std::make_shared<MockClipboard>());
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"ItemsWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
@@ -228,8 +230,8 @@ TEST(ItemsWindow, ItemsListFilteredWhenRoomSetAndTrackRoomEnabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
-        std::make_shared<MockClipboard>());
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"ItemsWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
@@ -264,8 +266,8 @@ TEST(ItemsWindow, ItemsListPopulatedOnSet)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
-        std::make_shared<MockClipboard>());
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"ItemsWindowTests"), std::make_shared<MockClipboard>());
 
     std::vector<Item> items
     {
@@ -301,8 +303,8 @@ TEST(ItemsWindow, ItemsListUpdatedWhenFiltered)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
-        std::make_shared<MockClipboard>());
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"ItemsWindowTests"), std::make_shared<MockClipboard>());
 
     std::vector<Item> items
     {
@@ -337,8 +339,8 @@ TEST(ItemsWindow, ItemsListUpdatedWhenNotFiltered)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
-        std::make_shared<MockClipboard>());
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"ItemsWindowTests"), std::make_shared<MockClipboard>());
 
     std::vector<Item> items
     {
@@ -368,8 +370,8 @@ TEST(ItemsWindow, SelectionSurvivesFiltering)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
-        std::make_shared<MockClipboard>());
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"ItemsWindowTests"), std::make_shared<MockClipboard>());
 
     std::vector<Item> items
     {
@@ -402,8 +404,8 @@ TEST(ItemsWindow, TriggersLoadedForItem)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
-        std::make_shared<MockClipboard>());
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"ItemsWindowTests"), std::make_shared<MockClipboard>());
 
     auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
@@ -438,8 +440,8 @@ TEST(ItemsWindow, TriggerSelectedEventRaised)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"ItemsWindowTests"),
-        std::make_shared<MockClipboard>());
+    ItemsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"ItemsWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };

--- a/trview.app.tests/RoomsWindowTests.cpp
+++ b/trview.app.tests/RoomsWindowTests.cpp
@@ -11,6 +11,7 @@
 #include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
 #include <trview.ui/Mocks/Input/IInput.h>
+#include <trview.input/Mocks/IMouse.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -19,13 +20,20 @@ using namespace trview::graphics::mocks;
 using namespace trview::ui::mocks;
 using namespace trview::ui::render::mocks;
 using namespace trview::mocks;
+using namespace trview::input::mocks;
+using testing::ReturnRef;
 
 TEST(RoomsWindow, ClearSelectedTriggerClearsSelection)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
+    auto [input_ptr_source, input] = create_mock<MockInput>();
+    auto input_ptr = std::move(input_ptr_source);
+    MockMouse mouse;
+    EXPECT_CALL(*input_ptr, mouse).WillRepeatedly(ReturnRef(mouse));
+
     RoomsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, 
-        [&](auto) { return std::make_unique<MockMapRenderer>(); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); }, create_test_window(L"RoomsWindowTests"));
+        [&](auto) { return std::make_unique<MockMapRenderer>(); }, [&](auto&&, auto&&) { return std::move(input_ptr); }, create_test_window(L"RoomsWindowTests"));
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -78,8 +86,13 @@ TEST(RoomsWindow, SetTriggersClearsSelection)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
+    auto [input_ptr_source, input] = create_mock<MockInput>();
+    auto input_ptr = std::move(input_ptr_source);
+    MockMouse mouse;
+    EXPECT_CALL(*input_ptr, mouse).WillRepeatedly(ReturnRef(mouse));
+
     RoomsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); },
-        [&](auto) { return std::make_unique<MockMapRenderer>(); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); }, create_test_window(L"RoomsWindowTests"));
+        [&](auto) { return std::make_unique<MockMapRenderer>(); }, [&](auto&&, auto&&) { return std::move(input_ptr); }, create_test_window(L"RoomsWindowTests"));
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };

--- a/trview.app.tests/RoomsWindowTests.cpp
+++ b/trview.app.tests/RoomsWindowTests.cpp
@@ -10,11 +10,13 @@
 #include <trlevel/Mocks/ILevel.h>
 #include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
+#include <trview.ui/Mocks/Input/IInput.h>
 
 using namespace trview;
 using namespace trview::tests;
 using namespace trview::graphics;
 using namespace trview::graphics::mocks;
+using namespace trview::ui::mocks;
 using namespace trview::ui::render::mocks;
 using namespace trview::mocks;
 
@@ -23,7 +25,7 @@ TEST(RoomsWindow, ClearSelectedTriggerClearsSelection)
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
     RoomsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, 
-        [&](auto) { return std::make_unique<MockMapRenderer>(); }, create_test_window(L"RoomsWindowTests"));
+        [&](auto) { return std::make_unique<MockMapRenderer>(); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); }, create_test_window(L"RoomsWindowTests"));
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -77,7 +79,7 @@ TEST(RoomsWindow, SetTriggersClearsSelection)
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
     RoomsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); },
-        [&](auto) { return std::make_unique<MockMapRenderer>(); }, create_test_window(L"RoomsWindowTests"));
+        [&](auto) { return std::make_unique<MockMapRenderer>(); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); }, create_test_window(L"RoomsWindowTests"));
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };

--- a/trview.app.tests/RoomsWindowTests.cpp
+++ b/trview.app.tests/RoomsWindowTests.cpp
@@ -12,6 +12,7 @@
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
 #include <trview.ui/Mocks/Input/IInput.h>
 #include <trview.input/Mocks/IMouse.h>
+#include <external/boost/di.hpp>
 
 using namespace trview;
 using namespace trview::tests;
@@ -23,20 +24,36 @@ using namespace trview::mocks;
 using namespace trview::input::mocks;
 using testing::ReturnRef;
 
+namespace
+{
+    MockMouse mouse;
+
+    auto register_test_module()
+    {
+        using namespace boost;
+        return di::make_injector(
+            di::bind<IDeviceWindow::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockDeviceWindow>(); }; }),
+            di::bind<ui::render::IRenderer::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockRenderer>(); }; }),
+            di::bind<ui::render::IMapRenderer::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockMapRenderer>(); }; }),
+            di::bind<ui::IInput::Source>.to([&](auto&&) { return [&](auto&&, auto&&) 
+                { 
+                    auto input = std::make_unique<MockInput>();
+                    EXPECT_CALL(*input, mouse).WillRepeatedly(ReturnRef(mouse));
+                    return std::move(input);
+                };
+            }),
+            di::bind<Window>.to(create_test_window(L"ItemsWindowTests")),
+            di::bind<RoomsWindow>()
+        );
+    }
+}
+
 TEST(RoomsWindow, ClearSelectedTriggerClearsSelection)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    auto [input_ptr_source, input] = create_mock<MockInput>();
-    auto input_ptr = std::move(input_ptr_source);
-    MockMouse mouse;
-    EXPECT_CALL(*input_ptr, mouse).WillRepeatedly(ReturnRef(mouse));
-
-    RoomsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, 
-        [&](auto) { return std::make_unique<MockMapRenderer>(); }, [&](auto&&, auto&&) { return std::move(input_ptr); }, create_test_window(L"RoomsWindowTests"));
+    auto window = register_test_module().create<std::unique_ptr<RoomsWindow>>();
 
     std::optional<Trigger*> raised_trigger;
-    auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
     auto [trlevel_ptr, trlevel] = create_mock<trlevel::mocks::MockLevel>();
     auto [level_ptr, level] = create_mock<MockLevel>();
@@ -51,10 +68,10 @@ TEST(RoomsWindow, ClearSelectedTriggerClearsSelection)
     auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {  } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     room->add_trigger(trigger1.get());
 
-    window.set_rooms({ room.get() });
-    window.set_triggers({ trigger1.get() });
+    window->set_rooms({ room.get() });
+    window->set_triggers({ trigger1.get() });
 
-    auto list = window.root_control()->find<ui::Listbox>(RoomsWindow::Names::rooms_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(RoomsWindow::Names::rooms_listbox);
     ASSERT_NE(list, nullptr);
 
     auto row = list->find<ui::Control>(ui::Listbox::Names::row_name_format + "0");
@@ -64,7 +81,7 @@ TEST(RoomsWindow, ClearSelectedTriggerClearsSelection)
     ASSERT_NE(cell, nullptr);
     cell->clicked(Point());
 
-    auto triggers_list = window.root_control()->find<ui::Listbox>(RoomsWindow::Names::triggers_listbox);
+    auto triggers_list = window->root_control()->find<ui::Listbox>(RoomsWindow::Names::triggers_listbox);
     ASSERT_NE(triggers_list, nullptr);
 
     auto triggers_row = triggers_list->find<ui::Control>(ui::Listbox::Names::row_name_format + "0");
@@ -78,24 +95,16 @@ TEST(RoomsWindow, ClearSelectedTriggerClearsSelection)
     triggers_cell->clicked(Point());
     ASSERT_TRUE(triggers_list->selected_item().has_value());
 
-    window.clear_selected_trigger();
+    window->clear_selected_trigger();
     ASSERT_FALSE(triggers_list->selected_item().has_value());
 }
 
 TEST(RoomsWindow, SetTriggersClearsSelection)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    auto [input_ptr_source, input] = create_mock<MockInput>();
-    auto input_ptr = std::move(input_ptr_source);
-    MockMouse mouse;
-    EXPECT_CALL(*input_ptr, mouse).WillRepeatedly(ReturnRef(mouse));
-
-    RoomsWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); },
-        [&](auto) { return std::make_unique<MockMapRenderer>(); }, [&](auto&&, auto&&) { return std::move(input_ptr); }, create_test_window(L"RoomsWindowTests"));
+    auto window = register_test_module().create<std::unique_ptr<RoomsWindow>>();
 
     std::optional<Trigger*> raised_trigger;
-    auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
     auto [trlevel_ptr, trlevel] = create_mock<trlevel::mocks::MockLevel>();
     auto [level_ptr, level] = create_mock<MockLevel>();
@@ -110,10 +119,10 @@ TEST(RoomsWindow, SetTriggersClearsSelection)
     auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {  } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     room->add_trigger(trigger1.get());
 
-    window.set_rooms({ room.get() });
-    window.set_triggers({ trigger1.get() });
+    window->set_rooms({ room.get() });
+    window->set_triggers({ trigger1.get() });
 
-    auto list = window.root_control()->find<ui::Listbox>(RoomsWindow::Names::rooms_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(RoomsWindow::Names::rooms_listbox);
     ASSERT_NE(list, nullptr);
 
     auto row = list->find<ui::Control>(ui::Listbox::Names::row_name_format + "0");
@@ -123,7 +132,7 @@ TEST(RoomsWindow, SetTriggersClearsSelection)
     ASSERT_NE(cell, nullptr);
     cell->clicked(Point());
 
-    auto triggers_list = window.root_control()->find<ui::Listbox>(RoomsWindow::Names::triggers_listbox);
+    auto triggers_list = window->root_control()->find<ui::Listbox>(RoomsWindow::Names::triggers_listbox);
     ASSERT_NE(triggers_list, nullptr);
 
     auto triggers_row = triggers_list->find<ui::Control>(ui::Listbox::Names::row_name_format + "0");
@@ -137,6 +146,6 @@ TEST(RoomsWindow, SetTriggersClearsSelection)
     triggers_cell->clicked(Point());
     ASSERT_TRUE(triggers_list->selected_item().has_value());
 
-    window.set_triggers({});
+    window->set_triggers({});
     ASSERT_FALSE(triggers_list->selected_item().has_value());
 }

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -8,6 +8,7 @@
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
 #include <trview.app/Mocks/Elements/ILevel.h>
 #include <trview.common/Mocks/Windows/IClipboard.h>
+#include <trview.ui/Mocks/Input/IInput.h>
 
 using namespace DirectX::SimpleMath;
 using namespace testing;
@@ -15,6 +16,7 @@ using namespace trview;
 using namespace trview::graphics::mocks;
 using namespace trview::mocks;
 using namespace trview::tests;
+using namespace trview::ui::mocks;
 using namespace trview::ui::render::mocks;
 
 TEST(RouteWindow, WaypointRoomPositionCalculatedCorrectly)
@@ -26,7 +28,7 @@ TEST(RouteWindow, WaypointRoomPositionCalculatedCorrectly)
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
     RouteWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); },
-        create_test_window(L"RouteWindowTests"), std::make_shared<MockClipboard>());
+        [&](auto&&, auto&&) { return std::make_unique<MockInput>(); }, create_test_window(L"RouteWindowTests"), std::make_shared<MockClipboard>());
 
     // All of these dependencies can be removed when room comes from DI (is IRoom)
     auto [trlevel_ptr, trlevel] = create_mock<trlevel::mocks::MockLevel>();
@@ -83,7 +85,7 @@ TEST(RouteWindow, PositionValuesCopiedToClipboard)
     EXPECT_CALL(*clipboard, write(An<const Window&>(), std::wstring(L"133120, 256000, 332800"))).Times(1);
 
     RouteWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::make_unique<MockRenderer>(); },
-        create_test_window(L"RouteWindowTests"), clipboard);
+        [&](auto&&, auto&&) { return std::make_unique<MockInput>(); }, create_test_window(L"RouteWindowTests"), clipboard);
 
     const Vector3 waypoint_pos{ 130, 250, 325 };
     auto [mesh_ptr, mesh] = create_mock<MockMesh>();
@@ -113,7 +115,7 @@ TEST(RouteWindow, RoomPositionValuesCopiedToClipboard)
     EXPECT_CALL(*clipboard, write(An<const Window&>(), std::wstring(L"133120, 256000, 332800"))).Times(1);
 
     RouteWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::make_unique<MockRenderer>(); },
-        create_test_window(L"RouteWindowTests"), clipboard);
+        [&](auto&&, auto&&) { return std::make_unique<MockInput>(); }, create_test_window(L"RouteWindowTests"), clipboard);
 
     const Vector3 waypoint_pos{ 130, 250, 325 };
     auto [mesh_ptr, mesh] = create_mock<MockMesh>();

--- a/trview.app.tests/TriggersWindowTests.cpp
+++ b/trview.app.tests/TriggersWindowTests.cpp
@@ -8,11 +8,13 @@
 #include <trview.graphics/mocks/IDeviceWindow.h>
 #include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.common/Mocks/Windows/IClipboard.h>
+#include <trview.ui/Mocks/Input/IInput.h>
 
 using namespace trview;
 using namespace trview::tests;
 using namespace trview::graphics;
 using namespace trview::graphics::mocks;
+using namespace trview::ui::mocks;
 using namespace trview::ui::render::mocks;
 using namespace trview::mocks;
 
@@ -20,8 +22,8 @@ TEST(TriggersWindow, TriggerSelectedRaisedWhenSyncTriggerEnabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<const Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -49,8 +51,8 @@ TEST(TriggersWindow, TriggerSelectedNotRaisedWhenSyncTriggerDisabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<const Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -81,8 +83,8 @@ TEST(TriggersWindow, TriggersListNotFilteredWhenRoomSetAndTrackRoomDisabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -110,8 +112,8 @@ TEST(TriggersWindow, TriggersListFilteredWhenRoomSetAndTrackRoomEnabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -143,8 +145,8 @@ TEST(TriggersWindow, TriggersListFilteredByCommand)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<const Trigger*> raised_trigger;
     auto token = window.on_add_to_route += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -185,8 +187,8 @@ TEST(TriggersWindow, AddToRouteEventRaised)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<const Trigger*> raised_trigger;
     auto token = window.on_add_to_route += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -209,8 +211,8 @@ TEST(TriggersWindow, TriggerVisibilityRaised)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<std::tuple<const Trigger*, bool>> raised_trigger;
     auto token = window.on_trigger_visibility += [&raised_trigger](const auto& trigger, bool state) { raised_trigger = { trigger, state }; };
@@ -238,8 +240,8 @@ TEST(TriggersWindow, ItemSelectedRaised)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
@@ -278,8 +280,8 @@ TEST(TriggersWindow, SetTriggersLoadsTriggers)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {  } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 78, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Antipad, 0, { { TriggerCommandType::Camera, 0 } } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
@@ -294,7 +296,8 @@ TEST(TriggersWindow, SetTriggerVisiblityUpdatesTrigger)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"),
         std::make_shared<MockClipboard>());
 
     auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
@@ -315,8 +318,8 @@ TEST(TriggersWindow, SetItemsLoadsItems)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     std::vector<Item> items
     {
@@ -341,8 +344,8 @@ TEST(TriggersWindow, ClearSelectedTriggerClearsSelection)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -391,8 +394,8 @@ TEST(TriggersWindow, SetTriggersClearsSelection)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -441,8 +444,8 @@ TEST(TriggersWindow, TriggerDetailsLoadedForTrigger)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -462,8 +465,8 @@ TEST(TriggersWindow, SelectionSurvivesFiltering)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 78, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
@@ -493,8 +496,8 @@ TEST(TriggersWindow, FlipmapsFiltersAllFlipTriggers)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
+        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{0,0,0,TriggerType::Trigger, 0, { { TriggerCommandType::FlipOff, 0 } } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 78, 100, 200, TriggerInfo{0,0,0,TriggerType::Trigger, 0, { { TriggerCommandType::FlipOn, 0 } } }, [](auto, auto) { return std::make_unique<MockMesh>(); });

--- a/trview.app.tests/TriggersWindowTests.cpp
+++ b/trview.app.tests/TriggersWindowTests.cpp
@@ -7,6 +7,7 @@
 #include <trview.app/Elements/Types.h>
 #include <trview.graphics/mocks/IDeviceWindow.h>
 #include <trview.app/Mocks/Geometry/IMesh.h>
+#include <trview.common/Mocks/Windows/IClipboard.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -19,7 +20,8 @@ TEST(TriggersWindow, TriggerSelectedRaisedWhenSyncTriggerEnabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<const Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -47,7 +49,8 @@ TEST(TriggersWindow, TriggerSelectedNotRaisedWhenSyncTriggerDisabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<const Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -78,7 +81,8 @@ TEST(TriggersWindow, TriggersListNotFilteredWhenRoomSetAndTrackRoomDisabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -106,7 +110,8 @@ TEST(TriggersWindow, TriggersListFilteredWhenRoomSetAndTrackRoomEnabled)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -138,7 +143,8 @@ TEST(TriggersWindow, TriggersListFilteredByCommand)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<const Trigger*> raised_trigger;
     auto token = window.on_add_to_route += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -179,7 +185,8 @@ TEST(TriggersWindow, AddToRouteEventRaised)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<const Trigger*> raised_trigger;
     auto token = window.on_add_to_route += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -202,7 +209,8 @@ TEST(TriggersWindow, TriggerVisibilityRaised)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<std::tuple<const Trigger*, bool>> raised_trigger;
     auto token = window.on_trigger_visibility += [&raised_trigger](const auto& trigger, bool state) { raised_trigger = { trigger, state }; };
@@ -230,7 +238,8 @@ TEST(TriggersWindow, ItemSelectedRaised)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<Item> raised_item;
     auto token = window.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
@@ -269,7 +278,8 @@ TEST(TriggersWindow, SetTriggersLoadsTriggers)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {  } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 78, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Antipad, 0, { { TriggerCommandType::Camera, 0 } } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
@@ -284,7 +294,8 @@ TEST(TriggersWindow, SetTriggerVisiblityUpdatesTrigger)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
     ASSERT_NE(list, nullptr);
@@ -304,7 +315,8 @@ TEST(TriggersWindow, SetItemsLoadsItems)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::vector<Item> items
     {
@@ -329,7 +341,8 @@ TEST(TriggersWindow, ClearSelectedTriggerClearsSelection)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -378,7 +391,8 @@ TEST(TriggersWindow, SetTriggersClearsSelection)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -427,7 +441,8 @@ TEST(TriggersWindow, TriggerDetailsLoadedForTrigger)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     std::optional<Trigger*> raised_trigger;
     auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
@@ -447,7 +462,8 @@ TEST(TriggersWindow, SelectionSurvivesFiltering)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 78, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
@@ -477,7 +493,8 @@ TEST(TriggersWindow, FlipmapsFiltersAllFlipTriggers)
 {
     auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
     auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"));
+    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, create_test_window(L"TriggersWindowTests"),
+        std::make_shared<MockClipboard>());
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{0,0,0,TriggerType::Trigger, 0, { { TriggerCommandType::FlipOff, 0 } } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 78, 100, 200, TriggerInfo{0,0,0,TriggerType::Trigger, 0, { { TriggerCommandType::FlipOn, 0 } } }, [](auto, auto) { return std::make_unique<MockMesh>(); });

--- a/trview.app.tests/TriggersWindowTests.cpp
+++ b/trview.app.tests/TriggersWindowTests.cpp
@@ -9,6 +9,7 @@
 #include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.common/Mocks/Windows/IClipboard.h>
 #include <trview.ui/Mocks/Input/IInput.h>
+#include <external/boost/di.hpp>
 
 using namespace trview;
 using namespace trview::tests;
@@ -18,22 +19,35 @@ using namespace trview::ui::mocks;
 using namespace trview::ui::render::mocks;
 using namespace trview::mocks;
 
+namespace
+{
+    auto register_test_module()
+    {
+        using namespace boost;
+        return di::make_injector(
+            di::bind<IDeviceWindow::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockDeviceWindow>(); }; }),
+            di::bind<ui::render::IRenderer::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockRenderer>(); }; }),
+            di::bind<ui::IInput::Source>.to([&](auto&&) { return [&](auto&&, auto&&) { return std::make_unique<MockInput>(); }; }),
+            di::bind<Window>.to(create_test_window(L"TriggersWindowTests")),
+            di::bind<IClipboard>.to<MockClipboard>(),
+            di::bind<TriggersWindow>()
+        );
+    }
+}
+
 TEST(TriggersWindow, TriggerSelectedRaisedWhenSyncTriggerEnabled)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     std::optional<const Trigger*> raised_trigger;
-    auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
     auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, { { TriggerCommandType::Object, 1 }} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, { { TriggerCommandType::Camera, 1 }} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     std::vector<Trigger*> triggers{ trigger1.get(), trigger2.get() };
-    window.set_triggers(triggers);
+    window->set_triggers(triggers);
 
-    auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
     ASSERT_NE(list, nullptr);
 
     auto row = list->find<ui::Control>(ui::Listbox::Names::row_name_format + "1");
@@ -49,24 +63,21 @@ TEST(TriggersWindow, TriggerSelectedRaisedWhenSyncTriggerEnabled)
 
 TEST(TriggersWindow, TriggerSelectedNotRaisedWhenSyncTriggerDisabled)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     std::optional<const Trigger*> raised_trigger;
-    auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
     auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, { { TriggerCommandType::Object, 1 }} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, { { TriggerCommandType::Camera, 1 }} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     std::vector<Trigger*> triggers{ trigger1.get(), trigger2.get() };
-    window.set_triggers(triggers);
+    window->set_triggers(triggers);
 
-    auto sync = window.root_control()->find<ui::Checkbox>(TriggersWindow::Names::sync_trigger_checkbox);
+    auto sync = window->root_control()->find<ui::Checkbox>(TriggersWindow::Names::sync_trigger_checkbox);
     ASSERT_NE(sync, nullptr);
     sync->clicked(Point());
 
-    auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
     ASSERT_NE(list, nullptr);
 
     auto row = list->find<ui::Control>(ui::Listbox::Names::row_name_format + "1");
@@ -81,20 +92,17 @@ TEST(TriggersWindow, TriggerSelectedNotRaisedWhenSyncTriggerDisabled)
 
 TEST(TriggersWindow, TriggersListNotFilteredWhenRoomSetAndTrackRoomDisabled)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     std::optional<Trigger*> raised_trigger;
-    auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 78, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
-    window.set_triggers({ trigger1.get(), trigger2.get() });
-    window.set_current_room(78);
+    window->set_triggers({ trigger1.get(), trigger2.get() });
+    window->set_current_room(78);
 
-    auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
     ASSERT_NE(list, nullptr);
 
     auto row = list->find<ui::Control>(ui::Listbox::Names::row_name_format + "0");
@@ -110,24 +118,21 @@ TEST(TriggersWindow, TriggersListNotFilteredWhenRoomSetAndTrackRoomDisabled)
 
 TEST(TriggersWindow, TriggersListFilteredWhenRoomSetAndTrackRoomEnabled)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     std::optional<Trigger*> raised_trigger;
-    auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 78, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
-    window.set_triggers({ trigger1.get(), trigger2.get() });
-    window.set_current_room(78);
+    window->set_triggers({ trigger1.get(), trigger2.get() });
+    window->set_current_room(78);
 
-    auto track = window.root_control()->find<ui::Checkbox>(TriggersWindow::Names::track_room_checkbox);
+    auto track = window->root_control()->find<ui::Checkbox>(TriggersWindow::Names::track_room_checkbox);
     ASSERT_NE(track, nullptr);
     track->clicked(Point());
 
-    auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
     ASSERT_NE(list, nullptr);
 
     auto row = list->find<ui::Control>(ui::Listbox::Names::row_name_format + "0");
@@ -143,26 +148,23 @@ TEST(TriggersWindow, TriggersListFilteredWhenRoomSetAndTrackRoomEnabled)
 
 TEST(TriggersWindow, TriggersListFilteredByCommand)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     std::optional<const Trigger*> raised_trigger;
-    auto token = window.on_add_to_route += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = window->on_add_to_route += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
     auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, { { TriggerCommandType::Object, 1 }} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, { { TriggerCommandType::Camera, 1 }} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     std::vector<Trigger*> triggers{ trigger1.get(), trigger2.get() };
-    window.set_triggers(triggers);
+    window->set_triggers(triggers);
 
-    auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
     ASSERT_NE(list, nullptr);
     ASSERT_EQ(list->items().size(), 2);
     ASSERT_EQ(list->items()[0].value(L"#"), L"0");
     ASSERT_EQ(list->items()[1].value(L"#"), L"1");
 
-    auto dropdown = window.root_control()->find<ui::Dropdown>(TriggersWindow::Names::filter_dropdown);
+    auto dropdown = window->root_control()->find<ui::Dropdown>(TriggersWindow::Names::filter_dropdown);
     ASSERT_NE(dropdown, nullptr);
 
     auto dropdown_button = dropdown->find<ui::Button>(ui::Dropdown::Names::dropdown_button);
@@ -185,21 +187,18 @@ TEST(TriggersWindow, TriggersListFilteredByCommand)
 
 TEST(TriggersWindow, AddToRouteEventRaised)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     std::optional<const Trigger*> raised_trigger;
-    auto token = window.on_add_to_route += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = window->on_add_to_route += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
     auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
     std::vector<Trigger*> triggers{ trigger1.get() };
 
-    window.set_triggers(triggers);
-    window.set_selected_trigger(trigger1.get());
+    window->set_triggers(triggers);
+    window->set_selected_trigger(trigger1.get());
 
-    auto button = window.root_control()->find<ui::Button>(TriggersWindow::Names::add_to_route_button);
+    auto button = window->root_control()->find<ui::Button>(TriggersWindow::Names::add_to_route_button);
     ASSERT_NE(button, nullptr);
     button->clicked(Point());
 
@@ -209,19 +208,16 @@ TEST(TriggersWindow, AddToRouteEventRaised)
 
 TEST(TriggersWindow, TriggerVisibilityRaised)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     std::optional<std::tuple<const Trigger*, bool>> raised_trigger;
-    auto token = window.on_trigger_visibility += [&raised_trigger](const auto& trigger, bool state) { raised_trigger = { trigger, state }; };
+    auto token = window->on_trigger_visibility += [&raised_trigger](const auto& trigger, bool state) { raised_trigger = { trigger, state }; };
 
     auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
     std::vector<Trigger*> triggers{ trigger1.get() };
-    window.set_triggers(triggers);
+    window->set_triggers(triggers);
 
-    auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
     ASSERT_NE(list, nullptr);
 
     auto row = list->find<ui::Control>(ui::Listbox::Names::row_name_format + "0");
@@ -238,13 +234,10 @@ TEST(TriggersWindow, TriggerVisibilityRaised)
 
 TEST(TriggersWindow, ItemSelectedRaised)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     std::optional<Item> raised_item;
-    auto token = window.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
+    auto token = window->on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
 
     std::vector<Item> items
     {
@@ -254,11 +247,11 @@ TEST(TriggersWindow, ItemSelectedRaised)
 
     auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, { { TriggerCommandType::Object, 1 }}}, [](auto, auto) { return std::make_unique<MockMesh>(); });
     std::vector<Trigger*> triggers{ trigger1.get() };
-    window.set_items(items);
-    window.set_triggers(triggers);
-    window.set_selected_trigger(trigger1.get());
+    window->set_items(items);
+    window->set_triggers(triggers);
+    window->set_selected_trigger(trigger1.get());
 
-    auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::trigger_commands_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::trigger_commands_listbox);
     ASSERT_NE(list, nullptr);
 
     auto row = list->find<ui::Control>(ui::Listbox::Names::row_name_format + "0");
@@ -271,67 +264,57 @@ TEST(TriggersWindow, ItemSelectedRaised)
     ASSERT_TRUE(raised_item.has_value());
     ASSERT_EQ(raised_item.value().number(), 1);
 
-    auto selected = window.selected_trigger();
+    auto selected = window->selected_trigger();
     ASSERT_NE(selected, nullptr);
     ASSERT_EQ(selected, trigger1.get());
 }
 
 TEST(TriggersWindow, SetTriggersLoadsTriggers)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {  } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 78, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Antipad, 0, { { TriggerCommandType::Camera, 0 } } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
-    window.set_triggers({ trigger1.get(), trigger2.get() });
+    window->set_triggers({ trigger1.get(), trigger2.get() });
 
-    auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
     ASSERT_NE(list, nullptr);
     ASSERT_EQ(list->items().size(), 2);
 }
 
 TEST(TriggersWindow, SetTriggerVisiblityUpdatesTrigger)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"),
-        std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
-    auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
     ASSERT_NE(list, nullptr);
     ASSERT_TRUE(list->items().empty());
 
     auto trigger1 = std::make_unique<Trigger>(100, 55, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
-    window.set_triggers({ trigger1.get() });
+    window->set_triggers({ trigger1.get() });
     ASSERT_EQ(list->items().size(), 1);
     ASSERT_EQ(list->items()[0].value(L"Hide"), L"0");
 
     trigger1->set_visible(false);
-    window.update_triggers({ trigger1.get() });
+    window->update_triggers({ trigger1.get() });
     ASSERT_EQ(list->items()[0].value(L"Hide"), L"1");
 }
 
 TEST(TriggersWindow, SetItemsLoadsItems)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     std::vector<Item> items
     {
         Item(0, 0, 0, L"Test Object", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
     };
-    window.set_items(items);
+    window->set_items(items);
     auto trigger1 = std::make_unique<Trigger>(100, 55, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, { { TriggerCommandType::Object, 0 }} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
-    window.set_triggers({ trigger1.get() });
+    window->set_triggers({ trigger1.get() });
 
-    window.set_selected_trigger(trigger1.get());
+    window->set_selected_trigger(trigger1.get());
 
-    auto commands_list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::trigger_commands_listbox);
+    auto commands_list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::trigger_commands_listbox);
     ASSERT_NE(commands_list, nullptr);
 
     auto command_items = commands_list->items();
@@ -342,19 +325,16 @@ TEST(TriggersWindow, SetItemsLoadsItems)
 
 TEST(TriggersWindow, ClearSelectedTriggerClearsSelection)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     std::optional<Trigger*> raised_trigger;
-    auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {  } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 78, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Antipad, 0, { { TriggerCommandType::Camera, 0 } } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
-    window.set_triggers({ trigger1.get(), trigger2.get() });
+    window->set_triggers({ trigger1.get(), trigger2.get() });
 
-    auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
     ASSERT_NE(list, nullptr);
 
     auto row = list->find<ui::Control>(ui::Listbox::Names::row_name_format + "1");
@@ -368,19 +348,19 @@ TEST(TriggersWindow, ClearSelectedTriggerClearsSelection)
     ASSERT_TRUE(raised_trigger.has_value());
     ASSERT_EQ(raised_trigger.value()->number(), 1);
 
-    auto stats_list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::stats_listbox);
+    auto stats_list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::stats_listbox);
     ASSERT_NE(stats_list, nullptr);
 
     auto stats_items = stats_list->items();
     ASSERT_NE(stats_items.size(), 0);
 
-    auto commands_list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::trigger_commands_listbox);
+    auto commands_list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::trigger_commands_listbox);
     ASSERT_NE(commands_list, nullptr);
 
     auto commands_items = commands_list->items();
     ASSERT_NE(commands_items.size(), 0);
 
-    window.clear_selected_trigger();
+    window->clear_selected_trigger();
     ASSERT_FALSE(list->selected_item().has_value());
 
     stats_items = stats_list->items();
@@ -392,19 +372,16 @@ TEST(TriggersWindow, ClearSelectedTriggerClearsSelection)
 
 TEST(TriggersWindow, SetTriggersClearsSelection)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     std::optional<Trigger*> raised_trigger;
-    auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {  } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 78, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Antipad, 0, { { TriggerCommandType::Camera, 0 } } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
-    window.set_triggers({ trigger1.get(), trigger2.get() });
+    window->set_triggers({ trigger1.get(), trigger2.get() });
 
-    auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
     ASSERT_NE(list, nullptr);
 
     auto row = list->find<ui::Control>(ui::Listbox::Names::row_name_format + "1");
@@ -418,19 +395,19 @@ TEST(TriggersWindow, SetTriggersClearsSelection)
     ASSERT_TRUE(raised_trigger.has_value());
     ASSERT_EQ(raised_trigger.value()->number(), 1);
 
-    auto stats_list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::stats_listbox);
+    auto stats_list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::stats_listbox);
     ASSERT_NE(stats_list, nullptr);
 
     auto stats_items = stats_list->items();
     ASSERT_NE(stats_items.size(), 0);
 
-    auto commands_list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::trigger_commands_listbox);
+    auto commands_list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::trigger_commands_listbox);
     ASSERT_NE(commands_list, nullptr);
 
     auto commands_items = commands_list->items();
     ASSERT_NE(commands_items.size(), 0);
 
-    window.set_triggers({});
+    window->set_triggers({});
     ASSERT_FALSE(list->selected_item().has_value());
 
     stats_items = stats_list->items();
@@ -442,38 +419,32 @@ TEST(TriggersWindow, SetTriggersClearsSelection)
 
 TEST(TriggersWindow, TriggerDetailsLoadedForTrigger)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     std::optional<Trigger*> raised_trigger;
-    auto token = window.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {  } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
-    window.set_triggers({ trigger1.get() });
+    window->set_triggers({ trigger1.get() });
 
-    auto stats_list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::stats_listbox);
+    auto stats_list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::stats_listbox);
     ASSERT_NE(stats_list, nullptr);
     ASSERT_EQ(stats_list->items().size(), 0);
 
-    window.set_selected_trigger(trigger1.get());
+    window->set_selected_trigger(trigger1.get());
     ASSERT_NE(stats_list->items().size(), 0);
 }
 
 TEST(TriggersWindow, SelectionSurvivesFiltering)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 78, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
-    window.set_triggers({ trigger1.get(), trigger2.get() });
-    window.set_current_room(78);
+    window->set_triggers({ trigger1.get(), trigger2.get() });
+    window->set_current_room(78);
 
-    auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
     ASSERT_NE(list, nullptr);
 
     auto row = list->find<ui::Control>(ui::Listbox::Names::row_name_format + "1");
@@ -483,7 +454,7 @@ TEST(TriggersWindow, SelectionSurvivesFiltering)
     ASSERT_NE(cell, nullptr);
     cell->clicked(Point());
 
-    auto track = window.root_control()->find<ui::Checkbox>(TriggersWindow::Names::track_room_checkbox);
+    auto track = window->root_control()->find<ui::Checkbox>(TriggersWindow::Names::track_room_checkbox);
     ASSERT_NE(track, nullptr);
     track->clicked(Point());
 
@@ -494,18 +465,15 @@ TEST(TriggersWindow, SelectionSurvivesFiltering)
 
 TEST(TriggersWindow, FlipmapsFiltersAllFlipTriggers)
 {
-    auto [renderer_ptr_source, renderer] = create_mock<MockRenderer>();
-    auto renderer_ptr = std::move(renderer_ptr_source);
-    TriggersWindow window([&](auto) { return std::make_unique<MockDeviceWindow>(); }, [&](auto) { return std::move(renderer_ptr); }, [&](auto&&, auto&&) { return std::make_unique<MockInput>(); },
-        create_test_window(L"TriggersWindowTests"), std::make_shared<MockClipboard>());
+    auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
 
     auto trigger1 = std::make_unique<Trigger>(0, 55, 100, 200, TriggerInfo{0,0,0,TriggerType::Trigger, 0, { { TriggerCommandType::FlipOff, 0 } } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger2 = std::make_unique<Trigger>(1, 78, 100, 200, TriggerInfo{0,0,0,TriggerType::Trigger, 0, { { TriggerCommandType::FlipOn, 0 } } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger3 = std::make_unique<Trigger>(2, 78, 100, 200, TriggerInfo{ 0,0,0,TriggerType::Trigger, 0, { { TriggerCommandType::FlipMap, 0 } } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     auto trigger4 = std::make_unique<Trigger>(3, 78, 100, 200, TriggerInfo{ 0,0,0,TriggerType::Trigger, 0, { { TriggerCommandType::Object, 0 } } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
-    window.set_triggers({ trigger1.get(), trigger2.get(), trigger3.get(), trigger4.get() });
+    window->set_triggers({ trigger1.get(), trigger2.get(), trigger3.get(), trigger4.get() });
 
-    auto list = window.root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
+    auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
     ASSERT_NE(list, nullptr);
 
     auto get_numbers = [&list]()
@@ -518,7 +486,7 @@ TEST(TriggersWindow, FlipmapsFiltersAllFlipTriggers)
     using ::testing::ElementsAre;
     ASSERT_THAT(get_numbers(), ElementsAre(0, 1, 2, 3));
 
-    auto dropdown = window.root_control()->find<ui::Dropdown>(TriggersWindow::Names::filter_dropdown);
+    auto dropdown = window->root_control()->find<ui::Dropdown>(TriggersWindow::Names::filter_dropdown);
     ASSERT_NE(dropdown, nullptr);
 
     auto dropdown_button = dropdown->find<ui::Button>(ui::Dropdown::Names::dropdown_button);

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -31,11 +31,7 @@ using namespace boost;
 namespace
 {
     /// Simulates a context menu activation - 
-    void activate_context_menu(
-        MockPicking& picking,
-        MockMouse& mouse,
-        PickResult::Type type,
-        uint32_t index)
+    void activate_context_menu(MockPicking& picking, MockMouse& mouse, PickResult::Type type, uint32_t index)
     {
         PickResult pick_result{};
         pick_result.hit = true;

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -33,7 +33,7 @@ namespace
     /// Simulates a context menu activation - 
     void activate_context_menu(
         MockPicking& picking,
-        input::mocks::MockMouse& mouse,
+        MockMouse& mouse,
         PickResult::Type type,
         uint32_t index)
     {
@@ -42,7 +42,7 @@ namespace
         pick_result.type = type;
         pick_result.index = index;
         picking.on_pick({}, pick_result);
-        mouse.mouse_click(input::IMouse::Button::Right);
+        mouse.mouse_click(IMouse::Button::Right);
     }
 
     Event<> shortcut_handler;
@@ -119,7 +119,7 @@ TEST(Viewer, ItemVisibilityRaisedForValidItem)
 
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
-    auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
+    auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto viewer = register_test_module(std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr));
     viewer->open(&level);
 
@@ -173,7 +173,7 @@ TEST(Viewer, SelectTriggerRaised)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
-    auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
+    auto [mouse_ptr, mouse] = create_mock<MockMouse>();
 
     MockLevel level;
     std::vector<Trigger*> triggers_list(101);
@@ -189,7 +189,7 @@ TEST(Viewer, SelectTriggerRaised)
     auto token = viewer->on_trigger_selected += [&selected_trigger](const auto& trigger) { selected_trigger = trigger; };
 
     activate_context_menu(picking, mouse, PickResult::Type::Trigger, 100);
-    mouse.mouse_click(input::IMouse::Button::Left);
+    mouse.mouse_click(IMouse::Button::Left);
 
     ASSERT_TRUE(selected_trigger.has_value());
     ASSERT_EQ(selected_trigger.value(), trigger.get());
@@ -200,7 +200,7 @@ TEST(Viewer, TriggerVisibilityRaised)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
-    auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
+    auto [mouse_ptr, mouse] = create_mock<MockMouse>();
 
     MockLevel level;
     std::vector<Trigger*> triggers_list(101);
@@ -229,14 +229,14 @@ TEST(Viewer, SelectWaypointRaised)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
-    auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
+    auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto viewer = register_test_module(std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr));
 
     std::optional<uint32_t> selected_waypoint;
     auto token = viewer->on_waypoint_selected += [&selected_waypoint](const auto& waypoint) { selected_waypoint = waypoint; };
 
     activate_context_menu(picking, mouse, PickResult::Type::Waypoint, 100);
-    mouse.mouse_click(input::IMouse::Button::Left);
+    mouse.mouse_click(IMouse::Button::Left);
 
     ASSERT_TRUE(selected_waypoint.has_value());
     ASSERT_EQ(selected_waypoint.value(), 100u);
@@ -247,7 +247,7 @@ TEST(Viewer, RemoveWaypointRaised)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
-    auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
+    auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto viewer = register_test_module(std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr));
 
     std::optional<uint32_t> removed_waypoint;
@@ -266,7 +266,7 @@ TEST(Viewer, AddWaypointRaised)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
-    auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
+    auto [mouse_ptr, mouse] = create_mock<MockMouse>();
 
     MockLevel level;
     std::vector<Item> items_list(51);
@@ -298,7 +298,7 @@ TEST(Viewer, RightClickActivatesContextMenu)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
-    auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
+    auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto viewer = register_test_module(std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr));
 
     EXPECT_CALL(ui, set_show_context_menu(false));

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -14,6 +14,7 @@
 #include <trview.graphics/mocks/IDeviceWindow.h>
 #include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.app/Mocks/Graphics/ISectorHighlight.h>
+#include <external/boost/di.hpp>
 
 using testing::NiceMock;
 using testing::Return;
@@ -21,8 +22,11 @@ using namespace trview;
 using namespace trview::mocks;
 using namespace trview::graphics;
 using namespace trview::graphics::mocks;
+using namespace trview::input;
+using namespace trview::input::mocks;
 using namespace trview::tests;
 using namespace DirectX::SimpleMath;
+using namespace boost;
 
 namespace
 {
@@ -40,37 +44,49 @@ namespace
         picking.on_pick({}, pick_result);
         mouse.mouse_click(input::IMouse::Button::Right);
     }
+
+    Event<> shortcut_handler;
+
+    auto register_test_module(std::unique_ptr<IViewerUI> ui, std::unique_ptr<IPicking> picking = std::make_unique<MockPicking>(), std::unique_ptr<IMouse> mouse = std::make_unique<MockMouse>())
+    {
+        auto shortcuts = std::make_shared<MockShortcuts>();
+        EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
+
+        return di::make_injector(
+            di::bind<Window>.to(create_test_window(L"ViewerTests")),
+            di::bind<IDevice>.to<MockDevice>(),
+            di::bind<IViewerUI>.to([&](auto&&) { return std::move(ui); }),
+            di::bind<IPicking>.to([&](auto&&) { return std::move(picking); }),
+            di::bind<IMouse>.to([&](auto&&) { return std::move(mouse); }),
+            di::bind<IShortcuts>.to(shortcuts),
+            di::bind<IRoute>.to<MockRoute>(),
+            di::bind<ISprite::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockSprite>(); }; }),
+            di::bind<ICompass>.to<MockCompass>(),
+            di::bind<IMeasure>.to<MockMeasure>(),
+            di::bind<IRenderTarget::SizeSource>.to([&](auto&&) { return [&](auto&&, auto&&, auto&&) { return std::make_unique<MockRenderTarget>(); }; }),
+            di::bind<IDeviceWindow::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockDeviceWindow>(); }; }),
+            di::bind<ISectorHighlight>.to<MockSectorHighlight>(),
+            di::bind<Viewer>()
+        ).create<std::unique_ptr<Viewer>>();
+    }
 }
 
 /// Tests that the on_select_item event from the UI is observed and forwarded.
 TEST(Viewer, SelectItemRaisedForValidItem)
 {
-    auto window = create_test_window(L"ViewerTests");
-
-    auto device = std::make_shared<MockDevice>();
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto route = std::make_shared<MockRoute>();
-
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [sprite_ptr_source, sprite] = create_mock<MockSprite>();
-    auto sprite_ptr = std::move(sprite_ptr_source);
 
     Item item(123, 0, 0, L"Test", 0, 0, {}, Vector3::Zero);
     MockLevel level;
 
     std::vector<Item> items_list{ item };
-    EXPECT_CALL(level, items)
-        .WillRepeatedly([&]() { return items_list; });
+    EXPECT_CALL(level, items).WillRepeatedly([&]() { return items_list; });
 
-    Viewer viewer(window, device, std::move(ui_ptr), std::make_unique<MockPicking>(), std::make_unique<input::mocks::MockMouse>(), shortcuts, route,
-        [&](auto) { return std::move(sprite_ptr); }, std::make_unique<MockCompass>(), std::make_unique<MockMeasure>(), [](auto, auto, auto) { return std::make_unique<MockRenderTarget>(); },
-        [&](auto) { return std::make_unique<MockDeviceWindow>(); }, std::make_unique<MockSectorHighlight>());
-    viewer.open(&level);
+    auto viewer = register_test_module(std::move(ui_ptr));
+    viewer->open(&level);
 
     std::optional<Item> raised_item;
-    auto token = viewer.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
+    auto token = viewer->on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
 
     ui.on_select_item(0);
 
@@ -81,24 +97,11 @@ TEST(Viewer, SelectItemRaisedForValidItem)
 /// Tests that the on_hide event from the UI is observed but not forwarded when the item is invalid.
 TEST(Viewer, SelectItemNotRaisedForInvalidItem)
 {
-    auto window = create_test_window(L"ViewerTests");
-
-    auto device = std::make_shared<MockDevice>();
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto route = std::make_shared<MockRoute>();
-
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [sprite_ptr_source, sprite] = create_mock<MockSprite>();
-    auto sprite_ptr = std::move(sprite_ptr_source);
-
-    Viewer viewer(window, device, std::move(ui_ptr), std::make_unique<MockPicking>(), std::make_unique<input::mocks::MockMouse>(), shortcuts, route,
-        [&](auto) { return std::move(sprite_ptr); }, std::make_unique<MockCompass>(), std::make_unique<MockMeasure>(), [](auto, auto, auto) { return std::make_unique<MockRenderTarget>(); },
-        [&](auto) { return std::make_unique<MockDeviceWindow>(); }, std::make_unique<MockSectorHighlight>());
+    auto viewer = register_test_module(std::move(ui_ptr));
 
     std::optional<Item> raised_item;
-    auto token = viewer.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
+    auto token = viewer->on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
 
     ui.on_select_item(0);
 
@@ -108,34 +111,20 @@ TEST(Viewer, SelectItemNotRaisedForInvalidItem)
 /// Tests that the on_hide event from the UI is observed and forwarded when the item is valid.
 TEST(Viewer, ItemVisibilityRaisedForValidItem)
 {
-    auto window = create_test_window(L"ViewerTests");
-
-    auto device = std::make_shared<MockDevice>();
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto route = std::make_shared<MockRoute>();
-
     Item item(123, 0, 0, L"Test", 0, 0, {}, Vector3::Zero);
     MockLevel level;
 
     std::vector<Item> items_list{ item };
-    EXPECT_CALL(level, items)
-        .WillRepeatedly([&]() { return items_list; });
+    EXPECT_CALL(level, items).WillRepeatedly([&]() { return items_list; });
 
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [sprite_ptr_source, sprite] = create_mock<MockSprite>();
-    auto sprite_ptr = std::move(sprite_ptr_source);
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
-
-    Viewer viewer(window, device, std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr), shortcuts, route,
-        [&](auto) { return std::move(sprite_ptr); }, std::make_unique<MockCompass>(), std::make_unique<MockMeasure>(), [](auto, auto, auto) { return std::make_unique<MockRenderTarget>(); },
-        [&](auto) { return std::make_unique<MockDeviceWindow>(); }, std::make_unique<MockSectorHighlight>());
-    viewer.open(&level);
+    auto viewer = register_test_module(std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr));
+    viewer->open(&level);
 
     std::optional<std::tuple<Item, bool>> raised_item;
-    auto token = viewer.on_item_visibility += [&raised_item](const auto& item, auto visible) { raised_item = { item, visible }; };
+    auto token = viewer->on_item_visibility += [&raised_item](const auto& item, auto visible) { raised_item = { item, visible }; };
 
     activate_context_menu(picking, mouse, PickResult::Type::Entity, 0);
 
@@ -149,26 +138,11 @@ TEST(Viewer, ItemVisibilityRaisedForValidItem)
 /// Tests that the on_settings event from the UI is observed and forwarded.
 TEST(Viewer, SettingsRaised)
 {
-    auto window = create_test_window(L"ViewerTests");
-
-    auto device = std::make_shared<MockDevice>();
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto route = std::make_shared<MockRoute>();
-
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [sprite_ptr_source, sprite] = create_mock<MockSprite>();
-    auto sprite_ptr = std::move(sprite_ptr_source);
-    auto [picking_ptr, picking] = create_mock<MockPicking>();
-    auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
-
-    Viewer viewer(window, device, std::move(ui_ptr), std::make_unique<MockPicking>(), std::make_unique<input::mocks::MockMouse>(), shortcuts, route,
-        [&](auto) { return std::move(sprite_ptr); }, std::make_unique<MockCompass>(), std::make_unique<MockMeasure>(), [](auto, auto, auto) { return std::make_unique<MockRenderTarget>(); },
-        [&](auto) { return std::make_unique<MockDeviceWindow>(); }, std::make_unique<MockSectorHighlight>());
+    auto viewer = register_test_module(std::move(ui_ptr));
 
     std::optional<UserSettings> raised_settings;
-    auto token = viewer.on_settings += [&raised_settings](const auto& settings) { raised_settings = settings; };
+    auto token = viewer->on_settings += [&raised_settings](const auto& settings) { raised_settings = settings; };
 
     UserSettings settings;
     settings.add_recent_file("test file");
@@ -182,26 +156,11 @@ TEST(Viewer, SettingsRaised)
 /// Tests that the on_select_room event from the UI is observed and forwarded.
 TEST(Viewer, SelectRoomRaised)
 {
-    auto window = create_test_window(L"ViewerTests");
-
-    auto device = std::make_shared<MockDevice>();
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto route = std::make_shared<MockRoute>();
-
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [sprite_ptr_source, sprite] = create_mock<MockSprite>();
-    auto sprite_ptr = std::move(sprite_ptr_source);
-    auto [picking_ptr, picking] = create_mock<MockPicking>();
-    auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
-
-    Viewer viewer(window, device, std::move(ui_ptr), std::make_unique<MockPicking>(), std::make_unique<input::mocks::MockMouse>(), shortcuts, route,
-        [&](auto) { return std::move(sprite_ptr); }, std::make_unique<MockCompass>(), std::make_unique<MockMeasure>(), [](auto, auto, auto) { return std::make_unique<MockRenderTarget>(); },
-        [&](auto) { return std::make_unique<MockDeviceWindow>(); }, std::make_unique<MockSectorHighlight>());
+    auto viewer = register_test_module(std::move(ui_ptr));
 
     std::optional<uint32_t> raised_room;
-    auto token = viewer.on_room_selected += [&raised_room](const auto& room) { raised_room = room; };
+    auto token = viewer->on_room_selected += [&raised_room](const auto& room) { raised_room = room; };
 
     ui.on_select_room(0);
 
@@ -212,17 +171,7 @@ TEST(Viewer, SelectRoomRaised)
 /// Tests that the trigger selected event is raised when the user clicks on a trigger.
 TEST(Viewer, SelectTriggerRaised)
 {
-    auto window = create_test_window(L"ViewerTests");
-
-    auto device = std::make_shared<MockDevice>();
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto route = std::make_shared<MockRoute>();
-
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [sprite_ptr_source, sprite] = create_mock<MockSprite>();
-    auto sprite_ptr = std::move(sprite_ptr_source);
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
 
@@ -231,16 +180,13 @@ TEST(Viewer, SelectTriggerRaised)
     auto trigger = std::make_unique<Trigger>(100, 10, 0, 0, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
     triggers_list[100] = trigger.get();
 
-    EXPECT_CALL(level, triggers)
-        .WillRepeatedly([&]() { return triggers_list; });
+    EXPECT_CALL(level, triggers).WillRepeatedly([&]() { return triggers_list; });
 
-    Viewer viewer(window, device, std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr), shortcuts, route,
-        [&](auto) { return std::move(sprite_ptr); }, std::make_unique<MockCompass>(), std::make_unique<MockMeasure>(), [](auto, auto, auto) { return std::make_unique<MockRenderTarget>(); },
-        [&](auto) { return std::make_unique<MockDeviceWindow>(); }, std::make_unique<MockSectorHighlight>());
-    viewer.open(&level);
+    auto viewer = register_test_module(std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr));
+    viewer->open(&level);
 
     std::optional<Trigger*> selected_trigger;
-    auto token = viewer.on_trigger_selected += [&selected_trigger](const auto& trigger) { selected_trigger = trigger; };
+    auto token = viewer->on_trigger_selected += [&selected_trigger](const auto& trigger) { selected_trigger = trigger; };
 
     activate_context_menu(picking, mouse, PickResult::Type::Trigger, 100);
     mouse.mouse_click(input::IMouse::Button::Left);
@@ -252,17 +198,7 @@ TEST(Viewer, SelectTriggerRaised)
 /// Tests that the on_hide event from the UI is observed and forwarded for triggers.
 TEST(Viewer, TriggerVisibilityRaised)
 {
-    auto window = create_test_window(L"ViewerTests");
-
-    auto device = std::make_shared<MockDevice>();
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto route = std::make_shared<MockRoute>();
-
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [sprite_ptr_source, sprite] = create_mock<MockSprite>();
-    auto sprite_ptr = std::move(sprite_ptr_source);
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
 
@@ -271,16 +207,13 @@ TEST(Viewer, TriggerVisibilityRaised)
     auto trigger = std::make_unique<Trigger>(100, 10, 0, 0, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
     triggers_list[100] = trigger.get();
 
-    EXPECT_CALL(level, triggers)
-        .WillRepeatedly([&]() { return triggers_list; });
+    EXPECT_CALL(level, triggers).WillRepeatedly([&]() { return triggers_list; });
 
-    Viewer viewer(window, device, std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr), shortcuts, route,
-        [&](auto) { return std::move(sprite_ptr); }, std::make_unique<MockCompass>(), std::make_unique<MockMeasure>(), [](auto, auto, auto) { return std::make_unique<MockRenderTarget>(); },
-        [&](auto) { return std::make_unique<MockDeviceWindow>(); }, std::make_unique<MockSectorHighlight>());
-    viewer.open(&level);
+    auto viewer = register_test_module(std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr));
+    viewer->open(&level);
 
     std::optional<std::tuple<Trigger*, bool>> raised_trigger;
-    auto token = viewer.on_trigger_visibility += [&raised_trigger](const auto& trigger, auto visible) { raised_trigger = { trigger, visible }; };
+    auto token = viewer->on_trigger_visibility += [&raised_trigger](const auto& trigger, auto visible) { raised_trigger = { trigger, visible }; };
 
     activate_context_menu(picking, mouse, PickResult::Type::Trigger, 100);
 
@@ -294,26 +227,13 @@ TEST(Viewer, TriggerVisibilityRaised)
 /// Tests that the waypoint selected event is raised when the user clicks on a waypoint.
 TEST(Viewer, SelectWaypointRaised)
 {
-    auto window = create_test_window(L"ViewerTests");
-
-    auto device = std::make_shared<MockDevice>();
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto route = std::make_shared<MockRoute>();
-
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [sprite_ptr_source, sprite] = create_mock<MockSprite>();
-    auto sprite_ptr = std::move(sprite_ptr_source);
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
-
-    Viewer viewer(window, device, std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr), shortcuts, route,
-        [&](auto) { return std::move(sprite_ptr); }, std::make_unique<MockCompass>(), std::make_unique<MockMeasure>(), [](auto, auto, auto) { return std::make_unique<MockRenderTarget>(); },
-        [&](auto) { return std::make_unique<MockDeviceWindow>(); }, std::make_unique<MockSectorHighlight>());
+    auto viewer = register_test_module(std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr));
 
     std::optional<uint32_t> selected_waypoint;
-    auto token = viewer.on_waypoint_selected += [&selected_waypoint](const auto& waypoint) { selected_waypoint = waypoint; };
+    auto token = viewer->on_waypoint_selected += [&selected_waypoint](const auto& waypoint) { selected_waypoint = waypoint; };
 
     activate_context_menu(picking, mouse, PickResult::Type::Waypoint, 100);
     mouse.mouse_click(input::IMouse::Button::Left);
@@ -325,26 +245,13 @@ TEST(Viewer, SelectWaypointRaised)
 /// Tests that the on_remove_waypoint event from the UI is observed and forwarded.
 TEST(Viewer, RemoveWaypointRaised)
 {
-    auto window = create_test_window(L"ViewerTests");
-
-    auto device = std::make_shared<MockDevice>();
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto route = std::make_shared<MockRoute>();
-
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [sprite_ptr_source, sprite] = create_mock<MockSprite>();
-    auto sprite_ptr = std::move(sprite_ptr_source);
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
-
-    Viewer viewer(window, device, std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr), shortcuts, route,
-        [&](auto) { return std::move(sprite_ptr); }, std::make_unique<MockCompass>(), std::make_unique<MockMeasure>(), [](auto, auto, auto) { return std::make_unique<MockRenderTarget>(); },
-        [&](auto) { return std::make_unique<MockDeviceWindow>(); }, std::make_unique<MockSectorHighlight>());
+    auto viewer = register_test_module(std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr));
 
     std::optional<uint32_t> removed_waypoint;
-    auto token = viewer.on_waypoint_removed += [&removed_waypoint](const auto& waypoint) { removed_waypoint = waypoint; };
+    auto token = viewer->on_waypoint_removed += [&removed_waypoint](const auto& waypoint) { removed_waypoint = waypoint; };
 
     activate_context_menu(picking, mouse, PickResult::Type::Waypoint, 100);
 
@@ -357,17 +264,7 @@ TEST(Viewer, RemoveWaypointRaised)
 /// Tests that the on_add_waypoint event from the UI is observed and forwarded.
 TEST(Viewer, AddWaypointRaised)
 {
-    auto window = create_test_window(L"ViewerTests");
-
-    auto device = std::make_shared<MockDevice>();
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto route = std::make_shared<MockRoute>();
-
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [sprite_ptr_source, sprite] = create_mock<MockSprite>();
-    auto sprite_ptr = std::move(sprite_ptr_source);
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
 
@@ -375,17 +272,13 @@ TEST(Viewer, AddWaypointRaised)
     std::vector<Item> items_list(51);
     Item item(50, 10, 0, L"Test", 0, 0, {}, Vector3::Zero);
     items_list[50] = item;
+    EXPECT_CALL(level, items).WillRepeatedly([&]() { return items_list; });
 
-    EXPECT_CALL(level, items)
-        .WillRepeatedly([&]() { return items_list; });
-
-    Viewer viewer(window, device, std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr), shortcuts, route,
-        [&](auto) { return std::move(sprite_ptr); }, std::make_unique<MockCompass>(), std::make_unique<MockMeasure>(), [](auto, auto, auto) { return std::make_unique<MockRenderTarget>(); },
-        [&](auto) { return std::make_unique<MockDeviceWindow>(); }, std::make_unique<MockSectorHighlight>());
-    viewer.open(&level);
+    auto viewer = register_test_module(std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr));
+    viewer->open(&level);
 
     std::optional<std::tuple<Vector3, uint32_t, Waypoint::Type, uint32_t>> added_waypoint;
-    auto token = viewer.on_waypoint_added += [&added_waypoint](const auto& position, uint32_t room, Waypoint::Type type, uint32_t index)
+    auto token = viewer->on_waypoint_added += [&added_waypoint](const auto& position, uint32_t room, Waypoint::Type type, uint32_t index)
     {
         added_waypoint = { position, room, type, index };
     };
@@ -403,23 +296,10 @@ TEST(Viewer, AddWaypointRaised)
 /// Tests that right clicking activates the context menu.
 TEST(Viewer, RightClickActivatesContextMenu)
 {
-    auto window = create_test_window(L"ViewerTests");
-
-    auto device = std::make_shared<MockDevice>();
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto route = std::make_shared<MockRoute>();
-
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [sprite_ptr_source, sprite] = create_mock<MockSprite>();
-    auto sprite_ptr = std::move(sprite_ptr_source);
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<input::mocks::MockMouse>();
-
-    Viewer viewer(window, device, std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr), shortcuts, route,
-        [&](auto) { return std::move(sprite_ptr); }, std::make_unique<MockCompass>(), std::make_unique<MockMeasure>(), [](auto, auto, auto) { return std::make_unique<MockRenderTarget>(); },
-        [&](auto) { return std::make_unique<MockDeviceWindow>(); }, std::make_unique<MockSectorHighlight>());
+    auto viewer = register_test_module(std::move(ui_ptr), std::move(picking_ptr), std::move(mouse_ptr));
 
     EXPECT_CALL(ui, set_show_context_menu(false));
     EXPECT_CALL(ui, set_show_context_menu(true)).Times(1);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -562,14 +562,6 @@ namespace trview
             di::bind<Window>.to(create_window(instance, command_show)),
             di::bind<IClipboard>.to<Clipboard>(),
             di::bind<IShortcuts>.to<Shortcuts>(),
-            di::bind<IShortcuts::Source>.to(
-                [](const auto&)-> IShortcuts::Source
-                {
-                    return [&](auto&& window)
-                    {
-                        return std::make_shared<Shortcuts>(window);
-                    };
-                }),
             di::bind<IApplication>.to<Application>(),
             di::bind<Application::CommandLine>.to(command_line)
         );

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -26,6 +26,7 @@
 #include <trview.app/Tools/di.h>
 #include <trview.app/UI/di.h>
 #include <trview.app/Windows/di.h>
+#include <trview.common/windows/Clipboard.h>
 
 using namespace DirectX::SimpleMath;
 
@@ -557,6 +558,7 @@ namespace trview
             register_app_ui_module(),
             register_app_windows_module(),
             di::bind<Window>.to(create_window(instance, command_show)),
+            di::bind<IClipboard>.to<Clipboard>(),
             di::bind<IShortcuts>.to<Shortcuts>(),
             di::bind<IApplication>.to<Application>(),
             di::bind<Application::CommandLine>.to(command_line)

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -15,6 +15,7 @@
 
 #include <trlevel/di.h>
 #include <trview.graphics/di.h>
+#include <trview.ui/di.h>
 #include <trview.ui.render/di.h>
 #include <trview.input/di.h>
 #include <trview.app/Elements/di.h>
@@ -547,6 +548,7 @@ namespace trview
             graphics::register_module(),
             input::register_module(),
             trlevel::register_module(),
+            ui::register_module(),
             ui::render::register_module(),
             register_app_elements_module(),
             register_app_geometry_module(),
@@ -560,6 +562,14 @@ namespace trview
             di::bind<Window>.to(create_window(instance, command_show)),
             di::bind<IClipboard>.to<Clipboard>(),
             di::bind<IShortcuts>.to<Shortcuts>(),
+            di::bind<IShortcuts::Source>.to(
+                [](const auto&)-> IShortcuts::Source
+                {
+                    return [&](auto&& window)
+                    {
+                        return std::make_shared<Shortcuts>(window);
+                    };
+                }),
             di::bind<IApplication>.to<Application>(),
             di::bind<Application::CommandLine>.to(command_line)
         );

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -72,7 +72,7 @@ namespace trview
     {
         auto line = std::make_unique<StackPanel>(Size(100, 20), Colour::Transparent, Size(), StackPanel::Direction::Horizontal);
         auto line_area = std::make_unique<StackPanel>(Size(10, 20), Colour::Transparent);
-        line_area->add_child(std::make_unique<Window>(Size(10, 1), Colour::Transparent));
+        line_area->add_child(std::make_unique<ui::Window>(Size(10, 1), Colour::Transparent));
         line_area->add_child(std::make_unique<Label>(Size(10, 20), Colour::Transparent, name + L": ", 8));
         line->add_child(std::move(line_area));
         auto entry = line->add_child(std::make_unique<TextArea>(Size(90, 20), Colour::Transparent, Colour::White));

--- a/trview.app/UI/GoTo.cpp
+++ b/trview.app/UI/GoTo.cpp
@@ -18,7 +18,7 @@ namespace trview
 
         auto parent_size = parent.size();
 
-        auto window = std::make_unique<Window>(
+        auto window = std::make_unique<ui::Window>(
             Point(parent_size.width / 2.0f - WindowWidth / 2.0f, parent_size.height / 2.0f - WindowHeight / 2.0f),
             Size(WindowWidth, WindowHeight),
             Colour(0.5f, 0.0f, 0.0f, 0.0f));

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -11,10 +11,12 @@ using namespace trview::ui;
 
 namespace trview
 {
-    ViewerUI::ViewerUI(const Window& window, const std::shared_ptr<ITextureStorage>& texture_storage, const std::shared_ptr<IShortcuts>& shortcuts,
+    ViewerUI::ViewerUI(const Window& window, const std::shared_ptr<ITextureStorage>& texture_storage,
+        const std::shared_ptr<IShortcuts>& shortcuts,
+        const ui::IInput::Source& input_source,
         const ui::render::IRenderer::Source& ui_renderer_source,
         const ui::render::IMapRenderer::Source& map_renderer_source)
-        : _mouse(window, std::make_unique<input::WindowTester>(window)), _window(window), _shortcuts(shortcuts)
+        : _mouse(window, std::make_unique<input::WindowTester>(window)), _window(window), _input_source(input_source)
     {
         _control = std::make_unique<ui::Window>(window.size(), Colour::Transparent);
 
@@ -500,6 +502,6 @@ namespace trview
 
     void ViewerUI::initialise_input()
     {
-        _ui_input = std::make_unique<Input>(_window, *_control, *_shortcuts);
+        _ui_input = _input_source(_window, *_control);
     }
 }

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -19,14 +19,13 @@
 
 namespace trview
 {
-    struct IShortcuts;
-
     class ViewerUI final : public IViewerUI
     {
     public:
         explicit ViewerUI(const Window& window,
             const std::shared_ptr<ITextureStorage>& texture_storage,
             const std::shared_ptr<IShortcuts>& shortcuts,
+            const ui::IInput::Source& input_source,
             const ui::render::IRenderer::Source& ui_renderer_source,
             const ui::render::IMapRenderer::Source& map_renderer_source);
 
@@ -209,10 +208,10 @@ namespace trview
         input::Mouse _mouse;
         Window _window;
         UserSettings _settings;
-        std::shared_ptr<IShortcuts> _shortcuts;
+        ui::IInput::Source _input_source;
         std::unique_ptr<ui::Control> _control;
         std::unique_ptr<ui::render::IRenderer> _ui_renderer;
-        std::unique_ptr<ui::Input> _ui_input;
+        std::unique_ptr<ui::IInput> _ui_input;
         std::unique_ptr<ContextMenu> _context_menu;
         std::unique_ptr<GoTo> _go_to;
         std::unique_ptr<RoomNavigator> _room_navigator;

--- a/trview.app/Windows/CollapsiblePanel.cpp
+++ b/trview.app/Windows/CollapsiblePanel.cpp
@@ -73,9 +73,9 @@ namespace trview
     }
 
     CollapsiblePanel::CollapsiblePanel(const graphics::IDeviceWindow::Source& device_window_source, std::unique_ptr<ui::render::IRenderer> ui_renderer,
-        const Window& parent, const std::wstring& window_class, const std::wstring& title, const Size& size)
+        const Window& parent, const std::wstring& window_class, const std::wstring& title, const ui::IInput::Source& input_source, const Size& size)
         : MessageHandler(create_window(parent, window_class, title, size)), _window_resizer(window()), _device_window(device_window_source(window())),
-        _ui_renderer(std::move(ui_renderer)), _parent(parent), _initial_size(size), _shortcuts(window())
+        _ui_renderer(std::move(ui_renderer)), _parent(parent), _initial_size(size)
     {
         _token_store += _window_resizer.on_resize += [=]()
         {
@@ -87,7 +87,7 @@ namespace trview
         _ui = std::make_unique<ui::Window>(window().size(), Colour(1.0f, 0.5f, 0.5f, 0.5f));
         register_change_detection(_ui.get());
 
-        _input = std::make_unique<ui::Input>(window(), *_ui, _shortcuts);
+        _input = input_source(window(), *_ui);
     }
 
     void CollapsiblePanel::register_change_detection(Control* control)

--- a/trview.app/Windows/CollapsiblePanel.h
+++ b/trview.app/Windows/CollapsiblePanel.h
@@ -8,7 +8,7 @@
 #include <trview.common/TokenStore.h>
 #include <trview.ui.render/IRenderer.h>
 #include <trview.graphics/IDeviceWindow.h>
-#include <trview.ui/Input.h>
+#include <trview.ui/IInput.h>
 #include <trview.ui/Window.h>
 #include <trview.app/Windows/WindowResizer.h>
 #include <trview.common/Windows/Shortcuts.h>
@@ -34,7 +34,7 @@ namespace trview
         /// @param title Window title
         /// @param size Window size
         CollapsiblePanel(const graphics::IDeviceWindow::Source& device_window_source, std::unique_ptr<ui::render::IRenderer> ui_renderer, const Window& parent,
-            const std::wstring& window_class, const std::wstring& title, const Size& size);
+            const std::wstring& window_class, const std::wstring& title, const ui::IInput::Source& input_source, const Size& size);
 
         virtual ~CollapsiblePanel() = default;
 
@@ -76,9 +76,8 @@ namespace trview
         ui::Control* _left_panel;
         ui::Control* _right_panel;
         std::unique_ptr<ui::Window> _ui;
-        std::unique_ptr<ui::Input> _input;
+        std::unique_ptr<ui::IInput> _input;
         std::unique_ptr<graphics::IDeviceWindow> _device_window;
-        Shortcuts _shortcuts;
     private:
         void toggle_expand();
         std::unique_ptr<ui::Control> create_divider();

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -40,9 +40,9 @@ namespace trview
     const std::string ItemsWindow::Names::track_room_checkbox{ "TrackRoom" };
     const std::string ItemsWindow::Names::triggers_listbox{ "Triggers" };
 
-    ItemsWindow::ItemsWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const Window& parent,
+    ItemsWindow::ItemsWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const ui::IInput::Source& input_source, const Window& parent,
         const std::shared_ptr<IClipboard>& clipboard)
-        : CollapsiblePanel(device_window_source, renderer_source(Size(450, Height)), parent, L"trview.items", L"Items", Size(450, Height)), _clipboard(clipboard)
+        : CollapsiblePanel(device_window_source, renderer_source(Size(450, Height)), parent, L"trview.items", L"Items", input_source, Size(450, Height)), _clipboard(clipboard)
     {
         CollapsiblePanel::on_window_closed += IItemsWindow::on_window_closed;
         set_panels(create_left_panel(), create_right_panel());

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -40,8 +40,9 @@ namespace trview
     const std::string ItemsWindow::Names::track_room_checkbox{ "TrackRoom" };
     const std::string ItemsWindow::Names::triggers_listbox{ "Triggers" };
 
-    ItemsWindow::ItemsWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const Window& parent)
-        : CollapsiblePanel(device_window_source, renderer_source(Size(450, Height)), parent, L"trview.items", L"Items", Size(450, Height))
+    ItemsWindow::ItemsWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const Window& parent,
+        const std::shared_ptr<IClipboard>& clipboard)
+        : CollapsiblePanel(device_window_source, renderer_source(Size(450, Height)), parent, L"trview.items", L"Items", Size(450, Height)), _clipboard(clipboard)
     {
         CollapsiblePanel::on_window_closed += IItemsWindow::on_window_closed;
         set_panels(create_left_panel(), create_right_panel());
@@ -200,7 +201,7 @@ namespace trview
 
         _token_store += _stats_list->on_item_selected += [this](const ui::Listbox::Item& item)
         {
-            write_clipboard(window(), item.value(L"Value"));
+            _clipboard->write(window(), item.value(L"Value"));
         };
 
         auto add_to_route = details_panel->add_child(std::make_unique<Button>(Size(180, 20), L"Add to Route"));

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -7,6 +7,7 @@
 #include <trview.app/Elements/Item.h>
 #include "CollapsiblePanel.h"
 #include "IItemsWindow.h"
+#include <trview.common/Windows/IClipboard.h>
 
 namespace trview
 {
@@ -33,7 +34,8 @@ namespace trview
         /// @param device The graphics device
         /// @param renderer_source The function to call to get a renderer.
         /// @param parent The parent window.
-        explicit ItemsWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const Window& parent);
+        explicit ItemsWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const Window& parent,
+            const std::shared_ptr<IClipboard>& clipboard);
 
         /// Destructor for items window
         virtual ~ItemsWindow() = default;
@@ -91,5 +93,6 @@ namespace trview
         bool _filter_applied{ false };
         bool _sync_item{ true };
         std::optional<Item> _selected_item;
+        std::shared_ptr<IClipboard> _clipboard;
     };
 }

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -34,7 +34,10 @@ namespace trview
         /// @param device The graphics device
         /// @param renderer_source The function to call to get a renderer.
         /// @param parent The parent window.
-        explicit ItemsWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const Window& parent,
+        explicit ItemsWindow(const graphics::IDeviceWindow::Source& device_window_source,
+            const ui::render::IRenderer::Source& renderer_source,
+            const ui::IInput::Source& input_source,
+            const Window& parent,
             const std::shared_ptr<IClipboard>& clipboard);
 
         /// Destructor for items window

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -6,6 +6,7 @@
 #include <trview.app/Elements/Item.h>
 #include <trview.app/Elements/Trigger.h>
 #include <trview.common/Strings.h>
+#include <trview.input/IMouse.h>
 
 namespace trview
 {
@@ -53,8 +54,12 @@ namespace trview
     const std::string RoomsWindow::Names::rooms_listbox{ "Rooms" };
     const std::string RoomsWindow::Names::triggers_listbox{ "Triggers" };
 
-    RoomsWindow::RoomsWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const ui::render::IMapRenderer::Source& map_renderer_source, const Window& parent)
-        : CollapsiblePanel(device_window_source, renderer_source(Size(630, 680)), parent, L"trview.rooms", L"Rooms", Size(630, 680)), _map_renderer(map_renderer_source(Size(341, 341)))
+    RoomsWindow::RoomsWindow(const graphics::IDeviceWindow::Source& device_window_source,
+        const ui::render::IRenderer::Source& renderer_source,
+        const ui::render::IMapRenderer::Source& map_renderer_source,
+        const ui::IInput::Source& input_source,
+        const Window& parent)
+        : CollapsiblePanel(device_window_source, renderer_source(Size(630, 680)), parent, L"trview.rooms", L"Rooms", input_source, Size(630, 680)), _map_renderer(map_renderer_source(Size(341, 341)))
     {
         CollapsiblePanel::on_window_closed += IRoomsWindow::on_window_closed;
 
@@ -64,7 +69,7 @@ namespace trview
         using namespace input;
         using namespace ui;
 
-        _token_store += _input->mouse().mouse_click += [&](Mouse::Button button)
+        _token_store += _input->mouse().mouse_click += [&](IMouse::Button button)
         {
             auto sector = _map_renderer->sector_at_cursor();
             if (!sector)
@@ -72,7 +77,7 @@ namespace trview
                 return;
             }
 
-            if (button == Mouse::Button::Left)
+            if (button == IMouse::Button::Left)
             {
                 if (sector->flags & SectorFlag::Portal)
                 {
@@ -99,7 +104,7 @@ namespace trview
                     }
                 }
             }
-            else if (button == Mouse::Button::Right)
+            else if (button == IMouse::Button::Right)
             {
                 if (sector->room_above() != 0xff)
                 {

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -28,7 +28,11 @@ namespace trview
         /// @param device The graphics device
         /// @param renderer_source The function to call to get a renderer.
         /// @param parent The parent window.
-        explicit RoomsWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const ui::render::IMapRenderer::Source& map_renderer_source, const Window& parent);
+        explicit RoomsWindow(const graphics::IDeviceWindow::Source& device_window_source,
+            const ui::render::IRenderer::Source& renderer_source,
+            const ui::render::IMapRenderer::Source& map_renderer_source,
+            const ui::IInput::Source& input_source,
+            const Window& parent);
 
         /// Destructor for rooms window
         virtual ~RoomsWindow() = default;

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -40,8 +40,8 @@ namespace trview
     using namespace graphics;
 
     RouteWindow::RouteWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
-        const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard)
-        : CollapsiblePanel(device_window_source, renderer_source(Size(470, 400)), parent, L"trview.route", L"Route", Size(470, 400)), _clipboard(clipboard)
+        const ui::IInput::Source& input_source, const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard)
+        : CollapsiblePanel(device_window_source, renderer_source(Size(470, 400)), parent, L"trview.route", L"Route", input_source, Size(470, 400)), _clipboard(clipboard)
     {
         CollapsiblePanel::on_window_closed += IRouteWindow::on_window_closed;
         set_panels(create_left_panel(), create_right_panel());

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -39,8 +39,9 @@ namespace trview
 
     using namespace graphics;
 
-    RouteWindow::RouteWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const trview::Window& parent)
-        : CollapsiblePanel(device_window_source, renderer_source(Size(470, 400)), parent, L"trview.route", L"Route", Size(470, 400))
+    RouteWindow::RouteWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
+        const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard)
+        : CollapsiblePanel(device_window_source, renderer_source(Size(470, 400)), parent, L"trview.route", L"Route", Size(470, 400)), _clipboard(clipboard)
     {
         CollapsiblePanel::on_window_closed += IRouteWindow::on_window_closed;
         set_panels(create_left_panel(), create_right_panel());
@@ -189,7 +190,7 @@ namespace trview
             if (item.value(L"Name") == L"Room Position" || 
                 item.value(L"Name") == L"Position")
             {
-                write_clipboard(window(), item.value(L"Value"));
+                _clipboard->write(window(), item.value(L"Value"));
                 return;
             }
 

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -3,6 +3,7 @@
 #include <trview.ui/GroupBox.h>
 #include <trview.ui/Button.h>
 #include <trview.common/Strings.h>
+#include <trview.common/Windows/Clipboard.h>
 
 namespace trview
 {
@@ -175,6 +176,7 @@ namespace trview
 
         _stats = details_panel->add_child(std::make_unique<Listbox>(Size(panel_width - 20, 80), Colours::ItemDetails));
         _stats->set_name(Names::waypoint_stats);
+        _stats->set_show_highlight(false);
         _stats->set_show_headers(false);
         _stats->set_show_scrollbar(true);
         _stats->set_columns(
@@ -182,8 +184,15 @@ namespace trview
                 { Listbox::Column::Type::String, L"Name", 100 },
                 { Listbox::Column::Type::String, L"Value", 140 }
             });
-        _token_store += _stats->on_item_selected += [&](const auto&)
+        _token_store += _stats->on_item_selected += [&](const auto& item)
         {
+            if (item.value(L"Name") == L"Room Position" || 
+                item.value(L"Name") == L"Position")
+            {
+                write_clipboard(window(), item.value(L"Value"));
+                return;
+            }
+
             const auto index = _route->waypoint(_selected_index).index();
             switch (_selected_type)
             {

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -29,7 +29,7 @@ namespace trview
         /// @param renderer_source The function to call to get a renderer.
         /// @param parent The parent window.
         explicit RouteWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
-            const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard);
+            const ui::IInput::Source& input_source, const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard);
 
         /// Destructor for triggers window
         virtual ~RouteWindow() = default;

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -9,6 +9,7 @@
 #include <trview.app/Routing/Waypoint.h>
 #include <trview.app/Elements/Item.h>
 #include <trview.app/Elements/Room.h>
+#include <trview.common/Windows/IClipboard.h>
 #include "IRouteWindow.h"
 
 namespace trview
@@ -27,7 +28,8 @@ namespace trview
         /// @param device The graphics device
         /// @param renderer_source The function to call to get a renderer.
         /// @param parent The parent window.
-        explicit RouteWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const trview::Window& parent);
+        explicit RouteWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
+            const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard);
 
         /// Destructor for triggers window
         virtual ~RouteWindow() = default;
@@ -72,5 +74,6 @@ namespace trview
         std::vector<Trigger*> _all_triggers;
         Waypoint::Type _selected_type{ Waypoint::Type::Position };
         uint32_t       _selected_index{ 0u };
+        std::shared_ptr<IClipboard> _clipboard;
     };
 }

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -47,9 +47,9 @@ namespace trview
 
     using namespace graphics;
 
-    TriggersWindow::TriggersWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const Window& parent,
-        const std::shared_ptr<IClipboard>& clipboard)
-        : CollapsiblePanel(device_window_source, renderer_source(Size(520, 400)), parent, L"trview.triggers", L"Triggers", Size(520, 400)), _clipboard(clipboard)
+    TriggersWindow::TriggersWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
+        const ui::IInput::Source& input_source, const Window& parent, const std::shared_ptr<IClipboard>& clipboard)
+        : CollapsiblePanel(device_window_source, renderer_source(Size(520, 400)), parent, L"trview.triggers", L"Triggers", input_source, Size(520, 400)), _clipboard(clipboard)
     {
         CollapsiblePanel::on_window_closed += ITriggersWindow::on_window_closed;
         set_panels(create_left_panel(), create_right_panel());

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -47,8 +47,9 @@ namespace trview
 
     using namespace graphics;
 
-    TriggersWindow::TriggersWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const Window& parent)
-        : CollapsiblePanel(device_window_source, renderer_source(Size(520, 400)), parent, L"trview.triggers", L"Triggers", Size(520, 400))
+    TriggersWindow::TriggersWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const Window& parent,
+        const std::shared_ptr<IClipboard>& clipboard)
+        : CollapsiblePanel(device_window_source, renderer_source(Size(520, 400)), parent, L"trview.triggers", L"Triggers", Size(520, 400)), _clipboard(clipboard)
     {
         CollapsiblePanel::on_window_closed += ITriggersWindow::on_window_closed;
         set_panels(create_left_panel(), create_right_panel());
@@ -170,7 +171,7 @@ namespace trview
 
         _token_store += _stats_list->on_item_selected += [this](const ui::Listbox::Item& item)
         {
-            write_clipboard(window(), item.value(L"Value"));
+            _clipboard->write(window(), item.value(L"Value"));
         };
 
         auto button = details_panel->add_child(std::make_unique<Button>(Size(panel_width - 20, 20), L"Add to Route"));

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -8,6 +8,7 @@
 #include <trview.app/Elements/Trigger.h>
 #include "ITriggersWindow.h"
 #include "CollapsiblePanel.h"
+#include <trview.common/Windows/IClipboard.h>
 
 namespace trview
 {
@@ -31,7 +32,8 @@ namespace trview
             static const std::string trigger_commands_listbox;
         };
 
-        explicit TriggersWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const Window& parent);
+        explicit TriggersWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const Window& parent,
+            const std::shared_ptr<IClipboard>& clipboard);
 
         /// Destructor for triggers window
         virtual ~TriggersWindow() = default;
@@ -90,5 +92,6 @@ namespace trview
         bool _sync_trigger{ true };
         std::optional<const Trigger*> _selected_trigger;
         std::vector<TriggerCommandType> _selected_commands;
+        std::shared_ptr<IClipboard> _clipboard;
     };
 }

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -32,8 +32,8 @@ namespace trview
             static const std::string trigger_commands_listbox;
         };
 
-        explicit TriggersWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const Window& parent,
-            const std::shared_ptr<IClipboard>& clipboard);
+        explicit TriggersWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
+            const ui::IInput::Source& input_source, const Window& parent, const std::shared_ptr<IClipboard>& clipboard);
 
         /// Destructor for triggers window
         virtual ~TriggersWindow() = default;

--- a/trview.app/Windows/di.hpp
+++ b/trview.app/Windows/di.hpp
@@ -28,7 +28,8 @@ namespace trview
                     return std::make_shared<ItemsWindow>(
                         injector.create<IDeviceWindow::Source>(),
                         injector.create<ui::render::IRenderer::Source>(),
-                        window);
+                        window,
+                        injector.create<std::shared_ptr<IClipboard>>());
                 };
             }),
             di::bind<IItemsWindowManager>.to<ItemsWindowManager>(),
@@ -40,7 +41,8 @@ namespace trview
                         return std::make_shared<TriggersWindow>(
                             injector.create<IDeviceWindow::Source>(),
                             injector.create<ui::render::IRenderer::Source>(),
-                            window);
+                            window,
+                            injector.create<std::shared_ptr<IClipboard>>());
                     };
                 }),
             di::bind<ITriggersWindowManager>.to<TriggersWindowManager>(),

--- a/trview.app/Windows/di.hpp
+++ b/trview.app/Windows/di.hpp
@@ -52,7 +52,8 @@ namespace trview
                         return std::make_shared<RouteWindow>(
                             injector.create<IDeviceWindow::Source>(),
                             injector.create<ui::render::IRenderer::Source>(),
-                            window);
+                            window,
+                            injector.create<std::shared_ptr<IClipboard>>());
                     };
                 }
             ),

--- a/trview.app/Windows/di.hpp
+++ b/trview.app/Windows/di.hpp
@@ -28,6 +28,7 @@ namespace trview
                     return std::make_shared<ItemsWindow>(
                         injector.create<IDeviceWindow::Source>(),
                         injector.create<ui::render::IRenderer::Source>(),
+                        injector.create<ui::IInput::Source>(),
                         window,
                         injector.create<std::shared_ptr<IClipboard>>());
                 };
@@ -41,6 +42,7 @@ namespace trview
                         return std::make_shared<TriggersWindow>(
                             injector.create<IDeviceWindow::Source>(),
                             injector.create<ui::render::IRenderer::Source>(),
+                            injector.create<ui::IInput::Source>(),
                             window,
                             injector.create<std::shared_ptr<IClipboard>>());
                     };
@@ -54,6 +56,7 @@ namespace trview
                         return std::make_shared<RouteWindow>(
                             injector.create<IDeviceWindow::Source>(),
                             injector.create<ui::render::IRenderer::Source>(),
+                            injector.create<ui::IInput::Source>(),
                             window,
                             injector.create<std::shared_ptr<IClipboard>>());
                     };
@@ -69,6 +72,7 @@ namespace trview
                             injector.create<IDeviceWindow::Source>(),
                             injector.create<ui::render::IRenderer::Source>(),
                             injector.create<ui::render::IMapRenderer::Source>(),
+                            injector.create<ui::IInput::Source>(),
                             window);
                     };
                 }),

--- a/trview.common/Mocks/Windows/IClipboard.h
+++ b/trview.common/Mocks/Windows/IClipboard.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "../../Windows/IClipboard.h"
+
+namespace trview
+{
+    struct MockClipboard final : public IClipboard
+    {
+        virtual ~MockClipboard() = default;
+        MOCK_METHOD(std::wstring, read, (const Window&), (const));
+        MOCK_METHOD(void, write, (const Window&, const std::wstring&));
+    };
+}

--- a/trview.common/Windows/Clipboard.cpp
+++ b/trview.common/Windows/Clipboard.cpp
@@ -3,7 +3,7 @@
 
 namespace trview
 {
-    std::wstring read_clipboard(const Window& window)
+    std::wstring Clipboard::read(const Window& window) const
     {
         OpenClipboard(window);
         HANDLE data = GetClipboardData(CF_UNICODETEXT);
@@ -19,7 +19,7 @@ namespace trview
         return result;
     }
 
-    void write_clipboard(const Window& window, const std::wstring& text)
+    void Clipboard::write(const Window& window, const std::wstring& text)
     {
         const size_t length = text.size() * sizeof(wchar_t) + sizeof(wchar_t);
         HGLOBAL memory = GlobalAlloc(GMEM_MOVEABLE | GMEM_ZEROINIT, length);
@@ -30,15 +30,5 @@ namespace trview
         EmptyClipboard();
         SetClipboardData(CF_UNICODETEXT, memory);
         CloseClipboard();
-    }
-
-    std::wstring Clipboard::read(const Window& window) const
-    {
-        return read_clipboard(window);
-    }
-
-    void Clipboard::write(const Window& window, const std::wstring& text)
-    {
-        write_clipboard(window, text);
     }
 }

--- a/trview.common/Windows/Clipboard.cpp
+++ b/trview.common/Windows/Clipboard.cpp
@@ -31,4 +31,14 @@ namespace trview
         SetClipboardData(CF_UNICODETEXT, memory);
         CloseClipboard();
     }
+
+    std::wstring Clipboard::read(const Window& window) const
+    {
+        return read_clipboard(window);
+    }
+
+    void Clipboard::write(const Window& window, const std::wstring& text)
+    {
+        write_clipboard(window, text);
+    }
 }

--- a/trview.common/Windows/Clipboard.h
+++ b/trview.common/Windows/Clipboard.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include "IClipboard.h"
 
 namespace trview
 {
@@ -8,4 +9,12 @@ namespace trview
 
     std::wstring read_clipboard(const Window& window);
     void write_clipboard(const Window& window, const std::wstring& text);
+
+    class Clipboard final : public IClipboard
+    {
+    public:
+        virtual ~Clipboard() = default;
+        virtual std::wstring read(const Window& window) const override;
+        virtual void write(const Window& window, const std::wstring& text) override;
+    };
 }

--- a/trview.common/Windows/Clipboard.h
+++ b/trview.common/Windows/Clipboard.h
@@ -6,10 +6,6 @@
 namespace trview
 {
     class Window;
-
-    std::wstring read_clipboard(const Window& window);
-    void write_clipboard(const Window& window, const std::wstring& text);
-
     class Clipboard final : public IClipboard
     {
     public:

--- a/trview.common/Windows/IClipboard.cpp
+++ b/trview.common/Windows/IClipboard.cpp
@@ -1,0 +1,8 @@
+#include "IClipboard.h"
+
+namespace trview
+{
+    IClipboard::~IClipboard()
+    {
+    }
+}

--- a/trview.common/Windows/IClipboard.h
+++ b/trview.common/Windows/IClipboard.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "../Window.h"
+#include <string>
+
+namespace trview
+{
+    struct IClipboard
+    {
+        virtual ~IClipboard() = 0;
+        virtual std::wstring read(const Window& window) const = 0;
+        virtual void write(const Window& window, const std::wstring& text) = 0;
+    };
+}

--- a/trview.common/Windows/IShortcuts.h
+++ b/trview.common/Windows/IShortcuts.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include "../Event.h"
+#include "../Window.h"
 
 namespace trview
 {
     struct IShortcuts
     {
+        using Source = std::function<std::shared_ptr<IShortcuts>(const Window&)>;
+
         struct Shortcut
         {
             uint8_t flags;

--- a/trview.common/Windows/IShortcuts.h
+++ b/trview.common/Windows/IShortcuts.h
@@ -7,8 +7,6 @@ namespace trview
 {
     struct IShortcuts
     {
-        using Source = std::function<std::shared_ptr<IShortcuts>(const Window&)>;
-
         struct Shortcut
         {
             uint8_t flags;

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -25,6 +25,7 @@
     <ClInclude Include="Event.h" />
     <ClInclude Include="FileLoader.h" />
     <ClInclude Include="MessageHandler.h" />
+    <ClInclude Include="Mocks\Windows\IClipboard.h" />
     <ClInclude Include="Mocks\Windows\IShortcuts.h" />
     <ClInclude Include="Point.h" />
     <ClInclude Include="Size.h" />
@@ -34,6 +35,7 @@
     <ClInclude Include="TokenStore.h" />
     <ClInclude Include="Window.h" />
     <ClInclude Include="Windows\Clipboard.h" />
+    <ClInclude Include="Windows\IClipboard.h" />
     <ClInclude Include="Windows\IShortcuts.h" />
     <ClInclude Include="Windows\Shortcuts.h" />
   </ItemGroup>
@@ -55,6 +57,7 @@
     <ClCompile Include="TokenStore.cpp" />
     <ClCompile Include="Window.cpp" />
     <ClCompile Include="Windows\Clipboard.cpp" />
+    <ClCompile Include="Windows\IClipboard.cpp" />
     <ClCompile Include="Windows\IShortcuts.cpp" />
     <ClCompile Include="Windows\Shortcuts.cpp" />
   </ItemGroup>

--- a/trview.common/trview.common.vcxproj.filters
+++ b/trview.common/trview.common.vcxproj.filters
@@ -32,6 +32,12 @@
     <ClInclude Include="Windows\IShortcuts.h">
       <Filter>Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Windows\IClipboard.h">
+      <Filter>Windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\Windows\IClipboard.h">
+      <Filter>Mocks\Windows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FileLoader.cpp" />
@@ -58,6 +64,9 @@
     </ClCompile>
     <ClCompile Include="stdafx.cpp" />
     <ClCompile Include="Windows\IShortcuts.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Windows\IClipboard.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
   </ItemGroup>

--- a/trview.input/IMouse.h
+++ b/trview.input/IMouse.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <trview.common/Event.h>
 
 namespace trview
 {

--- a/trview.ui.tests/GridTests.cpp
+++ b/trview.ui.tests/GridTests.cpp
@@ -9,10 +9,10 @@ TEST(Grid, ControlsPositionedCorrectly)
 {
     Grid grid(Size(100, 200), Colour::Transparent, 2, 2);
 
-    auto x1y1 = grid.add_child(std::make_unique<Window>(Size(10, 10), Colour::Transparent));
-    auto x2y1 = grid.add_child(std::make_unique<Window>(Size(10, 10), Colour::Transparent));
-    auto x1y2 = grid.add_child(std::make_unique<Window>(Size(10, 10), Colour::Transparent));
-    auto x2y2 = grid.add_child(std::make_unique<Window>(Size(10, 10), Colour::Transparent));
+    auto x1y1 = grid.add_child(std::make_unique<ui::Window>(Size(10, 10), Colour::Transparent));
+    auto x2y1 = grid.add_child(std::make_unique<ui::Window>(Size(10, 10), Colour::Transparent));
+    auto x1y2 = grid.add_child(std::make_unique<ui::Window>(Size(10, 10), Colour::Transparent));
+    auto x2y2 = grid.add_child(std::make_unique<ui::Window>(Size(10, 10), Colour::Transparent));
 
     ASSERT_EQ(x1y1->absolute_position(), Point(0, 0));
     ASSERT_EQ(x1y1->position(), Point());

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -275,9 +275,9 @@ namespace trview
             return child;
         }
 
-        void Control::set_input_query(IInputQuery* query)
+        void Control::set_input(IInput* input)
         {
-            _input_query = query;
+            _input = input;
         }
 
         bool Control::focused() const

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -10,7 +10,7 @@
 #include <trview.common/Point.h>
 #include <trview.common/TokenStore.h>
 #include "Align.h"
-#include "IInputQuery.h"
+#include "IInput.h"
 
 namespace trview
 {
@@ -232,7 +232,7 @@ namespace trview
 
             virtual bool cut(std::wstring& output);
 
-            void set_input_query(IInputQuery* query);
+            void set_input(IInput* input);
 
             bool focused() const;
         protected:
@@ -241,7 +241,7 @@ namespace trview
             virtual void inner_add_child(Control* child_element);
 
             TokenStore _token_store;
-            IInputQuery* _input_query{ nullptr };
+            IInput* _input{ nullptr };
         private:
             std::vector<std::unique_ptr<Control>> _child_elements;
 

--- a/trview.ui/IInput.cpp
+++ b/trview.ui/IInput.cpp
@@ -1,10 +1,10 @@
-#include "IInputQuery.h"
+#include "IInput.h"
 
 namespace trview
 {
     namespace ui
     {
-        IInputQuery::~IInputQuery()
+        IInput::~IInput()
         {
         }
     }

--- a/trview.ui/IInput.h
+++ b/trview.ui/IInput.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <trview.input/IMouse.h>
+#include <trview.common/Window.h>
 
 namespace trview
 {
@@ -10,6 +11,8 @@ namespace trview
 
         struct IInput
         {
+            using Source = std::function<std::unique_ptr<IInput>(const trview::Window, Control&)>;
+
             virtual ~IInput() = 0;
 
             /// Get the control that is currently focused.

--- a/trview.ui/IInput.h
+++ b/trview.ui/IInput.h
@@ -1,19 +1,22 @@
 #pragma once
 
+#include <trview.input/IMouse.h>
+
 namespace trview
 {
     namespace ui
     {
         class Control;
 
-        /// Allows controls to query the current state of user input.
-        struct IInputQuery
+        struct IInput
         {
-            virtual ~IInputQuery() = 0;
+            virtual ~IInput() = 0;
 
             /// Get the control that is currently focused.
             /// @returns The control, or nullptr if no control is focused.
             virtual Control* focus_control() const = 0;
+
+            virtual input::IMouse& mouse() = 0;
         };
     }
 }

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -27,7 +27,7 @@ namespace trview
             return _focus_control;
         }
 
-        input::Mouse& Input::mouse()
+        input::IMouse& Input::mouse()
         {
             return _mouse;
         }
@@ -66,7 +66,7 @@ namespace trview
 
         void Input::register_focus_controls(Control* control)
         {
-            control->set_input_query(this);
+            control->set_input(this);
 
             _token_store += control->on_focus_requested += [this, control]() { set_focus_control(control); };
             _token_store += control->on_focus_clear_requested += [&]() { set_focus_control(nullptr); };

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -16,8 +16,8 @@ namespace trview
             }
         }
 
-        Input::Input(const trview::Window& window, Control& control, const std::shared_ptr<IShortcuts>& shortcuts)
-            : _mouse(window, std::make_unique<input::WindowTester>(window)), _keyboard(window), _window(window), _control(control), _shortcuts(shortcuts)
+        Input::Input(const trview::Window& window, Control& control, const std::shared_ptr<IShortcuts>& shortcuts, const std::shared_ptr<IClipboard>& clipboard)
+            : _mouse(window, std::make_unique<input::WindowTester>(window)), _keyboard(window), _window(window), _control(control), _shortcuts(shortcuts), _clipboard(clipboard)
         {
             register_events();
         }
@@ -45,13 +45,13 @@ namespace trview
             _token_store += _mouse.mouse_wheel += [&](int16_t delta) { process_mouse_scroll(delta); };
             _token_store += _keyboard.on_key_down += [&](auto key, bool control, bool shift) { process_key_down(key, control, shift); };
             _token_store += _keyboard.on_char += [&](auto key) { process_char(key); };
-            _token_store += _shortcuts->add_shortcut(true, 'V') += [&]() { process_paste(read_clipboard(_window)); };
+            _token_store += _shortcuts->add_shortcut(true, 'V') += [&]() { process_paste(_clipboard->read(_window)); };
             _token_store += _shortcuts->add_shortcut(true, 'C') += [&]() 
             {
                 std::wstring output;
                 if (process_copy(output))
                 {
-                    write_clipboard(_window, output);
+                    _clipboard->write(_window, output);
                 }
             };
             _token_store += _shortcuts->add_shortcut(true, 'X') += [&]()
@@ -59,7 +59,7 @@ namespace trview
                 std::wstring output;
                 if (process_cut(output))
                 {
-                    write_clipboard(_window, output);
+                    _clipboard->write(_window, output);
                 }
             };
         }

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -16,7 +16,7 @@ namespace trview
             }
         }
 
-        Input::Input(const trview::Window& window, Control& control, IShortcuts& shortcuts)
+        Input::Input(const trview::Window& window, Control& control, const std::shared_ptr<IShortcuts>& shortcuts)
             : _mouse(window, std::make_unique<input::WindowTester>(window)), _keyboard(window), _window(window), _control(control), _shortcuts(shortcuts)
         {
             register_events();
@@ -45,8 +45,8 @@ namespace trview
             _token_store += _mouse.mouse_wheel += [&](int16_t delta) { process_mouse_scroll(delta); };
             _token_store += _keyboard.on_key_down += [&](auto key, bool control, bool shift) { process_key_down(key, control, shift); };
             _token_store += _keyboard.on_char += [&](auto key) { process_char(key); };
-            _token_store += _shortcuts.add_shortcut(true, 'V') += [&]() { process_paste(read_clipboard(_window)); };
-            _token_store += _shortcuts.add_shortcut(true, 'C') += [&]() 
+            _token_store += _shortcuts->add_shortcut(true, 'V') += [&]() { process_paste(read_clipboard(_window)); };
+            _token_store += _shortcuts->add_shortcut(true, 'C') += [&]() 
             {
                 std::wstring output;
                 if (process_copy(output))
@@ -54,7 +54,7 @@ namespace trview
                     write_clipboard(_window, output);
                 }
             };
-            _token_store += _shortcuts.add_shortcut(true, 'X') += [&]()
+            _token_store += _shortcuts->add_shortcut(true, 'X') += [&]()
             {
                 std::wstring output;
                 if (process_cut(output))

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -2,9 +2,9 @@
 
 #include <trview.common/Window.h>
 #include <trview.common/TokenStore.h>
-#include <trview.input/Mouse.h>
 #include <trview.input/Keyboard.h>
-#include "IInputQuery.h"
+#include "IInput.h"
+#include <trview.input/Mouse.h>
 
 namespace trview
 {
@@ -15,13 +15,13 @@ namespace trview
         class Control;
 
         /// Manages the mouse and keyboard input state for a control tree.
-        class Input final : public IInputQuery
+        class Input final : public IInput
         {
         public:
             explicit Input(const trview::Window& window, Control& control, IShortcuts& shortcuts);
             virtual ~Input() = default;
             virtual Control* focus_control() const;
-            input::Mouse& mouse();
+            virtual input::IMouse& mouse() override;
         private:
             void     register_events();
             void     register_focus_controls(Control* control);

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -18,7 +18,7 @@ namespace trview
         class Input final : public IInput
         {
         public:
-            explicit Input(const trview::Window& window, Control& control, IShortcuts& shortcuts);
+            explicit Input(const trview::Window& window, Control& control, const std::shared_ptr<IShortcuts>& shortcuts);
             virtual ~Input() = default;
             virtual Control* focus_control() const;
             virtual input::IMouse& mouse() override;
@@ -57,7 +57,7 @@ namespace trview
             Control&       _control;
             Control*       _hover_control{ nullptr };
             Control*       _focus_control{ nullptr };
-            IShortcuts&     _shortcuts;
+            std::shared_ptr<IShortcuts> _shortcuts;
         };
     }
 }

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -5,6 +5,7 @@
 #include <trview.input/Keyboard.h>
 #include "IInput.h"
 #include <trview.input/Mouse.h>
+#include <trview.common/Windows/IClipboard.h>
 
 namespace trview
 {
@@ -18,7 +19,7 @@ namespace trview
         class Input final : public IInput
         {
         public:
-            explicit Input(const trview::Window& window, Control& control, const std::shared_ptr<IShortcuts>& shortcuts);
+            explicit Input(const trview::Window& window, Control& control, const std::shared_ptr<IShortcuts>& shortcuts, const std::shared_ptr<IClipboard>& clipboard);
             virtual ~Input() = default;
             virtual Control* focus_control() const;
             virtual input::IMouse& mouse() override;
@@ -58,6 +59,7 @@ namespace trview
             Control*       _hover_control{ nullptr };
             Control*       _focus_control{ nullptr };
             std::shared_ptr<IShortcuts> _shortcuts;
+            std::shared_ptr<IClipboard> _clipboard;
         };
     }
 }

--- a/trview.ui/Mocks/Input/IInput.h
+++ b/trview.ui/Mocks/Input/IInput.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "../../IInput.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        namespace mocks
+        {
+            struct MockInput final : public IInput
+            {
+                virtual ~MockInput() = default;
+                MOCK_METHOD(Control*, focus_control, (), (const));
+                MOCK_METHOD(input::IMouse&, mouse, ());
+            };
+        }
+    }
+}
+

--- a/trview.ui/Scrollbar.cpp
+++ b/trview.ui/Scrollbar.cpp
@@ -48,7 +48,7 @@ namespace trview
 
         bool Scrollbar::move(Point position)
         {
-            if (_input_query && _input_query->focus_control() == this)
+            if (_input && _input->focus_control() == this)
             {
                 return clicked(position);
             }

--- a/trview.ui/Slider.cpp
+++ b/trview.ui/Slider.cpp
@@ -64,7 +64,7 @@ namespace trview
 
         bool Slider::move(Point position)
         {
-            if (_input_query && _input_query->focus_control() == this)
+            if (_input && _input->focus_control() == this)
             {
                 set_blob_position(position, true);
                 return true;

--- a/trview.ui/di.h
+++ b/trview.ui/di.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace trview
+{
+    namespace ui
+    {
+        auto register_module() noexcept;
+    }
+}
+
+#include "di.hpp"

--- a/trview.ui/di.hpp
+++ b/trview.ui/di.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <external/boost/di.hpp>
+#include "Input.h"
+
+namespace trview
+{
+    namespace ui
+    {
+        auto register_module() noexcept
+        {
+            using namespace boost;
+            return di::make_injector(
+                di::bind<IInput::Source>.to(
+                    [](const auto& injector) -> IInput::Source
+                    {
+                        return [&](auto&& window, auto&& control)
+                        {
+                            const auto shortcuts_source = injector.create<IShortcuts::Source>();
+                            return std::make_unique<Input>(
+                                window,
+                                control,
+                                shortcuts_source(window));
+                        };
+                    })
+            );
+        }
+    }
+}
+

--- a/trview.ui/di.hpp
+++ b/trview.ui/di.hpp
@@ -16,11 +16,11 @@ namespace trview
                     {
                         return [&](auto&& window, auto&& control)
                         {
-                            const auto shortcuts_source = injector.create<IShortcuts::Source>();
                             return std::make_unique<Input>(
                                 window,
                                 control,
-                                shortcuts_source(window));
+                                injector.create<std::shared_ptr<IShortcuts>>(),
+                                injector.create<std::shared_ptr<IClipboard>>());
                         };
                     })
             );

--- a/trview.ui/trview.ui.vcxproj
+++ b/trview.ui/trview.ui.vcxproj
@@ -26,7 +26,7 @@
     <ClInclude Include="Grid.h" />
     <ClInclude Include="GroupBox.h" />
     <ClInclude Include="IFontMeasurer.h" />
-    <ClInclude Include="IInputQuery.h" />
+    <ClInclude Include="IInput.h" />
     <ClInclude Include="Image.h" />
     <ClInclude Include="Input.h" />
     <ClInclude Include="Label.h" />
@@ -49,7 +49,7 @@
     <ClCompile Include="Grid.cpp" />
     <ClCompile Include="GroupBox.cpp" />
     <ClCompile Include="IFontMeasurer.cpp" />
-    <ClCompile Include="IInputQuery.cpp" />
+    <ClCompile Include="IInput.cpp" />
     <ClCompile Include="Image.cpp" />
     <ClCompile Include="Input.cpp" />
     <ClCompile Include="Label.cpp" />

--- a/trview.ui/trview.ui.vcxproj
+++ b/trview.ui/trview.ui.vcxproj
@@ -22,6 +22,8 @@
     <ClInclude Include="Align.h" />
     <ClInclude Include="Button.h" />
     <ClInclude Include="Control.h" />
+    <ClInclude Include="di.h" />
+    <ClInclude Include="di.hpp" />
     <ClInclude Include="Dropdown.h" />
     <ClInclude Include="Grid.h" />
     <ClInclude Include="GroupBox.h" />
@@ -31,6 +33,7 @@
     <ClInclude Include="Input.h" />
     <ClInclude Include="Label.h" />
     <ClInclude Include="Listbox.h" />
+    <ClInclude Include="Mocks\Input\IInput.h" />
     <ClInclude Include="NumericUpDown.h" />
     <ClInclude Include="Scrollbar.h" />
     <ClInclude Include="SizeDimension.h" />

--- a/trview.ui/trview.ui.vcxproj.filters
+++ b/trview.ui/trview.ui.vcxproj.filters
@@ -65,6 +65,11 @@
     <ClInclude Include="IInput.h">
       <Filter>Input</Filter>
     </ClInclude>
+    <ClInclude Include="di.h" />
+    <ClInclude Include="di.hpp" />
+    <ClInclude Include="Mocks\Input\IInput.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Control.cpp">
@@ -159,6 +164,9 @@
     </Filter>
     <Filter Include="Controls\Grid">
       <UniqueIdentifier>{1106c79a-72c2-4484-9448-0c9d678a06dc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Mocks">
+      <UniqueIdentifier>{d34f0bba-8f6c-4c35-b327-fdef824630ec}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/trview.ui/trview.ui.vcxproj.filters
+++ b/trview.ui/trview.ui.vcxproj.filters
@@ -58,12 +58,12 @@
     <ClInclude Include="Input.h">
       <Filter>Input</Filter>
     </ClInclude>
-    <ClInclude Include="IInputQuery.h">
-      <Filter>Input</Filter>
-    </ClInclude>
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="Grid.h">
       <Filter>Controls\Grid</Filter>
+    </ClInclude>
+    <ClInclude Include="IInput.h">
+      <Filter>Input</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -124,12 +124,12 @@
     <ClCompile Include="Input.cpp">
       <Filter>Input</Filter>
     </ClCompile>
-    <ClCompile Include="IInputQuery.cpp">
-      <Filter>Input</Filter>
-    </ClCompile>
     <ClCompile Include="stdafx.cpp" />
     <ClCompile Include="Grid.cpp">
       <Filter>Controls\Grid</Filter>
+    </ClCompile>
+    <ClCompile Include="IInput.cpp">
+      <Filter>Input</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Copy some stats from the route window (position and room position on waypoints) to clipboard when the cell is clicked.
Disable highlight on the stats list.
Also took the chance to convert all usages of the clipboard to use a new `IClipboard` interface and inject it with DI.
Also converted a lot of tests to use DI to create the test subject - this means there's a lot less repeated code in the tests.
Closes #762 