### PR TITLE
Switch to orbit if auto-orbit is enabled regardless of the selection source

### DIFF
--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -498,3 +498,12 @@ TEST(Viewer, OrbitNotEnabledWhenRoomSelectedAndAutoOrbitDisabled)
     viewer->select_room(0);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 }
+
+TEST(Viewer, SetSettingsUpdatesUI)
+{
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    EXPECT_CALL(ui, set_settings).Times(2);
+
+    auto viewer = register_test_module(std::move(ui_ptr));
+    viewer->set_settings({});
+}

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -308,7 +308,11 @@ TEST(Viewer, RightClickActivatesContextMenu)
 
 TEST(Viewer, OrbitEnabledWhenItemSelectedAndAutoOrbitEnabled)
 {
-    auto viewer = register_test_module();
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    EXPECT_CALL(ui, set_camera_mode);
+    EXPECT_CALL(ui, set_camera_mode(CameraMode::Orbit)).Times(2);
+
+    auto viewer = register_test_module(std::move(ui_ptr));
 
     UserSettings settings;
     settings.auto_orbit = true;
@@ -323,7 +327,11 @@ TEST(Viewer, OrbitEnabledWhenItemSelectedAndAutoOrbitEnabled)
 
 TEST(Viewer, OrbitNotEnabledWhenItemSelectedAndAutoOrbitDisabled)
 {
-    auto viewer = register_test_module();
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    EXPECT_CALL(ui, set_camera_mode);
+    EXPECT_CALL(ui, set_camera_mode(CameraMode::Orbit)).Times(1);
+
+    auto viewer = register_test_module(std::move(ui_ptr));
 
     UserSettings settings;
     settings.auto_orbit = false;
@@ -338,7 +346,11 @@ TEST(Viewer, OrbitNotEnabledWhenItemSelectedAndAutoOrbitDisabled)
 
 TEST(Viewer, OrbitEnabledWhenTriggerSelectedAndAutoOrbitEnabled)
 {
-    auto viewer = register_test_module();
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    EXPECT_CALL(ui, set_camera_mode);
+    EXPECT_CALL(ui, set_camera_mode(CameraMode::Orbit)).Times(2);
+
+    auto viewer = register_test_module(std::move(ui_ptr));
 
     UserSettings settings;
     settings.auto_orbit = true;
@@ -347,6 +359,7 @@ TEST(Viewer, OrbitEnabledWhenTriggerSelectedAndAutoOrbitEnabled)
     viewer->set_camera_mode(CameraMode::Free);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 
+    // TODO: Remove once Trigger is converted to DI.
     Trigger trigger(0, 0, 0, 0, {}, [](auto&&, auto&&) { return std::make_unique<MockMesh>(); });
     viewer->select_trigger(&trigger);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Orbit);
@@ -354,7 +367,11 @@ TEST(Viewer, OrbitEnabledWhenTriggerSelectedAndAutoOrbitEnabled)
 
 TEST(Viewer, OrbitNotEnabledWhenTriggerSelectedAndAutoOrbitDisabled)
 {
-    auto viewer = register_test_module();
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    EXPECT_CALL(ui, set_camera_mode);
+    EXPECT_CALL(ui, set_camera_mode(CameraMode::Orbit)).Times(1);
+
+    auto viewer = register_test_module(std::move(ui_ptr));
 
     UserSettings settings;
     settings.auto_orbit = false;
@@ -363,6 +380,7 @@ TEST(Viewer, OrbitNotEnabledWhenTriggerSelectedAndAutoOrbitDisabled)
     viewer->set_camera_mode(CameraMode::Free);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 
+    // TODO: Remove once Trigger is converted to DI.
     Trigger trigger(0, 0, 0, 0, {}, [](auto&&, auto&&) { return std::make_unique<MockMesh>(); });
     viewer->select_trigger(&trigger);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
@@ -370,7 +388,11 @@ TEST(Viewer, OrbitNotEnabledWhenTriggerSelectedAndAutoOrbitDisabled)
 
 TEST(Viewer, OrbitEnabledWhenWaypointSelectedAndAutoOrbitEnabled)
 {
-    auto viewer = register_test_module();
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    EXPECT_CALL(ui, set_camera_mode);
+    EXPECT_CALL(ui, set_camera_mode(CameraMode::Orbit)).Times(2);
+
+    auto viewer = register_test_module(std::move(ui_ptr));
 
     UserSettings settings;
     settings.auto_orbit = true;
@@ -387,7 +409,11 @@ TEST(Viewer, OrbitEnabledWhenWaypointSelectedAndAutoOrbitEnabled)
 
 TEST(Viewer, OrbitNotEnabledWhenWaypointSelectedAndAutoOrbitDisabled)
 {
-    auto viewer = register_test_module();
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    EXPECT_CALL(ui, set_camera_mode);
+    EXPECT_CALL(ui, set_camera_mode(CameraMode::Orbit)).Times(1);
+
+    auto viewer = register_test_module(std::move(ui_ptr));
 
     UserSettings settings;
     settings.auto_orbit = false;
@@ -405,13 +431,17 @@ TEST(Viewer, OrbitNotEnabledWhenWaypointSelectedAndAutoOrbitDisabled)
 
 TEST(Viewer, OrbitEnabledWhenRoomSelectedAndAutoOrbitEnabled)
 {
-    auto viewer = register_test_module();
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    EXPECT_CALL(ui, set_camera_mode);
+    EXPECT_CALL(ui, set_camera_mode(CameraMode::Orbit)).Times(2);
+
+    auto viewer = register_test_module(std::move(ui_ptr));
 
     UserSettings settings;
     settings.auto_orbit = true;
     viewer->set_settings(settings);
 
-    // To be removed once Room is converted to DI.
+    // TODO: Remove once Room is converted to DI.
     auto [trlevel_ptr, trlevel] = create_mock<trlevel::mocks::MockLevel>();
     auto [level_ptr, level] = create_mock<MockLevel>();
     auto [texture_storage_ptr, texture_storage] = create_mock<MockLevelTextureStorage>();
@@ -436,13 +466,17 @@ TEST(Viewer, OrbitEnabledWhenRoomSelectedAndAutoOrbitEnabled)
 
 TEST(Viewer, OrbitNotEnabledWhenRoomSelectedAndAutoOrbitDisabled)
 {
-    auto viewer = register_test_module();
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    EXPECT_CALL(ui, set_camera_mode);
+    EXPECT_CALL(ui, set_camera_mode(CameraMode::Orbit)).Times(1);
+
+    auto viewer = register_test_module(std::move(ui_ptr));
 
     UserSettings settings;
     settings.auto_orbit = false;
     viewer->set_settings(settings);
 
-    // To be removed once Room is converted to DI.
+    // TODO: Remove once Room is converted to DI.
     auto [trlevel_ptr, trlevel] = create_mock<trlevel::mocks::MockLevel>();
     auto [level_ptr, level] = create_mock<MockLevel>();
     auto [texture_storage_ptr, texture_storage] = create_mock<MockLevelTextureStorage>();

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -15,6 +15,9 @@
 #include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.app/Mocks/Graphics/ISectorHighlight.h>
 #include <external/boost/di.hpp>
+#include <trview.app/mocks/Graphics/ILevelTextureStorage.h>
+#include <trview.app/mocks/Graphics/IMeshStorage.h>
+#include <trlevel/Mocks/ILevel.h>
 
 using testing::NiceMock;
 using testing::Return;
@@ -43,7 +46,7 @@ namespace
 
     Event<> shortcut_handler;
 
-    auto register_test_module(std::unique_ptr<IViewerUI> ui, std::unique_ptr<IPicking> picking = std::make_unique<MockPicking>(), std::unique_ptr<IMouse> mouse = std::make_unique<MockMouse>())
+    auto register_test_module(std::unique_ptr<IViewerUI> ui = std::make_unique<MockViewerUI>(), std::unique_ptr<IPicking> picking = std::make_unique<MockPicking>(), std::unique_ptr<IMouse> mouse = std::make_unique<MockMouse>())
     {
         auto shortcuts = std::make_shared<MockShortcuts>();
         EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
@@ -301,4 +304,163 @@ TEST(Viewer, RightClickActivatesContextMenu)
     EXPECT_CALL(ui, set_show_context_menu(true)).Times(1);
 
     activate_context_menu(picking, mouse, PickResult::Type::Room, 0);
+}
+
+TEST(Viewer, OrbitEnabledWhenItemSelectedAndAutoOrbitEnabled)
+{
+    auto viewer = register_test_module();
+
+    UserSettings settings;
+    settings.auto_orbit = true;
+    viewer->set_settings(settings);
+
+    viewer->set_camera_mode(CameraMode::Free);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
+
+    viewer->select_item({});
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Orbit);
+}
+
+TEST(Viewer, OrbitNotEnabledWhenItemSelectedAndAutoOrbitDisabled)
+{
+    auto viewer = register_test_module();
+
+    UserSettings settings;
+    settings.auto_orbit = false;
+    viewer->set_settings(settings);
+
+    viewer->set_camera_mode(CameraMode::Free);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
+
+    viewer->select_item({});
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
+}
+
+TEST(Viewer, OrbitEnabledWhenTriggerSelectedAndAutoOrbitEnabled)
+{
+    auto viewer = register_test_module();
+
+    UserSettings settings;
+    settings.auto_orbit = true;
+    viewer->set_settings(settings);
+
+    viewer->set_camera_mode(CameraMode::Free);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
+
+    Trigger trigger(0, 0, 0, 0, {}, [](auto&&, auto&&) { return std::make_unique<MockMesh>(); });
+    viewer->select_trigger(&trigger);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Orbit);
+}
+
+TEST(Viewer, OrbitNotEnabledWhenTriggerSelectedAndAutoOrbitDisabled)
+{
+    auto viewer = register_test_module();
+
+    UserSettings settings;
+    settings.auto_orbit = false;
+    viewer->set_settings(settings);
+
+    viewer->set_camera_mode(CameraMode::Free);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
+
+    Trigger trigger(0, 0, 0, 0, {}, [](auto&&, auto&&) { return std::make_unique<MockMesh>(); });
+    viewer->select_trigger(&trigger);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
+}
+
+TEST(Viewer, OrbitEnabledWhenWaypointSelectedAndAutoOrbitEnabled)
+{
+    auto viewer = register_test_module();
+
+    UserSettings settings;
+    settings.auto_orbit = true;
+    viewer->set_settings(settings);
+
+    viewer->set_camera_mode(CameraMode::Free);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
+
+    MockMesh mesh;
+    Waypoint waypoint(&mesh, Vector3::Zero, 0);
+    viewer->select_waypoint(waypoint);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Orbit);
+}
+
+TEST(Viewer, OrbitNotEnabledWhenWaypointSelectedAndAutoOrbitDisabled)
+{
+    auto viewer = register_test_module();
+
+    UserSettings settings;
+    settings.auto_orbit = false;
+    viewer->set_settings(settings);
+
+    viewer->set_camera_mode(CameraMode::Free);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
+
+    MockMesh mesh;
+    Waypoint waypoint(&mesh, Vector3::Zero, 0);
+    viewer->select_waypoint(waypoint);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
+}
+
+
+TEST(Viewer, OrbitEnabledWhenRoomSelectedAndAutoOrbitEnabled)
+{
+    auto viewer = register_test_module();
+
+    UserSettings settings;
+    settings.auto_orbit = true;
+    viewer->set_settings(settings);
+
+    // To be removed once Room is converted to DI.
+    auto [trlevel_ptr, trlevel] = create_mock<trlevel::mocks::MockLevel>();
+    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto [texture_storage_ptr, texture_storage] = create_mock<MockLevelTextureStorage>();
+    auto [mesh_storage_ptr, mesh_storage] = create_mock<MockMeshStorage>();
+    trlevel::tr3_room tr_room{};
+
+    auto room = std::make_unique<Room>(
+        [](auto, auto, auto, auto, auto) { return std::make_unique<MockMesh>(); },
+        trlevel, tr_room, texture_storage, mesh_storage, 0, level);
+
+    EXPECT_CALL(level, number_of_rooms).WillRepeatedly(Return(1));
+    EXPECT_CALL(level, rooms).WillRepeatedly(Return(std::vector<Room*>{ room.get() }));
+    EXPECT_CALL(level, room).WillRepeatedly(Return(room.get()));
+    viewer->open(&level);
+
+    viewer->set_camera_mode(CameraMode::Free);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
+
+    viewer->select_room(0);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Orbit);
+}
+
+TEST(Viewer, OrbitNotEnabledWhenRoomSelectedAndAutoOrbitDisabled)
+{
+    auto viewer = register_test_module();
+
+    UserSettings settings;
+    settings.auto_orbit = false;
+    viewer->set_settings(settings);
+
+    // To be removed once Room is converted to DI.
+    auto [trlevel_ptr, trlevel] = create_mock<trlevel::mocks::MockLevel>();
+    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto [texture_storage_ptr, texture_storage] = create_mock<MockLevelTextureStorage>();
+    auto [mesh_storage_ptr, mesh_storage] = create_mock<MockMeshStorage>();
+    trlevel::tr3_room tr_room{};
+
+    auto room = std::make_unique<Room>(
+        [](auto, auto, auto, auto, auto) { return std::make_unique<MockMesh>(); },
+        trlevel, tr_room, texture_storage, mesh_storage, 0, level);
+
+    EXPECT_CALL(level, number_of_rooms).WillRepeatedly(Return(1));
+    EXPECT_CALL(level, rooms).WillRepeatedly(Return(std::vector<Room*>{ room.get() }));
+    EXPECT_CALL(level, room).WillRepeatedly(Return(room.get()));
+    viewer->open(&level);
+
+    viewer->set_camera_mode(CameraMode::Free);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
+
+    viewer->select_room(0);
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -320,6 +320,11 @@ namespace trview
         _token_store += _viewer->on_waypoint_added += [this](const auto& position, auto room, auto type, auto index) { add_waypoint(position, room, type, index); };
         _token_store += _viewer->on_waypoint_selected += [this](auto index) { select_waypoint(index); };
         _token_store += _viewer->on_waypoint_removed += [this](auto index) { remove_waypoint(index); };
+        _token_store += _viewer->on_settings += [this](auto&& settings)
+        {
+            _settings = settings;
+            _viewer->set_settings(_settings);
+        };
         _viewer->set_settings(_settings);
 
         // Open the level passed in on the command line, if there is one.

--- a/trview.app/Mocks/Windows/IViewer.h
+++ b/trview.app/Mocks/Windows/IViewer.h
@@ -9,6 +9,7 @@ namespace trview
         class MockViewer : public IViewer
         {
         public:
+            MOCK_METHOD(CameraMode, camera_mode, (), (const, override));
             MOCK_METHOD(void, render, ());
             MOCK_METHOD(void, open, (ILevel*));
             MOCK_METHOD(void, set_settings, (const UserSettings&));
@@ -16,6 +17,7 @@ namespace trview
             MOCK_METHOD(void, select_room, (uint32_t));
             MOCK_METHOD(void, select_trigger, (const Trigger* const));
             MOCK_METHOD(void, select_waypoint, (const Waypoint&));
+            MOCK_METHOD(void, set_camera_mode, (CameraMode), (override));
             MOCK_METHOD(void, set_route, (const std::shared_ptr<IRoute>&));
             MOCK_METHOD(void, set_show_compass, (bool));
             MOCK_METHOD(void, set_show_minimap, (bool));

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -10,6 +10,7 @@
 #include <trview.app/Routing/Route.h>
 #include <trview.app/Routing/Waypoint.h>
 #include <trview.app/Settings/UserSettings.h>
+#include <trview.app/Camera/CameraMode.h>
 
 namespace trview
 {
@@ -45,6 +46,8 @@ namespace trview
         /// Event raised when the viewer wants to add a waypoint.
         Event<DirectX::SimpleMath::Vector3, uint32_t, Waypoint::Type, uint32_t> on_waypoint_added;
 
+        virtual CameraMode camera_mode() const = 0;
+
         /// Render the viewer.
         virtual void render() = 0;
 
@@ -73,6 +76,8 @@ namespace trview
         /// @param index The waypoint to select.
         /// @remarks This will not raise the on_waypoint_selected event.
         virtual void select_waypoint(const Waypoint& waypoint) = 0;
+
+        virtual void set_camera_mode(CameraMode camera_mode) = 0;
 
         /// Set the current route.
         /// @param route The new route.

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -615,17 +615,30 @@ namespace trview
         _ui->set_selected_room(_level->room(_level->selected_room()));
         _was_alternate_select = false;
         _target = _level->room(_level->selected_room())->centre();
+        _scene_changed = true;
+        if (_settings.auto_orbit)
+        {
+            set_camera_mode(CameraMode::Orbit);
+        }
     }
 
     void Viewer::select_item(const Item& item)
     {
         _target = item.position();
+        if (_settings.auto_orbit)
+        {
+            set_camera_mode(CameraMode::Orbit);
+        }
         _scene_changed = true;
     }
 
     void Viewer::select_trigger(const Trigger* const trigger)
     {
         _target = trigger->position();
+        if (_settings.auto_orbit)
+        {
+            set_camera_mode(CameraMode::Orbit);
+        }
         _scene_changed = true;
     }
 
@@ -979,11 +992,6 @@ namespace trview
             on_waypoint_selected(pick.index);
             break;
         }
-
-        if (_settings.auto_orbit)
-        {
-            set_camera_mode(CameraMode::Orbit);
-        }
     }
 
     void Viewer::apply_acceleration_settings()
@@ -996,5 +1004,10 @@ namespace trview
         _settings = settings;
         apply_acceleration_settings();
         _scene_changed = true;
+    }
+
+    CameraMode Viewer::camera_mode() const
+    {
+        return _camera_mode;
     }
 }

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1002,6 +1002,7 @@ namespace trview
     void Viewer::set_settings(const UserSettings& settings)
     {
         _settings = settings;
+        _ui->set_settings(_settings);
         apply_acceleration_settings();
         _scene_changed = true;
     }

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -69,6 +69,8 @@ namespace trview
         /// Destructor for the viewer.
         virtual ~Viewer() = default;
 
+        virtual CameraMode camera_mode() const override;
+
         /// Render the viewer.
         virtual void render() override;
 
@@ -97,6 +99,8 @@ namespace trview
         /// @param index The waypoint to select.
         /// @remarks This will not raise the on_waypoint_selected event.
         virtual void select_waypoint(const Waypoint& waypoint) override;
+
+        virtual void set_camera_mode(CameraMode camera_mode) override;
 
         /// Set the current route.
         /// @param route The new route.
@@ -132,7 +136,6 @@ namespace trview
         bool should_pick() const;
         const ICamera& current_camera() const;
         ICamera& current_camera();
-        void set_camera_mode(CameraMode camera_mode);
         void set_camera_projection_mode(ProjectionMode projection_mode);
         void set_alternate_mode(bool enabled);
         void toggle_alternate_mode();

--- a/trview.tests.common/Mocks.hpp
+++ b/trview.tests.common/Mocks.hpp
@@ -11,5 +11,14 @@ namespace trview
             auto& ref = *ptr;
             return { std::move(ptr), ref };
         }
+
+        template <typename Mock, typename T>
+        auto choose_mock(std::unique_ptr<T>& ptr)
+        {
+            if (!ptr)
+            {
+                ptr = std::make_unique<Mock>();
+            }
+        }
     }
 }


### PR DESCRIPTION
Switch to orbit camera if auto-orbit is enabled regardless of selection source. Previously it was only working with picking - now if you select something in one of the windows it will enter orbit mode (if the setting is on).
Added tests for this.
Also a bug was spotted where settings weren't being saved - this is fixed here and tests are added for it.
Closes #765
Closes #770 