### PR TITLE
Convert static mesh to shared_ptr and DI

### DIFF
--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -111,8 +111,8 @@ namespace trlevel
 
     struct tr_room_sprite
     {
-        int16_t vertex;
-        int16_t texture;
+        int16_t vertex{ 0u };
+        int16_t texture{ 0u };
     };
 
     struct tr_animation // 32 bytes
@@ -574,8 +574,8 @@ namespace trlevel
 
         std::vector<tr_room_portal> portals;
 
-        uint16_t num_z_sectors;
-        uint16_t num_x_sectors;
+        uint16_t num_z_sectors{ 0u };
+        uint16_t num_x_sectors{ 0u };
         std::vector<tr_room_sector> sector_list;
 
         uint32_t colour{ 0xffffffff };

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -1,0 +1,78 @@
+#include <trview.app/Elements/Room.h>
+#include <trlevel/Mocks/ILevel.h>
+#include <trview.app/Mocks/Geometry/IMesh.h>
+#include <trview.app/Mocks/Elements/ILevel.h>
+#include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
+#include <trview.app/Mocks/Graphics/IMeshStorage.h>
+#include <trview.app/Mocks/Elements/IStaticMesh.h>
+#include <external/boost/di.hpp>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace trview::tests;
+using namespace boost;
+
+namespace
+{
+    auto default_mesh_source = [](auto&&...) { return std::make_shared<MockMesh>(); };
+    auto default_static_mesh_source = [](auto&&...) { return std::make_shared<MockStaticMesh>(); };
+    auto default_static_mesh_position_source = [](auto&&...) { return std::make_shared<MockStaticMesh>(); };
+
+    auto register_test_module(IMesh::Source mesh_source = default_mesh_source, std::shared_ptr<trlevel::ILevel> tr_level = nullptr, trlevel::tr3_room room = {},
+        std::shared_ptr<ILevelTextureStorage> level_texture_storage = nullptr, std::shared_ptr<IMeshStorage> mesh_storage = nullptr, uint32_t index = 0,
+        std::shared_ptr<ILevel> level = nullptr, IStaticMesh::MeshSource static_mesh_source = default_static_mesh_source,
+        IStaticMesh::PositionSource static_mesh_position_source = default_static_mesh_position_source)
+    {
+        choose_mock<trlevel::mocks::MockLevel>(tr_level);
+        choose_mock<MockLevelTextureStorage>(level_texture_storage);
+        choose_mock<MockMeshStorage>(mesh_storage);
+        choose_mock<MockLevel>(level);
+
+        return di::make_injector
+        (
+            di::bind<IMesh::Source>.to(mesh_source),
+            di::bind<trlevel::ILevel>.to(*tr_level),
+            di::bind<trlevel::tr3_room>.to(room),
+            di::bind<ILevelTextureStorage>.to(*level_texture_storage),
+            di::bind<IMeshStorage>.to(*mesh_storage),
+            di::bind<uint32_t>.to(index),
+            di::bind<ILevel>.to(*level),
+            di::bind<IStaticMesh::MeshSource>.to(static_mesh_source),
+            di::bind<IStaticMesh::PositionSource>.to(static_mesh_position_source)
+        ).create<std::unique_ptr<Room>>();
+    }
+}
+
+TEST(Room, StaticMeshesLoaded)
+{
+    trlevel::tr3_room level_room;
+    level_room.static_meshes.resize(2);
+
+    uint32_t times_called = 0;
+    auto static_mesh_source = [&](auto&&...)
+    {
+        ++times_called;
+        return std::make_shared<MockStaticMesh>();
+    };
+
+    auto room = register_test_module(default_mesh_source, nullptr, level_room, nullptr, nullptr, 0, nullptr, static_mesh_source, default_static_mesh_position_source);
+    ASSERT_EQ(times_called, 2);
+}
+
+TEST(Room, SpritesLoaded)
+{
+    trlevel::tr3_room level_room;
+    level_room.data.vertices.resize(1);
+    level_room.data.sprites.resize(2);
+
+    uint32_t times_called = 0;
+    auto static_mesh_position_source = [&](auto&&...)
+    {
+        ++times_called;
+        return std::make_shared<MockStaticMesh>();
+    };
+
+    auto room = register_test_module(default_mesh_source, nullptr, level_room, nullptr, nullptr, 0, nullptr, default_static_mesh_source, static_mesh_position_source);
+    ASSERT_EQ(times_called, 2);
+}
+

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="Camera\CameraInputTests.cpp" />
     <ClCompile Include="ContextMenuTests.cpp" />
     <ClCompile Include="Elements\LevelTests.cpp" />
+    <ClCompile Include="Elements\RoomTests.cpp" />
     <ClCompile Include="Elements\TypeNameLookupTests.cpp" />
     <ClCompile Include="FileDropperTests.cpp" />
     <ClCompile Include="FreeCameraTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -71,6 +71,9 @@
     <ClCompile Include="Graphics\MeshStorageTests.cpp">
       <Filter>Graphics</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\RoomTests.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Elements/IStaticMesh.cpp
+++ b/trview.app/Elements/IStaticMesh.cpp
@@ -1,0 +1,8 @@
+#include "IStaticMesh.h"
+
+namespace trview
+{
+    IStaticMesh::~IStaticMesh() 
+    {
+    }
+}

--- a/trview.app/Elements/IStaticMesh.h
+++ b/trview.app/Elements/IStaticMesh.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <cstdint>
+#include <SimpleMath.h>
+#include <trlevel/trtypes.h>
+#include <trview.app/Camera/ICamera.h>
+#include <trview.app/Geometry/IMesh.h>
+
+namespace trview
+{
+    struct ILevelTextureStorage;
+    struct ITransparencyBuffer;
+
+    struct IStaticMesh
+    {
+        using PositionSource = std::function<std::shared_ptr<IStaticMesh>(const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Matrix&, std::shared_ptr<IMesh>)>;
+        using MeshSource = std::function<std::shared_ptr<IStaticMesh>(const trlevel::tr3_room_staticmesh&, const trlevel::tr_staticmesh&, const std::shared_ptr<IMesh>&)>;
+
+        virtual ~IStaticMesh() = 0;
+        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) = 0;
+        virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) = 0;
+    };
+}

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -15,7 +15,7 @@
 #include <trview.app/Elements/Sector.h>
 #include <trview.app/Geometry/PickResult.h>
 #include <trview.graphics/Texture.h>
-#include "StaticMesh.h"
+#include "IStaticMesh.h"
 #include "IRoom.h"
 
 namespace trview
@@ -29,7 +29,9 @@ namespace trview
             const ILevelTextureStorage& texture_storage,
             const IMeshStorage& mesh_storage,
             uint32_t index,
-            const ILevel& parent_level);
+            const ILevel& parent_level,
+            const IStaticMesh::MeshSource& static_mesh_mesh_source,
+            const IStaticMesh::PositionSource& static_mesh_position_source);
 
         Room(const Room&) = delete;
         Room& operator=(const Room&) = delete;
@@ -61,7 +63,8 @@ namespace trview
     private:
         void generate_geometry(trlevel::LevelVersion level_version, const IMesh::Source& mesh_source, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage);
         void generate_adjacency();
-        void generate_static_meshes(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr3_room& room, const IMeshStorage& mesh_storage);
+        void generate_static_meshes(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr3_room& room, const IMeshStorage& mesh_storage,
+            const IStaticMesh::MeshSource& static_mesh_mesh_source, const IStaticMesh::PositionSource& static_mesh_position_source);
         void render_contained(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour);
         void get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour);
         void generate_sectors(const trlevel::ILevel& level, const trlevel::tr3_room& room);
@@ -90,7 +93,7 @@ namespace trview
         std::set<uint16_t>                 _neighbours;
         uint32_t _index;
 
-        std::vector<std::unique_ptr<StaticMesh>> _static_meshes;
+        std::vector<std::shared_ptr<IStaticMesh>> _static_meshes;
 
         std::shared_ptr<IMesh> _mesh;
         std::shared_ptr<IMesh> _unmatched_mesh;

--- a/trview.app/Elements/StaticMesh.h
+++ b/trview.app/Elements/StaticMesh.h
@@ -1,23 +1,17 @@
 #pragma once
 
-#include <cstdint>
-#include <SimpleMath.h>
-#include <trlevel/trtypes.h>
-#include <trview.app/Camera/ICamera.h>
-#include <trview.app/Geometry/IMesh.h>
+#include <trview.app/Elements/IStaticMesh.h>
 
 namespace trview
 {
-    struct ILevelTextureStorage;
-    struct ITransparencyBuffer;
-
-    class StaticMesh
+    class StaticMesh final : public IStaticMesh
     {
     public:
         StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, const std::shared_ptr<IMesh>& mesh);
         StaticMesh(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Matrix& scale, std::shared_ptr<IMesh> mesh);
-        void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour);
-        void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour);
+        virtual ~StaticMesh() = default;
+        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
+        virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
     private:
         float                        _rotation;
         DirectX::SimpleMath::Vector3 _position;

--- a/trview.app/Elements/di.hpp
+++ b/trview.app/Elements/di.hpp
@@ -56,7 +56,7 @@ namespace trview
                     };
                 }),
             di::bind<IStaticMesh::MeshSource>.to(
-                [](const auto& injector) -> IStaticMesh::MeshSource
+                [](const auto&) -> IStaticMesh::MeshSource
                 {
                     return [&](auto&& room_mesh, auto&& level_mesh, auto&& mesh)
                     {
@@ -64,7 +64,7 @@ namespace trview
                     };
                 }),
             di::bind<IStaticMesh::PositionSource>.to(
-                [](const auto& injector) -> IStaticMesh::PositionSource
+                [](const auto&) -> IStaticMesh::PositionSource
                 {
                     return [&](auto&& position, auto&& scale, auto&& mesh)
                     {

--- a/trview.app/Elements/di.hpp
+++ b/trview.app/Elements/di.hpp
@@ -4,6 +4,7 @@
 #include "Level.h"
 #include "TypeNameLookup.h"
 #include "Entity.h"
+#include "StaticMesh.h"
 
 #include "Resources/resource.h"
 #include "Resources/ResourceHelper.h"
@@ -42,7 +43,8 @@ namespace trview
                 {
                     return [&](auto&& level, auto&& room, auto&& texture_storage, auto&& mesh_storage, auto&& index, auto&& parent_level)
                     {
-                        return std::make_shared<Room>(injector.create<IMesh::Source>(), level, room, texture_storage, mesh_storage, index, parent_level);
+                        return std::make_shared<Room>(injector.create<IMesh::Source>(), level, room, texture_storage, mesh_storage, index, parent_level,
+                            injector.create<IStaticMesh::MeshSource>(), injector.create<IStaticMesh::PositionSource>());
                     };
                 }),
             di::bind<ITrigger::Source>.to(
@@ -51,6 +53,22 @@ namespace trview
                     return [&](auto&& number, auto&& room, auto&& x, auto&& z, auto&& trigger_info)
                     {
                         return std::make_shared<Trigger>(number, room, x, z, trigger_info, injector.create<IMesh::TransparentSource>());
+                    };
+                }),
+            di::bind<IStaticMesh::MeshSource>.to(
+                [](const auto& injector) -> IStaticMesh::MeshSource
+                {
+                    return [&](auto&& room_mesh, auto&& level_mesh, auto&& mesh)
+                    {
+                        return std::make_shared<StaticMesh>(room_mesh, level_mesh, mesh);
+                    };
+                }),
+            di::bind<IStaticMesh::PositionSource>.to(
+                [](const auto& injector) -> IStaticMesh::PositionSource
+                {
+                    return [&](auto&& position, auto&& scale, auto&& mesh)
+                    {
+                        return std::make_shared<StaticMesh>(position, scale, mesh);
                     };
                 }),
             di::bind<ILevel::Source>.to(

--- a/trview.app/Mocks/Elements/IStaticMesh.h
+++ b/trview.app/Mocks/Elements/IStaticMesh.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <trview.app/Elements/IStaticMesh.h>
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockStaticMesh final : public IStaticMesh
+        {
+            virtual ~MockStaticMesh() = default;
+            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
+        };
+    }
+}

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -39,6 +39,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Elements\Entity.cpp" />
     <ClCompile Include="Elements\IEntity.cpp" />
     <ClCompile Include="Elements\IRoom.cpp" />
+    <ClCompile Include="Elements\IStaticMesh.cpp" />
     <ClCompile Include="Elements\Item.cpp" />
     <ClCompile Include="Elements\ITrigger.cpp" />
     <ClCompile Include="Elements\ITypeNameLookup.cpp" />
@@ -154,6 +155,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Elements\IEntity.h" />
     <ClInclude Include="Elements\ILevel.h" />
     <ClInclude Include="Elements\IRoom.h" />
+    <ClInclude Include="Elements\IStaticMesh.h" />
     <ClInclude Include="Elements\Item.h" />
     <ClInclude Include="Elements\ITrigger.h" />
     <ClInclude Include="Elements\ITypeNameLookup.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -212,6 +212,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\Elements\IEntity.h" />
     <ClInclude Include="Mocks\Elements\ILevel.h" />
     <ClInclude Include="Mocks\Elements\IRoom.h" />
+    <ClInclude Include="Mocks\Elements\IStaticMesh.h" />
     <ClInclude Include="Mocks\Elements\ITrigger.h" />
     <ClInclude Include="Mocks\Elements\ITypeNameLookup.h" />
     <ClInclude Include="Mocks\Geometry\IMesh.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -797,6 +797,9 @@
     <ClInclude Include="Elements\IStaticMesh.h">
       <Filter>Elements</Filter>
     </ClInclude>
+    <ClInclude Include="Mocks\Elements\IStaticMesh.h">
+      <Filter>Mocks\Elements</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -310,6 +310,9 @@
     <ClCompile Include="Elements\ITrigger.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\IStaticMesh.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -790,6 +793,9 @@
     </ClInclude>
     <ClInclude Include="Mocks\Elements\ITrigger.h">
       <Filter>Mocks\Elements</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\IStaticMesh.h">
+      <Filter>Elements</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Convert creation of static meshes to DI and shared_ptr.
Add tests now that tests can be added.
Closes #774