### PR TITLE
Convert Mesh Storage to shared_ptr

### DIFF
--- a/trview.app.tests/Graphics/MeshStorageTests.cpp
+++ b/trview.app.tests/Graphics/MeshStorageTests.cpp
@@ -2,7 +2,17 @@
 
 using namespace trview;
 
-TEST(MeshStorage, Something)
+TEST(MeshStorage, MeshesLoadedFromLevel)
 {
+    FAIL();
+}
 
+TEST(MeshStorage, MeshCanBeRetrieved)
+{
+    FAIL();
+}
+
+TEST(MeshStorage, MissingMeshNotFound)
+{
+    FAIL();
 }

--- a/trview.app.tests/Graphics/MeshStorageTests.cpp
+++ b/trview.app.tests/Graphics/MeshStorageTests.cpp
@@ -1,18 +1,53 @@
 #include <trview.app/Graphics/MeshStorage.h>
+#include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
+#include <trview.app/Mocks/Geometry/IMesh.h>
+#include <trlevel/Mocks/ILevel.h>
+#include <external/boost/di.hpp>
 
 using namespace trview;
+using namespace trview::mocks;
+using namespace trlevel;
+using namespace trlevel::mocks;
+
+namespace
+{
+    auto register_test_module(ILevel& level)
+    {
+        using namespace boost;
+        return di::make_injector
+        (
+            di::bind<IMesh::Source>.to([](auto&&) { return [](auto&&...) { return std::make_shared<MockMesh>(); }; }),
+            di::bind<ILevel>.to(level),
+            di::bind<ILevelTextureStorage>.to<MockLevelTextureStorage>()
+        ).create<std::unique_ptr<MeshStorage>>();
+    }
+}
 
 TEST(MeshStorage, MeshesLoadedFromLevel)
 {
-    FAIL();
+    MockLevel level;
+    ON_CALL(level, num_mesh_pointers).WillByDefault(testing::Return(2));
+    EXPECT_CALL(level, get_mesh_by_pointer(0)).Times(1);
+    EXPECT_CALL(level, get_mesh_by_pointer(1)).Times(1);
+    auto storage = register_test_module(level);
 }
 
 TEST(MeshStorage, MeshCanBeRetrieved)
 {
-    FAIL();
+    MockLevel level;
+    ON_CALL(level, num_mesh_pointers).WillByDefault(testing::Return(1));
+    EXPECT_CALL(level, get_mesh_by_pointer(0)).Times(1);
+    auto storage = register_test_module(level);
+    auto mesh = storage->mesh(0);
+    ASSERT_NE(mesh, nullptr);
 }
 
 TEST(MeshStorage, MissingMeshNotFound)
 {
-    FAIL();
+    MockLevel level;
+    ON_CALL(level, num_mesh_pointers).WillByDefault(testing::Return(1));
+    EXPECT_CALL(level, get_mesh_by_pointer(0)).Times(1);
+    auto storage = register_test_module(level);
+    auto mesh = storage->mesh(1);
+    ASSERT_EQ(mesh, nullptr);
 }

--- a/trview.app.tests/Graphics/MeshStorageTests.cpp
+++ b/trview.app.tests/Graphics/MeshStorageTests.cpp
@@ -1,0 +1,8 @@
+#include <trview.app/Graphics/MeshStorage.h>
+
+using namespace trview;
+
+TEST(MeshStorage, Something)
+{
+
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="FileDropperTests.cpp" />
     <ClCompile Include="FreeCameraTests.cpp" />
     <ClCompile Include="Graphics\LevelTextureStorageTests.cpp" />
+    <ClCompile Include="Graphics\MeshStorageTests.cpp" />
     <ClCompile Include="ItemsWindowManagerTests.cpp" />
     <ClCompile Include="ItemsWindowTests.cpp" />
     <ClCompile Include="Main.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClCompile Include="Settings\StartupOptionsTests.cpp">
       <Filter>Settings</Filter>
     </ClCompile>
+    <ClCompile Include="Graphics\MeshStorageTests.cpp">
+      <Filter>Graphics</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -52,7 +52,7 @@ namespace trview
 
         DirectX::SimpleMath::Matrix               _world;
         std::vector<std::shared_ptr<IMesh>>       _meshes;
-        std::unique_ptr<IMesh>                    _sprite_mesh;
+        std::shared_ptr<IMesh>                    _sprite_mesh;
         std::vector<DirectX::SimpleMath::Matrix>  _world_transforms;
         uint16_t                                  _room;
         uint32_t                                  _index;

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -24,7 +24,6 @@ namespace trview
     struct IMeshStorage;
     struct ILevelTextureStorage;
     struct ICamera;
-    class TransparencyBuffer;
 
     class Entity final : public IEntity
     {
@@ -52,7 +51,7 @@ namespace trview
         void apply_ocb_adjustment(uint32_t ocb);
 
         DirectX::SimpleMath::Matrix               _world;
-        std::vector<IMesh*>                       _meshes;
+        std::vector<std::shared_ptr<IMesh>>       _meshes;
         std::unique_ptr<IMesh>                    _sprite_mesh;
         std::vector<DirectX::SimpleMath::Matrix>  _world_transforms;
         uint16_t                                  _room;

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -25,8 +25,7 @@ namespace trview
         const IRoom::Source& room_source,
         const ITrigger::Source& trigger_source)
         : _device(device), _version(level->get_version()), _texture_storage(std::move(level_texture_storage)),
-        _mesh_storage(std::move(mesh_storage)), _transparency(std::move(transparency_buffer)),
-        _selection_renderer(std::move(selection_renderer))
+        _transparency(std::move(transparency_buffer)), _selection_renderer(std::move(selection_renderer))
     {
         _vertex_shader = shader_storage->get("level_vertex_shader");
         _pixel_shader = shader_storage->get("level_pixel_shader");
@@ -52,9 +51,9 @@ namespace trview
         // Create the texture sampler state.
         _sampler_state = device->create_sampler_state(sampler_desc);
 
-        generate_rooms(*level, room_source);
+        generate_rooms(*level, room_source, *mesh_storage);
         generate_triggers(trigger_source);
-        generate_entities(*level, *type_names, entity_source, ai_source);
+        generate_entities(*level, *type_names, entity_source, ai_source, *mesh_storage);
 
         for (auto& room : _rooms)
         {
@@ -319,13 +318,13 @@ namespace trview
         return rooms;
     }
 
-    void Level::generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source)
+    void Level::generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage)
     {
         const auto num_rooms = level.num_rooms();
         for (uint32_t i = 0u; i < num_rooms; ++i)
         {
             auto room = level.get_room(i);
-            _rooms.push_back(room_source(level, room, *_texture_storage, *_mesh_storage, i, *this));
+            _rooms.push_back(room_source(level, room, *_texture_storage, mesh_storage, i, *this));
         }
 
         std::set<uint32_t> alternate_groups;
@@ -369,13 +368,13 @@ namespace trview
         }
     }
 
-    void Level::generate_entities(const trlevel::ILevel& level, const ITypeNameLookup& type_names, const IEntity::EntitySource& entity_source, const IEntity::AiSource& ai_source)
+    void Level::generate_entities(const trlevel::ILevel& level, const ITypeNameLookup& type_names, const IEntity::EntitySource& entity_source, const IEntity::AiSource& ai_source, const IMeshStorage& mesh_storage)
     {
         const uint32_t num_entities = level.num_entities();
         for (uint32_t i = 0; i < num_entities; ++i)
         {
             auto level_entity = level.get_entity(i);
-            auto entity = entity_source(level, level_entity, i, *_mesh_storage);
+            auto entity = entity_source(level, level_entity, i, mesh_storage);
             _rooms[entity->room()]->add_entity(entity.get());
             _entities.push_back(entity);
 
@@ -396,7 +395,7 @@ namespace trview
         for (uint32_t i = 0; i < num_ai_objects; ++i)
         {
             auto ai_object = level.get_ai_object(i);
-            auto entity = ai_source(level, ai_object, num_entities + i, *_mesh_storage);
+            auto entity = ai_source(level, ai_object, num_entities + i, mesh_storage);
             _rooms[entity->room()]->add_entity(entity.get());
             _entities.push_back(entity);
 

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -80,9 +80,9 @@ namespace trview
         virtual std::string filename() const override;
         virtual void set_filename(const std::string& filename) override;
     private:
-        void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source);
+        void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage);
         void generate_triggers(const ITrigger::Source& trigger_source);
-        void generate_entities(const trlevel::ILevel& level, const ITypeNameLookup& type_names, const IEntity::EntitySource& entity_source, const IEntity::AiSource& ai_source);
+        void generate_entities(const trlevel::ILevel& level, const ITypeNameLookup& type_names, const IEntity::EntitySource& entity_source, const IEntity::AiSource& ai_source, const IMeshStorage& mesh_storage);
         void regenerate_neighbours();
         void generate_neighbours(std::set<uint16_t>& results, uint16_t selected_room, int32_t max_depth);
 
@@ -141,7 +141,6 @@ namespace trview
         std::set<uint16_t> _neighbours;
 
         std::unique_ptr<ILevelTextureStorage> _texture_storage;
-        std::unique_ptr<IMeshStorage> _mesh_storage;
         std::unique_ptr<ITransparencyBuffer> _transparency;
 
         bool _regenerate_transparency{ true };

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -92,8 +92,8 @@ namespace trview
 
         std::vector<std::unique_ptr<StaticMesh>> _static_meshes;
 
-        std::unique_ptr<IMesh> _mesh;
-        std::unique_ptr<IMesh> _unmatched_mesh;
+        std::shared_ptr<IMesh> _mesh;
+        std::shared_ptr<IMesh> _unmatched_mesh;
         DirectX::SimpleMath::Matrix _room_offset;
 
         DirectX::BoundingBox  _bounding_box;

--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -1,13 +1,12 @@
 #include "StaticMesh.h"
 #include <trview.app/Geometry/Matrix.h>
-#include <trview.app/Geometry/Mesh.h>
-#include <trview.app/Geometry/TransparencyBuffer.h>
+#include <trview.app/Geometry/ITransparencyBuffer.h>
 
 namespace trview
 {
     using namespace DirectX::SimpleMath;
 
-    StaticMesh::StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, IMesh* mesh)
+    StaticMesh::StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, const std::shared_ptr<IMesh>& mesh)
         : _mesh(mesh),
         _visibility_min(level_static_mesh.VisibilityBox.MinX, level_static_mesh.VisibilityBox.MinY, level_static_mesh.VisibilityBox.MinZ),
         _visibility_max(level_static_mesh.VisibilityBox.MaxX, level_static_mesh.VisibilityBox.MaxY, level_static_mesh.VisibilityBox.MaxZ),

--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -19,8 +19,8 @@ namespace trview
         _world = Matrix::CreateRotationY(_rotation) * Matrix::CreateTranslation(_position);
     }
 
-    StaticMesh::StaticMesh(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Matrix& scale, std::unique_ptr<IMesh> mesh)
-        : _position(position), _sprite_mesh(std::move(mesh)), _rotation(0), _scale(scale)
+    StaticMesh::StaticMesh(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Matrix& scale, std::shared_ptr<IMesh> mesh)
+        : _position(position), _sprite_mesh(mesh), _rotation(0), _scale(scale)
     {
         using namespace DirectX::SimpleMath;
         _world = Matrix::CreateRotationY(_rotation) * Matrix::CreateTranslation(_position);

--- a/trview.app/Elements/StaticMesh.h
+++ b/trview.app/Elements/StaticMesh.h
@@ -15,7 +15,7 @@ namespace trview
     {
     public:
         StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, const std::shared_ptr<IMesh>& mesh);
-        StaticMesh(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Matrix& scale, std::unique_ptr<IMesh> mesh);
+        StaticMesh(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Matrix& scale, std::shared_ptr<IMesh> mesh);
         void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour);
         void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour);
     private:
@@ -27,7 +27,7 @@ namespace trview
         DirectX::SimpleMath::Vector3 _collision_max;
         DirectX::SimpleMath::Matrix  _world;
         std::shared_ptr<IMesh> _mesh;
-        std::unique_ptr<IMesh> _sprite_mesh;
+        std::shared_ptr<IMesh> _sprite_mesh;
         DirectX::SimpleMath::Matrix _scale;
     };
 }

--- a/trview.app/Elements/StaticMesh.h
+++ b/trview.app/Elements/StaticMesh.h
@@ -9,18 +9,14 @@
 namespace trview
 {
     struct ILevelTextureStorage;
-    class Mesh;
     struct ITransparencyBuffer;
 
     class StaticMesh
     {
     public:
-        StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, IMesh* mesh);
-
+        StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, const std::shared_ptr<IMesh>& mesh);
         StaticMesh(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Matrix& scale, std::unique_ptr<IMesh> mesh);
-
         void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour);
-
         void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour);
     private:
         float                        _rotation;
@@ -30,7 +26,7 @@ namespace trview
         DirectX::SimpleMath::Vector3 _collision_min;
         DirectX::SimpleMath::Vector3 _collision_max;
         DirectX::SimpleMath::Matrix  _world;
-        IMesh*                       _mesh;
+        std::shared_ptr<IMesh> _mesh;
         std::unique_ptr<IMesh> _sprite_mesh;
         DirectX::SimpleMath::Matrix _scale;
     };

--- a/trview.app/Elements/Trigger.h
+++ b/trview.app/Elements/Trigger.h
@@ -36,7 +36,7 @@ namespace trview
     private:
         std::vector<uint16_t> _objects;
         std::vector<Command> _commands;
-        std::unique_ptr<IMesh> _mesh;
+        std::shared_ptr<IMesh> _mesh;
         DirectX::SimpleMath::Vector3 _position;
         IMesh::TransparentSource _mesh_source;
         TriggerType _type;

--- a/trview.app/Geometry/IMesh.cpp
+++ b/trview.app/Geometry/IMesh.cpp
@@ -28,7 +28,7 @@ namespace trview
     {
     }
 
-    std::unique_ptr<IMesh> create_mesh(trlevel::LevelVersion level_version, const trlevel::tr_mesh& mesh, const IMesh::Source& source, const ILevelTextureStorage& texture_storage, bool transparent_collision)
+    std::shared_ptr<IMesh> create_mesh(trlevel::LevelVersion level_version, const trlevel::tr_mesh& mesh, const IMesh::Source& source, const ILevelTextureStorage& texture_storage, bool transparent_collision)
     {
         std::vector<std::vector<uint32_t>> indices(texture_storage.num_tiles());
         std::vector<MeshVertex> vertices;
@@ -44,7 +44,7 @@ namespace trview
         return source(vertices, indices, untextured_indices, transparent_triangles, collision_triangles);
     }
 
-    std::unique_ptr<IMesh> create_cube_mesh(const IMesh::Source& source)
+    std::shared_ptr<IMesh> create_cube_mesh(const IMesh::Source& source)
     {
         const std::vector<MeshVertex> vertices
         {
@@ -98,7 +98,7 @@ namespace trview
         return source(vertices, std::vector<std::vector<uint32_t>>(), indices, std::vector<TransparentTriangle>(), std::vector<Triangle>());
     }
 
-    std::unique_ptr<IMesh> create_sprite_mesh(const IMesh::Source& source, const trlevel::tr_sprite_texture& sprite, Matrix& scale, Vector3& offset, SpriteOffsetMode offset_mode)
+    std::shared_ptr<IMesh> create_sprite_mesh(const IMesh::Source& source, const trlevel::tr_sprite_texture& sprite, Matrix& scale, Vector3& offset, SpriteOffsetMode offset_mode)
     {
         // Calculate UVs.
         float u = static_cast<float>(sprite.x) / 256.0f;
@@ -140,12 +140,12 @@ namespace trview
         return source(std::vector<MeshVertex>(), std::vector<std::vector<uint32_t>>(), std::vector<uint32_t>(), transparent_triangles, collision_triangles);
     }
 
-    std::unique_ptr<IMesh> create_sprite_mesh(const IMesh::Source& source, const trlevel::tr_sprite_texture& sprite, Matrix& scale, Matrix& offset, SpriteOffsetMode offset_mode)
+    std::shared_ptr<IMesh> create_sprite_mesh(const IMesh::Source& source, const trlevel::tr_sprite_texture& sprite, Matrix& scale, Matrix& offset, SpriteOffsetMode offset_mode)
     {
         Vector3 offset_vector;
         auto mesh = create_sprite_mesh(source, sprite, scale, offset_vector, offset_mode);
         offset = Matrix::CreateTranslation(offset_vector);
-        return std::move(mesh);
+        return mesh;
     }
 
     void process_textured_rectangles(

--- a/trview.app/Geometry/IMesh.h
+++ b/trview.app/Geometry/IMesh.h
@@ -10,11 +10,11 @@ namespace trview
 {
     struct IMesh
     {
-        using Source = std::function<std::unique_ptr<IMesh>(
+        using Source = std::function<std::shared_ptr<IMesh>(
             const std::vector<MeshVertex>&, const std::vector<std::vector<uint32_t>>&, const std::vector<uint32_t>&,
             const std::vector<TransparentTriangle>&, const std::vector<Triangle>&)>;
 
-        using TransparentSource = std::function<std::unique_ptr<IMesh>(const std::vector<TransparentTriangle>&, const std::vector<Triangle>&)>;
+        using TransparentSource = std::function<std::shared_ptr<IMesh>(const std::vector<TransparentTriangle>&, const std::vector<Triangle>&)>;
 
         virtual ~IMesh() = 0;
 
@@ -37,10 +37,10 @@ namespace trview
     /// @param texture_storage The textures for the level.
     /// @param transparent_collision Whether to include transparent triangles in collision triangles.
     /// @returns The new mesh.
-    std::unique_ptr<IMesh> create_mesh(trlevel::LevelVersion level_version, const trlevel::tr_mesh& mesh, const IMesh::Source& source, const ILevelTextureStorage& texture_storage, bool transparent_collision = true);
+    std::shared_ptr<IMesh> create_mesh(trlevel::LevelVersion level_version, const trlevel::tr_mesh& mesh, const IMesh::Source& source, const ILevelTextureStorage& texture_storage, bool transparent_collision = true);
 
     /// Create a new cube mesh.
-    std::unique_ptr<IMesh> create_cube_mesh(const IMesh::Source& source);
+    std::shared_ptr<IMesh> create_cube_mesh(const IMesh::Source& source);
 
     enum class SpriteOffsetMode
     {
@@ -53,7 +53,7 @@ namespace trview
     /// @param sprite The game sprite definition to use.
     /// @param scale The output scale matrix.
     /// @param offset The output offset.
-    std::unique_ptr<IMesh> create_sprite_mesh(
+    std::shared_ptr<IMesh> create_sprite_mesh(
         const IMesh::Source& source,
         const trlevel::tr_sprite_texture& sprite,
         DirectX::SimpleMath::Matrix& scale,
@@ -64,7 +64,7 @@ namespace trview
     /// @param source The function to call to create a IMesh
     /// @param sprite The game sprite definition to use.
     /// @param scale The output scale matrix.
-    std::unique_ptr<IMesh> create_sprite_mesh(
+    std::shared_ptr<IMesh> create_sprite_mesh(
         const IMesh::Source& source,
         const trlevel::tr_sprite_texture& sprite,
         DirectX::SimpleMath::Matrix& scale,

--- a/trview.app/Geometry/Mesh.h
+++ b/trview.app/Geometry/Mesh.h
@@ -53,7 +53,7 @@ namespace trview
         std::vector<Microsoft::WRL::ComPtr<ID3D11Buffer>> _index_buffers;
         Microsoft::WRL::ComPtr<ID3D11Buffer>              _matrix_buffer;
         Microsoft::WRL::ComPtr<ID3D11Buffer>              _untextured_index_buffer;
-        uint32_t                                          _untextured_index_count;
+        uint32_t                                          _untextured_index_count{ 0u };
         std::vector<TransparentTriangle>                  _transparent_triangles;
         std::vector<Triangle>                             _collision_triangles;
         DirectX::BoundingBox                              _bounding_box;

--- a/trview.app/Geometry/di.hpp
+++ b/trview.app/Geometry/di.hpp
@@ -17,7 +17,7 @@ namespace trview
                 {
                     return [&](auto&& vertices, auto&& indices, auto&& untextured_indices, auto&& transparent_triangles, auto&& collision_triangles)
                     {
-                        return std::make_unique<Mesh>(
+                        return std::make_shared<Mesh>(
                             injector.create<std::shared_ptr<IDevice>>(),
                             vertices,
                             indices,
@@ -31,7 +31,7 @@ namespace trview
                 {
                     return [&](auto&& transparent_triangles, auto&& collision_triangles)
                     {
-                        return std::make_unique<Mesh>(transparent_triangles, collision_triangles);
+                        return std::make_shared<Mesh>(transparent_triangles, collision_triangles);
                     };
                 }),
             di::bind<IPicking>.to<Picking>(),

--- a/trview.app/Graphics/IMeshStorage.h
+++ b/trview.app/Graphics/IMeshStorage.h
@@ -7,13 +7,10 @@
 namespace trview
 {
     struct IMesh;
-
     struct IMeshStorage
     {
         using Source = std::function<std::unique_ptr<IMeshStorage>(const trlevel::ILevel&, const ILevelTextureStorage&)>;
-
         virtual ~IMeshStorage() = 0;
-
-        virtual IMesh* mesh(uint32_t mesh_pointer) const = 0;
+        virtual std::shared_ptr<IMesh> mesh(uint32_t mesh_pointer) const = 0;
     };
 }

--- a/trview.app/Graphics/MeshStorage.cpp
+++ b/trview.app/Graphics/MeshStorage.cpp
@@ -13,12 +13,12 @@ namespace trview
         }
     }
 
-    IMesh* MeshStorage::mesh(uint32_t mesh_pointer) const 
+    std::shared_ptr<IMesh> MeshStorage::mesh(uint32_t mesh_pointer) const 
     {
         auto found = _meshes.find(mesh_pointer);
         if (found != _meshes.end())
         {
-            return found->second.get();
+            return found->second;
         }
         return nullptr;
     }

--- a/trview.app/Graphics/MeshStorage.cpp
+++ b/trview.app/Graphics/MeshStorage.cpp
@@ -7,9 +7,7 @@ namespace trview
         const uint32_t pointers = level.num_mesh_pointers();
         for (uint32_t i = 0; i < pointers; ++i)
         {
-            auto level_mesh = level.get_mesh_by_pointer(i);
-            auto new_mesh = create_mesh(level.get_version(), level_mesh, mesh_source, texture_storage);
-            _meshes.insert({ i, std::move(new_mesh) });
+            _meshes.insert({ i, create_mesh(level.get_version(), level.get_mesh_by_pointer(i), mesh_source, texture_storage) });
         }
     }
 

--- a/trview.app/Graphics/MeshStorage.h
+++ b/trview.app/Graphics/MeshStorage.h
@@ -3,7 +3,6 @@
 #include <unordered_map>
 #include <cstdint>
 #include <memory>
-
 #include <trlevel/ILevel.h>
 #include "IMeshStorage.h"
 #include <trview.app/Geometry/IMesh.h>
@@ -16,11 +15,9 @@ namespace trview
     {
     public:
         explicit MeshStorage(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const ILevelTextureStorage& texture_storage);
-
         virtual ~MeshStorage() = default;
-
-        virtual IMesh* mesh(uint32_t mesh_pointer) const override;
+        virtual std::shared_ptr<IMesh> mesh(uint32_t mesh_pointer) const override;
     private:
-        mutable std::unordered_map<uint32_t, std::unique_ptr<IMesh>> _meshes;
+        mutable std::unordered_map<uint32_t, std::shared_ptr<IMesh>> _meshes;
     };
 }

--- a/trview.app/Graphics/SectorHighlight.h
+++ b/trview.app/Graphics/SectorHighlight.h
@@ -15,7 +15,7 @@ namespace trview
     private:
         DirectX::SimpleMath::Matrix _room_offset;
         std::shared_ptr<Sector> _sector;
-        std::unique_ptr<IMesh> _mesh;
+        std::shared_ptr<IMesh> _mesh;
         IMesh::Source _mesh_source;
     };
 }

--- a/trview.app/Mocks/Graphics/IMeshStorage.h
+++ b/trview.app/Mocks/Graphics/IMeshStorage.h
@@ -8,7 +8,7 @@ namespace trview
     {
         class MockMeshStorage final : public IMeshStorage
         {
-            MOCK_METHOD(IMesh*, mesh, (uint32_t), (const));
+            MOCK_METHOD(std::shared_ptr<IMesh>, mesh, (uint32_t), (const, override));
         };
     }
 }

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -104,7 +104,7 @@ namespace trview
         uint32_t next_index() const;
 
         std::vector<Waypoint> _waypoints;
-        std::unique_ptr<IMesh> _waypoint_mesh;
+        std::shared_ptr<IMesh> _waypoint_mesh;
         std::unique_ptr<ISelectionRenderer> _selection_renderer;
         uint32_t              _selected_index{ 0u };
         Colour                _colour{ Colour::Green };

--- a/trview.app/Tools/Compass.h
+++ b/trview.app/Tools/Compass.h
@@ -37,7 +37,7 @@ namespace trview
     private:
         std::shared_ptr<graphics::IDevice> _device;
         std::unique_ptr<graphics::IRenderTarget> _render_target;
-        std::unique_ptr<IMesh> _mesh;
+        std::shared_ptr<IMesh> _mesh;
         std::unique_ptr<graphics::ISprite> _sprite;
         OrbitCamera _mesh_camera;
         bool _visible{ true };

--- a/trview.app/Tools/Measure.h
+++ b/trview.app/Tools/Measure.h
@@ -47,7 +47,7 @@ namespace trview
         std::shared_ptr<graphics::IDevice> _device;
         std::optional<DirectX::SimpleMath::Vector3> _start;
         std::optional<DirectX::SimpleMath::Vector3> _end;
-        std::unique_ptr<IMesh>                      _mesh;
-        bool                                        _visible{ true };
+        std::shared_ptr<IMesh> _mesh;
+        bool _visible{ true };
     };
 }


### PR DESCRIPTION
Convert `MeshStorage` to use `shared_ptr` so that the storage itself can be safely discarded after the level is loaded and all elements are generated.
Add some tests for `MeshStorage`
Closes #773