### PR TITLE
Use `auto&&...` for `Source` functions in tests

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -61,13 +61,13 @@ namespace
             di::bind<ILevelSwitcher>.to([&](auto&&) { return std::move(level_switcher); }),
             di::bind<IRecentFiles>.to([&](auto&&) { return std::move(recent_files); }),
             di::bind<IViewer>.to([&](auto&&) { return std::move(viewer); }),
-            di::bind<IRoute::Source>.to([&](const auto& injector)->IRoute::Source { return [&]() { return std::move(route); }; }),
+            di::bind<IRoute::Source>.to([&](auto&&) { return [&](auto&&...) { return std::move(route); }; }),
             di::bind<IShortcuts>.to(shortcuts),
             di::bind<IItemsWindowManager>.to([&](auto&&) { return std::move(items_window_manager); }),
             di::bind<ITriggersWindowManager>.to([&](auto&&) { return std::move(triggers_window_manager); }),
             di::bind<IRouteWindowManager>.to([&](auto&&) { return std::move(route_window_manager); }),
             di::bind<IRoomsWindowManager>.to([&](auto&&) { return std::move(rooms_window_manager); }),
-            di::bind<ILevel::Source>.to([](const auto& injector)->ILevel::Source { return [](auto) { return std::make_unique<trview::mocks::MockLevel>(); }; }),
+            di::bind<ILevel::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<trview::mocks::MockLevel>(); }; }),
             di::bind<IStartupOptions>.to(startup_options)
         ).create<std::unique_ptr<Application>>();
     }

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -23,9 +23,9 @@ using testing::Return;
 
 namespace
 {
-    auto default_entity_source(const trlevel::ILevel&, const trlevel::tr2_entity&, uint32_t, const IMeshStorage&) { return std::make_shared<MockEntity>(); }
-    auto default_ai_source(const trlevel::ILevel&, const trlevel::tr4_ai_object&, uint32_t, const IMeshStorage&) { return std::make_shared<MockEntity>(); }
-    auto default_room_source(const trlevel::ILevel&, const trlevel::tr3_room&, const ILevelTextureStorage&, const IMeshStorage&, uint32_t, const trview::ILevel&) { return std::make_shared<MockRoom>(); }
+    auto default_entity_source = [](auto&&...) { return std::make_shared<MockEntity>(); };
+    auto default_ai_source = [](auto&&...) { return std::make_shared<MockEntity>(); };
+    auto default_room_source = [](auto&&...) { return std::make_shared<MockRoom>(); };
 
     auto register_test_module(std::unique_ptr<trlevel::ILevel> level, std::shared_ptr<ITypeNameLookup> type_name_lookup = nullptr, IEntity::EntitySource entity_source = default_entity_source,
         IEntity::AiSource ai_source = default_ai_source, IRoom::Source room_source = default_room_source)
@@ -89,12 +89,12 @@ TEST(Level, LoadFromEntitySources)
     uint32_t ai_source_called = 0;
 
     auto level = register_test_module(std::move(mock_level_ptr), nullptr,
-        [&](auto&&, auto&&, auto&&, auto&&)
+        [&](auto&&...)
         {
             ++entity_source_called;
             return std::make_shared<MockEntity>();
         },
-        [&](auto&&, auto&&, auto&&, auto&)
+        [&](auto&&...)
         {
             ++ai_source_called;
             return std::make_shared<MockEntity>();
@@ -113,7 +113,7 @@ TEST(Level, LoadRooms)
     int room_called = 0;
 
     auto level = register_test_module(std::move(mock_level_ptr), nullptr, default_entity_source, default_ai_source, 
-        [&](auto&&, auto&&, auto&&, auto&&, auto&&, auto&&) 
+        [&](auto&&...) 
         { 
             ++room_called;
             return std::make_shared<MockRoom>(); 

--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -25,9 +25,9 @@ namespace
     {
         using namespace boost;
         return di::make_injector(
-            di::bind<IDeviceWindow::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockDeviceWindow>(); }; }),
-            di::bind<ui::render::IRenderer::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockRenderer>(); }; }),
-            di::bind<ui::IInput::Source>.to([&](auto&&) { return [&](auto&&, auto&&) { return std::make_unique<MockInput>(); }; }),
+            di::bind<IDeviceWindow::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockDeviceWindow>(); }; }),
+            di::bind<ui::render::IRenderer::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockRenderer>(); }; }),
+            di::bind<ui::IInput::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockInput>(); }; }),
             di::bind<Window>.to(create_test_window(L"ItemsWindowTests")),
             di::bind<IClipboard>.to<MockClipboard>(),
             di::bind<ItemsWindow>()

--- a/trview.app.tests/RoomsWindowTests.cpp
+++ b/trview.app.tests/RoomsWindowTests.cpp
@@ -29,10 +29,10 @@ namespace
     {
         using namespace boost;
         return di::make_injector(
-            di::bind<IDeviceWindow::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockDeviceWindow>(); }; }),
-            di::bind<ui::render::IRenderer::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockRenderer>(); }; }),
-            di::bind<ui::render::IMapRenderer::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockMapRenderer>(); }; }),
-            di::bind<ui::IInput::Source>.to([&](auto&&) { return [&](auto&&, auto&&) 
+            di::bind<IDeviceWindow::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockDeviceWindow>(); }; }),
+            di::bind<ui::render::IRenderer::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockRenderer>(); }; }),
+            di::bind<ui::render::IMapRenderer::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockMapRenderer>(); }; }),
+            di::bind<ui::IInput::Source>.to([&](auto&&) { return [&](auto&&...) 
                 { 
                     auto input = std::make_unique<MockInput>();
                     EXPECT_CALL(*input, mouse).WillRepeatedly(ReturnRef(mouse));

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -26,9 +26,9 @@ namespace
     {
         using namespace boost;
         return di::make_injector(
-            di::bind<IDeviceWindow::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockDeviceWindow>(); }; }),
-            di::bind<ui::render::IRenderer::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockRenderer>(); }; }),
-            di::bind<ui::IInput::Source>.to([&](auto&&) { return [&](auto&&, auto&&) { return std::make_unique<MockInput>(); }; }),
+            di::bind<IDeviceWindow::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockDeviceWindow>(); }; }),
+            di::bind<ui::render::IRenderer::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockRenderer>(); }; }),
+            di::bind<ui::IInput::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockInput>(); }; }),
             di::bind<Window>.to(create_test_window(L"RouteWindowTests")),
             di::bind<RouteWindow>(),
             di::bind<IClipboard>.to(clipboard ? clipboard : std::make_shared<MockClipboard>())

--- a/trview.app.tests/TriggersWindowTests.cpp
+++ b/trview.app.tests/TriggersWindowTests.cpp
@@ -26,9 +26,9 @@ namespace
     {
         using namespace boost;
         return di::make_injector(
-            di::bind<IDeviceWindow::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockDeviceWindow>(); }; }),
-            di::bind<ui::render::IRenderer::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockRenderer>(); }; }),
-            di::bind<ui::IInput::Source>.to([&](auto&&) { return [&](auto&&, auto&&) { return std::make_unique<MockInput>(); }; }),
+            di::bind<IDeviceWindow::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockDeviceWindow>(); }; }),
+            di::bind<ui::render::IRenderer::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockRenderer>(); }; }),
+            di::bind<ui::IInput::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockInput>(); }; }),
             di::bind<Window>.to(create_test_window(L"TriggersWindowTests")),
             di::bind<IClipboard>.to<MockClipboard>(),
             di::bind<TriggersWindow>()

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -58,11 +58,11 @@ namespace
             di::bind<IMouse>.to([&](auto&&) { return std::move(mouse); }),
             di::bind<IShortcuts>.to(shortcuts),
             di::bind<IRoute>.to<MockRoute>(),
-            di::bind<ISprite::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockSprite>(); }; }),
+            di::bind<ISprite::Source>.to([&](auto&&) { return [&](auto&&...) { return std::make_unique<MockSprite>(); }; }),
             di::bind<ICompass>.to<MockCompass>(),
             di::bind<IMeasure>.to<MockMeasure>(),
-            di::bind<IRenderTarget::SizeSource>.to([&](auto&&) { return [&](auto&&, auto&&, auto&&) { return std::make_unique<MockRenderTarget>(); }; }),
-            di::bind<IDeviceWindow::Source>.to([&](auto&&) { return [&](auto&&) { return std::make_unique<MockDeviceWindow>(); }; }),
+            di::bind<IRenderTarget::SizeSource>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockRenderTarget>(); }; }),
+            di::bind<IDeviceWindow::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockDeviceWindow>(); }; }),
             di::bind<ISectorHighlight>.to<MockSectorHighlight>(),
             di::bind<Viewer>()
         ).create<std::unique_ptr<Viewer>>();

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -58,7 +58,7 @@ namespace
             di::bind<IMouse>.to([&](auto&&) { return std::move(mouse); }),
             di::bind<IShortcuts>.to(shortcuts),
             di::bind<IRoute>.to<MockRoute>(),
-            di::bind<ISprite::Source>.to([&](auto&&) { return [&](auto&&...) { return std::make_unique<MockSprite>(); }; }),
+            di::bind<ISprite::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockSprite>(); }; }),
             di::bind<ICompass>.to<MockCompass>(),
             di::bind<IMeasure>.to<MockMeasure>(),
             di::bind<IRenderTarget::SizeSource>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockRenderTarget>(); }; }),


### PR DESCRIPTION
This means that if they change I don't have to update all of the tests - and they don't use the parameters anyway.
Closes #793