### PR TITLE
Convert Triggers to DI

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -150,14 +150,14 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
     EXPECT_CALL(level_loader, load_level("test_path.tr2")).WillOnce(Return(ByMove(std::move(level_ptr))));
     
     EXPECT_CALL(items_window_manager, set_items(A<const std::vector<Item>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_items"); });
-    EXPECT_CALL(items_window_manager, set_triggers(A<const std::vector<Trigger*>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_triggers"); });
+    EXPECT_CALL(items_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_triggers"); });
     EXPECT_CALL(triggers_window_manager, set_items(A<const std::vector<Item>&>())).Times(1).WillOnce([&](auto) { events.push_back("triggers_items"); });
-    EXPECT_CALL(triggers_window_manager, set_triggers(A<const std::vector<Trigger*>&>())).Times(1).WillOnce([&](auto) { events.push_back("triggers_triggers"); });
+    EXPECT_CALL(triggers_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("triggers_triggers"); });
     EXPECT_CALL(rooms_window_manager, set_items(A<const std::vector<Item>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_items"); });
-    EXPECT_CALL(rooms_window_manager, set_triggers(A<const std::vector<Trigger*>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_triggers"); });
+    EXPECT_CALL(rooms_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_triggers"); });
     EXPECT_CALL(rooms_window_manager, set_rooms(A<const std::vector<std::weak_ptr<IRoom>>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_rooms"); });
     EXPECT_CALL(route_window_manager, set_items(A<const std::vector<Item>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_items"); });
-    EXPECT_CALL(route_window_manager, set_triggers(A<const std::vector<Trigger*>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_triggers"); });
+    EXPECT_CALL(route_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_triggers"); });
     EXPECT_CALL(route_window_manager, set_rooms(A<const std::vector<std::weak_ptr<IRoom>>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_rooms"); });
     EXPECT_CALL(route_window_manager, set_route(A<IRoute*>())).Times(1).WillOnce([&](auto) { events.push_back("route_route"); });
     EXPECT_CALL(route, clear()).Times(1).WillOnce([&] { events.push_back("route_clear"); });

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -1,4 +1,5 @@
 #include <trview.app/Application.h>
+#include <trview.app/Mocks/Elements/ILevel.h>
 #include <trview.app/Mocks/Menus/IUpdateChecker.h>
 #include <trview.app/Mocks/Menus/IFileDropper.h>
 #include <trview.app/Mocks/Menus/ILevelSwitcher.h>
@@ -13,7 +14,6 @@
 #include <trview.common/Mocks/Windows/IShortcuts.h>
 #include <trlevel/Mocks/ILevelLoader.h>
 #include <trlevel/Mocks/ILevel.h>
-#include <trview.app/Mocks/Elements/ILevel.h>
 #include <external/boost/di.hpp>
 
 using namespace trview;

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -1,5 +1,4 @@
 #include <trview.app/Elements/Level.h>
-#include <trview.app/Elements/ITypeNameLookup.h>
 #include <trlevel/Mocks/ILevel.h>
 #include <trview.graphics/mocks/IDevice.h>
 #include <trview.graphics/mocks/IShaderStorage.h>

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -4,7 +4,6 @@
 #include <trview.graphics/mocks/IDevice.h>
 #include <trview.graphics/mocks/IShaderStorage.h>
 #include <trview.app/Mocks/Geometry/ITransparencyBuffer.h>
-#include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
 #include <trview.app/Mocks/Graphics/ISelectionRenderer.h>
@@ -45,7 +44,6 @@ namespace
             di::bind<ILevelTextureStorage>.to<MockLevelTextureStorage>(),
             di::bind<trlevel::ILevel>.to([&](auto&&) { return std::move(level); }),
             di::bind<IMeshStorage>.to<MockMeshStorage>(),
-            di::bind<IMesh::TransparentSource>.to([&](auto&) { return [](auto, auto) { return std::make_unique<MockMesh>(); }; }),
             di::bind<IEntity::EntitySource>.to(entity_source),
             di::bind<IEntity::AiSource>.to(ai_source),
             di::bind<IRoom::Source>.to(room_source),

--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -65,14 +65,14 @@ TEST(ItemsWindow, ClearSelectedItemClearsSelection)
     std::optional<Item> raised_item;
     auto token = window->on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
 
-    auto trigger = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
+    auto trigger = std::make_shared<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
     std::vector<Item> items
     {
         Item(0, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
-        Item(1, 0, 0, L"Type", 0, 0, { trigger.get() }, DirectX::SimpleMath::Vector3::Zero)
+        Item(1, 0, 0, L"Type", 0, 0, { trigger }, DirectX::SimpleMath::Vector3::Zero)
     };
     window->set_items(items);
-    window->set_triggers({ trigger.get() });
+    window->set_triggers({ trigger });
 
     auto list = window->root_control()->find<ui::Listbox>(ItemsWindow::Names::items_listbox);
     ASSERT_NE(list, nullptr);

--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -389,10 +389,8 @@ TEST(ItemsWindow, TriggersLoadedForItem)
 {
     auto window = register_test_module().create<std::unique_ptr<ItemsWindow>>();
 
-    auto trigger1 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger1, number).WillByDefault(testing::Return(0));
-    auto trigger2 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger2, number).WillByDefault(testing::Return(1));
+    auto trigger1 = std::make_shared<MockTrigger>()->with_number(0);
+    auto trigger2 = std::make_shared<MockTrigger>()->with_number(1);
     std::vector<Item> items
     {
         Item(0, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),

--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -6,7 +6,6 @@
 #include <trview.app/Elements/Types.h>
 #include <trview.graphics/mocks/IDeviceWindow.h>
 #include <trview.ui.render/Mocks/IRenderer.h>
-#include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.common/Mocks/Windows/IClipboard.h>
 #include <trview.ui/Mocks/Input/IInput.h>
 #include <external/boost/di.hpp>

--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -66,7 +66,7 @@ TEST(ItemsWindow, ClearSelectedItemClearsSelection)
     std::optional<Item> raised_item;
     auto token = window->on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
 
-    auto trigger = std::make_shared<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {} }, [](auto, auto) { return std::make_unique<MockMesh>(); });
+    auto trigger = std::make_shared<MockTrigger>();
     std::vector<Item> items
     {
         Item(0, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),

--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -3,6 +3,7 @@
 #include <trview.app/Mocks/Windows/IRoomsWindow.h>
 #include <trview.common/Mocks/Windows/IShortcuts.h>
 #include <trview.app/Mocks/Geometry/IMesh.h>
+#include <trview.app/Mocks/Elements/ITrigger.h>
 
 using namespace trview;
 using namespace trview::mocks;
@@ -22,12 +23,12 @@ TEST(RoomsWindowManager, SetTriggersClearsSelectedTrigger)
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
-    auto trigger1 = std::make_unique<Trigger>(100, 55, 100, 200, TriggerInfo{}, [](auto, auto) { return std::make_unique<MockMesh>(); });
-    manager.set_triggers({ trigger1.get() });
+    auto trigger = std::make_shared<MockTrigger>();
+    manager.set_triggers({ trigger });
 
-    ASSERT_EQ(manager.selected_trigger(), nullptr);
-    manager.set_selected_trigger(trigger1.get());
-    ASSERT_EQ(manager.selected_trigger(), trigger1.get());
+    ASSERT_EQ(manager.selected_trigger().lock(), nullptr);
+    manager.set_selected_trigger(trigger);
+    ASSERT_EQ(manager.selected_trigger().lock(), trigger);
     manager.set_triggers({});
-    ASSERT_EQ(manager.selected_trigger(), nullptr);
+    ASSERT_EQ(manager.selected_trigger().lock(), nullptr);
 }

--- a/trview.app.tests/RoomsWindowTests.cpp
+++ b/trview.app.tests/RoomsWindowTests.cpp
@@ -4,7 +4,6 @@
 #include <trview.ui/Listbox.h>
 #include <trview.app/Elements/Types.h>
 #include <trview.graphics/mocks/IDeviceWindow.h>
-#include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.ui.render/Mocks/IMapRenderer.h>
 #include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.ui/Mocks/Input/IInput.h>

--- a/trview.app.tests/RoomsWindowTests.cpp
+++ b/trview.app.tests/RoomsWindowTests.cpp
@@ -10,6 +10,7 @@
 #include <trview.ui/Mocks/Input/IInput.h>
 #include <trview.input/Mocks/IMouse.h>
 #include <external/boost/di.hpp>
+#include <trview.app/Mocks/Elements/ITrigger.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -48,15 +49,11 @@ namespace
 TEST(RoomsWindow, ClearSelectedTriggerClearsSelection)
 {
     auto window = register_test_module().create<std::unique_ptr<RoomsWindow>>();
-
-    std::optional<Trigger*> raised_trigger;
-    auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
-
     auto room = std::make_shared<MockRoom>();
-    auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {  } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
+    auto trigger = std::make_shared<MockTrigger>();
 
     window->set_rooms({ room });
-    window->set_triggers({ trigger1.get() });
+    window->set_triggers({ trigger });
 
     auto list = window->root_control()->find<ui::Listbox>(RoomsWindow::Names::rooms_listbox);
     ASSERT_NE(list, nullptr);
@@ -89,15 +86,11 @@ TEST(RoomsWindow, ClearSelectedTriggerClearsSelection)
 TEST(RoomsWindow, SetTriggersClearsSelection)
 {
     auto window = register_test_module().create<std::unique_ptr<RoomsWindow>>();
-
-    std::optional<Trigger*> raised_trigger;
-    auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
-
     auto room = std::make_shared<MockRoom>();
-    auto trigger1 = std::make_unique<Trigger>(0, 0, 100, 200, TriggerInfo{ 0, 0, 0, TriggerType::Trigger, 0, {  } }, [](auto, auto) { return std::make_unique<MockMesh>(); });
+    auto trigger = std::make_shared<MockTrigger>();
 
     window->set_rooms({ room });
-    window->set_triggers({ trigger1.get() });
+    window->set_triggers({ trigger });
 
     auto list = window->root_control()->find<ui::Listbox>(RoomsWindow::Names::rooms_listbox);
     ASSERT_NE(list, nullptr);

--- a/trview.app.tests/TriggersWindowManagerTests.cpp
+++ b/trview.app.tests/TriggersWindowManagerTests.cpp
@@ -2,7 +2,6 @@
 #include <trview.app/Elements/Types.h>
 #include <trview.app/Mocks/Windows/ITriggersWindow.h>
 #include <trview.common/Mocks/Windows/IShortcuts.h>
-#include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
 
 using namespace trview;

--- a/trview.app.tests/TriggersWindowTests.cpp
+++ b/trview.app.tests/TriggersWindowTests.cpp
@@ -44,10 +44,8 @@ TEST(TriggersWindow, TriggerSelectedRaisedWhenSyncTriggerEnabled)
     std::optional<std::weak_ptr<ITrigger>> raised_trigger;
     auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
-    auto trigger1 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger1, number).WillByDefault(Return(0));
-    auto trigger2 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger2, number).WillByDefault(Return(1));
+    auto trigger1 = std::make_shared<MockTrigger>()->with_number(0);
+    auto trigger2 = std::make_shared<MockTrigger>()->with_number(1);
     window->set_triggers({ trigger1, trigger2 });
 
     auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
@@ -125,12 +123,8 @@ TEST(TriggersWindow, TriggersListFilteredWhenRoomSetAndTrackRoomEnabled)
     std::optional<std::weak_ptr<ITrigger>> raised_trigger;
     auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
-    auto trigger1 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger1, room).WillByDefault(Return(55));
-    ON_CALL(*trigger1, number).WillByDefault(Return(0));
-    auto trigger2 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger2, room).WillByDefault(Return(78));
-    ON_CALL(*trigger2, number).WillByDefault(Return(1));
+    auto trigger1 = std::make_shared<MockTrigger>()->with_number(0)->with_room(55);
+    auto trigger2 = std::make_shared<MockTrigger>()->with_number(1)->with_room(78);
     window->set_triggers({ trigger1, trigger2 });
     window->set_current_room(78);
 
@@ -155,11 +149,8 @@ TEST(TriggersWindow, TriggersListFilteredWhenRoomSetAndTrackRoomEnabled)
 TEST(TriggersWindow, TriggersListFilteredByCommand)
 {
     auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
-    auto trigger1 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger1, commands).WillByDefault(Return<std::vector<Command>>({ Command(0, TriggerCommandType::Object, 1) }));
-    auto trigger2 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger2, number).WillByDefault(Return(1));
-    ON_CALL(*trigger2, commands).WillByDefault(Return<std::vector<Command>>({ Command(0, TriggerCommandType::Camera, 1) }));
+    auto trigger1 = std::make_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Object, 1) });
+    auto trigger2 = std::make_shared<MockTrigger>()->with_number(1)->with_commands({ Command(0, TriggerCommandType::Camera, 1) });
     std::vector<std::weak_ptr<ITrigger>> triggers{ trigger1, trigger2 };
     window->set_triggers(triggers);
 
@@ -197,18 +188,18 @@ TEST(TriggersWindow, AddToRouteEventRaised)
     std::optional<std::weak_ptr<ITrigger>> raised_trigger;
     auto token = window->on_add_to_route += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
-    auto trigger1 = std::make_shared<MockTrigger>();
-    std::vector<std::weak_ptr<ITrigger>> triggers{ trigger1 };
+    auto trigger = std::make_shared<MockTrigger>();
+    std::vector<std::weak_ptr<ITrigger>> triggers{ trigger };
 
     window->set_triggers(triggers);
-    window->set_selected_trigger(trigger1);
+    window->set_selected_trigger(trigger);
 
     auto button = window->root_control()->find<ui::Button>(TriggersWindow::Names::add_to_route_button);
     ASSERT_NE(button, nullptr);
     button->clicked(Point());
 
     ASSERT_TRUE(raised_trigger.has_value());
-    ASSERT_EQ(raised_trigger.value().lock(), trigger1);
+    ASSERT_EQ(raised_trigger.value().lock(), trigger);
 }
 
 TEST(TriggersWindow, TriggerVisibilityRaised)
@@ -218,8 +209,7 @@ TEST(TriggersWindow, TriggerVisibilityRaised)
     std::optional<std::tuple<std::weak_ptr<ITrigger>, bool>> raised_trigger;
     auto token = window->on_trigger_visibility += [&raised_trigger](const auto& trigger, bool state) { raised_trigger = { trigger, state }; };
 
-    auto trigger = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger, visible).WillByDefault(Return(true));
+    auto trigger = std::make_shared<MockTrigger>()->with_visible(true);
     std::vector<std::weak_ptr<ITrigger>> triggers{ trigger };
     window->set_triggers(triggers);
 
@@ -251,8 +241,7 @@ TEST(TriggersWindow, ItemSelectedRaised)
         Item(1, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero)
     };
 
-    auto trigger = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger, commands).WillByDefault(Return<std::vector<Command>>({ Command(0, TriggerCommandType::Object, 1) }));
+    auto trigger = std::make_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Object, 1) });
     window->set_items(items);
     window->set_triggers({ trigger });
     window->set_selected_trigger(trigger);
@@ -297,8 +286,7 @@ TEST(TriggersWindow, SetTriggerVisiblityUpdatesTrigger)
     ASSERT_TRUE(list->items().empty());
 
     bool visible = true;
-    auto trigger = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger, visible).WillByDefault([&]() { return visible; });
+    auto trigger = std::make_shared<MockTrigger>()->with_visible([&]() { return visible; });
     window->set_triggers({ trigger });
     ASSERT_EQ(list->items().size(), 1);
     ASSERT_EQ(list->items()[0].value(L"Hide"), L"0");
@@ -317,8 +305,7 @@ TEST(TriggersWindow, SetItemsLoadsItems)
         Item(0, 0, 0, L"Test Object", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
     };
     window->set_items(items);
-    auto trigger = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger, commands).WillByDefault(Return<std::vector<Command>>({ Command(0, TriggerCommandType::Object, 0) }));
+    auto trigger = std::make_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Object, 0) });
     window->set_triggers({ trigger });
     window->set_selected_trigger(trigger);
 
@@ -338,11 +325,8 @@ TEST(TriggersWindow, ClearSelectedTriggerClearsSelection)
     std::optional<std::weak_ptr<ITrigger>> raised_trigger;
     auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
-    auto trigger1 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger1, number).WillByDefault(Return(0));
-    auto trigger2 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger2, number).WillByDefault(Return(1));
-    ON_CALL(*trigger2, commands).WillByDefault(Return<std::vector<Command>>({ Command(0, TriggerCommandType::Camera, 1) }));
+    auto trigger1 = std::make_shared<MockTrigger>()->with_number(0);
+    auto trigger2 = std::make_shared<MockTrigger>()->with_number(1)->with_commands({ Command(0, TriggerCommandType::Camera, 1) });
     window->set_triggers({ trigger1, trigger2 });
 
     auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
@@ -389,9 +373,7 @@ TEST(TriggersWindow, SetTriggersClearsSelection)
     auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
     auto trigger1 = std::make_shared<MockTrigger>();
-    auto trigger2 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger2, number).WillByDefault(Return(1));
-    ON_CALL(*trigger2, commands).WillByDefault(Return<std::vector<Command>>({ Command(0, TriggerCommandType::Camera, 1) }));
+    auto trigger2 = std::make_shared<MockTrigger>()->with_number(1)->with_commands({ Command(0, TriggerCommandType::Camera, 1) });
     window->set_triggers({ trigger1, trigger2 });
 
     auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);
@@ -448,12 +430,8 @@ TEST(TriggersWindow, TriggerDetailsLoadedForTrigger)
 TEST(TriggersWindow, SelectionSurvivesFiltering)
 {
     auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
-    auto trigger1 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger1, room).WillByDefault(Return(55));
-    ON_CALL(*trigger1, number).WillByDefault(Return(0));
-    auto trigger2 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger2, room).WillByDefault(Return(78));
-    ON_CALL(*trigger2, number).WillByDefault(Return(1));
+    auto trigger1 = std::make_shared<MockTrigger>()->with_number(0)->with_room(55);
+    auto trigger2 = std::make_shared<MockTrigger>()->with_number(1)->with_room(78);
     window->set_triggers({ trigger1, trigger2 });
     window->set_current_room(78);
 
@@ -479,17 +457,10 @@ TEST(TriggersWindow, SelectionSurvivesFiltering)
 TEST(TriggersWindow, FlipmapsFiltersAllFlipTriggers)
 {
     auto window = register_test_module().create<std::unique_ptr<TriggersWindow>>();
-    auto trigger1 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger1, number).WillByDefault(Return(0));
-    ON_CALL(*trigger1, commands).WillByDefault(Return<std::vector<Command>>({ Command(0, TriggerCommandType::FlipOff, 0) }));
-    auto trigger2 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger2, number).WillByDefault(Return(1));
-    ON_CALL(*trigger2, commands).WillByDefault(Return<std::vector<Command>>({ Command(0, TriggerCommandType::FlipOn, 0) }));
-    auto trigger3 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger3, number).WillByDefault(Return(2));
-    ON_CALL(*trigger3, commands).WillByDefault(Return<std::vector<Command>>({ Command(0, TriggerCommandType::FlipMap, 0) }));
-    auto trigger4 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger4, number).WillByDefault(Return(3));
+    auto trigger1 = std::make_shared<MockTrigger>()->with_number(0)->with_commands({ Command(0, TriggerCommandType::FlipOff, 0) });
+    auto trigger2 = std::make_shared<MockTrigger>()->with_number(1)->with_commands({ Command(0, TriggerCommandType::FlipOn, 0) });
+    auto trigger3 = std::make_shared<MockTrigger>()->with_number(2)->with_commands({ Command(0, TriggerCommandType::FlipMap, 0) });
+    auto trigger4 = std::make_shared<MockTrigger>()->with_number(3);
     window->set_triggers({ trigger1, trigger2, trigger3, trigger4 });
 
     auto list = window->root_control()->find<ui::Listbox>(TriggersWindow::Names::triggers_listbox);

--- a/trview.app.tests/TriggersWindowTests.cpp
+++ b/trview.app.tests/TriggersWindowTests.cpp
@@ -6,7 +6,6 @@
 #include <trview.ui/Listbox.h>
 #include <trview.app/Elements/Types.h>
 #include <trview.graphics/mocks/IDeviceWindow.h>
-#include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.common/Mocks/Windows/IClipboard.h>
 #include <trview.ui/Mocks/Input/IInput.h>
 #include <external/boost/di.hpp>

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -73,12 +73,12 @@ namespace trview
         void remove_waypoint(uint32_t index);
         void select_item(const Item& item);
         void select_room(uint32_t room);
-        void select_trigger(const Trigger* const trigger);
+        void select_trigger(const std::weak_ptr<ITrigger>& trigger);
         void select_waypoint(uint32_t index);
         void select_next_waypoint();
         void select_previous_waypoint();
         void set_item_visibility(const Item& item, bool visible);
-        void set_trigger_visibility(Trigger* const trigger, bool visible);
+        void set_trigger_visibility(const std::weak_ptr<ITrigger>& trigger, bool visible);
 
         // Rendering
         void render();

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -86,7 +86,7 @@ namespace trview
         virtual const ILevelTextureStorage& texture_storage() const = 0;
         /// Get the triggers in this level.
         /// @returns All triggers in the level.
-        virtual std::vector<Trigger*> triggers() const = 0;
+        virtual std::vector<std::weak_ptr<ITrigger>> triggers() const = 0;
         virtual trlevel::LevelVersion version() const = 0;
         // Event raised when the level needs to change the selected room.
         Event<uint16_t> on_room_selected;

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -2,9 +2,9 @@
 
 #include <SimpleMath.h>
 #include <trview.app/Elements/Item.h>
-#include <trview.app/Elements/Trigger.h>
-#include <trview.app/Elements/Room.h>
-#include <trview.app/Elements/Entity.h>
+#include <trview.app/Elements/ITrigger.h>
+#include <trview.app/Elements/IRoom.h>
+#include <trview.app/Elements/IEntity.h>
 #include <trview.common/Event.h>
 
 namespace trview

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -5,7 +5,7 @@
 #include <trview.app/Elements/Sector.h>
 #include <trview.app/Elements/RoomInfo.h>
 #include <trview.app/Elements/IEntity.h>
-#include <trview.app/Elements/Trigger.h>
+#include <trview.app/Elements/ITrigger.h>
 
 namespace trview
 {
@@ -39,7 +39,7 @@ namespace trview
         virtual void add_entity(IEntity* entity) = 0;
         /// Add the specified trigger to the room.
         /// @paramt trigger The trigger to add.
-        virtual void add_trigger(Trigger* trigger) = 0;
+        virtual void add_trigger(const std::weak_ptr<ITrigger>& trigger) = 0;
         /// Gets the alternate group for the room.
         /// @returns The alternate group number.
         virtual int16_t alternate_group() const = 0;
@@ -90,7 +90,7 @@ namespace trview
         /// This will change the alternate_mode of this room to IsAlternate.
         /// @param number The room number.
         virtual void set_is_alternate(int16_t number) = 0;
-        virtual Trigger* trigger_at(int32_t x, int32_t z) const = 0;
+        virtual std::weak_ptr<ITrigger> trigger_at(int32_t x, int32_t z) const = 0;
         virtual void update_bounding_box() = 0;
         virtual bool water() const = 0;
     };

--- a/trview.app/Elements/ITrigger.cpp
+++ b/trview.app/Elements/ITrigger.cpp
@@ -2,7 +2,108 @@
 
 namespace trview
 {
+    namespace
+    {
+        const std::unordered_map<TriggerType, std::wstring> trigger_type_names
+        {
+            { TriggerType::Trigger, L"Trigger" },
+            { TriggerType::Pad, L"Pad" },
+            { TriggerType::Switch, L"Switch" },
+            { TriggerType::Key, L"Key" },
+            { TriggerType::Pickup, L"Pickup" },
+            { TriggerType::HeavyTrigger, L"Heavy Trigger" },
+            { TriggerType::Antipad, L"Antipad" },
+            { TriggerType::Combat, L"Combat" },
+            { TriggerType::Dummy, L"Dummy" },
+            { TriggerType::AntiTrigger, L"Antitrigger" },
+            { TriggerType::HeavySwitch, L"Heavy Switch" },
+            { TriggerType::HeavyAntiTrigger, L"Heavy Antitrigger" },
+            { TriggerType::Monkey, L"Monkey" },
+            { TriggerType::Skeleton, L"Skeleton" },
+            { TriggerType::Tightrope, L"Tightrope" },
+            { TriggerType::Crawl, L"Crawl" },
+            { TriggerType::Climb, L"Climb"}
+        };
+
+        const std::unordered_map<TriggerCommandType, std::wstring> command_type_names
+        {
+            { TriggerCommandType::Object, L"Object" },
+            { TriggerCommandType::Camera, L"Camera" },
+            { TriggerCommandType::UnderwaterCurrent, L"Current" },
+            { TriggerCommandType::FlipMap, L"Flip Map" },
+            { TriggerCommandType::FlipOn, L"Flip On" },
+            { TriggerCommandType::FlipOff, L"Flip Off" },
+            { TriggerCommandType::LookAtItem, L"Look at Item" },
+            { TriggerCommandType::EndLevel, L"End Level" },
+            { TriggerCommandType::PlaySoundtrack, L"Music" },
+            { TriggerCommandType::Flipeffect, L"Flipeffect" },
+            { TriggerCommandType::SecretFound, L"Secret" },
+            { TriggerCommandType::ClearBodies, L"Clear Bodies" },
+            { TriggerCommandType::Flyby, L"Flyby" },
+            { TriggerCommandType::Cutscene, L"Cutscene" }
+        };
+
+        const std::unordered_map<std::wstring, TriggerCommandType> command_type_lookup
+        {
+            { L"Object", TriggerCommandType::Object },
+            { L"Camera", TriggerCommandType::Camera },
+            { L"Current", TriggerCommandType::UnderwaterCurrent },
+            { L"Flip Map", TriggerCommandType::FlipMap },
+            { L"Flip On", TriggerCommandType::FlipOn },
+            { L"Flip Off", TriggerCommandType::FlipOff },
+            { L"Look at Item", TriggerCommandType::LookAtItem },
+            { L"End Level", TriggerCommandType::EndLevel },
+            { L"Music", TriggerCommandType::PlaySoundtrack },
+            { L"Flipeffect", TriggerCommandType::Flipeffect },
+            { L"Secret", TriggerCommandType::SecretFound },
+            { L"Clear Bodies", TriggerCommandType::ClearBodies },
+            { L"Flyby", TriggerCommandType::Flyby },
+            { L"Cutscene", TriggerCommandType::Cutscene }
+        };
+    }
+
     ITrigger::~ITrigger()
     {
+    }
+
+    bool has_command(const ITrigger& trigger, TriggerCommandType type)
+    {
+        const auto commands = trigger.commands();
+        return std::any_of(commands.begin(), commands.end(), [&](const auto& c) { return c.type() == type; });
+    }
+
+    bool has_any_command(const ITrigger& trigger, const std::vector<TriggerCommandType>& types)
+    {
+        return std::any_of(types.begin(), types.end(), [&](const auto& type) { return has_command(trigger, type); });
+    }
+
+    std::wstring trigger_type_name(TriggerType type)
+    {
+        auto name = trigger_type_names.find(type);
+        if (name == trigger_type_names.end())
+        {
+            return L"Unknown";
+        }
+        return name->second;
+    }
+
+    std::wstring command_type_name(TriggerCommandType type)
+    {
+        auto name = command_type_names.find(type);
+        if (name == command_type_names.end())
+        {
+            return L"Unknown";
+        }
+        return name->second;
+    }
+
+    TriggerCommandType command_from_name(const std::wstring& name)
+    {
+        auto type = command_type_lookup.find(name);
+        if (type == command_type_lookup.end())
+        {
+            return TriggerCommandType::Object;
+        }
+        return type->second;
     }
 }

--- a/trview.app/Elements/ITrigger.cpp
+++ b/trview.app/Elements/ITrigger.cpp
@@ -1,0 +1,8 @@
+#include "ITrigger.h"
+
+namespace trview
+{
+    ITrigger::~ITrigger()
+    {
+    }
+}

--- a/trview.app/Elements/ITrigger.h
+++ b/trview.app/Elements/ITrigger.h
@@ -24,12 +24,10 @@ namespace trview
         virtual uint16_t flags() const = 0;
         virtual uint8_t timer() const = 0;
         virtual uint16_t sector_id() const = 0;
-        virtual const std::vector<Command>& commands() const = 0;
+        virtual const std::vector<Command> commands() const = 0;
         virtual const std::vector<TransparentTriangle>& triangles() const = 0;
         virtual void set_triangles(const std::vector<TransparentTriangle>& transparent_triangles) = 0;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
-        virtual bool has_command(TriggerCommandType type) const = 0;
-        virtual bool has_any_command(const std::vector<TriggerCommandType>& type) const = 0;
         virtual void set_position(const DirectX::SimpleMath::Vector3& position) = 0;
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
     };
@@ -49,4 +47,7 @@ namespace trview
     /// @param name The string to convert.
     /// @returns The trigger command type.
     TriggerCommandType command_from_name(const std::wstring& name);
+
+    bool has_command(const ITrigger& trigger, TriggerCommandType type);
+    bool has_any_command(const ITrigger& trigger, const std::vector<TriggerCommandType>& type);
 }

--- a/trview.app/Elements/ITrigger.h
+++ b/trview.app/Elements/ITrigger.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <trview.app/Geometry/IRenderable.h>
+#include <trview.app/Geometry/TransparentTriangle.h>
+#include <trview.app/Geometry/PickResult.h>
+
+namespace trview
+{
+    enum class TriggerType
+    {
+        Trigger, Pad, Switch, Key, Pickup, HeavyTrigger, Antipad, Combat, Dummy,
+        AntiTrigger, HeavySwitch, HeavyAntiTrigger, Monkey, Skeleton, Tightrope, Crawl, Climb
+    };
+
+    enum class TriggerCommandType
+    {
+        Object, Camera, UnderwaterCurrent, FlipMap, FlipOn, FlipOff, LookAtItem,
+        EndLevel, PlaySoundtrack, Flipeffect, SecretFound, ClearBodies, Flyby, Cutscene
+    };
+
+    class Command final
+    {
+    public:
+        Command(uint32_t number, TriggerCommandType type, uint16_t index);
+        uint32_t number() const;
+        TriggerCommandType type() const;
+        uint16_t index() const;
+    private:
+        uint32_t _number;
+        TriggerCommandType _type;
+        uint16_t _index;
+    };
+
+    struct ITrigger : public IRenderable
+    {
+        virtual ~ITrigger() = 0;
+        virtual uint32_t number() const = 0;
+        virtual uint32_t room() const = 0;
+        virtual uint16_t x() const = 0;
+        virtual uint16_t z() const = 0;
+        virtual bool triggers_item(uint32_t index) const = 0;
+        virtual TriggerType type() const = 0;
+        virtual bool only_once() const = 0;
+        virtual uint16_t flags() const = 0;
+        virtual uint8_t timer() const = 0;
+        virtual uint16_t sector_id() const = 0;
+        virtual const std::vector<Command>& commands() const = 0;
+        virtual const std::vector<TransparentTriangle>& triangles() const = 0;
+        virtual void set_triangles(const std::vector<TransparentTriangle>& transparent_triangles) = 0;
+        virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
+        virtual bool has_command(TriggerCommandType type) const = 0;
+        virtual bool has_any_command(const std::vector<TriggerCommandType>& type) const = 0;
+        virtual void set_position(const DirectX::SimpleMath::Vector3& position) = 0;
+        virtual DirectX::SimpleMath::Vector3 position() const = 0;
+    };
+
+
+    /// Get the string representation of the trigger type specified.
+    /// @param type The type to test.
+    /// @returns The string version of the enum.
+    std::wstring trigger_type_name(TriggerType type);
+
+    /// Get the string representation of the command type specified.
+    /// @param type The type to test.
+    /// @returns The string version of the enum.
+    std::wstring command_type_name(TriggerCommandType type);
+
+    /// Get the trigger command type from a string.
+    /// @param name The string to convert.
+    /// @returns The trigger command type.
+    TriggerCommandType command_from_name(const std::wstring& name);
+}

--- a/trview.app/Elements/ITrigger.h
+++ b/trview.app/Elements/ITrigger.h
@@ -5,36 +5,14 @@
 #include <trview.app/Geometry/IRenderable.h>
 #include <trview.app/Geometry/TransparentTriangle.h>
 #include <trview.app/Geometry/PickResult.h>
+#include <trview.app/Elements/Types.h>
 
 namespace trview
 {
-    enum class TriggerType
-    {
-        Trigger, Pad, Switch, Key, Pickup, HeavyTrigger, Antipad, Combat, Dummy,
-        AntiTrigger, HeavySwitch, HeavyAntiTrigger, Monkey, Skeleton, Tightrope, Crawl, Climb
-    };
-
-    enum class TriggerCommandType
-    {
-        Object, Camera, UnderwaterCurrent, FlipMap, FlipOn, FlipOff, LookAtItem,
-        EndLevel, PlaySoundtrack, Flipeffect, SecretFound, ClearBodies, Flyby, Cutscene
-    };
-
-    class Command final
-    {
-    public:
-        Command(uint32_t number, TriggerCommandType type, uint16_t index);
-        uint32_t number() const;
-        TriggerCommandType type() const;
-        uint16_t index() const;
-    private:
-        uint32_t _number;
-        TriggerCommandType _type;
-        uint16_t _index;
-    };
-
     struct ITrigger : public IRenderable
     {
+        using Source = std::function<std::shared_ptr<ITrigger>(uint32_t, uint32_t, uint16_t, uint16_t, const TriggerInfo&)>;
+
         virtual ~ITrigger() = 0;
         virtual uint32_t number() const = 0;
         virtual uint32_t room() const = 0;

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -2,7 +2,7 @@
 
 namespace trview
 {
-    Item::Item(uint32_t number, uint32_t room, uint32_t type_id, const std::wstring& type, int32_t ocb, uint16_t flags, const std::vector<Trigger*>& triggers, const DirectX::SimpleMath::Vector3& position)
+    Item::Item(uint32_t number, uint32_t room, uint32_t type_id, const std::wstring& type, int32_t ocb, uint16_t flags, const std::vector<std::weak_ptr<ITrigger>>& triggers, const DirectX::SimpleMath::Vector3& position)
         : _number(number), _room(room), _type_id(type_id), _type(type), _ocb(ocb), _flags(flags), _triggers(triggers), _position(position)
     {
     }
@@ -47,7 +47,7 @@ namespace trview
         return (_flags & 0x100) != 0;
     }
 
-    const std::vector<Trigger*>& Item::triggers() const
+    std::vector<std::weak_ptr<ITrigger>> Item::triggers() const
     {
         return _triggers;
     }

--- a/trview.app/Elements/Item.h
+++ b/trview.app/Elements/Item.h
@@ -22,7 +22,7 @@ namespace trview
         /// @param flags The flags for the entity.
         /// @param triggers The triggers that affect this entity.
         /// @param position The position of the entity.
-        explicit Item(uint32_t number, uint32_t room, const uint32_t type_id, const std::wstring& type, int32_t ocb, uint16_t flags, const std::vector<Trigger*>& triggers, const DirectX::SimpleMath::Vector3& position);
+        explicit Item(uint32_t number, uint32_t room, const uint32_t type_id, const std::wstring& type, int32_t ocb, uint16_t flags, const std::vector<std::weak_ptr<ITrigger>>& triggers, const DirectX::SimpleMath::Vector3& position);
 
         /// Get the item number.
         /// @returns The item number.
@@ -58,7 +58,7 @@ namespace trview
 
         /// Get the triggers that affect this object.
         /// @returns The triggers.
-        const std::vector<Trigger*>& triggers() const;
+        std::vector<std::weak_ptr<ITrigger>> triggers() const;
 
         /// Get the position of the entity.
         DirectX::SimpleMath::Vector3 position() const;
@@ -71,7 +71,7 @@ namespace trview
         /// @param value Whether the item is visible.
         void set_visible(bool value);
     private:
-        std::vector<Trigger*> _triggers;
+        std::vector<std::weak_ptr<ITrigger>> _triggers;
         DirectX::SimpleMath::Vector3 _position;
         uint32_t _number{ 0u };
         uint32_t _room{ 0u };

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -25,7 +25,6 @@ namespace trview
         std::unique_ptr<ITransparencyBuffer> transparency_buffer,
         std::unique_ptr<ISelectionRenderer> selection_renderer,
         std::shared_ptr<ITypeNameLookup> type_names,
-        const IMesh::TransparentSource& mesh_transparent_source,
         const IEntity::EntitySource& entity_source,
         const IEntity::AiSource& ai_source,
         const IRoom::Source& room_source,
@@ -230,7 +229,7 @@ namespace trview
             }
 
             // If this is an alternate room, render the items from the original room in the sample places.
-            if (!is_alternate_mismatch(room.room) && room.room.alternate_mode() == Room::AlternateMode::IsAlternate)
+            if (!is_alternate_mismatch(room.room) && room.room.alternate_mode() == IRoom::AlternateMode::IsAlternate)
             {
                 auto& original_room = _rooms[room.room.alternate_room()];
                 original_room->render_contained(camera, *_texture_storage.get(), room.selection_mode, room.room.water(), _show_water);
@@ -306,7 +305,7 @@ namespace trview
                 {
                     continue;
                 }
-                rooms.emplace_back(*room.get(), highlight ? (i == _selected_room ? Room::SelectionMode::Selected : Room::SelectionMode::NotSelected) : Room::SelectionMode::Selected, i);
+                rooms.emplace_back(*room.get(), highlight ? (i == _selected_room ? IRoom::SelectionMode::Selected : IRoom::SelectionMode::NotSelected) : IRoom::SelectionMode::Selected, i);
             }
         }
         else
@@ -318,7 +317,7 @@ namespace trview
                 {
                     continue;
                 }
-                rooms.emplace_back(*room, highlight ? (_selected_room == static_cast<uint16_t>(i) ? Room::SelectionMode::Selected : Room::SelectionMode::NotSelected) : Room::SelectionMode::Selected, static_cast<uint16_t>(i));
+                rooms.emplace_back(*room, highlight ? (_selected_room == static_cast<uint16_t>(i) ? IRoom::SelectionMode::Selected : IRoom::SelectionMode::NotSelected) : IRoom::SelectionMode::Selected, static_cast<uint16_t>(i));
             }
         }
 
@@ -341,7 +340,7 @@ namespace trview
         for (auto i = 0u; i < _rooms.size(); ++i)
         {
             const auto& room = _rooms[i];
-            if (room->alternate_mode() == Room::AlternateMode::HasAlternate)
+            if (room->alternate_mode() == IRoom::AlternateMode::HasAlternate)
             {
                 alternate_groups.insert(room->alternate_group());
 
@@ -484,7 +483,7 @@ namespace trview
         for (auto& room : rooms)
         {
             choose(room.room.pick(position, direction, true, _show_triggers, _show_hidden_geometry));
-            if (!is_alternate_mismatch(room.room) && room.room.alternate_mode() == Room::AlternateMode::IsAlternate)
+            if (!is_alternate_mismatch(room.room) && room.room.alternate_mode() == IRoom::AlternateMode::IsAlternate)
             {
                 auto& original_room = _rooms[room.room.alternate_room()];
                 choose(original_room->pick(position, direction, true, false, false, false));
@@ -577,12 +576,12 @@ namespace trview
     {
         if (version() >= trlevel::LevelVersion::Tomb4)
         {
-            return room.alternate_mode() == Room::AlternateMode::HasAlternate && is_alternate_group_set(room.alternate_group()) ||
-                   room.alternate_mode() == Room::AlternateMode::IsAlternate && !is_alternate_group_set(room.alternate_group());
+            return room.alternate_mode() == IRoom::AlternateMode::HasAlternate && is_alternate_group_set(room.alternate_group()) ||
+                   room.alternate_mode() == IRoom::AlternateMode::IsAlternate && !is_alternate_group_set(room.alternate_group());
         }
 
-        return room.alternate_mode() == Room::AlternateMode::IsAlternate && !_alternate_mode ||
-               room.alternate_mode() == Room::AlternateMode::HasAlternate && _alternate_mode;
+        return room.alternate_mode() == IRoom::AlternateMode::IsAlternate && !_alternate_mode ||
+               room.alternate_mode() == IRoom::AlternateMode::HasAlternate && _alternate_mode;
     }
 
     // Get the current state of the alternate mode (flipmap).
@@ -595,7 +594,7 @@ namespace trview
     {
         return std::any_of(_rooms.begin(), _rooms.end(), [](const std::shared_ptr<IRoom>& room)
         {
-            return room->alternate_mode() != Room::AlternateMode::None;
+            return room->alternate_mode() != IRoom::AlternateMode::None;
         });
     }
 
@@ -653,7 +652,7 @@ namespace trview
         for (auto i = 0u; i < _rooms.size(); ++i)
         {
             const auto& room = _rooms[i];
-            if (room->alternate_mode() != Room::AlternateMode::None)
+            if (room->alternate_mode() != IRoom::AlternateMode::None)
             {
                 groups.insert(room->alternate_group());
             }

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -4,15 +4,10 @@
 #include <trview.graphics/IShader.h>
 
 #include <trview.app/Graphics/LevelTextureStorage.h>
-#include <trview.app/Graphics/IMeshStorage.h>
 #include <trview.app/Camera/ICamera.h>
-#include <trview.app/Geometry/TransparencyBuffer.h>
-#include <trview.app/Graphics/SelectionRenderer.h>
-#include <trview.app/Graphics/MeshStorage.h>
 #include <trview.app/Elements/ITypeNameLookup.h>
 #include <trview.graphics/RasterizerStateStore.h>
 
-using namespace Microsoft::WRL;
 using namespace DirectX::SimpleMath;
 
 namespace trview
@@ -462,7 +457,7 @@ namespace trview
     // Returns: The result of the operation. If 'hit' is true, distance and position contain
     // how far along the ray the hit was and the position in world space. The room that was hit
     // is also specified.
-    PickResult Level::pick(const ICamera& camera, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const
+    PickResult Level::pick(const ICamera& camera, const Vector3& position, const Vector3& direction) const
     {
         PickResult final_result;
         

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -25,8 +25,7 @@ namespace trview
         const IRoom::Source& room_source,
         const ITrigger::Source& trigger_source)
         : _device(device), _version(level->get_version()), _texture_storage(std::move(level_texture_storage)),
-        _mesh_storage(std::move(mesh_storage)), _transparency(std::move(transparency_buffer)),
-        _selection_renderer(std::move(selection_renderer))
+        _transparency(std::move(transparency_buffer)), _selection_renderer(std::move(selection_renderer))
     {
         _vertex_shader = shader_storage->get("level_vertex_shader");
         _pixel_shader = shader_storage->get("level_pixel_shader");
@@ -52,9 +51,9 @@ namespace trview
         // Create the texture sampler state.
         _sampler_state = device->create_sampler_state(sampler_desc);
 
-        generate_rooms(*level, room_source);
+        generate_rooms(*level, room_source, *mesh_storage);
         generate_triggers(trigger_source);
-        generate_entities(*level, *type_names, entity_source, ai_source);
+        generate_entities(*level, *type_names, entity_source, ai_source, *mesh_storage);
 
         for (auto& room : _rooms)
         {
@@ -319,13 +318,13 @@ namespace trview
         return rooms;
     }
 
-    void Level::generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source)
+    void Level::generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage)
     {
         const auto num_rooms = level.num_rooms();
         for (uint32_t i = 0u; i < num_rooms; ++i)
         {
             auto room = level.get_room(i);
-            _rooms.push_back(room_source(level, room, *_texture_storage, *_mesh_storage, i, *this));
+            _rooms.push_back(room_source(level, room, *_texture_storage, mesh_storage, i, *this));
         }
 
         std::set<uint32_t> alternate_groups;
@@ -369,13 +368,13 @@ namespace trview
         }
     }
 
-    void Level::generate_entities(const trlevel::ILevel& level, const ITypeNameLookup& type_names, const IEntity::EntitySource& entity_source, const IEntity::AiSource& ai_source)
+    void Level::generate_entities(const trlevel::ILevel& level, const ITypeNameLookup& type_names, const IEntity::EntitySource& entity_source, const IEntity::AiSource& ai_source, const IMeshStorage& mesh_storage)
     {
         const uint32_t num_entities = level.num_entities();
         for (uint32_t i = 0; i < num_entities; ++i)
         {
             auto level_entity = level.get_entity(i);
-            auto entity = entity_source(level, level_entity, i, *_mesh_storage);
+            auto entity = entity_source(level, level_entity, i, mesh_storage);
             _rooms[entity->room()]->add_entity(entity.get());
             _entities.push_back(entity);
 
@@ -396,7 +395,7 @@ namespace trview
         for (uint32_t i = 0; i < num_ai_objects; ++i)
         {
             auto ai_object = level.get_ai_object(i);
-            auto entity = ai_source(level, ai_object, num_entities + i, *_mesh_storage);
+            auto entity = ai_source(level, ai_object, num_entities + i, mesh_storage);
             _rooms[entity->room()]->add_entity(entity.get());
             _entities.push_back(entity);
 

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -80,9 +80,9 @@ namespace trview
         virtual std::string filename() const override;
         virtual void set_filename(const std::string& filename) override;
     private:
-        void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage);
+        void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source);
         void generate_triggers(const ITrigger::Source& trigger_source);
-        void generate_entities(const trlevel::ILevel& level, const ITypeNameLookup& type_names, const IEntity::EntitySource& entity_source, const IEntity::AiSource& ai_source, const IMeshStorage& mesh_storage);
+        void generate_entities(const trlevel::ILevel& level, const ITypeNameLookup& type_names, const IEntity::EntitySource& entity_source, const IEntity::AiSource& ai_source);
         void regenerate_neighbours();
         void generate_neighbours(std::set<uint16_t>& results, uint16_t selected_room, int32_t max_depth);
 
@@ -141,6 +141,7 @@ namespace trview
         std::set<uint16_t> _neighbours;
 
         std::unique_ptr<ILevelTextureStorage> _texture_storage;
+        std::unique_ptr<IMeshStorage> _mesh_storage;
         std::unique_ptr<ITransparencyBuffer> _transparency;
 
         bool _regenerate_transparency{ true };

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -38,7 +38,6 @@ namespace trview
             std::unique_ptr<ITransparencyBuffer> transparency_buffer,
             std::unique_ptr<ISelectionRenderer> selection_renderer,
             std::shared_ptr<ITypeNameLookup> type_names,
-            const IMesh::TransparentSource& mesh_transparent_source,
             const IEntity::EntitySource& entity_source,
             const IEntity::AiSource& ai_source,
             const IRoom::Source& room_source,

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -41,7 +41,8 @@ namespace trview
             const IMesh::TransparentSource& mesh_transparent_source,
             const IEntity::EntitySource& entity_source,
             const IEntity::AiSource& ai_source,
-            const IRoom::Source& room_source);
+            const IRoom::Source& room_source,
+            const ITrigger::Source& trigger_source);
         virtual ~Level() = default;
         virtual std::vector<RoomInfo> room_info() const override;
         virtual RoomInfo room_info(uint32_t room) const override;
@@ -50,7 +51,7 @@ namespace trview
         virtual std::vector<Item> items() const override;
         virtual uint32_t number_of_rooms() const override;
         virtual std::vector<std::weak_ptr<IRoom>> rooms() const override;
-        virtual std::vector<Trigger*> triggers() const override;
+        virtual std::vector<std::weak_ptr<ITrigger>> triggers() const override;
         virtual PickResult pick(const ICamera& camera, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
         virtual void render(const ICamera& camera, bool render_selection) override;
         virtual void render_transparency(const ICamera& camera) override;
@@ -82,7 +83,7 @@ namespace trview
         virtual void set_filename(const std::string& filename) override;
     private:
         void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source);
-        void generate_triggers(const IMesh::TransparentSource& mesh_transparent_source);
+        void generate_triggers(const ITrigger::Source& trigger_source);
         void generate_entities(const trlevel::ILevel& level, const ITypeNameLookup& type_names, const IEntity::EntitySource& entity_source, const IEntity::AiSource& ai_source);
         void regenerate_neighbours();
         void generate_neighbours(std::set<uint16_t>& results, uint16_t selected_room, int32_t max_depth);
@@ -123,7 +124,7 @@ namespace trview
 
         std::shared_ptr<graphics::IDevice> _device;
         std::vector<std::shared_ptr<IRoom>>   _rooms;
-        std::vector<std::unique_ptr<Trigger>> _triggers;
+        std::vector<std::shared_ptr<ITrigger>> _triggers;
         std::vector<std::shared_ptr<IEntity>> _entities;
         std::vector<Item> _items;
 
@@ -137,7 +138,7 @@ namespace trview
         
         uint16_t           _selected_room{ 0u };
         std::weak_ptr<IEntity> _selected_item;
-        Trigger*           _selected_trigger{ nullptr };
+        std::weak_ptr<ITrigger> _selected_trigger;
         uint32_t           _neighbour_depth{ 1 };
         std::set<uint16_t> _neighbours;
 

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -9,7 +9,6 @@
 #include <trlevel/ILevel.h>
 #include <trview.app/Elements/ILevel.h>
 #include <trview.app/Geometry/ITransparencyBuffer.h>
-#include <trview.app/Geometry/Mesh.h>
 #include <trview.app/Graphics/ISelectionRenderer.h>
 #include <trview.app/Graphics/IMeshStorage.h>
 #include <trview.graphics/RenderTarget.h>
@@ -81,9 +80,9 @@ namespace trview
         virtual std::string filename() const override;
         virtual void set_filename(const std::string& filename) override;
     private:
-        void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source);
+        void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage);
         void generate_triggers(const ITrigger::Source& trigger_source);
-        void generate_entities(const trlevel::ILevel& level, const ITypeNameLookup& type_names, const IEntity::EntitySource& entity_source, const IEntity::AiSource& ai_source);
+        void generate_entities(const trlevel::ILevel& level, const ITypeNameLookup& type_names, const IEntity::EntitySource& entity_source, const IEntity::AiSource& ai_source, const IMeshStorage& mesh_storage);
         void regenerate_neighbours();
         void generate_neighbours(std::set<uint16_t>& results, uint16_t selected_room, int32_t max_depth);
 
@@ -142,7 +141,6 @@ namespace trview
         std::set<uint16_t> _neighbours;
 
         std::unique_ptr<ILevelTextureStorage> _texture_storage;
-        std::unique_ptr<IMeshStorage> _mesh_storage;
         std::unique_ptr<ITransparencyBuffer> _transparency;
 
         bool _regenerate_transparency{ true };

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -27,7 +27,7 @@ namespace trview
         struct IShader;
     }
 
-    class Level : public ILevel
+    class Level final : public ILevel
     {
     public:
         Level(const std::shared_ptr<graphics::IDevice>& device,

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -1,6 +1,7 @@
 #include "Room.h"
 #include <trview.app/Geometry/MeshVertex.h>
 #include <trview.app/Camera/ICamera.h>
+#include <trview.app/Elements/ILevel.h>
 
 using namespace DirectX::SimpleMath;
 

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -1,15 +1,7 @@
 #include "Room.h"
 #include <trview.app/Geometry/MeshVertex.h>
-#include "Entity.h"
-#include <trview.app/Elements/Level.h>
-
-#include <trview.app/Graphics/ILevelTextureStorage.h>
-#include <trview.app/Graphics/IMeshStorage.h>
 #include <trview.app/Camera/ICamera.h>
-#include <trview.app/Geometry/Mesh.h>
-#include <trview.app/Geometry/TransparencyBuffer.h>
 
-using namespace Microsoft::WRL;
 using namespace DirectX::SimpleMath;
 
 namespace trview

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -10,7 +10,7 @@
 
 #include <trlevel/trtypes.h>
 #include <trlevel/ILevel.h>
-#include <trview.app/Geometry/TransparencyBuffer.h>
+#include <trview.app/Geometry/ITransparencyBuffer.h>
 #include <trview.app/Geometry/IMesh.h>
 #include <trview.app/Elements/Sector.h>
 #include <trview.app/Geometry/PickResult.h>

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -39,7 +39,7 @@ namespace trview
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_hidden_geometry, bool show_water) override;
         virtual void render_contained(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_water, bool force_water = false) override;
         virtual void add_entity(IEntity* entity) override;
-        virtual void add_trigger(Trigger* trigger) override;
+        virtual void add_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual const std::vector<std::shared_ptr<Sector>> sectors() const override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool include_triggers, bool show_water) override;
         virtual void get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool show_water, bool force_water = false) override;
@@ -57,7 +57,7 @@ namespace trview
         virtual bool outside() const override;
         virtual bool water() const override;
         virtual bool quicksand() const override;
-        virtual Trigger* trigger_at(int32_t x, int32_t z) const override;
+        virtual std::weak_ptr<ITrigger> trigger_at(int32_t x, int32_t z) const override;
     private:
         void generate_geometry(trlevel::LevelVersion level_version, const IMesh::Source& mesh_source, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage);
         void generate_adjacency();
@@ -110,7 +110,7 @@ namespace trview
         int16_t              _alternate_group;
         AlternateMode        _alternate_mode;
 
-        std::unordered_map<uint32_t, Trigger*> _triggers;
+        std::unordered_map<uint32_t, std::weak_ptr<ITrigger>> _triggers;
         uint16_t _flags{ 0 };
         const ILevel& _level;
     };

--- a/trview.app/Elements/Trigger.cpp
+++ b/trview.app/Elements/Trigger.cpp
@@ -6,66 +6,6 @@ using namespace Microsoft::WRL;
 
 namespace trview
 {
-    namespace
-    {
-        const std::unordered_map<TriggerType, std::wstring> trigger_type_names
-        {
-            { TriggerType::Trigger, L"Trigger" },
-            { TriggerType::Pad, L"Pad" },
-            { TriggerType::Switch, L"Switch" },
-            { TriggerType::Key, L"Key" },
-            { TriggerType::Pickup, L"Pickup" },
-            { TriggerType::HeavyTrigger, L"Heavy Trigger" },
-            { TriggerType::Antipad, L"Antipad" },
-            { TriggerType::Combat, L"Combat" },
-            { TriggerType::Dummy, L"Dummy" },
-            { TriggerType::AntiTrigger, L"Antitrigger" },
-            { TriggerType::HeavySwitch, L"Heavy Switch" },
-            { TriggerType::HeavyAntiTrigger, L"Heavy Antitrigger" },
-            { TriggerType::Monkey, L"Monkey" },
-            { TriggerType::Skeleton, L"Skeleton" },
-            { TriggerType::Tightrope, L"Tightrope" },
-            { TriggerType::Crawl, L"Crawl" },
-            { TriggerType::Climb, L"Climb"}
-        };
-
-        const std::unordered_map<TriggerCommandType, std::wstring> command_type_names
-        {
-            { TriggerCommandType::Object, L"Object" },
-            { TriggerCommandType::Camera, L"Camera" },
-            { TriggerCommandType::UnderwaterCurrent, L"Current" },
-            { TriggerCommandType::FlipMap, L"Flip Map" },
-            { TriggerCommandType::FlipOn, L"Flip On" },
-            { TriggerCommandType::FlipOff, L"Flip Off" },
-            { TriggerCommandType::LookAtItem, L"Look at Item" },
-            { TriggerCommandType::EndLevel, L"End Level" },
-            { TriggerCommandType::PlaySoundtrack, L"Music" },
-            { TriggerCommandType::Flipeffect, L"Flipeffect" },
-            { TriggerCommandType::SecretFound, L"Secret" },
-            { TriggerCommandType::ClearBodies, L"Clear Bodies" },
-            { TriggerCommandType::Flyby, L"Flyby" },
-            { TriggerCommandType::Cutscene, L"Cutscene" }
-        };
-
-        const std::unordered_map<std::wstring, TriggerCommandType> command_type_lookup
-        {
-            { L"Object", TriggerCommandType::Object },
-            { L"Camera", TriggerCommandType::Camera },
-            { L"Current", TriggerCommandType::UnderwaterCurrent },
-            { L"Flip Map", TriggerCommandType::FlipMap },
-            { L"Flip On", TriggerCommandType::FlipOn },
-            { L"Flip Off", TriggerCommandType::FlipOff },
-            { L"Look at Item", TriggerCommandType::LookAtItem },
-            { L"End Level", TriggerCommandType::EndLevel },
-            { L"Music", TriggerCommandType::PlaySoundtrack },
-            { L"Flipeffect", TriggerCommandType::Flipeffect },
-            { L"Secret", TriggerCommandType::SecretFound },
-            { L"Clear Bodies", TriggerCommandType::ClearBodies },
-            { L"Flyby", TriggerCommandType::Flyby },
-            { L"Cutscene", TriggerCommandType::Cutscene }
-        };
-    }
-
     Command::Command(uint32_t number, TriggerCommandType type, uint16_t index)
         : _number(number), _type(type), _index(index)
     {
@@ -147,7 +87,7 @@ namespace trview
         return _timer;
     }
 
-    const std::vector<Command>& Trigger::commands() const
+    const std::vector<Command> Trigger::commands() const
     {
         return _commands;
     }
@@ -186,16 +126,6 @@ namespace trview
         return PickResult();
     }
 
-    bool Trigger::has_command(TriggerCommandType type) const
-    {
-        return std::any_of(_commands.begin(), _commands.end(), [&](const auto& c) { return c.type() == type; });
-    }
-
-    bool Trigger::has_any_command(const std::vector<TriggerCommandType>& types) const
-    {
-        return std::any_of(types.begin(), types.end(), [&](const auto& type) { return has_command(type); });
-    }
-
     void Trigger::render(const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&)
     {
     }
@@ -227,35 +157,5 @@ namespace trview
     void Trigger::set_visible(bool value)
     {
         _visible = value;
-    }
-
-    std::wstring trigger_type_name(TriggerType type)
-    {
-        auto name = trigger_type_names.find(type);
-        if (name == trigger_type_names.end())
-        {
-            return L"Unknown";
-        } 
-        return name->second;
-    }
-
-    std::wstring command_type_name(TriggerCommandType type)
-    {
-        auto name = command_type_names.find(type);
-        if (name == command_type_names.end())
-        {
-            return L"Unknown";
-        }
-        return name->second;
-    }
-
-    TriggerCommandType command_from_name(const std::wstring& name)
-    {
-        auto type = command_type_lookup.find(name);
-        if (type == command_type_lookup.end())
-        {
-            return TriggerCommandType::Object;
-        }
-        return type->second;
     }
 }

--- a/trview.app/Elements/Trigger.cpp
+++ b/trview.app/Elements/Trigger.cpp
@@ -1,8 +1,5 @@
 #include "Trigger.h"
 #include <trview.app/Elements/Types.h>
-#include <trview.app/Geometry/TransparencyBuffer.h>
-
-using namespace Microsoft::WRL;
 
 namespace trview
 {

--- a/trview.app/Elements/Trigger.h
+++ b/trview.app/Elements/Trigger.h
@@ -8,14 +8,11 @@ namespace trview
 {
     struct TriggerInfo;
 
-    class TransparencyBuffer;
-
     class Trigger final : public ITrigger
     {
     public:
         explicit Trigger(uint32_t number, uint32_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info, const IMesh::TransparentSource& mesh_source);
         virtual ~Trigger() = default;
-
         virtual uint32_t number() const override;
         virtual uint32_t room() const override;
         virtual uint16_t x() const override;
@@ -32,7 +29,6 @@ namespace trview
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
         virtual void set_position(const DirectX::SimpleMath::Vector3& position) override;
         virtual DirectX::SimpleMath::Vector3 position() const override;
-
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         virtual bool visible() const override;

--- a/trview.app/Elements/Trigger.h
+++ b/trview.app/Elements/Trigger.h
@@ -1,68 +1,39 @@
 #pragma once
 
-#include <cstdint>
-#include <vector>
-#include <trview.app/Geometry/TransparentTriangle.h>
-#include <trview.app/Geometry/PickResult.h>
 #include <trview.app/Geometry/IMesh.h>
-#include <trview.app/Geometry/IRenderable.h>
+#include <trview.app/Elements/ITrigger.h>
 
 namespace trview
 {
     struct TriggerInfo;
 
-    enum class TriggerType
-    {
-        Trigger, Pad, Switch, Key, Pickup, HeavyTrigger, Antipad, Combat, Dummy,
-        AntiTrigger, HeavySwitch, HeavyAntiTrigger, Monkey, Skeleton, Tightrope, Crawl, Climb
-    };
-
-    enum class TriggerCommandType
-    {
-        Object, Camera, UnderwaterCurrent, FlipMap, FlipOn, FlipOff, LookAtItem,
-        EndLevel, PlaySoundtrack, Flipeffect, SecretFound, ClearBodies, Flyby, Cutscene
-    };
-
-    class Command final
-    {
-    public:
-        Command(uint32_t number, TriggerCommandType type, uint16_t index);
-        uint32_t number() const;
-        TriggerCommandType type() const;
-        uint16_t index() const;
-    private:
-        uint32_t _number;
-        TriggerCommandType _type;
-        uint16_t _index;
-    };
-
     class TransparencyBuffer;
     struct ICamera;
 
-    class Trigger final : public IRenderable
+    class Trigger final : public ITrigger
     {
     public:
         explicit Trigger(uint32_t number, uint32_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info, const IMesh::TransparentSource& mesh_source);
         virtual ~Trigger() = default;
 
-        uint32_t    number() const;
-        uint32_t    room() const;
-        uint16_t    x() const;
-        uint16_t    z() const;
-        bool        triggers_item(uint32_t index) const;
-        TriggerType type() const;
-        bool        only_once() const;
-        uint16_t    flags() const;
-        uint8_t     timer() const;
-        uint16_t    sector_id() const;
-        const std::vector<Command>& commands() const;
-        const std::vector<TransparentTriangle>& triangles() const;
-        void set_triangles(const std::vector<TransparentTriangle>& transparent_triangles);
-        PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const;
-        bool has_command(TriggerCommandType type) const;
-        bool has_any_command(const std::vector<TriggerCommandType>& type) const;
-        void set_position(const DirectX::SimpleMath::Vector3& position);
-        DirectX::SimpleMath::Vector3 position() const;
+        virtual uint32_t number() const override;
+        virtual uint32_t room() const override;
+        virtual uint16_t x() const override;
+        virtual uint16_t z() const override;
+        virtual bool triggers_item(uint32_t index) const override;
+        virtual TriggerType type() const override;
+        virtual bool only_once() const override;
+        virtual uint16_t flags() const override;
+        virtual uint8_t timer() const override;
+        virtual uint16_t sector_id() const override;
+        virtual const std::vector<Command>& commands() const override;
+        virtual const std::vector<TransparentTriangle>& triangles() const override;
+        virtual void set_triangles(const std::vector<TransparentTriangle>& transparent_triangles) override;
+        virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
+        virtual bool has_command(TriggerCommandType type) const override;
+        virtual bool has_any_command(const std::vector<TriggerCommandType>& type) const override;
+        virtual void set_position(const DirectX::SimpleMath::Vector3& position) override;
+        virtual DirectX::SimpleMath::Vector3 position() const override;
 
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
@@ -85,19 +56,4 @@ namespace trview
         uint16_t _sector_id;
         bool _visible{ true };
     };
-
-    /// Get the string representation of the trigger type specified.
-    /// @param type The type to test.
-    /// @returns The string version of the enum.
-    std::wstring trigger_type_name(TriggerType type);
-
-    /// Get the string representation of the command type specified.
-    /// @param type The type to test.
-    /// @returns The string version of the enum.
-    std::wstring command_type_name(TriggerCommandType type);
-
-    /// Get the trigger command type from a string.
-    /// @param name The string to convert.
-    /// @returns The trigger command type.
-    TriggerCommandType command_from_name(const std::wstring& name);
 }

--- a/trview.app/Elements/Trigger.h
+++ b/trview.app/Elements/Trigger.h
@@ -2,13 +2,13 @@
 
 #include <trview.app/Geometry/IMesh.h>
 #include <trview.app/Elements/ITrigger.h>
+#include <trview.app/Camera/ICamera.h>
 
 namespace trview
 {
     struct TriggerInfo;
 
     class TransparencyBuffer;
-    struct ICamera;
 
     class Trigger final : public ITrigger
     {
@@ -26,12 +26,10 @@ namespace trview
         virtual uint16_t flags() const override;
         virtual uint8_t timer() const override;
         virtual uint16_t sector_id() const override;
-        virtual const std::vector<Command>& commands() const override;
+        virtual const std::vector<Command> commands() const override;
         virtual const std::vector<TransparentTriangle>& triangles() const override;
         virtual void set_triangles(const std::vector<TransparentTriangle>& transparent_triangles) override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
-        virtual bool has_command(TriggerCommandType type) const override;
-        virtual bool has_any_command(const std::vector<TriggerCommandType>& type) const override;
         virtual void set_position(const DirectX::SimpleMath::Vector3& position) override;
         virtual DirectX::SimpleMath::Vector3 position() const override;
 

--- a/trview.app/Elements/Types.h
+++ b/trview.app/Elements/Types.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <vector>
-#include <trview.app/Elements/Trigger.h>
 
 namespace trview
 {
@@ -36,12 +35,37 @@ namespace trview
         Left = 0x8
     };
 
+    enum class TriggerType
+    {
+        Trigger, Pad, Switch, Key, Pickup, HeavyTrigger, Antipad, Combat, Dummy,
+        AntiTrigger, HeavySwitch, HeavyAntiTrigger, Monkey, Skeleton, Tightrope, Crawl, Climb
+    };
+
+    enum class TriggerCommandType
+    {
+        Object, Camera, UnderwaterCurrent, FlipMap, FlipOn, FlipOff, LookAtItem,
+        EndLevel, PlaySoundtrack, Flipeffect, SecretFound, ClearBodies, Flyby, Cutscene
+    };
+
     struct TriggerInfo
     {
         std::uint8_t timer, oneshot, mask;
         TriggerType type; 
         uint16_t sector_id;
         std::vector<std::pair<TriggerCommandType, std::uint16_t>> commands;
+    };
+
+    class Command final
+    {
+    public:
+        Command(uint32_t number, TriggerCommandType type, uint16_t index);
+        uint32_t number() const;
+        TriggerCommandType type() const;
+        uint16_t index() const;
+    private:
+        uint32_t _number;
+        TriggerCommandType _type;
+        uint16_t _index;
     };
     
 }

--- a/trview.app/Elements/di.hpp
+++ b/trview.app/Elements/di.hpp
@@ -3,6 +3,7 @@
 #include <external/boost/di.hpp>
 #include "Level.h"
 #include "TypeNameLookup.h"
+#include "Entity.h"
 
 #include "Resources/resource.h"
 #include "Resources/ResourceHelper.h"
@@ -68,7 +69,6 @@ namespace trview
                             injector.create<std::unique_ptr<ITransparencyBuffer>>(),
                             injector.create<std::unique_ptr<ISelectionRenderer>>(),
                             injector.create<std::shared_ptr<ITypeNameLookup>>(),
-                            injector.create<IMesh::TransparentSource>(),
                             injector.create<IEntity::EntitySource>(),
                             injector.create<IEntity::AiSource>(),
                             injector.create<IRoom::Source>(),

--- a/trview.app/Elements/di.hpp
+++ b/trview.app/Elements/di.hpp
@@ -44,6 +44,14 @@ namespace trview
                         return std::make_shared<Room>(injector.create<IMesh::Source>(), level, room, texture_storage, mesh_storage, index, parent_level);
                     };
                 }),
+            di::bind<ITrigger::Source>.to(
+                [](const auto& injector) -> ITrigger::Source
+                {
+                    return [&](auto&& number, auto&& room, auto&& x, auto&& z, auto&& trigger_info)
+                    {
+                        return std::make_shared<Trigger>(number, room, x, z, trigger_info, injector.create<IMesh::TransparentSource>());
+                    };
+                }),
             di::bind<ILevel::Source>.to(
                 [](const auto& injector) -> ILevel::Source
                 {
@@ -63,7 +71,8 @@ namespace trview
                             injector.create<IMesh::TransparentSource>(),
                             injector.create<IEntity::EntitySource>(),
                             injector.create<IEntity::AiSource>(),
-                            injector.create<IRoom::Source>());
+                            injector.create<IRoom::Source>(),
+                            injector.create<ITrigger::Source>());
                     };
                 })
         );

--- a/trview.app/Geometry/IRenderable.h
+++ b/trview.app/Geometry/IRenderable.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <trview.graphics/Device.h>
 #include <SimpleMath.h>
 #include <trview.app/Geometry/ITransparencyBuffer.h>
 

--- a/trview.app/Geometry/IRenderable.h
+++ b/trview.app/Geometry/IRenderable.h
@@ -2,12 +2,12 @@
 
 #include <trview.graphics/Device.h>
 #include <SimpleMath.h>
+#include <trview.app/Geometry/ITransparencyBuffer.h>
 
 namespace trview
 {
     struct ICamera;
     struct ILevelTextureStorage;
-    struct ITransparencyBuffer;
 
     /// Interface for something that can be rendered by the viewer.
     struct IRenderable

--- a/trview.app/Graphics/SelectionRenderer.h
+++ b/trview.app/Graphics/SelectionRenderer.h
@@ -28,7 +28,6 @@ namespace trview
     struct IRenderable;
     struct ICamera;
     struct ILevelTextureStorage;
-    class Trigger;
 
     /// Draws an outline around an object.
     class SelectionRenderer final : public ISelectionRenderer

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -44,7 +44,7 @@ namespace trview
             MOCK_METHOD(bool, show_hidden_geometry, (), (const));
             MOCK_METHOD(bool, show_triggers, (), (const));
             MOCK_METHOD(const ILevelTextureStorage&, texture_storage, (), (const));
-            MOCK_METHOD(std::vector<Trigger*>, triggers, (), (const));
+            MOCK_METHOD(std::vector<std::weak_ptr<ITrigger>>, triggers, (), (const));
             MOCK_METHOD(trlevel::LevelVersion, version, (), (const));
         };
     }

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -10,7 +10,7 @@ namespace trview
         {
             virtual ~MockRoom() = default;
             MOCK_METHOD(void, add_entity, (IEntity*), (override));
-            MOCK_METHOD(void, add_trigger, (Trigger*), (override));
+            MOCK_METHOD(void, add_trigger, (const std::weak_ptr<ITrigger>&), (override));
             MOCK_METHOD(int16_t, alternate_group, (), (const, override));
             MOCK_METHOD(AlternateMode, alternate_mode, (), (const, override));
             MOCK_METHOD(int16_t, alternate_room, (), (const, override));
@@ -31,7 +31,7 @@ namespace trview
             MOCK_METHOD(void, render_contained, (const ICamera&, const ILevelTextureStorage&, SelectionMode, bool, bool), (override));;
             MOCK_METHOD(const std::vector<std::shared_ptr<Sector>>, sectors, (), (const, override));
             MOCK_METHOD(void, set_is_alternate, (int16_t), (override));
-            MOCK_METHOD(Trigger*, trigger_at, (int32_t, int32_t), (const, override));
+            MOCK_METHOD(std::weak_ptr<ITrigger>, trigger_at, (int32_t, int32_t), (const, override));
             MOCK_METHOD(void, update_bounding_box, (), (override));
             MOCK_METHOD(bool, water, (), (const, override));
         };

--- a/trview.app/Mocks/Elements/ITrigger.h
+++ b/trview.app/Mocks/Elements/ITrigger.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "../../Elements/ITrigger.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockTrigger final : public ITrigger
+        {
+            virtual ~MockTrigger() = default;
+            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&));
+            MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&));
+            MOCK_METHOD(bool, visible, (), (const));
+            MOCK_METHOD(void, set_visible, (bool));
+            MOCK_METHOD(uint32_t, number, (), (const));
+            MOCK_METHOD(uint32_t, room, (), (const));
+            MOCK_METHOD(uint16_t, x, (), (const));
+            MOCK_METHOD(uint16_t, z, (), (const));
+            MOCK_METHOD(bool, triggers_item, (uint32_t index), (const));
+            MOCK_METHOD(TriggerType, type, (), (const));
+            MOCK_METHOD(bool, only_once, (), (const));
+            MOCK_METHOD(uint16_t, flags, (), (const));
+            MOCK_METHOD(uint8_t, timer, (), (const));
+            MOCK_METHOD(uint16_t, sector_id, (), (const));
+            MOCK_METHOD(const std::vector<Command>, commands, (), (const));
+            MOCK_METHOD(const std::vector<TransparentTriangle>&, triangles, (), (const));
+            MOCK_METHOD(void, set_triangles, (const std::vector<TransparentTriangle>&));
+            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const));
+            MOCK_METHOD(void, set_position, (const DirectX::SimpleMath::Vector3&));
+            MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const));
+        };
+    }
+}

--- a/trview.app/Mocks/Elements/ITrigger.h
+++ b/trview.app/Mocks/Elements/ITrigger.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockTrigger final : public ITrigger
+        struct MockTrigger final : public ITrigger, public std::enable_shared_from_this<MockTrigger>
         {
             virtual ~MockTrigger() = default;
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&));
@@ -29,6 +29,36 @@ namespace trview
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const));
             MOCK_METHOD(void, set_position, (const DirectX::SimpleMath::Vector3&));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const));
+
+            std::shared_ptr<MockTrigger> with_number(uint32_t number)
+            {
+                ON_CALL(*this, number).WillByDefault(testing::Return(number));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockTrigger> with_room(uint32_t room)
+            {
+                ON_CALL(*this, room).WillByDefault(testing::Return(room));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockTrigger> with_commands(const std::vector<Command>& commands)
+            {
+                ON_CALL(*this, commands).WillByDefault(testing::Return(commands));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockTrigger> with_visible(bool visible)
+            {
+                ON_CALL(*this, visible).WillByDefault(testing::Return(visible));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockTrigger> with_visible(const std::function<bool()>& visible)
+            {
+                ON_CALL(*this, visible).WillByDefault(visible);
+                return shared_from_this();
+            }
         };
     }
 }

--- a/trview.app/Mocks/Windows/IItemsWindow.h
+++ b/trview.app/Mocks/Windows/IItemsWindow.h
@@ -13,7 +13,7 @@ namespace trview
             MOCK_METHOD(void, set_items, (const std::vector<Item>&));
             MOCK_METHOD(void, update_items, (const std::vector<Item>&));
             MOCK_METHOD(void, render, (bool));
-            MOCK_METHOD(void, set_triggers, (const std::vector<Trigger*>&));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
             MOCK_METHOD(void, clear_selected_item, ());
             MOCK_METHOD(void, set_current_room, (uint32_t));
             MOCK_METHOD(void, set_selected_item, (const Item&));

--- a/trview.app/Mocks/Windows/IItemsWindowManager.h
+++ b/trview.app/Mocks/Windows/IItemsWindowManager.h
@@ -12,7 +12,7 @@ namespace trview
             MOCK_METHOD(void, render, (bool));
             MOCK_METHOD(void, set_items, (const std::vector<Item>&));
             MOCK_METHOD(void, set_item_visible, (const Item&, bool));
-            MOCK_METHOD(void, set_triggers, (const std::vector<Trigger*>&));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
             MOCK_METHOD(void, set_room, (uint32_t));
             MOCK_METHOD(void, set_selected_item, (const Item&));
             MOCK_METHOD(std::weak_ptr<IItemsWindow>, create_window, ());

--- a/trview.app/Mocks/Windows/IRoomsWindow.h
+++ b/trview.app/Mocks/Windows/IRoomsWindow.h
@@ -15,8 +15,8 @@ namespace trview
             MOCK_METHOD(void, set_items, (const std::vector<Item>&));
             MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&));
             MOCK_METHOD(void, set_selected_item, (const Item&));;
-            MOCK_METHOD(void, set_selected_trigger, (const Trigger* const));
-            MOCK_METHOD(void, set_triggers, (const std::vector<Trigger*>&));
+            MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRoomsWindowManager.h
+++ b/trview.app/Mocks/Windows/IRoomsWindowManager.h
@@ -14,8 +14,8 @@ namespace trview
             MOCK_METHOD(void, set_room, (uint32_t));
             MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&));
             MOCK_METHOD(void, set_selected_item, (const Item&));
-            MOCK_METHOD(void, set_selected_trigger, (const Trigger* const ));
-            MOCK_METHOD(void, set_triggers, (const std::vector<Trigger*>&));
+            MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>& ));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
             MOCK_METHOD(std::weak_ptr<IRoomsWindow>, create_window, ());
         };
     }

--- a/trview.app/Mocks/Windows/IRouteWindowManager.h
+++ b/trview.app/Mocks/Windows/IRouteWindowManager.h
@@ -14,7 +14,7 @@ namespace trview
             MOCK_METHOD(void, create_window, ());
             MOCK_METHOD(void, set_items, (const std::vector<Item>&));
             MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&) );
-            MOCK_METHOD(void, set_triggers, (const std::vector<Trigger*>&));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
             MOCK_METHOD(void, select_waypoint, (uint32_t));
         };
     }

--- a/trview.app/Mocks/Windows/ITriggersWindow.h
+++ b/trview.app/Mocks/Windows/ITriggersWindow.h
@@ -11,12 +11,12 @@ namespace trview
         public:
             MOCK_METHOD(void, clear_selected_trigger, ());
             MOCK_METHOD(void, render, (bool));
-            MOCK_METHOD(std::optional<const Trigger*>, selected_trigger, (), (const));
+            MOCK_METHOD(std::weak_ptr<ITrigger>, selected_trigger, (), (const));
             MOCK_METHOD(void, set_current_room, (uint32_t));
             MOCK_METHOD(void, set_items, (const std::vector<Item>&));
-            MOCK_METHOD(void, set_selected_trigger, (const Trigger* const));
-            MOCK_METHOD(void, set_triggers, (const std::vector<Trigger*>&));
-            MOCK_METHOD(void, update_triggers, (const std::vector<Trigger*>&));
+            MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
+            MOCK_METHOD(void, update_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
         };
     }
 }

--- a/trview.app/Mocks/Windows/ITriggersWindowManager.h
+++ b/trview.app/Mocks/Windows/ITriggersWindowManager.h
@@ -11,10 +11,10 @@ namespace trview
         public:
             MOCK_METHOD(void, render, (bool));
             MOCK_METHOD(void, set_items, (const std::vector<Item>&));
-            MOCK_METHOD(void, set_triggers, (const std::vector<Trigger*>&));
-            MOCK_METHOD(void, set_trigger_visible, (Trigger* trigger, bool));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
+            MOCK_METHOD(void, set_trigger_visible, (const std::weak_ptr<ITrigger>& trigger, bool));
             MOCK_METHOD(void, set_room, (uint32_t));
-            MOCK_METHOD(void, set_selected_trigger, (const Trigger* const));
+            MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&));
             MOCK_METHOD(std::weak_ptr<ITriggersWindow>, create_window, ());
         };
     }

--- a/trview.app/Mocks/Windows/IViewer.h
+++ b/trview.app/Mocks/Windows/IViewer.h
@@ -15,7 +15,7 @@ namespace trview
             MOCK_METHOD(void, set_settings, (const UserSettings&));
             MOCK_METHOD(void, select_item, (const Item&));
             MOCK_METHOD(void, select_room, (uint32_t));
-            MOCK_METHOD(void, select_trigger, (const Trigger* const));
+            MOCK_METHOD(void, select_trigger, (const std::weak_ptr<ITrigger>&));
             MOCK_METHOD(void, select_waypoint, (const Waypoint&));
             MOCK_METHOD(void, set_camera_mode, (CameraMode), (override));
             MOCK_METHOD(void, set_route, (const std::shared_ptr<IRoute>&));

--- a/trview.app/Windows/IItemsWindow.h
+++ b/trview.app/Windows/IItemsWindow.h
@@ -4,7 +4,7 @@
 #include <optional>
 #include <trview.common/Event.h>
 #include <trview.app/Elements/Item.h>
-#include <trview.app/Elements/Trigger.h>
+#include <trview.app/Elements/ITrigger.h>
 
 namespace trview
 {

--- a/trview.app/Windows/IItemsWindow.h
+++ b/trview.app/Windows/IItemsWindow.h
@@ -21,7 +21,7 @@ namespace trview
         Event<Item, bool> on_item_visibility;
 
         /// Event raised when a trigger is selected in the list.
-        Event<Trigger*> on_trigger_selected;
+        Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
         /// Event raised when the 'add to route' button is pressed.
         Event<Item> on_add_to_route;
@@ -42,7 +42,7 @@ namespace trview
 
         /// Set the triggers to display in the window.
         /// @param triggers The triggers.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) = 0;
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
 
         /// Clear the currently selected item from the details panel.
         virtual void clear_selected_item() = 0;

--- a/trview.app/Windows/IItemsWindowManager.h
+++ b/trview.app/Windows/IItemsWindowManager.h
@@ -15,7 +15,7 @@ namespace trview
         Event<Item, bool> on_item_visibility;
 
         /// Event raised when a trigger is selected in one of the item windows.
-        Event<Trigger*> on_trigger_selected;
+        Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
         /// Event raised when the 'add to route' button is pressed in one of the item windows.
         Event<Item> on_add_to_route;
@@ -36,7 +36,7 @@ namespace trview
 
         /// Set the triggers to use in the windows.
         /// @param triggers The triggers in the level.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) = 0;
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
 
         /// Set the current room to filter item windows.
         /// @param room The current room.

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -3,8 +3,8 @@
 #include <cstdint>
 #include <trview.common/Event.h>
 #include <trview.app/Elements/Item.h>
-#include <trview.app/Elements/Trigger.h>
-#include <trview.app/Elements/Room.h>
+#include <trview.app/Elements/ITrigger.h>
+#include <trview.app/Elements/IRoom.h>
 
 namespace trview
 {

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -21,7 +21,7 @@ namespace trview
         Event<Item> on_item_selected;
 
         /// Event raised when the user has selected a trigger in the room window.
-        Event<Trigger*> on_trigger_selected;
+        Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
         /// Event raised when the window is closed.
         Event<> on_window_closed;
@@ -51,10 +51,10 @@ namespace trview
 
         /// Set the trigger currently selected in the viewer.
         /// @param trigger The trigger currently selected.
-        virtual void set_selected_trigger(const Trigger* const trigger) = 0;
+        virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) = 0;
 
         /// Set the triggers in the level.
         /// @param triggers The triggers in the level.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) = 0;
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -15,7 +15,7 @@ namespace trview
         Event<Item> on_item_selected;
 
         /// Event raised when the user has selected a trigger in the room window.
-        Event<Trigger*> on_trigger_selected;
+        Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
         /// Render all of the rooms windows.
         /// @param vsync Whether to use vsync.
@@ -38,11 +38,11 @@ namespace trview
 
         /// Set the trigger currently selected in the viewer.
         /// @param trigger The trigger currently selected.
-        virtual void set_selected_trigger(const Trigger* const trigger) = 0;
+        virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) = 0;
 
         /// Set the triggers in the level.
         /// @param triggers The triggers in the level.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) = 0;
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
 
         /// Create a new rooms window.
         virtual std::weak_ptr<IRoomsWindow> create_window() = 0;

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -21,7 +21,7 @@ namespace trview
         Event<Item> on_item_selected;
 
         /// Event raised when a trigger is selected.
-        Event<Trigger*> on_trigger_selected;
+        Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
         /// Event raised when the route colour has been changed.
         Event<Colour> on_colour_changed;
@@ -58,7 +58,7 @@ namespace trview
 
         /// Set the triggers in the level.
         /// @param triggers The triggers.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) = 0;
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& trigger) = 0;
 
         virtual void focus() = 0;
     };

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -2,8 +2,8 @@
 
 #include <trview.common/Event.h>
 #include <trview.app/Elements/Item.h>
-#include <trview.app/Elements/Room.h>
-#include <trview.app/Elements/Trigger.h>
+#include <trview.app/Elements/IRoom.h>
+#include <trview.app/Elements/ITrigger.h>
 #include <trview.app/Routing/IRoute.h>
 
 namespace trview

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -25,7 +25,7 @@ namespace trview
         Event<Item> on_item_selected;
 
         /// Event raised when a trigger is selected.
-        Event<Trigger*> on_trigger_selected;
+        Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
         /// Event raised when a waypoint is deleted.
         Event<uint32_t> on_waypoint_deleted;
@@ -49,7 +49,7 @@ namespace trview
 
         /// Set the triggers in the level.
         /// @param triggers The triggers.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) = 0;
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
 
         virtual void select_waypoint(uint32_t index) = 0;
     };

--- a/trview.app/Windows/ITriggersWindow.h
+++ b/trview.app/Windows/ITriggersWindow.h
@@ -16,16 +16,16 @@ namespace trview
         virtual ~ITriggersWindow() = 0;
 
         /// Event raised when a trigger is selected in the list.
-        Event<Trigger*> on_trigger_selected;
+        Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
         /// Event raised when the visibility of a trigger is changed.
-        Event<Trigger*, bool> on_trigger_visibility;
+        Event<std::weak_ptr<ITrigger>, bool> on_trigger_visibility;
 
         /// Event raised when an item is selected in the list.
         Event<Item> on_item_selected;
 
         /// Event raised when the 'add to route' button is pressed.
-        Event<const Trigger*> on_add_to_route;
+        Event<std::weak_ptr<ITrigger>> on_add_to_route;
 
         /// Event raised when the window is closed.
         Event<> on_window_closed;
@@ -37,7 +37,7 @@ namespace trview
         /// @param vsync Whether to use vsync or not.
         virtual void render(bool vsync) = 0;
 
-        virtual std::optional<const Trigger*> selected_trigger() const = 0;
+        virtual std::weak_ptr<ITrigger> selected_trigger() const = 0;
 
         /// Set the current room. This will be used when the track room setting is on.
         /// @param room The current room number.
@@ -45,17 +45,17 @@ namespace trview
 
         virtual void set_items(const std::vector<Item>& items) = 0;
 
-        /// Set the selected item.
-        /// @param item The selected item.
-        virtual void set_selected_trigger(const Trigger* const item) = 0;
+        /// Set the selected trigger.
+        /// @param item The selected trigger.
+        virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) = 0;
 
         /// Set the triggers to display in the window.
         /// @param triggers The triggers.
         /// @param reset_filters Whether to reset the trigger filters.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) = 0;
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
 
         /// Update the trigers - this doesn't reset the filters.
-        virtual void update_triggers(const std::vector<Trigger*>& triggers) = 0;
+        virtual void update_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
     };
 }
 

--- a/trview.app/Windows/ITriggersWindow.h
+++ b/trview.app/Windows/ITriggersWindow.h
@@ -4,7 +4,7 @@
 #include <optional>
 #include <trview.common/Event.h>
 #include <trview.app/Elements/Item.h>
-#include <trview.app/Elements/Trigger.h>
+#include <trview.app/Elements/ITrigger.h>
 #include <trview.ui/Control.h>
 
 namespace trview

--- a/trview.app/Windows/ITriggersWindowManager.h
+++ b/trview.app/Windows/ITriggersWindowManager.h
@@ -11,13 +11,13 @@ namespace trview
         /// Event raised when an item is selected in one of the trigger windows.
         Event<Item> on_item_selected;
 
-        Event<Trigger*, bool> on_trigger_visibility;
+        Event<std::weak_ptr<ITrigger>, bool> on_trigger_visibility;
 
         /// Event raised when a trigger is selected in one of the trigger windows.
-        Event<Trigger*> on_trigger_selected;
+        Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
         /// Event raised when the 'add to route' button is pressed in one of the trigger windows.
-        Event<const Trigger*> on_add_to_route;
+        Event<std::weak_ptr<ITrigger>> on_add_to_route;
 
         /// Render all of the triggers windows.
         /// @param vsync Whether to use vsync.
@@ -29,12 +29,12 @@ namespace trview
 
         /// Set the triggers to use in the windows.
         /// @param triggers The triggers in the level.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) = 0;
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
 
         /// Set whether a trigger is visible.
         /// @param trigger The trigger.
         /// @param visible Whether the trigger is visible.
-        virtual void set_trigger_visible(Trigger* trigger, bool visible) = 0;
+        virtual void set_trigger_visible(const std::weak_ptr<ITrigger>& trigger, bool visible) = 0;
 
         /// Set the current room to filter trigger windows.
         /// @param room The current room.
@@ -42,7 +42,7 @@ namespace trview
 
         /// Set the currently selected trigger.
         /// @param item The selected trigger.
-        virtual void set_selected_trigger(const Trigger* const trigger) = 0;
+        virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) = 0;
 
         /// Create a new triggers window.
         virtual std::weak_ptr<ITriggersWindow> create_window() = 0;

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -5,7 +5,7 @@
 
 #include <trview.common/Event.h>
 #include <trview.app/Elements/Item.h>
-#include <trview.app/Elements/Trigger.h>
+#include <trview.app/Elements/ITrigger.h>
 #include <trview.app/Elements/ILevel.h>
 #include <trview.app/Routing/Route.h>
 #include <trview.app/Routing/Waypoint.h>

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -32,10 +32,10 @@ namespace trview
         Event<uint32_t> on_room_selected;
 
         /// Event raised when the viewer wants to select a trigger.
-        Event<Trigger*> on_trigger_selected;
+        Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
         /// Event raised when the viewer wants to change the visibility of a trigger.
-        Event<Trigger*, bool> on_trigger_visibility;
+        Event<std::weak_ptr<ITrigger>, bool> on_trigger_visibility;
 
         /// Event raised when the viewer wants to select a waypoint.
         Event<uint32_t> on_waypoint_selected;
@@ -70,7 +70,7 @@ namespace trview
         /// Select the specified trigger.
         /// @param trigger The trigger to select.
         /// @remarks This will not raise the on_trigger_selected event.
-        virtual void select_trigger(const Trigger* const trigger) = 0;
+        virtual void select_trigger(const std::weak_ptr<ITrigger>& trigger) = 0;
 
         /// Select the specified waypoint
         /// @param index The waypoint to select.

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -64,7 +64,7 @@ namespace trview
         }
     }
 
-    void ItemsWindow::set_triggers(const std::vector<Trigger*>& triggers)
+    void ItemsWindow::set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers)
     {
         _all_triggers = triggers;
         _trigger_list->set_items({});
@@ -276,12 +276,17 @@ namespace trview
         std::vector<Listbox::Item> triggers;
         for (auto& trigger : item.triggers())
         {
+            auto trigger_ptr = trigger.lock();
+            if (!trigger_ptr)
+            {
+                continue;
+            }
             triggers.push_back(
                 {
                     {
-                        { L"#", std::to_wstring(trigger->number()) },
-                        { L"Room", std::to_wstring(trigger->room()) },
-                        { L"Type", trigger_type_name(trigger->type()) },
+                        { L"#", std::to_wstring(trigger_ptr->number()) },
+                        { L"Room", std::to_wstring(trigger_ptr->room()) },
+                        { L"Type", trigger_type_name(trigger_ptr->type()) },
                     }
                 });
         }

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -39,36 +39,14 @@ namespace trview
             const ui::IInput::Source& input_source,
             const Window& parent,
             const std::shared_ptr<IClipboard>& clipboard);
-
-        /// Destructor for items window
         virtual ~ItemsWindow() = default;
-
         virtual void render(bool vsync) override;
-
-        /// Set the items to display in the window.
-        /// @param items The items to show.
         virtual void set_items(const std::vector<Item>& items) override;
-
-        /// Update the items - this doesn't reset the filters.
         virtual void update_items(const std::vector<Item>& items) override;
-
-        /// Set the triggers to display in the window.
-        /// @param triggers The triggers.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) override;
-
-        /// Clear the currently selected item from the details panel.
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void clear_selected_item() override;
-
-        /// Set the current room. This will be used when the track room setting is on.
-        /// @param room The current room number.
         virtual void set_current_room(uint32_t room) override;
-
-        /// Set the selected item.
-        /// @param item The selected item.
         virtual void set_selected_item(const Item& item) override;
-
-        /// Get the selected item.
-        /// @returns The selected item, if present.
         virtual std::optional<Item> selected_item() const override;
     protected:
         /// After the window has been resized, adjust the sizes of the child elements.
@@ -87,7 +65,7 @@ namespace trview
         ui::Listbox* _trigger_list;
         ui::Checkbox* _track_room_checkbox;
         std::vector<Item> _all_items;
-        std::vector<Trigger*> _all_triggers;
+        std::vector<std::weak_ptr<ITrigger>> _all_triggers;
         /// Whether the item window is tracking the current room.
         bool _track_room{ false };
         /// The current room number selected for tracking.

--- a/trview.app/Windows/ItemsWindowManager.cpp
+++ b/trview.app/Windows/ItemsWindowManager.cpp
@@ -83,7 +83,7 @@ namespace trview
         }
     }
 
-    void ItemsWindowManager::set_triggers(const std::vector<Trigger*>& triggers)
+    void ItemsWindowManager::set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers)
     {
         _triggers = triggers;
         for (auto& window : _windows)

--- a/trview.app/Windows/ItemsWindowManager.h
+++ b/trview.app/Windows/ItemsWindowManager.h
@@ -23,48 +23,20 @@ namespace trview
         /// @param shortcuts The shortcuts instance to use.
         /// @param items_window_source Function to call to create a triggers window.
         explicit ItemsWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const IItemsWindow::Source& items_window_source);
-
-        /// Destructor for the ItemsWindowManager.
         virtual ~ItemsWindowManager() = default;
-
-        /// Handles a window message.
-        /// @param message The message that was received.
-        /// @param wParam The WPARAM for the message.
-        /// @param lParam The LPARAM for the message.
         virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
-
-        /// Render all of the item windows.
-        /// @param vsync Whether to use vsync.
         virtual void render(bool vsync) override;
-
-        /// Set the items to use in the windows.
-        /// @param items The items in the level.
         virtual void set_items(const std::vector<Item>& items) override;
-
-        /// Set whether an item is visible.
-        /// @param item The item.
-        /// @param visible Whether the item is visible.
         virtual void set_item_visible(const Item& item, bool visible) override;
-
-        /// Set the triggers to use in the windows.
-        /// @param triggers The triggers in the level.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) override;
-
-        /// Set the current room to filter item windows.
-        /// @param room The current room.
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void set_room(uint32_t room) override;
-
-        /// Set the currently selected item.
-        /// @param item The selected item.
         virtual void set_selected_item(const Item& item) override;
-
-        /// Create a new items window.
         virtual std::weak_ptr<IItemsWindow> create_window() override;
     private:
         std::vector<std::shared_ptr<IItemsWindow>> _windows;
         std::vector<std::weak_ptr<IItemsWindow>> _closing_windows;
         std::vector<Item> _items;
-        std::vector<Trigger*> _triggers;
+        std::vector<std::weak_ptr<ITrigger>> _triggers;
         uint32_t _current_room{ 0u };
         TokenStore _token_store;
         std::optional<Item> _selected_item;

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -2,9 +2,9 @@
 #include <trview.ui/StackPanel.h>
 #include <trview.ui/GroupBox.h>
 #include <trview.ui/Image.h>
-#include <trview.app/Elements/Room.h>
+#include <trview.app/Elements/IRoom.h>
 #include <trview.app/Elements/Item.h>
-#include <trview.app/Elements/Trigger.h>
+#include <trview.app/Elements/ITrigger.h>
 #include <trview.common/Strings.h>
 #include <trview.input/IMouse.h>
 

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -12,9 +12,6 @@
 
 namespace trview
 {
-    class Room;
-    class Trigger;
-
     class RoomsWindow final : public IRoomsWindow, public CollapsiblePanel
     {
     public:

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -33,37 +33,15 @@ namespace trview
             const ui::render::IMapRenderer::Source& map_renderer_source,
             const ui::IInput::Source& input_source,
             const Window& parent);
-
-        /// Destructor for rooms window
         virtual ~RoomsWindow() = default;
-
         virtual void clear_selected_trigger() override;
-
         virtual void render(bool vsync) override;
-
-        /// Set the current room that the viewer is focusing on.
-        /// @param room The current room.
         virtual void set_current_room(uint32_t room) override;
-
-        /// Set the items in the level.
-        /// @param items The items in the level.
         virtual void set_items(const std::vector<Item>& items) override;
-
-        /// Set the rooms to display in the window.
-        /// @param rooms The rooms to show.
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& rooms) override;
-
-        /// Set the item currently selected in the viewer.
-        /// @param item The item currently selected.
         virtual void set_selected_item(const Item& item) override;
-
-        /// Set the trigger currently selected in the viewer.
-        /// @param trigger The trigger currently selected.
-        virtual void set_selected_trigger(const Trigger* const trigger) override;
-
-        /// Set the triggers in the level.
-        /// @param triggers The triggers in the level.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) override;
+        virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
     private:
         void load_room_details(const std::weak_ptr<IRoom>& room_ptr);
         std::unique_ptr<ui::Control> create_left_panel();
@@ -79,7 +57,7 @@ namespace trview
 
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<Item> _all_items;
-        std::vector<Trigger*> _all_triggers;
+        std::vector<std::weak_ptr<ITrigger>> _all_triggers;
 
         ui::Listbox* _rooms_list;
         ui::Listbox* _neighbours_list;
@@ -96,7 +74,7 @@ namespace trview
         bool _track_trigger{ false };
         uint32_t _current_room{ 0u };
         std::optional<Item> _selected_item;
-        std::optional<const Trigger*> _selected_trigger;
+        std::weak_ptr<ITrigger> _selected_trigger;
 
         std::unique_ptr<ui::render::IMapRenderer> _map_renderer;
         std::unique_ptr<Tooltip> _map_tooltip;

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -38,9 +38,9 @@ namespace trview
         }
     }
 
-    const Trigger* RoomsWindowManager::selected_trigger() const
+    std::weak_ptr<ITrigger> RoomsWindowManager::selected_trigger() const
     {
-        return _selected_trigger.value_or(nullptr);
+        return _selected_trigger;
     }
 
     void RoomsWindowManager::set_items(const std::vector<Item>& items)
@@ -79,7 +79,7 @@ namespace trview
         }
     }
 
-    void RoomsWindowManager::set_selected_trigger(const Trigger* const trigger)
+    void RoomsWindowManager::set_selected_trigger(const std::weak_ptr<ITrigger>& trigger)
     {
         _selected_trigger = trigger;
         for (auto& window : _windows)
@@ -88,7 +88,7 @@ namespace trview
         }
     }
 
-    void RoomsWindowManager::set_triggers(const std::vector<Trigger*>& triggers)
+    void RoomsWindowManager::set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers)
     {
         _all_triggers = triggers;
         _selected_trigger.reset();

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -26,57 +26,26 @@ namespace trview
         /// @param shortcuts The shortcuts instance.
         /// @param rooms_window_source The function to call to get a rooms window.
         explicit RoomsWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const IRoomsWindow::Source& rooms_window_source);
-
-        /// Destructor for the RoomsWindowManager.
         virtual ~RoomsWindowManager() = default;
-
-        /// Handles a window message.
-        /// @param message The message that was received.
-        /// @param wParam The WPARAM for the message.
-        /// @param lParam The LPARAM for the message.
         virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
-
-        /// Render all of the rooms windows.
-        /// @param vsync Whether to use vsync.
         virtual void render(bool vsync) override;
-
-        /// Get the currently selected trigger.
-        const Trigger* selected_trigger() const;
-
-        /// Set the items in the current level.
+        std::weak_ptr<ITrigger> selected_trigger() const;
         virtual void set_items(const std::vector<Item>& items) override;
-
-        /// Set the current room that the viewer is focusing on.
-        /// @param room The current room.
         virtual void set_room(uint32_t room) override;
-
-        /// Set the rooms to display in the window.
-        /// @param rooms The rooms to show.
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& items) override;
-
-        /// Set the item currently selected in the viewer.
-        /// @param item The item currently selected.
         virtual void set_selected_item(const Item& item) override;
-
-        /// Set the trigger currently selected in the viewer.
-        /// @param trigger The trigger currently selected.
-        virtual void set_selected_trigger(const Trigger* const trigger) override;
-
-        /// Set the triggers in the level.
-        /// @param triggers The triggers in the level.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) override;
-
-        /// Create a new rooms window.
+        virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual std::weak_ptr<IRoomsWindow> create_window() override;
     private:
         std::vector<std::shared_ptr<IRoomsWindow>> _windows;
         std::vector<std::weak_ptr<IRoomsWindow>> _closing_windows;
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
-        std::vector<Trigger*> _all_triggers;
+        std::vector<std::weak_ptr<ITrigger>> _all_triggers;
         TokenStore _token_store;
         uint32_t _current_room;
-        std::optional<const Trigger*> _selected_trigger;
+        std::weak_ptr<ITrigger> _selected_trigger;
         std::optional<Item> _selected_item;
         IRoomsWindow::Source _rooms_window_source;
     };

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -366,7 +366,10 @@ namespace trview
         {
             if (waypoint.index() < _all_triggers.size())
             {
-                type = trigger_type_name(_all_triggers[waypoint.index()]->type());
+                if (auto trigger = _all_triggers[waypoint.index()].lock())
+                {
+                    type = trigger_type_name(trigger->type());
+                }
             }
             else
             {
@@ -437,7 +440,10 @@ namespace trview
                 std::wstring type = L"Invalid trigger";
                 if (waypoint.index() < _all_triggers.size())
                 {
-                    type = trigger_type_name(_all_triggers[waypoint.index()]->type());
+                    if (auto trigger = _all_triggers[waypoint.index()].lock())
+                    {
+                        type = trigger_type_name(trigger->type());
+                    }
                 }
                 stats.push_back(make_item(L"Trigger Type", type));
             }
@@ -485,9 +491,7 @@ namespace trview
         _all_rooms = rooms;
     }
 
-    /// Set the triggers in the level.
-    /// @param triggers The triggers.
-    void RouteWindow::set_triggers(const std::vector<Trigger*>& triggers)
+    void RouteWindow::set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers)
     {
         _all_triggers = triggers;
     }

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -30,30 +30,13 @@ namespace trview
         /// @param parent The parent window.
         explicit RouteWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
             const ui::IInput::Source& input_source, const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard);
-
-        /// Destructor for triggers window
         virtual ~RouteWindow() = default;
-
         virtual void render(bool vsync) override;
-
-        /// Load the waypoints from the route.
-        /// @param route The route to load from.
         virtual void set_route(IRoute* route) override;
-
-        /// Select the specified waypoint.
-        /// @param index The index of the waypoint to select.
         virtual void select_waypoint(uint32_t index) override;
-
-        /// Set the items to that are in the level.
-        /// @param items The items to show.
         virtual void set_items(const std::vector<Item>& items) override;
-
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& rooms) override;
-
-        /// Set the triggers in the level.
-        /// @param triggers The triggers.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) override;
-
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void focus() override;
     private:
         void load_waypoint_details(uint32_t index);
@@ -71,7 +54,7 @@ namespace trview
         IRoute* _route{ nullptr };
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
-        std::vector<Trigger*> _all_triggers;
+        std::vector<std::weak_ptr<ITrigger>> _all_triggers;
         Waypoint::Type _selected_type{ Waypoint::Type::Position };
         uint32_t       _selected_index{ 0u };
         std::shared_ptr<IClipboard> _clipboard;

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -89,12 +89,9 @@ namespace trview
         }
     }
 
-    /// Set the triggers in the level.
-    /// @param triggers The triggers.
-    void RouteWindowManager::set_triggers(const std::vector<Trigger*>& triggers)
+    void RouteWindowManager::set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers)
     {
         _all_triggers = triggers;
-
         if (_route_window)
         {
             _route_window->set_triggers(triggers);

--- a/trview.app/Windows/RouteWindowManager.h
+++ b/trview.app/Windows/RouteWindowManager.h
@@ -12,36 +12,14 @@ namespace trview
     {
     public:
         explicit RouteWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const IRouteWindow::Source& route_window_source);
-
         virtual ~RouteWindowManager() = default;
-
-        /// Handles a window message.
-        /// @param message The message that was received.
-        /// @param wParam The WPARAM for the message.
-        /// @param lParam The LPARAM for the message.
         virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
-
-        /// Render all of the route windows.
-        /// @param vsync Whether to use vsync.
         virtual void render(bool vsync) override;
-
-        /// Load the waypoints from the route.
-        /// @param route The route to load from.
         virtual void set_route(IRoute* route) override;
-
-        /// Create a new route window.
         virtual void create_window() override;
-
-        /// Set the items to that are in the level.
-        /// @param items The items to show.
         virtual void set_items(const std::vector<Item>& items) override;
-
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& rooms) override;
-
-        /// Set the triggers in the level.
-        /// @param triggers The triggers.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) override;
-
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void select_waypoint(uint32_t index) override;
     private:
         TokenStore _token_store;
@@ -50,7 +28,7 @@ namespace trview
         IRoute* _route{ nullptr };
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
-        std::vector<Trigger*> _all_triggers;
+        std::vector<std::weak_ptr<ITrigger>> _all_triggers;
         uint32_t _selected_waypoint{ 0u };
         IRouteWindow::Source _route_window_source;
     };

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -31,7 +31,7 @@ namespace trview
                      { L"Hide", std::to_wstring(!item.visible()) }}};
         }
 
-        ui::Listbox::Item create_listbox_item_pointer(const std::weak_ptr<ITrigger>& const trigger)
+        ui::Listbox::Item create_listbox_item_pointer(const std::weak_ptr<ITrigger>& trigger)
         {
             if (const auto trigger_ptr = trigger.lock())
             {
@@ -297,7 +297,7 @@ namespace trview
                 return;
             }
 
-            if (!_selected_commands.empty() && !trigger_ptr->has_any_command(_selected_commands))
+            if (!_selected_commands.empty() && !has_any_command(*trigger_ptr, _selected_commands))
             {
                 _selected_commands.clear();
                 _command_filter->set_selected_value(L"All");
@@ -413,7 +413,7 @@ namespace trview
 
         auto command_filter = [&](const auto& trigger)
         {
-            return _selected_commands.empty() || trigger->has_any_command(_selected_commands);
+            return _selected_commands.empty() || has_any_command(*trigger, _selected_commands);
         };
 
         std::vector<std::weak_ptr<ITrigger>> filtered_triggers;

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -23,7 +23,7 @@ namespace trview
             const Colour DetailsBorder{ 0.0f, 0.0f, 0.0f, 0.0f };
         }
 
-        ui::Listbox::Item create_listbox_item(const Trigger& item)
+        ui::Listbox::Item create_listbox_item(const ITrigger& item)
         {
             return { {{ L"#", std::to_wstring(item.number()) },
                      { L"Room", std::to_wstring(item.room()) },
@@ -31,9 +31,13 @@ namespace trview
                      { L"Hide", std::to_wstring(!item.visible()) }}};
         }
 
-        ui::Listbox::Item create_listbox_item_pointer(const Trigger* const item)
+        ui::Listbox::Item create_listbox_item_pointer(const std::weak_ptr<ITrigger>& const trigger)
         {
-            return create_listbox_item(*item);
+            if (const auto trigger_ptr = trigger.lock())
+            {
+                return create_listbox_item(*trigger_ptr);
+            }
+            return { {} };
         }
     }
 
@@ -126,7 +130,10 @@ namespace trview
         _token_store += _triggers_list->on_item_selected += [&](const auto& item)
         {
             auto index = std::stoi(item.value(L"#"));
-            load_trigger_details(*_all_triggers[index]);
+            if (auto trigger = _all_triggers[index].lock())
+            {
+                load_trigger_details(*trigger);
+            }
             if (_sync_trigger)
             {
                 on_trigger_selected(_all_triggers[index]);
@@ -178,9 +185,9 @@ namespace trview
         button->set_name(Names::add_to_route_button);
         _token_store += button->on_click += [&]()
         {
-            if (_selected_trigger.has_value())
+            if (const auto trigger_ptr = _selected_trigger.lock())
             {
-                on_add_to_route(_selected_trigger.value());
+                on_add_to_route(_selected_trigger);
             }
         };
 
@@ -205,18 +212,21 @@ namespace trview
         _token_store += _command_list->on_item_selected += [&](const auto& trigger_item)
         {
             auto index = std::stoi(trigger_item.value(L"#"));
-            auto command = _selected_trigger.value()->commands()[index];
-            if (command.type() == TriggerCommandType::LookAtItem || command.type() == TriggerCommandType::Object && command.index() < _all_items.size())
+            if (const auto trigger = _selected_trigger.lock())
             {
-                set_track_room(false);
-                on_item_selected(_all_items[command.index()]);
+                auto command = trigger->commands()[index];
+                if (command.type() == TriggerCommandType::LookAtItem || command.type() == TriggerCommandType::Object && command.index() < _all_items.size())
+                {
+                    set_track_room(false);
+                    on_item_selected(_all_items[command.index()]);
+                }
             }
         };
 
         return right_panel;
     }
 
-    void TriggersWindow::set_triggers(const std::vector<Trigger*>& triggers)
+    void TriggersWindow::set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers)
     {
         _all_triggers = triggers;
         populate_triggers(triggers);
@@ -229,7 +239,8 @@ namespace trview
         std::set<TriggerCommandType> command_set;
         for (const auto& trigger : triggers)
         {
-            for (const auto& command : trigger->commands())
+            const auto trigger_ptr = trigger.lock();
+            for (const auto& command : trigger_ptr->commands())
             {
                 command_set.insert(command.type());
             }
@@ -240,7 +251,7 @@ namespace trview
         _command_filter->set_selected_value(L"All");
     }
 
-    void TriggersWindow::update_triggers(const std::vector<Trigger*>& triggers)
+    void TriggersWindow::update_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers)
     {
         _all_triggers = triggers;
         populate_triggers(triggers);
@@ -255,7 +266,7 @@ namespace trview
         _command_list->set_items({});
     }
 
-    void TriggersWindow::populate_triggers(const std::vector<Trigger*>& triggers)
+    void TriggersWindow::populate_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers)
     {
         using namespace ui;
         std::vector<Listbox::Item> list_items;
@@ -275,22 +286,28 @@ namespace trview
         _current_room = room;
     }
 
-    void TriggersWindow::set_selected_trigger(const Trigger* const trigger)
+    void TriggersWindow::set_selected_trigger(const std::weak_ptr<ITrigger>& trigger)
     {
         _selected_trigger = trigger;
         if (_sync_trigger)
         {
-            if (!_selected_commands.empty() && !trigger->has_any_command(_selected_commands))
+            const auto trigger_ptr = trigger.lock();
+            if (!trigger_ptr)
+            {
+                return;
+            }
+
+            if (!_selected_commands.empty() && !trigger_ptr->has_any_command(_selected_commands))
             {
                 _selected_commands.clear();
                 _command_filter->set_selected_value(L"All");
                 apply_filters();
             }
 
-            const auto& list_item = create_listbox_item(*trigger);
+            const auto& list_item = create_listbox_item(*trigger_ptr);
             if (_triggers_list->set_selected_item(list_item))
             {
-                load_trigger_details(*trigger);
+                load_trigger_details(*trigger_ptr);
             }
             else
             {
@@ -310,10 +327,7 @@ namespace trview
         if (_sync_trigger != value)
         {
             _sync_trigger = value;
-            if (_selected_trigger.has_value())
-            {
-                set_selected_trigger(_selected_trigger.value());
-            }
+            set_selected_trigger(_selected_trigger);
         }
     }
 
@@ -339,7 +353,7 @@ namespace trview
         }
     }
 
-    void TriggersWindow::load_trigger_details(const Trigger& trigger)
+    void TriggersWindow::load_trigger_details(const ITrigger& trigger)
     {
         auto make_item = [](const auto& name, const auto& value)
         {
@@ -402,10 +416,11 @@ namespace trview
             return _selected_commands.empty() || trigger->has_any_command(_selected_commands);
         };
 
-        std::vector<Trigger*> filtered_triggers;
+        std::vector<std::weak_ptr<ITrigger>> filtered_triggers;
         for (const auto& trigger : _all_triggers)
         {
-            if (room_filter(trigger) && command_filter(trigger))
+            const auto trigger_ptr = trigger.lock();
+            if (room_filter(trigger_ptr) && command_filter(trigger_ptr))
             {
                 filtered_triggers.push_back(trigger);
             }
@@ -413,7 +428,7 @@ namespace trview
         populate_triggers(filtered_triggers);
     }
 
-    std::optional<const Trigger*> TriggersWindow::selected_trigger() const
+    std::weak_ptr<ITrigger> TriggersWindow::selected_trigger() const
     {
         return _selected_trigger;
     }

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -5,7 +5,7 @@
 
 #include <trview.ui/Listbox.h>
 #include <trview.app/Elements/Item.h>
-#include <trview.app/Elements/Trigger.h>
+#include <trview.app/Elements/ITrigger.h>
 #include "ITriggersWindow.h"
 #include "CollapsiblePanel.h"
 #include <trview.common/Windows/IClipboard.h>

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -34,43 +34,24 @@ namespace trview
 
         explicit TriggersWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
             const ui::IInput::Source& input_source, const Window& parent, const std::shared_ptr<IClipboard>& clipboard);
-
-        /// Destructor for triggers window
         virtual ~TriggersWindow() = default;
-
         virtual void render(bool vsync) override;
-
-        /// Set the triggers to display in the window.
-        /// @param triggers The triggers.
-        /// @param reset_filters Whether to reset the trigger filters.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) override;
-
-        /// Update the trigers - this doesn't reset the filters.
-        virtual void update_triggers(const std::vector<Trigger*>& triggers) override;
-
-        /// Clear the currently selected trigger from the details panel.
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
+        virtual void update_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void clear_selected_trigger() override;
-
-        /// Set the current room. This will be used when the track room setting is on.
-        /// @param room The current room number.
         virtual void set_current_room(uint32_t room) override;
-
-        /// Set the selected item.
-        /// @param item The selected item.
-        virtual void set_selected_trigger(const Trigger* const item) override;
-
+        virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual void set_items(const std::vector<Item>& items) override;
-
-        virtual std::optional<const Trigger*> selected_trigger() const override;
+        virtual std::weak_ptr<ITrigger> selected_trigger() const override;
     protected:
         virtual void update_layout() override;
     private:
-        void populate_triggers(const std::vector<Trigger*>& triggers);
+        void populate_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers);
         std::unique_ptr<ui::Control> create_left_panel();
         std::unique_ptr<ui::Control> create_right_panel();
         void set_track_room(bool value);
         void set_sync_trigger(bool value);
-        void load_trigger_details(const Trigger& trigger);
+        void load_trigger_details(const ITrigger& trigger);
         void apply_filters();
 
         ui::StackPanel* _controls;
@@ -81,7 +62,7 @@ namespace trview
         ui::Dropdown* _command_filter;
 
         std::vector<Item> _all_items;
-        std::vector<Trigger*> _all_triggers;
+        std::vector<std::weak_ptr<ITrigger>> _all_triggers;
 
         /// Whether the trigger window is tracking the current room.
         bool _track_room{ false };
@@ -90,7 +71,7 @@ namespace trview
         /// Whether the room tracking filter has been applied.
         bool _filter_applied{ false };
         bool _sync_trigger{ true };
-        std::optional<const Trigger*> _selected_trigger;
+        std::weak_ptr<ITrigger> _selected_trigger;
         std::vector<TriggerCommandType> _selected_commands;
         std::shared_ptr<IClipboard> _clipboard;
     };

--- a/trview.app/Windows/TriggersWindowManager.h
+++ b/trview.app/Windows/TriggersWindowManager.h
@@ -20,54 +20,24 @@ namespace trview
         /// @param shortcuts The shortcuts instance to use.
         /// @param triggers_window_source Function to call to create a triggers window.
         explicit TriggersWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const ITriggersWindow::Source& triggers_window_source);
-
-        /// Destructor for the TriggersWindowManager.
         virtual ~TriggersWindowManager() = default;
-
-        /// Handles a window message.
-        /// @param message The message that was received.
-        /// @param wParam The WPARAM for the message.
-        /// @param lParam The LPARAM for the message.
         virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
-
-        /// Render all of the triggers windows.
-        /// @param vsync Whether to use vsync.
         virtual void render(bool vsync) override;
-
-        /// Get the currently selected trigger.
-        const Trigger* selected_trigger() const;
-
-        /// Set the items to use in the windows.
-        /// @param items The items in the level.
+        const std::weak_ptr<ITrigger> selected_trigger() const;
         virtual void set_items(const std::vector<Item>& items) override;
-
-        /// Set the triggers to use in the windows.
-        /// @param triggers The triggers in the level.
-        virtual void set_triggers(const std::vector<Trigger*>& triggers) override;
-
-        /// Set whether a trigger is visible.
-        /// @param trigger The trigger.
-        /// @param visible Whether the trigger is visible.
-        virtual void set_trigger_visible(Trigger* trigger, bool visible) override;
-
-        /// Set the current room to filter trigger windows.
-        /// @param room The current room.
+        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
+        virtual void set_trigger_visible(const std::weak_ptr<ITrigger>& trigger, bool visible) override;
         virtual void set_room(uint32_t room) override;
-
-        /// Set the currently selected trigger.
-        /// @param item The selected trigger.
-        virtual void set_selected_trigger(const Trigger* const trigger) override;
-
-        /// Create a new triggers window.
+        virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual std::weak_ptr<ITriggersWindow> create_window() override;
     private:
         std::vector<std::shared_ptr<ITriggersWindow>> _windows;
         std::vector<std::weak_ptr<ITriggersWindow>> _closing_windows;
         std::vector<Item> _items;
-        std::vector<Trigger*> _triggers;
+        std::vector<std::weak_ptr<ITrigger>> _triggers;
         uint32_t _current_room{ 0u };
         TokenStore _token_store;
-        std::optional<const Trigger*> _selected_trigger;
+        std::weak_ptr<ITrigger> _selected_trigger;
         ITriggersWindow::Source _triggers_window_source;
     };
 }

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -65,68 +65,24 @@ namespace trview
             const graphics::IRenderTarget::SizeSource& render_target_source,
             const graphics::IDeviceWindow::Source& device_window_source,
             std::unique_ptr<ISectorHighlight> sector_highlight);
-
-        /// Destructor for the viewer.
         virtual ~Viewer() = default;
-
         virtual CameraMode camera_mode() const override;
-
-        /// Render the viewer.
         virtual void render() override;
-
-        /// Attempt to open the specified level file.
-        /// @param filename The level file to open.
         virtual void open(ILevel* level) override;
-
         virtual void set_settings(const UserSettings& settings) override;
-
-        /// Select the specified item.
-        /// @param item The item to select.
-        /// @remarks This will not raise the on_item_selected event.
         virtual void select_item(const Item& item) override;
-
-        /// Select the specified room.
-        /// @param room_number The room to select.
-        /// @remarks This will not raise the on_room_selected event.
         virtual void select_room(uint32_t room_number) override;
-
-        /// Select the specified trigger.
-        /// @param trigger The trigger to select.
-        /// @remarks This will not raise the on_trigger_selected event.
-        virtual void select_trigger(const Trigger* const trigger) override;
-
-        /// Select the specified waypoint
-        /// @param index The waypoint to select.
-        /// @remarks This will not raise the on_waypoint_selected event.
+        virtual void select_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual void select_waypoint(const Waypoint& waypoint) override;
-
         virtual void set_camera_mode(CameraMode camera_mode) override;
-
-        /// Set the current route.
-        /// @param route The new route.
         virtual void set_route(const std::shared_ptr<IRoute>& route) override;
-
-        /// Set whether the compass is visible.
         virtual void set_show_compass(bool value) override;
-
-        /// Set whether the minimap is visible.
         virtual void set_show_minimap(bool value) override;
-
-        /// Set whether the route is visible.
         virtual void set_show_route(bool value) override;
-
-        /// Set whether the selection is visible.
         virtual void set_show_selection(bool value) override;
-
-        /// Set whether the tools are visible.
         virtual void set_show_tools(bool value) override;
-
-        /// Set whether the tooltip is visible.
         virtual void set_show_tooltip(bool value) override;
-
-        /// Set whether the ui is visible.
         virtual void set_show_ui(bool value) override;
-
         virtual bool ui_input_active() const override;
     private:
         void initialise_input();

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -40,6 +40,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Elements\IEntity.cpp" />
     <ClCompile Include="Elements\IRoom.cpp" />
     <ClCompile Include="Elements\Item.cpp" />
+    <ClCompile Include="Elements\ITrigger.cpp" />
     <ClCompile Include="Elements\ITypeNameLookup.cpp" />
     <ClCompile Include="Elements\ILevel.cpp" />
     <ClCompile Include="Elements\Level.cpp" />
@@ -152,6 +153,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Elements\ILevel.h" />
     <ClInclude Include="Elements\IRoom.h" />
     <ClInclude Include="Elements\Item.h" />
+    <ClInclude Include="Elements\ITrigger.h" />
     <ClInclude Include="Elements\ITypeNameLookup.h" />
     <ClInclude Include="Elements\Level.h" />
     <ClInclude Include="Elements\Room.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -208,6 +208,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\Elements\IEntity.h" />
     <ClInclude Include="Mocks\Elements\ILevel.h" />
     <ClInclude Include="Mocks\Elements\IRoom.h" />
+    <ClInclude Include="Mocks\Elements\ITrigger.h" />
     <ClInclude Include="Mocks\Elements\ITypeNameLookup.h" />
     <ClInclude Include="Mocks\Geometry\IMesh.h" />
     <ClInclude Include="Mocks\Geometry\IPicking.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -301,6 +301,9 @@
     <ClCompile Include="Elements\IRoom.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\ITrigger.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -766,6 +769,9 @@
     </ClInclude>
     <ClInclude Include="Mocks\Elements\IRoom.h">
       <Filter>Mocks\Elements</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\ITrigger.h">
+      <Filter>Elements</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -773,6 +773,9 @@
     <ClInclude Include="Elements\ITrigger.h">
       <Filter>Elements</Filter>
     </ClInclude>
+    <ClInclude Include="Mocks\Elements\ITrigger.h">
+      <Filter>Mocks\Elements</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">


### PR DESCRIPTION
Convert Triggers to use DI.
Creates an ITrigger interface and makes all triggers `shared_ptr` for ownership and `weak_ptr` for a view.
Update affected files - which is quite a lot. Managed to delete some usage of real triggers from some tests though.
Closes #752 