### PR TITLE
Add a StartupOptions class for feature flags and command line parsing

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -5,6 +5,7 @@
 #include <trview.app/Mocks/Menus/IRecentFiles.h>
 #include <trview.app/Mocks/Routing/IRoute.h>
 #include <trview.app/Mocks/Settings/ISettingsLoader.h>
+#include <trview.app/Mocks/Settings/IStartupOptions.h>
 #include <trview.app/Mocks/Windows/IViewer.h>
 #include <trview.app/Mocks/Windows/IItemsWindowManager.h>
 #include <trview.app/Mocks/Windows/ITriggersWindowManager.h>
@@ -31,7 +32,8 @@ namespace
     auto register_test_module(std::unique_ptr<IUpdateChecker> update_checker = nullptr, std::unique_ptr<ISettingsLoader> settings_loader = nullptr, std::unique_ptr<IFileDropper> file_dropper = nullptr,
         std::unique_ptr<trlevel::ILevelLoader> level_loader = nullptr, std::unique_ptr<ILevelSwitcher> level_switcher = nullptr, std::unique_ptr<IRecentFiles> recent_files = nullptr,
         std::unique_ptr<IViewer> viewer = nullptr, std::unique_ptr<IRoute> route = nullptr, std::unique_ptr<IItemsWindowManager> items_window_manager = nullptr, std::unique_ptr<ITriggersWindowManager> triggers_window_manager = nullptr,
-        std::unique_ptr<IRouteWindowManager> route_window_manager = nullptr, std::unique_ptr<IRoomsWindowManager> rooms_window_manager = nullptr)
+        std::unique_ptr<IRouteWindowManager> route_window_manager = nullptr, std::unique_ptr<IRoomsWindowManager> rooms_window_manager = nullptr,
+        std::shared_ptr<IStartupOptions> startup_options = nullptr)
     {
         choose_mock<MockUpdateChecker>(update_checker);
         choose_mock<MockSettingsLoader>(settings_loader);
@@ -45,6 +47,7 @@ namespace
         choose_mock<MockTriggersWindowManager>(triggers_window_manager);
         choose_mock<MockRouteWindowManager>(route_window_manager);
         choose_mock<MockRoomsWindowManager>(rooms_window_manager);
+        choose_mock<MockStartupOptions>(startup_options);
 
         auto shortcuts = std::make_shared<MockShortcuts>();
         EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
@@ -65,7 +68,7 @@ namespace
             di::bind<IRouteWindowManager>.to([&](auto&&) { return std::move(route_window_manager); }),
             di::bind<IRoomsWindowManager>.to([&](auto&&) { return std::move(rooms_window_manager); }),
             di::bind<ILevel::Source>.to([](const auto& injector)->ILevel::Source { return [](auto) { return std::make_unique<trview::mocks::MockLevel>(); }; }),
-            di::bind<IStartupOptions::CommandLine>.to(std::wstring())
+            di::bind<IStartupOptions>.to(startup_options)
         ).create<std::unique_ptr<Application>>();
     }
 }

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -189,3 +189,15 @@ TEST(Application, SavesSettingsOnShutdown)
     EXPECT_CALL(settings_loader, save_user_settings).Times(1);
     auto application = register_test_module(nullptr, std::move(settings_loader_ptr));
 }
+
+TEST(Application, FileOpenedFromCommandLine)
+{
+    auto startup_options = std::make_shared<MockStartupOptions>();
+    ON_CALL(*startup_options, filename).WillByDefault(testing::Return("test.tr2"));
+    auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
+    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
+    EXPECT_CALL(level_loader, load_level("test.tr2")).Times(1);
+    EXPECT_CALL(viewer, open).Times(1);
+    auto application = register_test_module(nullptr, nullptr, nullptr, std::move(level_loader_ptr), nullptr, nullptr, std::move(viewer_ptr),
+        nullptr, nullptr, nullptr, nullptr, nullptr, startup_options);
+}

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -65,7 +65,7 @@ namespace
             di::bind<IRouteWindowManager>.to([&](auto&&) { return std::move(route_window_manager); }),
             di::bind<IRoomsWindowManager>.to([&](auto&&) { return std::move(rooms_window_manager); }),
             di::bind<ILevel::Source>.to([](const auto& injector)->ILevel::Source { return [](auto) { return std::make_unique<trview::mocks::MockLevel>(); }; }),
-            di::bind<Application::CommandLine>.to(std::wstring())
+            di::bind<IStartupOptions::CommandLine>.to(std::wstring())
         ).create<std::unique_ptr<Application>>();
     }
 }

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -201,3 +201,12 @@ TEST(Application, FileOpenedFromCommandLine)
     auto application = register_test_module(nullptr, nullptr, nullptr, std::move(level_loader_ptr), nullptr, nullptr, std::move(viewer_ptr),
         nullptr, nullptr, nullptr, nullptr, nullptr, startup_options);
 }
+
+TEST(Application, FileNotOpenedWhenNotSpecified)
+{
+    auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
+    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
+    EXPECT_CALL(level_loader, load_level("test.tr2")).Times(0);
+    EXPECT_CALL(viewer, open).Times(0);
+    auto application = register_test_module(nullptr, nullptr, nullptr, std::move(level_loader_ptr), nullptr, nullptr, std::move(viewer_ptr));
+}

--- a/trview.app.tests/Settings/StartupOptionsTests.cpp
+++ b/trview.app.tests/Settings/StartupOptionsTests.cpp
@@ -12,14 +12,14 @@ TEST(StartupOptions, FlagsWithNoFile)
 {
     StartupOptions startup_options{ L"trview.exe -ff1 -ff2" };
     ASSERT_EQ(startup_options.filename(), "");
-    ASSERT_EQ(startup_options.feature(L"ff1"), true);
-    ASSERT_EQ(startup_options.feature(L"ff2"), true);
+    ASSERT_EQ(startup_options.feature("ff1"), true);
+    ASSERT_EQ(startup_options.feature("ff2"), true);
 }
 
 TEST(StartupOptions, FlagsWithFile)
 {
     StartupOptions startup_options{ L"trview.exe c:\\test.tr2 -ff1 -ff2" };
     ASSERT_EQ(startup_options.filename(), "c:\\test.tr2");
-    ASSERT_EQ(startup_options.feature(L"ff1"), true);
-    ASSERT_EQ(startup_options.feature(L"ff2"), true);
+    ASSERT_EQ(startup_options.feature("ff1"), true);
+    ASSERT_EQ(startup_options.feature("ff2"), true);
 }

--- a/trview.app.tests/Settings/StartupOptionsTests.cpp
+++ b/trview.app.tests/Settings/StartupOptionsTests.cpp
@@ -1,0 +1,25 @@
+#include <trview.app/Settings/StartupOptions.h>
+
+using namespace trview;
+
+TEST(StartupOptions, FilenameLoadedFromCommandLine)
+{
+    StartupOptions startup_options{ L"trview.exe c:\\test.tr2" };
+    ASSERT_EQ(startup_options.filename(), "c:\\test.tr2");
+}
+
+TEST(StartupOptions, FlagsWithNoFile)
+{
+    StartupOptions startup_options{ L"trview.exe -ff1 -ff2" };
+    ASSERT_EQ(startup_options.filename(), "");
+    ASSERT_EQ(startup_options.feature(L"ff1"), true);
+    ASSERT_EQ(startup_options.feature(L"ff2"), true);
+}
+
+TEST(StartupOptions, FlagsWithFile)
+{
+    StartupOptions startup_options{ L"trview.exe c:\\test.tr2 -ff1 -ff2" };
+    ASSERT_EQ(startup_options.filename(), "c:\\test.tr2");
+    ASSERT_EQ(startup_options.feature(L"ff1"), true);
+    ASSERT_EQ(startup_options.feature(L"ff2"), true);
+}

--- a/trview.app.tests/Settings/StartupOptionsTests.cpp
+++ b/trview.app.tests/Settings/StartupOptionsTests.cpp
@@ -23,3 +23,9 @@ TEST(StartupOptions, FlagsWithFile)
     ASSERT_EQ(startup_options.feature("ff1"), true);
     ASSERT_EQ(startup_options.feature("ff2"), true);
 }
+
+TEST(StartupOptions, MissingFlagIsFalse)
+{
+    StartupOptions startup_options{ L"trview.exe c:\\test.tr2 -ff2" };
+    ASSERT_EQ(startup_options.feature("ff1"), false);
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -38,6 +38,7 @@
     <ClCompile Include="RoomsWindowTests.cpp" />
     <ClCompile Include="RouteWindowTests.cpp" />
     <ClCompile Include="SettingsWindowTests.cpp" />
+    <ClCompile Include="Settings\StartupOptionsTests.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -65,6 +65,9 @@
     <ClCompile Include="RouteWindowTests.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
+    <ClCompile Include="Settings\StartupOptionsTests.cpp">
+      <Filter>Settings</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">
@@ -87,6 +90,9 @@
     </Filter>
     <Filter Include="Windows">
       <UniqueIdentifier>{0c7c1192-4ae6-44cc-960c-e3f136dea95d}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Settings">
+      <UniqueIdentifier>{42d0c262-c6f9-4419-b646-41d45f31fc72}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -28,6 +28,7 @@
 #include <trview.app/UI/di.h>
 #include <trview.app/Windows/di.h>
 #include <trview.common/windows/Clipboard.h>
+#include <trview.app/Settings/IStartupOptions.h>
 
 using namespace DirectX::SimpleMath;
 
@@ -120,7 +121,7 @@ namespace trview
         std::unique_ptr<IRouteWindowManager> route_window_manager,
         std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
         const ILevel::Source& level_source,
-        const CommandLine& command_line)
+        const IStartupOptions::CommandLine& command_line)
         : MessageHandler(application_window), _instance(GetModuleHandle(nullptr)),
         _file_dropper(std::move(file_dropper)), _level_switcher(std::move(level_switcher)), _recent_files(std::move(recent_files)), _update_checker(std::move(update_checker)),
         _view_menu(window()), _settings_loader(std::move(settings_loader)), _level_loader(std::move(level_loader)), _viewer(std::move(viewer)), _route_source(route_source),
@@ -568,7 +569,7 @@ namespace trview
             di::bind<IClipboard>.to<Clipboard>(),
             di::bind<IShortcuts>.to<Shortcuts>(),
             di::bind<IApplication>.to<Application>(),
-            di::bind<Application::CommandLine>.to(command_line)
+            di::bind<IStartupOptions::CommandLine>.to(command_line)
         );
 
         load_default_shaders(

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -1,7 +1,6 @@
 #include "Application.h"
 
 #include <shellapi.h>
-#include <Shlwapi.h>
 #include <commdlg.h>
 
 #include <trview.common/Strings.h>
@@ -121,7 +120,7 @@ namespace trview
         std::unique_ptr<IRouteWindowManager> route_window_manager,
         std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
         const ILevel::Source& level_source,
-        const IStartupOptions::CommandLine& command_line)
+        std::shared_ptr<IStartupOptions> startup_options)
         : MessageHandler(application_window), _instance(GetModuleHandle(nullptr)),
         _file_dropper(std::move(file_dropper)), _level_switcher(std::move(level_switcher)), _recent_files(std::move(recent_files)), _update_checker(std::move(update_checker)),
         _view_menu(window()), _settings_loader(std::move(settings_loader)), _level_loader(std::move(level_loader)), _viewer(std::move(viewer)), _route_source(route_source),
@@ -143,7 +142,7 @@ namespace trview
         setup_triggers_windows();
         setup_rooms_windows();
         setup_route_window();
-        setup_viewer(command_line);
+        setup_viewer(*startup_options);
 
         register_lua();
         lua_init(&lua_registry);
@@ -311,7 +310,7 @@ namespace trview
         };
     }
 
-    void Application::setup_viewer(const std::wstring& command_line)
+    void Application::setup_viewer(const IStartupOptions& startup_options)
     {
         _token_store += _viewer->on_item_visibility += [this](const auto& item, bool value) { set_item_visibility(item, value); };
         _token_store += _viewer->on_item_selected += [this](const auto& item) { select_item(item); };
@@ -328,12 +327,10 @@ namespace trview
         };
         _viewer->set_settings(_settings);
 
-        // Open the level passed in on the command line, if there is one.
-        int number_of_arguments = 0;
-        const LPWSTR* const arguments = CommandLineToArgvW(command_line.c_str(), &number_of_arguments);
-        if (number_of_arguments > 1)
+        auto filename = startup_options.filename();
+        if (!filename.empty())
         {
-            open(trview::to_utf8(arguments[1]));
+            open(filename);
         }
     }
 

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -12,6 +12,7 @@
 #include <trview.app/Menus/ViewMenu.h>
 #include <trview.app/Routing/Route.h>
 #include <trview.app/Settings/ISettingsLoader.h>
+#include <trview.app/Settings/IStartupOptions.h>
 #include <trview.app/Windows/IItemsWindowManager.h>
 #include <trview.app/Windows/IRoomsWindowManager.h>
 #include <trview.app/Windows/IRouteWindowManager.h>
@@ -30,8 +31,6 @@ namespace trview
     class Application final : public IApplication, public MessageHandler
     {
     public:
-        using CommandLine = std::wstring;
-
         explicit Application(
             const Window& application_window,
             std::unique_ptr<IUpdateChecker> update_checker,
@@ -48,7 +47,7 @@ namespace trview
             std::unique_ptr<IRouteWindowManager> route_window_manager,
             std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
             const ILevel::Source& level_source,
-            const CommandLine& command_line);
+            const IStartupOptions::CommandLine& command_line);
         virtual ~Application();
 
         /// Attempt to open the specified level file.

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -47,7 +47,7 @@ namespace trview
             std::unique_ptr<IRouteWindowManager> route_window_manager,
             std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
             const ILevel::Source& level_source,
-            const IStartupOptions::CommandLine& command_line);
+            std::shared_ptr<IStartupOptions> startup_options);
         virtual ~Application();
 
         /// Attempt to open the specified level file.
@@ -60,7 +60,7 @@ namespace trview
     private:
         // Window setup functions.
         void setup_view_menu();
-        void setup_viewer(const std::wstring& command_line);
+        void setup_viewer(const IStartupOptions& startup_options);
         void setup_items_windows();
         void setup_triggers_windows();
         void setup_rooms_windows();

--- a/trview.app/Mocks/Settings/IStartupOptions.h
+++ b/trview.app/Mocks/Settings/IStartupOptions.h
@@ -10,8 +10,8 @@ namespace trview
         {
         public:
             virtual ~MockStartupOptions() = default;
-            MOCK_METHOD(std::string, filename, (), (const));
-            MOCK_METHOD(bool, feature, (const std::string&), (const));
+            MOCK_METHOD(std::string, filename, (), (const, override));
+            MOCK_METHOD(bool, feature, (const std::string&), (const, override));
         };
     }
 }

--- a/trview.app/Mocks/Settings/IStartupOptions.h
+++ b/trview.app/Mocks/Settings/IStartupOptions.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "../../Settings/IStartupOptions.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        class MockStartupOptions final : public IStartupOptions
+        {
+        public:
+            virtual ~MockStartupOptions() = default;
+            MOCK_METHOD(std::string, filename, (), (const));
+            MOCK_METHOD(bool, feature, (const std::wstring&), (const));
+        };
+    }
+}

--- a/trview.app/Mocks/Settings/IStartupOptions.h
+++ b/trview.app/Mocks/Settings/IStartupOptions.h
@@ -11,7 +11,7 @@ namespace trview
         public:
             virtual ~MockStartupOptions() = default;
             MOCK_METHOD(std::string, filename, (), (const));
-            MOCK_METHOD(bool, feature, (const std::wstring&), (const));
+            MOCK_METHOD(bool, feature, (const std::string&), (const));
         };
     }
 }

--- a/trview.app/Settings/IStartupOptions.cpp
+++ b/trview.app/Settings/IStartupOptions.cpp
@@ -1,0 +1,8 @@
+#include "IStartupOptions.h"
+
+namespace trview
+{
+    IStartupOptions::~IStartupOptions()
+    {
+    }
+}

--- a/trview.app/Settings/IStartupOptions.h
+++ b/trview.app/Settings/IStartupOptions.h
@@ -8,7 +8,7 @@ namespace trview
     {
         using CommandLine = std::wstring;
         virtual ~IStartupOptions() = 0;
-        virtual std::wstring filename() const = 0;
+        virtual std::string filename() const = 0;
         virtual bool feature(const std::wstring& flag) const = 0;
     };
 }

--- a/trview.app/Settings/IStartupOptions.h
+++ b/trview.app/Settings/IStartupOptions.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+
+namespace trview
+{
+    struct IStartupOptions
+    {
+        using CommandLine = std::wstring;
+        virtual ~IStartupOptions() = 0;
+        virtual std::wstring filename() const = 0;
+        virtual bool feature(const std::wstring& flag) const = 0;
+    };
+}

--- a/trview.app/Settings/IStartupOptions.h
+++ b/trview.app/Settings/IStartupOptions.h
@@ -9,6 +9,6 @@ namespace trview
         using CommandLine = std::wstring;
         virtual ~IStartupOptions() = 0;
         virtual std::string filename() const = 0;
-        virtual bool feature(const std::wstring& flag) const = 0;
+        virtual bool feature(const std::string& flag) const = 0;
     };
 }

--- a/trview.app/Settings/StartupOptions.cpp
+++ b/trview.app/Settings/StartupOptions.cpp
@@ -12,7 +12,7 @@ namespace trview
             std::wstring arg = arguments[i];
             if (arg.front() == L'-')
             {
-                _flags.insert(arg.substr(1));
+                _flags.insert(to_utf8(arg.substr(1)));
             }
             else if(i == 1)
             {
@@ -26,7 +26,7 @@ namespace trview
         return _filename;
     }
 
-    bool StartupOptions::feature(const std::wstring& flag) const
+    bool StartupOptions::feature(const std::string& flag) const
     {
         return _flags.find(flag) != _flags.end();
     }

--- a/trview.app/Settings/StartupOptions.cpp
+++ b/trview.app/Settings/StartupOptions.cpp
@@ -7,9 +7,17 @@ namespace trview
     {
         int number_of_arguments = 0;
         const LPWSTR* const arguments = CommandLineToArgvW(command_line.c_str(), &number_of_arguments);
-        if (number_of_arguments > 1)
+        for (int i = 1; i < number_of_arguments; ++i)
         {
-            _filename = trview::to_utf8(arguments[1]);
+            std::wstring arg = arguments[i];
+            if (arg.front() == L'-')
+            {
+                _flags.insert(arg.substr(1));
+            }
+            else if(i == 1)
+            {
+                _filename = trview::to_utf8(arg);
+            }
         }
     }
 
@@ -20,7 +28,7 @@ namespace trview
 
     bool StartupOptions::feature(const std::wstring& flag) const
     {
-        return false;
+        return _flags.find(flag) != _flags.end();
     }
 }
 

--- a/trview.app/Settings/StartupOptions.cpp
+++ b/trview.app/Settings/StartupOptions.cpp
@@ -1,14 +1,21 @@
 #include "StartupOptions.h"
+#include <trview.common/Strings.h>
 
 namespace trview
 {
     StartupOptions::StartupOptions(const CommandLine& command_line)
     {
+        int number_of_arguments = 0;
+        const LPWSTR* const arguments = CommandLineToArgvW(command_line.c_str(), &number_of_arguments);
+        if (number_of_arguments > 1)
+        {
+            _filename = trview::to_utf8(arguments[1]);
+        }
     }
 
-    std::wstring StartupOptions::filename() const
+    std::string StartupOptions::filename() const
     {
-        return {};
+        return _filename;
     }
 
     bool StartupOptions::feature(const std::wstring& flag) const

--- a/trview.app/Settings/StartupOptions.cpp
+++ b/trview.app/Settings/StartupOptions.cpp
@@ -1,0 +1,19 @@
+#include "StartupOptions.h"
+
+namespace trview
+{
+    StartupOptions::StartupOptions(const CommandLine& command_line)
+    {
+    }
+
+    std::wstring StartupOptions::filename() const
+    {
+        return {};
+    }
+
+    bool StartupOptions::feature(const std::wstring& flag) const
+    {
+        return false;
+    }
+}
+

--- a/trview.app/Settings/StartupOptions.h
+++ b/trview.app/Settings/StartupOptions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "IStartupOptions.h"
+#include <set>
 
 namespace trview
 {
@@ -13,5 +14,6 @@ namespace trview
         virtual bool feature(const std::wstring& flag) const override;
     private:
         std::string _filename;
+        std::set<std::wstring> _flags;
     };
 }

--- a/trview.app/Settings/StartupOptions.h
+++ b/trview.app/Settings/StartupOptions.h
@@ -9,7 +9,9 @@ namespace trview
     public:
         explicit StartupOptions(const CommandLine& command_line);
         virtual ~StartupOptions() = default;
-        virtual std::wstring filename() const override;
+        virtual std::string filename() const override;
         virtual bool feature(const std::wstring& flag) const override;
+    private:
+        std::string _filename;
     };
 }

--- a/trview.app/Settings/StartupOptions.h
+++ b/trview.app/Settings/StartupOptions.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "IStartupOptions.h"
+
+namespace trview
+{
+    class StartupOptions final : public IStartupOptions
+    {
+    public:
+        explicit StartupOptions(const CommandLine& command_line);
+        virtual ~StartupOptions() = default;
+        virtual std::wstring filename() const override;
+        virtual bool feature(const std::wstring& flag) const override;
+    };
+}

--- a/trview.app/Settings/StartupOptions.h
+++ b/trview.app/Settings/StartupOptions.h
@@ -11,9 +11,9 @@ namespace trview
         explicit StartupOptions(const CommandLine& command_line);
         virtual ~StartupOptions() = default;
         virtual std::string filename() const override;
-        virtual bool feature(const std::wstring& flag) const override;
+        virtual bool feature(const std::string& flag) const override;
     private:
         std::string _filename;
-        std::set<std::wstring> _flags;
+        std::set<std::string> _flags;
     };
 }

--- a/trview.app/Settings/di.hpp
+++ b/trview.app/Settings/di.hpp
@@ -2,6 +2,7 @@
 
 #include <external/boost/di.hpp>
 #include "SettingsLoader.h"
+#include "StartupOptions.h"
 
 namespace trview
 {
@@ -9,7 +10,8 @@ namespace trview
     {
         using namespace boost;
         return di::make_injector(
-            di::bind<ISettingsLoader>.to<SettingsLoader>()
+            di::bind<ISettingsLoader>.to<SettingsLoader>(),
+            di::bind<IStartupOptions>.to<StartupOptions>()
         );
     }
 }

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -223,6 +223,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\Menus\IUpdateChecker.h" />
     <ClInclude Include="Mocks\Routing\IRoute.h" />
     <ClInclude Include="Mocks\Settings\ISettingsLoader.h" />
+    <ClInclude Include="Mocks\Settings\IStartupOptions.h" />
     <ClInclude Include="Mocks\Tools\ICompass.h" />
     <ClInclude Include="Mocks\Tools\IMeasure.h" />
     <ClInclude Include="Mocks\UI\IViewerUI.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -89,7 +89,9 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Routing\Route.cpp" />
     <ClCompile Include="Routing\Waypoint.cpp" />
     <ClCompile Include="Settings\ISettingsLoader.cpp" />
+    <ClCompile Include="Settings\IStartupOptions.cpp" />
     <ClCompile Include="Settings\SettingsLoader.cpp" />
+    <ClCompile Include="Settings\StartupOptions.cpp" />
     <ClCompile Include="Settings\UserSettings.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
@@ -245,8 +247,10 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Routing\Waypoint.h" />
     <ClInclude Include="Settings\di.h" />
     <ClInclude Include="Settings\di.hpp" />
+    <ClInclude Include="Settings\IStartupOptions.h" />
     <ClInclude Include="Settings\ISettingsLoader.h" />
     <ClInclude Include="Settings\SettingsLoader.h" />
+    <ClInclude Include="Settings\StartupOptions.h" />
     <ClInclude Include="Settings\UserSettings.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="Tools\Compass.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -779,6 +779,9 @@
     <ClInclude Include="Settings\StartupOptions.h">
       <Filter>Settings</Filter>
     </ClInclude>
+    <ClInclude Include="Mocks\Settings\IStartupOptions.h">
+      <Filter>Mocks\Settings</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -301,6 +301,12 @@
     <ClCompile Include="Elements\IRoom.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
+    <ClCompile Include="Settings\StartupOptions.cpp">
+      <Filter>Settings</Filter>
+    </ClCompile>
+    <ClCompile Include="Settings\IStartupOptions.cpp">
+      <Filter>Settings</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -766,6 +772,12 @@
     </ClInclude>
     <ClInclude Include="Mocks\Elements\IRoom.h">
       <Filter>Mocks\Elements</Filter>
+    </ClInclude>
+    <ClInclude Include="Settings\IStartupOptions.h">
+      <Filter>Settings</Filter>
+    </ClInclude>
+    <ClInclude Include="Settings\StartupOptions.h">
+      <Filter>Settings</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Add a `StartupOptions` class and interface that deals with feature flags passed on the command line as well as taking the handling of the filename parameter away from the `Application` class.
Add tests for the new class.
Add tests for behaviour of `Application` that was previously untested.
Closes #787 