### PR TITLE
Room tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       run: msbuild trview.sln /property:Configuration=Release /property:Platform=x86 /m
     
     - name: Test Solution (x86)
-      run: foreach ($file in Get-ChildItem Release\*.tests.exe) { . $file; return $LASTEXITCODE; }        
+      run: foreach ($file in Get-ChildItem Release\*.tests.exe) { & $file }        
       
     - name: Upload Artifact (x86)
       uses: actions/upload-artifact@v2
@@ -54,7 +54,7 @@ jobs:
       run: msbuild trview.sln /property:Configuration=Release /property:Platform=x64 /m
   
     - name: Test Solution (x64)
-      run: foreach ($file in Get-ChildItem x64\Release\*.tests.exe) { . $file; return $LASTEXITCODE; }
+      run: foreach ($file in Get-ChildItem x64\Release\*.tests.exe) { & $file }
 
     - name: Upload Artifact (x64)
       uses: actions/upload-artifact@v2

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -587,7 +587,7 @@ namespace trlevel
 
         std::vector<tr3_room_staticmesh> static_meshes;
 
-        int16_t alternate_room;
+        int16_t alternate_room{ -1 };
         int16_t flags;
 
         uint16_t water_scheme;

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -44,11 +44,11 @@ namespace trlevel
 
     struct tr_room_info
     {
-        int32_t x;
-        int32_t y;
-        int32_t z;
-        int32_t yBottom;
-        int32_t yTop;
+        int32_t x{ 0 };
+        int32_t y{ 0 };
+        int32_t z{ 0 };
+        int32_t yBottom{ 0 };
+        int32_t yTop{ 0 };
     };
 
     struct tr1_4_room_info

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -116,11 +116,46 @@ TEST(Room, AlternateModeDetected)
 }
 
 /// <summary>
+/// Tests that the bounding box is calculated.
+/// </summary>
+TEST(Room, BoundingBoxCalculated)
+{
+    trlevel::tr3_room level_room;
+    level_room.num_x_sectors = 1;
+    level_room.num_z_sectors = 1;
+    level_room.info.yBottom = 0;
+    level_room.info.yTop = -1024;
+    auto room = register_test_module().with_room(level_room).build();
+    auto box = room->bounding_box();
+    ASSERT_EQ(box.Center.x, 0.5);
+    ASSERT_EQ(box.Center.z, 0.5);
+    ASSERT_EQ(box.Center.y, -0.5);
+}
+
+/// <summary>
 /// Tests that the bounding box takes into accounts entities.
 /// </summary>
 TEST(Room, BoundingBoxIncorporatesContents)
 {
-    FAIL();
+    using namespace DirectX;
+    using namespace DirectX::SimpleMath;
+
+    trlevel::tr3_room level_room;
+    level_room.num_x_sectors = 1;
+    level_room.num_z_sectors = 1;
+    level_room.info.yBottom = 0;
+    level_room.info.yTop = -1024;
+    auto room = register_test_module().with_room(level_room).build();
+
+    auto entity = std::make_shared<MockEntity>();
+    EXPECT_CALL(*entity, bounding_box).WillOnce(Return(BoundingBox(Vector3(1.0f, -1.0f, 1.0f), Vector3(0.5f, 0.5f, 0.5f))));
+    room->add_entity(entity);
+    room->update_bounding_box();
+
+    auto box = room->bounding_box();
+    ASSERT_EQ(box.Center.x, 0.75f);
+    ASSERT_EQ(box.Center.z, 0.75f);
+    ASSERT_EQ(box.Center.y, -0.75f);
 }
 
 /// <summary>

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -123,7 +123,10 @@ TEST(Room, GetTransparentTrianglesFromContents)
     auto room = register_test_module().build();
     auto entity = std::make_shared<MockEntity>();
     EXPECT_CALL(*entity, get_transparent_triangles).Times(1);
+    auto trigger = std::make_shared<MockTrigger>();
+    EXPECT_CALL(*trigger, get_transparent_triangles).Times(1);
     room->add_entity(entity);
+    room->add_trigger(trigger);
     room->get_transparent_triangles(MockTransparencyBuffer{}, MockCamera{}, IRoom::SelectionMode::NotSelected, true, true);
 }
 

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -116,6 +116,22 @@ TEST(Room, AlternateModeDetected)
 }
 
 /// <summary>
+/// Tests that the bounding box takes into accounts entities.
+/// </summary>
+TEST(Room, BoundingBoxIncorporatesContents)
+{
+    FAIL();
+}
+
+/// <summary>
+/// Tests that the centre is calculated correctly.
+/// </summary>
+TEST(Room, CentreCalculated)
+{
+    FAIL();
+}
+
+/// <summary>
 /// Tests that the room gets transparent triangles when rendering.
 /// </summary>
 TEST(Room, GetTransparentTriangles)
@@ -244,6 +260,38 @@ TEST(Room, OutsideDetected)
 }
 
 /// <summary>
+/// Tests that the pick function checks the bounding box before testing contents.
+/// </summary>
+TEST(Room, PickTestsBoundingBox)
+{
+    FAIL();
+}
+
+/// <summary>
+/// Tests that the pick function tests entities when commanded.
+/// </summary>
+TEST(Room, PickTestsEntities)
+{
+    FAIL();
+}
+
+/// <summary>
+/// Tests that the pick function tests triggers when commanded.
+/// </summary>
+TEST(Room, PickTestsTriggers)
+{
+    FAIL();
+}
+
+/// <summary>
+/// Tests that the pick function chooses the closest entry.
+/// </summary>
+TEST(Room, PickChoosesClosest)
+{
+    FAIL();
+}
+
+/// <summary>
 /// Tests that the 'quicksand' flag is correctly detected when the version is >= TR3.
 /// </summary>
 TEST(Room, QuicksandDetectedAfterTR3)
@@ -362,9 +410,9 @@ TEST(Room, TriggerAtSectorId)
     auto room = register_test_module().with_room(level_room).build();
 
     auto trigger1 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger1, sector_id).WillByDefault(testing::Return(0));
+    ON_CALL(*trigger1, sector_id).WillByDefault(Return(0));
     auto trigger2 = std::make_shared<MockTrigger>();
-    ON_CALL(*trigger2, sector_id).WillByDefault(testing::Return(4));
+    ON_CALL(*trigger2, sector_id).WillByDefault(Return(4));
 
     room->add_trigger(trigger1);
     room->add_trigger(trigger2);
@@ -377,11 +425,13 @@ TEST(Room, TriggerAtSectorId)
 }
 
 /// <summary>
-/// Tests that trigger_at will follow portals to other rooms in the level.
+/// Tests that a missing trigger return empty.
 /// </summary>
-TEST(Room, TriggerAtFollowsPortals)
+TEST(Room, TriggerAtNotFound)
 {
-    FAIL();
+    auto room = register_test_module().build();
+    auto trigger = room->trigger_at(1, 2);
+    ASSERT_EQ(trigger.lock(), nullptr);
 }
 
 /// <summary>

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -91,6 +91,15 @@ TEST(Room, AlternateModeDetected)
     ASSERT_EQ(room->alternate_room(), 100);
 }
 
+TEST(Room, IsAlternateSet)
+{
+    auto room = register_test_module().build();
+    ASSERT_EQ(room->alternate_mode(), IRoom::AlternateMode::None);
+    room->set_is_alternate(100);
+    ASSERT_EQ(room->alternate_mode(), IRoom::AlternateMode::IsAlternate);
+    ASSERT_EQ(room->alternate_room(), 100);
+}
+
 TEST(Room, NeighboursLoaded)
 {
     trlevel::tr3_room level_room;

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -40,7 +40,7 @@ namespace
                     di::bind<IMesh::Source>.to(mesh_source),
                     di::bind<trlevel::ILevel>.to(*tr_level),
                     di::bind<trlevel::tr3_room>.to(room),
-                    di::bind<ILevelTextureStorage>.to(*level_texture_storage),
+                    di::bind<ILevelTextureStorage>.to(level_texture_storage),
                     di::bind<IMeshStorage>.to(*mesh_storage),
                     di::bind<uint32_t>.to(index),
                     di::bind<ILevel>.to(*level),

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -6,6 +6,7 @@
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
 #include <trview.app/Mocks/Elements/IStaticMesh.h>
 #include <trview.app/Mocks/Elements/ISector.h>
+#include <trview.app/Mocks/Elements/ITrigger.h>
 #include <external/boost/di.hpp>
 
 using namespace trview;
@@ -109,6 +110,27 @@ TEST(Room, AlternateModeDetected)
     auto room = register_test_module().with_room(level_room).build();
     ASSERT_EQ(room->alternate_mode(), IRoom::AlternateMode::HasAlternate);
     ASSERT_EQ(room->alternate_room(), 100);
+}
+
+/// <summary>
+/// Tests that the info is loaded correctly from the room. Also checks that y is ignored and set to 0 as
+/// it seems to be better to use yBottom and yTop.
+/// </summary>
+TEST(Room, InfoLoaded)
+{
+    trlevel::tr3_room level_room;
+    level_room.info.x = 100;
+    level_room.info.y = 200;
+    level_room.info.z = 300;
+    level_room.info.yBottom = 400;
+    level_room.info.yTop = 500;
+    auto room = register_test_module().with_room(level_room).build();
+    auto info = room->info();
+    ASSERT_EQ(info.x, 100);
+    ASSERT_EQ(info.y, 0);
+    ASSERT_EQ(info.z, 300);
+    ASSERT_EQ(info.yBottom, 400);
+    ASSERT_EQ(info.yTop, 500);
 }
 
 /// <summary>
@@ -267,6 +289,23 @@ TEST(Room, SpritesLoaded)
 
     register_test_module().with_room(level_room).with_static_mesh_position_source(static_mesh_position_source).build();
     ASSERT_EQ(times_called, 2);
+}
+
+/// <summary>
+/// Tests that the triggers have their geometries generated when called.
+/// </summary>
+TEST(Room, TriggerGeometryGenerated)
+{
+    auto trigger = std::make_shared<MockTrigger>();
+    EXPECT_CALL(*trigger, set_triangles).Times(1);
+    EXPECT_CALL(*trigger, set_position).Times(1);
+
+    trlevel::tr3_room level_room;
+    level_room.sector_list.resize(1);
+
+    auto room = register_test_module().with_room(level_room).build();
+    room->add_trigger(trigger);
+    room->generate_trigger_geometry();
 }
 
 /// <summary>

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -4,6 +4,7 @@
 #include <trview.app/Mocks/Elements/ILevel.h>
 #include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
+#include <trview.app/Mocks/Elements/IEntity.h>
 #include <trview.app/Mocks/Elements/IStaticMesh.h>
 #include <trview.app/Mocks/Elements/ISector.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
@@ -113,6 +114,14 @@ TEST(Room, AlternateModeDetected)
 }
 
 /// <summary>
+/// Tests that the room gets transparent triangles from its contents when rendering.
+/// </summary>
+TEST(Room, GetTransparentTrianglesFromContents)
+{
+    FAIL();
+}
+
+/// <summary>
 /// Tests that the info is loaded correctly from the room. Also checks that y is ignored and set to 0 as
 /// it seems to be better to use yBottom and yTop.
 /// </summary>
@@ -219,6 +228,17 @@ TEST(Room, QuicksandNotDetectedBeforeTR3)
     ON_CALL(*level, version).WillByDefault(Return(trlevel::LevelVersion::Tomb1));
     auto room = register_test_module().with_room(level_room).with_level(level).build();
     ASSERT_EQ(room->quicksand(), false);
+}
+
+/// <summary>
+/// Tests that entities are rendered when the room is rendererd.
+/// </summary>
+TEST(Room, RendersContainedEntities)
+{
+    auto room = register_test_module().build();
+    auto entity = std::make_shared<MockEntity>();
+    room->add_entity(entity);
+    FAIL();
 }
 
 /// <summary>

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -82,6 +82,20 @@ namespace
     }
 }
 
+/// <summary>
+/// Tests that alternate group information is loaded from the level room.
+/// </summary>
+TEST(Room, AlternateGroupLoaded)
+{
+    trlevel::tr3_room level_room;
+    level_room.alternate_group = 4;
+    auto room = register_test_module().with_room(level_room).build();
+    ASSERT_EQ(room->alternate_group(), 4);
+}
+
+/// <summary>
+/// Tests that the room detects alternate room and has the correct alternate mode.
+/// </summary>
 TEST(Room, AlternateModeDetected)
 {
     trlevel::tr3_room level_room;
@@ -91,6 +105,9 @@ TEST(Room, AlternateModeDetected)
     ASSERT_EQ(room->alternate_room(), 100);
 }
 
+/// <summary>
+/// Tests that setting an alternate room marks this room as an alternate and returns the correct alternate room.
+/// </summary>
 TEST(Room, IsAlternateSet)
 {
     auto room = register_test_module().build();
@@ -100,6 +117,9 @@ TEST(Room, IsAlternateSet)
     ASSERT_EQ(room->alternate_room(), 100);
 }
 
+/// <summary>
+/// Tests that neighbours are correctly extracted from the sectors in the room.
+/// </summary>
 TEST(Room, NeighboursLoaded)
 {
     trlevel::tr3_room level_room;
@@ -127,6 +147,9 @@ TEST(Room, NeighboursLoaded)
     ASSERT_EQ(actual, expected);
 }
 
+/// <summary>
+/// Tests that the 'outside' flag is correctly detected.
+/// </summary>
 TEST(Room, OutsideDetected)
 {
     trlevel::tr3_room level_room;
@@ -135,6 +158,9 @@ TEST(Room, OutsideDetected)
     ASSERT_EQ(room->outside(), true);
 }
 
+/// <summary>
+/// Tests that the 'quicksand' flag is correctly detected when the version is >= TR3.
+/// </summary>
 TEST(Room, QuicksandDetectedAfterTR3)
 {
     trlevel::tr3_room level_room;
@@ -145,6 +171,9 @@ TEST(Room, QuicksandDetectedAfterTR3)
     ASSERT_EQ(room->quicksand(), true);
 }
 
+/// <summary>
+/// Tests that the 'quicksand' flag is not detected before TR3.
+/// </summary>
 TEST(Room, QuicksandNotDetectedBeforeTR3)
 {
     trlevel::tr3_room level_room;
@@ -155,6 +184,9 @@ TEST(Room, QuicksandNotDetectedBeforeTR3)
     ASSERT_EQ(room->quicksand(), false);
 }
 
+/// <summary>
+/// Tests that the appropriate number of static meshes in the room are created.
+/// </summary>
 TEST(Room, StaticMeshesLoaded)
 {
     trlevel::tr3_room level_room;
@@ -171,6 +203,9 @@ TEST(Room, StaticMeshesLoaded)
     ASSERT_EQ(times_called, 2);
 }
 
+/// <summary>
+/// Tests that the appropriate number of sprites in the room are created.
+/// </summary>
 TEST(Room, SpritesLoaded)
 {
     trlevel::tr3_room level_room;
@@ -188,6 +223,9 @@ TEST(Room, SpritesLoaded)
     ASSERT_EQ(times_called, 2);
 }
 
+/// <summary>
+/// Tests that the 'water' flag is correctly detected.
+/// </summary>
 TEST(Room, WaterDetected)
 {
     trlevel::tr3_room level_room;

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -1,10 +1,11 @@
 #include <trview.app/Elements/Room.h>
 #include <trlevel/Mocks/ILevel.h>
+#include <trview.app/Mocks/Camera/ICamera.h>
 #include <trview.app/Mocks/Geometry/IMesh.h>
-#include <trview.app/Mocks/Elements/ILevel.h>
 #include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
 #include <trview.app/Mocks/Elements/IEntity.h>
+#include <trview.app/Mocks/Elements/ILevel.h>
 #include <trview.app/Mocks/Elements/IStaticMesh.h>
 #include <trview.app/Mocks/Elements/ISector.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
@@ -237,8 +238,9 @@ TEST(Room, RendersContainedEntities)
 {
     auto room = register_test_module().build();
     auto entity = std::make_shared<MockEntity>();
+    EXPECT_CALL(*entity, render).Times(1);
     room->add_entity(entity);
-    FAIL();
+    room->render(MockCamera{}, IRoom::SelectionMode::NotSelected, true, true);
 }
 
 /// <summary>

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -82,9 +82,13 @@ namespace
     }
 }
 
-TEST(Room, AlternateModeLoaded)
+TEST(Room, AlternateModeDetected)
 {
-    FAIL();
+    trlevel::tr3_room level_room;
+    level_room.alternate_room = 100;
+    auto room = register_test_module().with_room(level_room).build();
+    ASSERT_EQ(room->alternate_mode(), IRoom::AlternateMode::HasAlternate);
+    ASSERT_EQ(room->alternate_room(), 100);
 }
 
 TEST(Room, NeighboursLoaded)

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -2,6 +2,7 @@
 #include <trlevel/Mocks/ILevel.h>
 #include <trview.app/Mocks/Camera/ICamera.h>
 #include <trview.app/Mocks/Geometry/IMesh.h>
+#include <trview.app/Mocks/Geometry/ITransparencyBuffer.h>
 #include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
 #include <trview.app/Mocks/Elements/IEntity.h>
@@ -119,7 +120,11 @@ TEST(Room, AlternateModeDetected)
 /// </summary>
 TEST(Room, GetTransparentTrianglesFromContents)
 {
-    FAIL();
+    auto room = register_test_module().build();
+    auto entity = std::make_shared<MockEntity>();
+    EXPECT_CALL(*entity, get_transparent_triangles).Times(1);
+    room->add_entity(entity);
+    room->get_transparent_triangles(MockTransparencyBuffer{}, MockCamera{}, IRoom::SelectionMode::NotSelected, true, true);
 }
 
 /// <summary>

--- a/trview.app/Camera/Camera.cpp
+++ b/trview.app/Camera/Camera.cpp
@@ -30,7 +30,7 @@ namespace trview
         return _forward;
     }
 
-    const DirectX::BoundingFrustum& Camera::frustum() const
+    const DirectX::BoundingFrustum Camera::frustum() const
     {
         return _bounding_frustum;
     }
@@ -47,7 +47,7 @@ namespace trview
             : _position;
     }
 
-    const Matrix& Camera::projection() const
+    const Matrix Camera::projection() const
     {
         return _projection;
     }
@@ -169,17 +169,17 @@ namespace trview
         }
     }
 
-    const Matrix& Camera::view() const
+    const Matrix Camera::view() const
     {
         return _view;
     }
 
-    const Matrix& Camera::view_projection() const
+    const Matrix Camera::view_projection() const
     {
         return _view_projection;
     }
 
-    const Size& Camera::view_size() const
+    const Size Camera::view_size() const
     {
         return _view_size;
     }

--- a/trview.app/Camera/Camera.h
+++ b/trview.app/Camera/Camera.h
@@ -18,10 +18,10 @@ namespace trview
         explicit Camera(const Size& size);
         virtual ~Camera() = default;
         virtual DirectX::SimpleMath::Vector3 forward() const override;
-        virtual const DirectX::BoundingFrustum& frustum() const override;
+        virtual const DirectX::BoundingFrustum frustum() const override;
         virtual DirectX::SimpleMath::Vector3 position() const override;
         virtual DirectX::SimpleMath::Vector3 rendering_position() const override;
-        virtual const DirectX::SimpleMath::Matrix& projection() const override;
+        virtual const DirectX::SimpleMath::Matrix projection() const override;
         virtual ProjectionMode projection_mode() const override;
         virtual float rotation_pitch() const override;
         virtual float rotation_yaw() const override;
@@ -34,9 +34,9 @@ namespace trview
         virtual void set_zoom(float zoom) override;
         virtual DirectX::SimpleMath::Vector3 up() const override;
         virtual void update(float elapsed) override;
-        virtual const DirectX::SimpleMath::Matrix& view() const override;
-        virtual const DirectX::SimpleMath::Matrix& view_projection() const override;
-        virtual const Size& view_size() const override;
+        virtual const DirectX::SimpleMath::Matrix view() const override;
+        virtual const DirectX::SimpleMath::Matrix view_projection() const override;
+        virtual const Size view_size() const override;
         virtual float zoom() const override;
 
         /// Event raised when the view of the camera has changed.

--- a/trview.app/Camera/ICamera.h
+++ b/trview.app/Camera/ICamera.h
@@ -20,7 +20,7 @@ namespace trview
 
         /// Get the bounding frustum for the camera. This is a left handed frustum and can be used for culling.
         /// @returns The bounding frustum.
-        virtual const DirectX::BoundingFrustum& frustum() const = 0;
+        virtual const DirectX::BoundingFrustum frustum() const = 0;
 
         /// Gets the current position of the camera in the world.
         /// @returns The position of the camera.
@@ -32,7 +32,7 @@ namespace trview
 
         /// Gets the current projection matrix for the camera.
         /// @returns The projection matrix.
-        virtual const DirectX::SimpleMath::Matrix& projection() const = 0;
+        virtual const DirectX::SimpleMath::Matrix projection() const = 0;
 
         /// Gets the current projection mode for the camera.
         /// @returns The projection mode.
@@ -84,15 +84,15 @@ namespace trview
 
         /// Gets the current view matrix for the camera.
         /// @returns The view matrix.
-        virtual const DirectX::SimpleMath::Matrix& view() const = 0;
+        virtual const DirectX::SimpleMath::Matrix view() const = 0;
 
         /// Gets the current view projection matrix for the camera.
         /// @returns The view projection matrix.
-        virtual const DirectX::SimpleMath::Matrix& view_projection() const = 0;
+        virtual const DirectX::SimpleMath::Matrix view_projection() const = 0;
 
         /// Gets the current size of the viewport for the camera.
         /// @returns The viewport size.
-        virtual const Size& view_size() const = 0;
+        virtual const Size view_size() const = 0;
 
         /// Gets the zoom level.
         /// @returns The zoom level.

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -11,87 +11,202 @@ namespace trview
 {
     struct ILevel;
 
+    /// <summary>
+    /// Represents a room in a level.
+    /// </summary>
     struct IRoom
     {
+        /// <summary>
+        /// The different types of alternate modes for a <see cref="IRoom"/>.
+        /// </summary>
         enum class AlternateMode
         {
-            // This room does not have an alternate room and is not an alternate room to another room.
+            /// <summary>
+            /// This room does is not an alternate of another room and does not have an alternate room.
+            /// </summary>
             None,
-            // This room has an alternate room.
+            /// <summary>
+            /// The room has an alternate room.
+            /// </summary>
             HasAlternate,
-            // This room is an alternate room to another room.
+            /// <summary>
+            /// This room is an alternate room to another room.
+            /// Note that this won't be set at room creation as it requires an extra processing pass once all rooms are loaded.
+            /// </summary>
             IsAlternate
         };
 
+        /// <summary>
+        /// Selection modes for the <see cref="IRoom"/> used for rendering.
+        /// </summary>
         enum class SelectionMode
         {
+            /// <summary>
+            /// The room is selected and should be highlighted.
+            /// </summary>
             Selected,
+            /// <summary>
+            /// The room is not selected so should be darkened.
+            /// </summary>
             NotSelected
         };
 
+        /// <summary>
+        /// Create a new implementation of <see cref="IRoom"/>.
+        /// </summary>
         using Source = std::function<std::shared_ptr<IRoom>(const trlevel::ILevel&, const trlevel::tr3_room&,
             const ILevelTextureStorage&, const IMeshStorage&, uint32_t, const ILevel&)>;
-
+        /// <summary>
+        /// Destructor for <see cref="IRoom"/>.
+        /// </summary>
         virtual ~IRoom() = 0;
-        
-        // Add the specified entity to the room.
-        // Entity: The entity to add.
-        virtual void add_entity(IEntity* entity) = 0;
-        /// Add the specified trigger to the room.
-        /// @paramt trigger The trigger to add.
+        /// <summary>
+        /// Add the specified <see cref="IEntity"/> to the room. The room will not take ownership of this entity.
+        /// </summary>
+        /// <param name="entity">The <see cref="IEntity"/> to add.</param>
+        virtual void add_entity(const std::weak_ptr<IEntity>& entity) = 0;
+        /// <summary>
+        /// Add the specified <see cref="ITrigger"/> to the room. The room will not take ownership of this trigger.
+        /// </summary>
+        /// <param name="trigger">The <see cref="ITrigger"/> to add.</param>
         virtual void add_trigger(const std::weak_ptr<ITrigger>& trigger) = 0;
-        /// Gets the alternate group for the room.
-        /// @returns The alternate group number.
+        /// <summary>
+        /// Gets the alternate group number for the room. A value of -1 indicates that the room is not part of an alternate group.
+        /// </summary>
+        /// <returns>The alternate group number of the room.</returns>
         virtual int16_t alternate_group() const = 0;
-        /// Determines the alternate state of the room.
+        /// <summary>
+        /// Gets the alternate mode for the room.
+        /// </summary>
+        /// <returns>The alternate mode for the room</returns>
         virtual AlternateMode alternate_mode() const = 0;
-        /// Gets the room number of the room that is the alternate to this room.
-        /// If this room does not have an alternate this will be -1.
-        /// @returns The room number of the alternate room.
+        /// <summary>
+        /// Gets the alternate room for this room. If this room does not have an alternate room the value will be -1.
+        /// </summary>
+        /// <returns>The alternate room number.</returns>
         virtual int16_t alternate_room() const = 0;
-        /// Get the bounding box of the room. The bounding box is pre-transformed to the coordinates of the room.
-        /// @returns The bounding box for the room.
+        /// <summary>
+        /// Gets the bounding box of the room. The bounding box is pre-transformed to the coordinates of the room.
+        /// </summary>
+        /// <returns>The transformed room bounding box.</returns>
         virtual DirectX::BoundingBox bounding_box() const = 0;
-        /// Get the centre point of the room.
-        /// @returns The centre position of the room.
+        /// <summary>
+        /// Get the centre point of the room based on the room info. This doesn't take into account the contents of the room.
+        /// </summary>
+        /// <returns>The centre point of the room.</returns>
         virtual DirectX::SimpleMath::Vector3 centre() const = 0;
+        /// <summary>
+        /// Generate the trigger geometry based on the triggers in the room. This should be called when all adjacent rooms have been
+        /// created so that continguous trigger areas can have redundant sides removed.
+        /// </summary>
         virtual void generate_trigger_geometry() = 0;
-        /// Add the transparent triangles for entities that are contained inside this room. This is called automatically
-        /// if get_transparent_triangles is used.
-        /// @param transparency The buffer to add triangles to.
-        /// @param camera The current viewpoint.
-        /// @param selected The current selection mode.
+        /// <summary>
+        /// Add the transparent triangles for the contents of the room.
+        /// </summary>
+        /// <param name="transparency">The buffer to which to add triangles.</param>
+        /// <param name="camera">The current viewpoint.</param>
+        /// <param name="selected">The selection mode for the room.</param>
+        /// <param name="show_water">Whether to render water effects.</param>
+        /// <param name="force_water">Whether to render water effects.</param>
         virtual void get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool show_water, bool force_water = false) = 0;
-        /// Add the transparent triangles to the specified transparency buffer.
-        /// @param transparency The buffer to add triangles to.
-        /// @param camera The current viewpoint.
-        /// @param selected The current selection mode.
-        /// @param include_triggers Whether to render triggers.
+        /// <summary>
+        /// Get the transparent triangles for the room geometry.
+        /// </summary>
+        /// <param name="transparency">The buffer to which to add triangles to.</param>
+        /// <param name="camera">The current viewpoint.</param>
+        /// <param name="selected">The selection mode for the room.</param>
+        /// <param name="include_triggers">Whether to include triggers in the output.</param>
+        /// <param name="show_water">Whether to render water effects.</param>
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool include_triggers, bool show_water) = 0;
+        /// <summary>
+        /// Get the room info. This contains basic raw positional information about the room.
+        /// </summary>
+        /// <returns>The room info.</returns>
         virtual RoomInfo info() const = 0;
+        /// <summary>
+        /// Get the neighbours of this room. This a set of room numbers that border this room based on sector information.
+        /// </summary>
+        /// <returns>The neighbours of the room.</returns>
         virtual std::set<uint16_t> neighbours() const = 0;
-        // Returns the number of x sectors in the room 
+        /// <summary>
+        /// Gets the X dimension of the room measured in sectors.
+        /// </summary>
+        /// <returns>The X dimension of the room.</returns>
         virtual uint16_t num_x_sectors() const = 0;
-        // Returns the number of z sectors in the room 
+        /// <summary>
+        /// Gets the Z dimension of the room measured in sectors.
+        /// </summary>
+        /// <returns>The Z dimension of the room.</returns>
         virtual uint16_t num_z_sectors() const = 0;
+        /// <summary>
+        /// Get the room number.
+        /// </summary>
+        /// <returns>The room number.</returns>
         virtual uint32_t number() const = 0;
+        /// <summary>
+        /// Gets whether the room is an outside room based on the room flags.
+        /// </summary>
+        /// <returns>Whether the room is an outside room.</returns>
         virtual bool outside() const = 0;
+        /// <summary>
         /// Determine whether the specified ray hits any of the triangles in the room geometry.
-        /// @param position The world space position of the source of the ray.
-        /// @param direction The direction of the ray.
-        /// @returns: The result of the operation. If 'hit' is true, distance and position contain how far along the ray the hit was and the position in world space.
+        /// </summary>
+        /// <param name="position">The world space position of the source of the ray.</param>
+        /// <param name="direction">The direction of the ray.</param>
+        /// <param name="include_entities">Whether to include contained entities in the pick operation.</param>
+        /// <param name="include_triggers">Whether to include contained triggers in the pick operation.</param>
+        /// <param name="include_hidden_geometry">Whether hidden geometry should be included in the pick operation. This requires include_room_geometry to be set as well.</param>
+        /// <param name="include_room_geometry">Whether regular room geometry should be included in the pick operation.</param>
+        /// <returns>The <see cref="PickResult"/>.</returns>
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, bool include_entities, bool include_triggers, bool include_hidden_geometry = false, bool include_room_geometry = true) const = 0;
+        /// <summary>
+        /// Gets whether the room is a quicksand room based on the room flags. This can only be true if the game is TR3 or later.
+        /// </summary>
+        /// <returns>Whether the room is a quicksand room.</returns>
         virtual bool quicksand() const = 0;
+        /// <summary>
+        /// Render the room.
+        /// </summary>
+        /// <param name="camera">The current viewpoint.</param>
+        /// <param name="texture_storage">The texture storage for the level.</param>
+        /// <param name="selected">Whether the room is selected.</param>
+        /// <param name="show_hidden_geometry">Whether to render hidden geometry.</param>
+        /// <param name="show_water">Whether to render water effects.</param>
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_hidden_geometry, bool show_water) = 0;
+        /// <summary>
+        /// Render the contents of the room.
+        /// </summary>
+        /// <param name="camera">The current viewpoint.</param>
+        /// <param name="texture_storage">The texture storage for the level.</param>
+        /// <param name="selected">Whether the room is selected.</param>
+        /// <param name="show_water">Whether to render water effects.</param>
+        /// <param name="force_water">Whether to render water effects.</param>
         virtual void render_contained(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_water, bool force_water = false) = 0;
-        /// Returns all sectors 
+        /// <summary>
+        /// Gets all sectors in the room.
+        /// </summary>
+        /// <returns>The sectors in the room.</returns>
         virtual const std::vector<std::shared_ptr<ISector>> sectors() const = 0;
-        /// Set this room to be the alternate room of the room specified.
-        /// This will change the alternate_mode of this room to IsAlternate.
-        /// @param number The room number.
+        /// <summary>
+        /// Set this room to be the alternate room of the room specified. This will change the alternate mode of this room to IsAlternate.
+        /// </summary>
+        /// <param name="number">The alternate room number.</param>
         virtual void set_is_alternate(int16_t number) = 0;
+        /// <summary>
+        /// Get the trigger at the sector coordinates, if any.
+        /// </summary>
+        /// <param name="x">The sector X coordinate.</param>
+        /// <param name="z">The sector Z coordinate.</param>
+        /// <returns>The <see cref="ITrigger"/> if found, otherwise empty.</returns>
         virtual std::weak_ptr<ITrigger> trigger_at(int32_t x, int32_t z) const = 0;
+        /// <summary>
+        /// Update the bounding box based on the geometry and the entities that are in the room.
+        /// </summary>
         virtual void update_bounding_box() = 0;
+        /// <summary>
+        /// Gets whether the room is a water room based on the room flags.
+        /// </summary>
+        /// <returns>Whether the room is a water room.</returns>
         virtual bool water() const = 0;
     };
 }

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -62,7 +62,7 @@ namespace trview
         /// Create a new implementation of <see cref="IRoom"/>.
         /// </summary>
         using Source = std::function<std::shared_ptr<IRoom>(const trlevel::ILevel&, const trlevel::tr3_room&,
-            const ILevelTextureStorage&, const IMeshStorage&, uint32_t, const ILevel&)>;
+            const std::shared_ptr<ILevelTextureStorage>&, const IMeshStorage&, uint32_t, const ILevel&)>;
         /// <summary>
         /// Destructor for <see cref="IRoom"/>.
         /// </summary>
@@ -174,19 +174,17 @@ namespace trview
         /// Render the room.
         /// </summary>
         /// <param name="camera">The current viewpoint.</param>
-        /// <param name="texture_storage">The texture storage for the level.</param>
         /// <param name="selected">Whether the room is selected.</param>
         /// <param name="show_hidden_geometry">Whether to render hidden geometry.</param>
         /// <param name="show_water">Whether to render water effects.</param>
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_hidden_geometry, bool show_water) = 0;
+        virtual void render(const ICamera& camera, SelectionMode selected, bool show_hidden_geometry, bool show_water) = 0;
         /// <summary>
         /// Render the contents of the room.
         /// </summary>
         /// <param name="camera">The current viewpoint.</param>
-        /// <param name="texture_storage">The texture storage for the level.</param>
         /// <param name="selected">Whether the room is selected.</param>
         /// <param name="show_water">Whether to render water effects.</param>
-        virtual void render_contained(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_water) = 0;
+        virtual void render_contained(const ICamera& camera, SelectionMode selected, bool show_water) = 0;
         /// <summary>
         /// Gets all sectors in the room.
         /// </summary>

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -1,11 +1,18 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <set>
+#include <vector>
+#include <SimpleMath.h>
+#include <trview.app/Elements/IEntity.h>
+#include <trview.app/Elements/ISector.h>
+#include <trview.app/Elements/ITrigger.h>
+#include <trview.app/Elements/RoomInfo.h>
+#include <trview.app/Geometry/ITransparencyBuffer.h>
+#include <trview.app/Geometry/PickInfo.h>
 #include <trview.app/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Graphics/IMeshStorage.h>
-#include <trview.app/Elements/ISector.h>
-#include <trview.app/Elements/RoomInfo.h>
-#include <trview.app/Elements/IEntity.h>
-#include <trview.app/Elements/ITrigger.h>
 
 namespace trview
 {

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -107,8 +107,7 @@ namespace trview
         /// <param name="camera">The current viewpoint.</param>
         /// <param name="selected">The selection mode for the room.</param>
         /// <param name="show_water">Whether to render water effects.</param>
-        /// <param name="force_water">Whether to render water effects.</param>
-        virtual void get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool show_water, bool force_water = false) = 0;
+        virtual void get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool show_water) = 0;
         /// <summary>
         /// Get the transparent triangles for the room geometry.
         /// </summary>
@@ -180,8 +179,7 @@ namespace trview
         /// <param name="texture_storage">The texture storage for the level.</param>
         /// <param name="selected">Whether the room is selected.</param>
         /// <param name="show_water">Whether to render water effects.</param>
-        /// <param name="force_water">Whether to render water effects.</param>
-        virtual void render_contained(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_water, bool force_water = false) = 0;
+        virtual void render_contained(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_water) = 0;
         /// <summary>
         /// Gets all sectors in the room.
         /// </summary>

--- a/trview.app/Elements/ITrigger.h
+++ b/trview.app/Elements/ITrigger.h
@@ -25,7 +25,6 @@ namespace trview
         virtual uint8_t timer() const = 0;
         virtual uint16_t sector_id() const = 0;
         virtual const std::vector<Command> commands() const = 0;
-        virtual const std::vector<TransparentTriangle>& triangles() const = 0;
         virtual void set_triangles(const std::vector<TransparentTriangle>& transparent_triangles) = 0;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
         virtual void set_position(const DirectX::SimpleMath::Vector3& position) = 0;

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -226,10 +226,10 @@ namespace trview
             if (!is_alternate_mismatch(room.room) && room.room.alternate_mode() == IRoom::AlternateMode::IsAlternate)
             {
                 auto& original_room = _rooms[room.room.alternate_room()];
-                original_room->render_contained(camera, *_texture_storage.get(), room.selection_mode, room.room.water(), _show_water);
+                original_room->render_contained(camera, *_texture_storage.get(), room.selection_mode, _show_water);
                 if (_regenerate_transparency)
                 {
-                    original_room->get_contained_transparent_triangles(*_transparency, camera, room.selection_mode, room.room.water(), _show_water);
+                    original_room->get_contained_transparent_triangles(*_transparency, camera, room.selection_mode, _show_water);
                 }
             }
         }

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -375,7 +375,7 @@ namespace trview
         {
             auto level_entity = level.get_entity(i);
             auto entity = entity_source(level, level_entity, i, mesh_storage);
-            _rooms[entity->room()]->add_entity(entity.get());
+            _rooms[entity->room()]->add_entity(entity);
             _entities.push_back(entity);
 
             std::vector<std::weak_ptr<ITrigger>> relevant_triggers;
@@ -396,7 +396,7 @@ namespace trview
         {
             auto ai_object = level.get_ai_object(i);
             auto entity = ai_source(level, ai_object, num_entities + i, mesh_storage);
-            _rooms[entity->room()]->add_entity(entity.get());
+            _rooms[entity->room()]->add_entity(entity);
             _entities.push_back(entity);
 
             _items.push_back(Item(num_entities + i, ai_object.room, ai_object.type_id, type_names.lookup_type_name(_version, ai_object.type_id), ai_object.ocb,

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -32,7 +32,7 @@ namespace trview
         Level(const std::shared_ptr<graphics::IDevice>& device,
             const std::shared_ptr<graphics::IShaderStorage>& shader_storage,
             std::unique_ptr<trlevel::ILevel> level,
-            std::unique_ptr<ILevelTextureStorage> level_texture_storage,
+            std::shared_ptr<ILevelTextureStorage> level_texture_storage,
             std::unique_ptr<IMeshStorage> mesh_storage,
             std::unique_ptr<ITransparencyBuffer> transparency_buffer,
             std::unique_ptr<ISelectionRenderer> selection_renderer,
@@ -140,7 +140,7 @@ namespace trview
         uint32_t           _neighbour_depth{ 1 };
         std::set<uint16_t> _neighbours;
 
-        std::unique_ptr<ILevelTextureStorage> _texture_storage;
+        std::shared_ptr<ILevelTextureStorage> _texture_storage;
         std::unique_ptr<ITransparencyBuffer> _transparency;
 
         bool _regenerate_transparency{ true };

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -332,15 +332,9 @@ namespace trview
         {
             for (const auto& trigger_pair : _triggers)
             {
-                auto trigger = trigger_pair.second.lock();
-                if (!trigger || !trigger->visible())
+                if (auto trigger = trigger_pair.second.lock())
                 {
-                    continue;
-                }
-
-                for (const auto& triangle : trigger->triangles())
-                {
-                    transparency.add(triangle);
+                    trigger->get_transparent_triangles(transparency, camera, Trigger_Colour);
                 }
             }
         }

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -35,7 +35,7 @@ namespace trview
     Room::Room(const IMesh::Source& mesh_source,
         const trlevel::ILevel& level, 
         const trlevel::tr3_room& room,
-        const std::shared_ptr<ILevelTextureStorage>& texture_storage,
+        std::shared_ptr<ILevelTextureStorage> texture_storage,
         const IMeshStorage& mesh_storage,
         uint32_t index,
         const ILevel& parent_level,

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -190,9 +190,9 @@ namespace trview
         render_contained(camera, texture_storage, colour);
     }
 
-    void Room::render_contained(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_water, bool force_water)
+    void Room::render_contained(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_water)
     {
-        Color colour = room_colour((water() || force_water) && show_water, selected);
+        Color colour = room_colour(water() && show_water, selected);
         render_contained(camera, texture_storage, colour);
     }
 
@@ -347,9 +347,9 @@ namespace trview
         get_contained_transparent_triangles(transparency, camera, colour);
     }
 
-    void Room::get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool show_water, bool force_water)
+    void Room::get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool show_water)
     {
-        Color colour = room_colour((force_water || water()) && show_water, selected);
+        Color colour = room_colour(water() && show_water, selected);
         get_contained_transparent_triangles(transparency, camera, colour);
     }
 

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -96,12 +96,13 @@ namespace trview
             // Pick against the entity geometry:
             for (const auto& entity : _entities)
             {
-                if (!entity->visible())
+                auto entity_ptr = entity.lock();
+                if (!entity_ptr || !entity_ptr->visible())
                 {
                     continue;
                 }
 
-                auto entity_result = entity->pick(position, direction);
+                auto entity_result = entity_ptr->pick(position, direction);
                 if (entity_result.hit)
                 {
                     pick_results.push_back(entity_result);
@@ -199,7 +200,10 @@ namespace trview
     {
         for (const auto& entity : _entities)
         {
-            entity->render(camera, texture_storage, colour);
+            if (auto entity_ptr = entity.lock())
+            {
+                entity_ptr->render(camera, texture_storage, colour);
+            }
         }
     }
 
@@ -284,7 +288,7 @@ namespace trview
         });
     }
 
-    void Room::add_entity(IEntity* entity)
+    void Room::add_entity(const std::weak_ptr<IEntity>& entity)
     {
         _entities.push_back(entity);
     }
@@ -353,7 +357,10 @@ namespace trview
     {
         for (const auto& entity : _entities)
         {
-            entity->get_transparent_triangles(transparency, camera, colour);
+            if (auto entity_ptr = entity.lock())
+            {
+                entity_ptr->get_transparent_triangles(transparency, camera, colour);
+            }
         }
     }
 
@@ -688,7 +695,10 @@ namespace trview
         // Merge all entity bounding boxes with the room bounding box.
         for (const auto& entity : _entities)
         {
-            BoundingBox::CreateMerged(_bounding_box, _bounding_box, entity->bounding_box());
+            if (auto entity_ptr = entity.lock())
+            {
+                BoundingBox::CreateMerged(_bounding_box, _bounding_box, entity_ptr->bounding_box());
+            }
         }
     }
 

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -523,6 +523,11 @@ namespace trview
             return _sectors[sector_id].get();
         }
 
+        if (sector_id >= _sectors.size())
+        {
+            return nullptr;
+        }
+
         // Check if this sector is a portal.
         auto sector = _sectors[sector_id];
         if (!(sector->flags() & SectorFlag::Portal))

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -41,7 +41,7 @@ namespace trview
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, bool include_entities, bool include_triggers, bool include_hidden_geometry = false, bool include_room_geometry = true) const override;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_hidden_geometry, bool show_water) override;
         virtual void render_contained(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_water, bool force_water = false) override;
-        virtual void add_entity(IEntity* entity) override;
+        virtual void add_entity(const std::weak_ptr<IEntity>& entity) override;
         virtual void add_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual const std::vector<std::shared_ptr<ISector>> sectors() const override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool include_triggers, bool show_water) override;
@@ -102,7 +102,7 @@ namespace trview
 
         DirectX::BoundingBox  _bounding_box;
 
-        std::vector<IEntity*> _entities;
+        std::vector<std::weak_ptr<IEntity>> _entities;
 
         // Maps a sector to its sector ID 
         std::vector<std::shared_ptr<ISector>> _sectors; 

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -26,7 +26,7 @@ namespace trview
         explicit Room(const IMesh::Source& mesh_source,
             const trlevel::ILevel& level, 
             const trlevel::tr3_room& room,
-            const std::shared_ptr<ILevelTextureStorage>& texture_storage,
+            std::shared_ptr<ILevelTextureStorage> texture_storage,
             const IMeshStorage& mesh_storage,
             uint32_t index,
             const ILevel& parent_level,

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -26,7 +26,7 @@ namespace trview
         explicit Room(const IMesh::Source& mesh_source,
             const trlevel::ILevel& level, 
             const trlevel::tr3_room& room,
-            const ILevelTextureStorage& texture_storage,
+            const std::shared_ptr<ILevelTextureStorage>& texture_storage,
             const IMeshStorage& mesh_storage,
             uint32_t index,
             const ILevel& parent_level,
@@ -39,8 +39,8 @@ namespace trview
         virtual RoomInfo info() const override;
         virtual std::set<uint16_t> neighbours() const override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, bool include_entities, bool include_triggers, bool include_hidden_geometry = false, bool include_room_geometry = true) const override;
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_hidden_geometry, bool show_water) override;
-        virtual void render_contained(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_water) override;
+        virtual void render(const ICamera& camera, SelectionMode selected, bool show_hidden_geometry, bool show_water) override;
+        virtual void render_contained(const ICamera& camera, SelectionMode selected, bool show_water) override;
         virtual void add_entity(const std::weak_ptr<IEntity>& entity) override;
         virtual void add_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual const std::vector<std::shared_ptr<ISector>> sectors() const override;
@@ -62,11 +62,11 @@ namespace trview
         virtual bool quicksand() const override;
         virtual std::weak_ptr<ITrigger> trigger_at(int32_t x, int32_t z) const override;
     private:
-        void generate_geometry(trlevel::LevelVersion level_version, const IMesh::Source& mesh_source, const trlevel::tr3_room& room, const ILevelTextureStorage& texture_storage);
+        void generate_geometry(trlevel::LevelVersion level_version, const IMesh::Source& mesh_source, const trlevel::tr3_room& room);
         void generate_adjacency();
         void generate_static_meshes(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr3_room& room, const IMeshStorage& mesh_storage,
             const IStaticMesh::MeshSource& static_mesh_mesh_source, const IStaticMesh::PositionSource& static_mesh_position_source);
-        void render_contained(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour);
+        void render_contained(const ICamera& camera, const DirectX::SimpleMath::Color& colour);
         void get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour);
         void generate_sectors(const trlevel::ILevel& level, const trlevel::tr3_room& room, const ISector::Source& sector_source);
         ISector* get_trigger_sector(int32_t x, int32_t z);
@@ -117,5 +117,6 @@ namespace trview
         std::unordered_map<uint32_t, std::weak_ptr<ITrigger>> _triggers;
         uint16_t _flags{ 0 };
         const ILevel& _level;
+        std::shared_ptr<ILevelTextureStorage> _texture_storage;
     };
 }

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -40,12 +40,12 @@ namespace trview
         virtual std::set<uint16_t> neighbours() const override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, bool include_entities, bool include_triggers, bool include_hidden_geometry = false, bool include_room_geometry = true) const override;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_hidden_geometry, bool show_water) override;
-        virtual void render_contained(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_water, bool force_water = false) override;
+        virtual void render_contained(const ICamera& camera, const ILevelTextureStorage& texture_storage, SelectionMode selected, bool show_water) override;
         virtual void add_entity(const std::weak_ptr<IEntity>& entity) override;
         virtual void add_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual const std::vector<std::shared_ptr<ISector>> sectors() const override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool include_triggers, bool show_water) override;
-        virtual void get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool show_water, bool force_water = false) override;
+        virtual void get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool show_water) override;
         virtual AlternateMode alternate_mode() const override;
         virtual int16_t alternate_room() const override;
         virtual int16_t alternate_group() const override;

--- a/trview.app/Elements/Trigger.cpp
+++ b/trview.app/Elements/Trigger.cpp
@@ -129,6 +129,11 @@ namespace trview
 
     void Trigger::get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera&, const DirectX::SimpleMath::Color& colour)
     {
+        if (!_visible)
+        {
+            return;
+        }
+
         using namespace DirectX::SimpleMath;
         for (auto& triangle : _mesh->transparent_triangles())
         {

--- a/trview.app/Elements/Trigger.cpp
+++ b/trview.app/Elements/Trigger.cpp
@@ -94,11 +94,6 @@ namespace trview
         return _sector_id;
     }
 
-    const std::vector<TransparentTriangle>& Trigger::triangles() const
-    {
-        return _mesh->transparent_triangles();
-    }
-
     void Trigger::set_triangles(const std::vector<TransparentTriangle>& transparent_triangles)
     {
         std::vector<Triangle> collision;

--- a/trview.app/Elements/Trigger.h
+++ b/trview.app/Elements/Trigger.h
@@ -24,7 +24,6 @@ namespace trview
         virtual uint8_t timer() const override;
         virtual uint16_t sector_id() const override;
         virtual const std::vector<Command> commands() const override;
-        virtual const std::vector<TransparentTriangle>& triangles() const override;
         virtual void set_triangles(const std::vector<TransparentTriangle>& transparent_triangles) override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
         virtual void set_position(const DirectX::SimpleMath::Vector3& position) override;

--- a/trview.app/Elements/di.hpp
+++ b/trview.app/Elements/di.hpp
@@ -91,7 +91,7 @@ namespace trview
                             injector.create<std::shared_ptr<IDevice>>(),
                             injector.create<std::shared_ptr<IShaderStorage>>(),
                             std::move(level),
-                            std::move(texture_storage),
+                            texture_storage,
                             std::move(mesh_storage),
                             injector.create<std::unique_ptr<ITransparencyBuffer>>(),
                             injector.create<std::unique_ptr<ISelectionRenderer>>(),

--- a/trview.app/Geometry/IMesh.h
+++ b/trview.app/Geometry/IMesh.h
@@ -23,7 +23,7 @@ namespace trview
             const DirectX::SimpleMath::Color& colour,
             DirectX::SimpleMath::Vector3 light_direction = DirectX::SimpleMath::Vector3::Zero) = 0;
 
-        virtual const std::vector<TransparentTriangle>& transparent_triangles() const = 0;
+        virtual std::vector<TransparentTriangle> transparent_triangles() const = 0;
 
         virtual const DirectX::BoundingBox& bounding_box() const = 0;
 

--- a/trview.app/Geometry/Mesh.cpp
+++ b/trview.app/Geometry/Mesh.cpp
@@ -159,7 +159,7 @@ namespace trview
         }
     }
 
-    const std::vector<TransparentTriangle>& Mesh::transparent_triangles() const
+    std::vector<TransparentTriangle> Mesh::transparent_triangles() const
     {
         return _transparent_triangles;
     }

--- a/trview.app/Geometry/Mesh.h
+++ b/trview.app/Geometry/Mesh.h
@@ -39,7 +39,7 @@ namespace trview
             const DirectX::SimpleMath::Color& colour,
             DirectX::SimpleMath::Vector3 light_direction = DirectX::SimpleMath::Vector3::Zero) override;
 
-        virtual const std::vector<TransparentTriangle>& transparent_triangles() const override;
+        virtual std::vector<TransparentTriangle> transparent_triangles() const override;
 
         virtual const DirectX::BoundingBox& bounding_box() const override;
 

--- a/trview.app/Graphics/ILevelTextureStorage.h
+++ b/trview.app/Graphics/ILevelTextureStorage.h
@@ -10,7 +10,7 @@ namespace trview
 {
     struct ILevelTextureStorage : public ITextureStorage
     {
-        using Source = std::function<std::unique_ptr<ILevelTextureStorage>(const trlevel::ILevel&)>;
+        using Source = std::function<std::shared_ptr<ILevelTextureStorage>(const trlevel::ILevel&)>;
 
         virtual ~ILevelTextureStorage() = 0;
 

--- a/trview.app/Graphics/di.hpp
+++ b/trview.app/Graphics/di.hpp
@@ -19,7 +19,7 @@ namespace trview
                 {
                     return [&](auto&& level)
                     {
-                        return std::make_unique<LevelTextureStorage>(
+                        return std::make_shared<LevelTextureStorage>(
                             injector.create<std::shared_ptr<IDevice>>(),
                             injector.create<std::unique_ptr<ITextureStorage>>(),
                             level);

--- a/trview.app/Mocks/Camera/ICamera.h
+++ b/trview.app/Mocks/Camera/ICamera.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "../../Camera/ICamera.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockCamera final : public ICamera
+        {
+            virtual ~MockCamera() = default;
+            MOCK_METHOD(DirectX::SimpleMath::Vector3, forward, (), (const, override));
+            MOCK_METHOD(const DirectX::BoundingFrustum, frustum, (), (const, override));
+            MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
+            MOCK_METHOD(DirectX::SimpleMath::Vector3, rendering_position, (), (const, override));
+            MOCK_METHOD(const DirectX::SimpleMath::Matrix, projection, (), (const, override));
+            MOCK_METHOD(ProjectionMode, projection_mode, (), (const, override));
+            MOCK_METHOD(float, rotation_pitch, (), (const, override));
+            MOCK_METHOD(float, rotation_yaw, (), (const, override));
+            MOCK_METHOD(void, rotate_to_pitch, (float), (override));
+            MOCK_METHOD(void, rotate_to_yaw, (float), (override));
+            MOCK_METHOD(void, set_projection_mode, (ProjectionMode), (override));
+            MOCK_METHOD(void, set_rotation_pitch, (float), (override));
+            MOCK_METHOD(void, set_rotation_yaw, (float), (override));
+            MOCK_METHOD(void, set_view_size, (const Size&), (override));
+            MOCK_METHOD(void, set_zoom, (float), (override));
+            MOCK_METHOD(DirectX::SimpleMath::Vector3, up, (), (const, override));
+            MOCK_METHOD(void, update, (float), (override));
+            MOCK_METHOD(const DirectX::SimpleMath::Matrix, view, (), (const, override));
+            MOCK_METHOD(const DirectX::SimpleMath::Matrix, view_projection, (), (const, override));
+            MOCK_METHOD(const Size, view_size, (), (const, override));
+            MOCK_METHOD(float, zoom, (), (const, override));
+        };
+    }
+}

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -27,8 +27,8 @@ namespace trview
             MOCK_METHOD(bool, outside, (), (const, override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, bool, bool, bool, bool), (const, override));
             MOCK_METHOD(bool, quicksand, (), (const, override));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, SelectionMode, bool, bool), (override));
-            MOCK_METHOD(void, render_contained, (const ICamera&, const ILevelTextureStorage&, SelectionMode, bool), (override));;
+            MOCK_METHOD(void, render, (const ICamera&, SelectionMode, bool, bool), (override));
+            MOCK_METHOD(void, render_contained, (const ICamera&, SelectionMode, bool), (override));;
             MOCK_METHOD(const std::vector<std::shared_ptr<ISector>>, sectors, (), (const, override));
             MOCK_METHOD(void, set_is_alternate, (int16_t), (override));
             MOCK_METHOD(std::weak_ptr<ITrigger>, trigger_at, (int32_t, int32_t), (const, override));

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -9,7 +9,7 @@ namespace trview
         struct MockRoom final : public IRoom
         {
             virtual ~MockRoom() = default;
-            MOCK_METHOD(void, add_entity, (IEntity*), (override));
+            MOCK_METHOD(void, add_entity, (const std::weak_ptr<IEntity>&), (override));
             MOCK_METHOD(void, add_trigger, (const std::weak_ptr<ITrigger>&), (override));
             MOCK_METHOD(int16_t, alternate_group, (), (const, override));
             MOCK_METHOD(AlternateMode, alternate_mode, (), (const, override));

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -17,7 +17,7 @@ namespace trview
             MOCK_METHOD(DirectX::BoundingBox, bounding_box, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, centre, (), (const, override));
             MOCK_METHOD(void, generate_trigger_geometry, (), (override));
-            MOCK_METHOD(void, get_contained_transparent_triangles, (ITransparencyBuffer&, const ICamera&, SelectionMode, bool, bool), (override));
+            MOCK_METHOD(void, get_contained_transparent_triangles, (ITransparencyBuffer&, const ICamera&, SelectionMode, bool), (override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, SelectionMode, bool, bool), (override));
             MOCK_METHOD(RoomInfo, info, (), (const, override));
             MOCK_METHOD(std::set<uint16_t>, neighbours, (), (const, override));
@@ -28,7 +28,7 @@ namespace trview
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, bool, bool, bool, bool), (const, override));
             MOCK_METHOD(bool, quicksand, (), (const, override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, SelectionMode, bool, bool), (override));
-            MOCK_METHOD(void, render_contained, (const ICamera&, const ILevelTextureStorage&, SelectionMode, bool, bool), (override));;
+            MOCK_METHOD(void, render_contained, (const ICamera&, const ILevelTextureStorage&, SelectionMode, bool), (override));;
             MOCK_METHOD(const std::vector<std::shared_ptr<ISector>>, sectors, (), (const, override));
             MOCK_METHOD(void, set_is_alternate, (int16_t), (override));
             MOCK_METHOD(std::weak_ptr<ITrigger>, trigger_at, (int32_t, int32_t), (const, override));

--- a/trview.app/Mocks/Geometry/IMesh.h
+++ b/trview.app/Mocks/Geometry/IMesh.h
@@ -10,10 +10,10 @@ namespace trview
         {
         public:
             virtual ~MockMesh() = default;
-            MOCK_METHOD(void, render, (const DirectX::SimpleMath::Matrix&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&, DirectX::SimpleMath::Vector3));
-            MOCK_METHOD(const std::vector<TransparentTriangle>&, transparent_triangles, (), (const));
-            MOCK_METHOD(const DirectX::BoundingBox&, bounding_box, (), (const));
-            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const));
+            MOCK_METHOD(void, render, (const DirectX::SimpleMath::Matrix&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&, DirectX::SimpleMath::Vector3), (override));
+            MOCK_METHOD(std::vector<TransparentTriangle>, transparent_triangles, (), (const, override));
+            MOCK_METHOD(const DirectX::BoundingBox&, bounding_box, (), (const, override));
+            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
         };
     }
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -79,7 +79,7 @@ namespace trview
         using namespace input;
         using namespace ui;
 
-        _token_store += _input->mouse().mouse_click += [&](IMouse::Button button)
+        _token_store += _input->mouse()->mouse_click += [&](IMouse::Button button)
         {
             auto sector = _map_renderer->sector_at_cursor();
             if (!sector)
@@ -126,7 +126,7 @@ namespace trview
             }
         };
 
-        _token_store += _input->mouse().mouse_move += [&](long, long)
+        _token_store += _input->mouse()->mouse_move += [&](long, long)
         {
             // Only do work if we have actually loaded a map.
             if (_map_renderer->loaded())

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -211,6 +211,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Menus\RecentFiles.h" />
     <ClInclude Include="Menus\UpdateChecker.h" />
     <ClInclude Include="Menus\ViewMenu.h" />
+    <ClInclude Include="Mocks\Camera\ICamera.h" />
     <ClInclude Include="Mocks\Elements\IEntity.h" />
     <ClInclude Include="Mocks\Elements\ILevel.h" />
     <ClInclude Include="Mocks\Elements\IRoom.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -809,6 +809,9 @@
     <ClInclude Include="Mocks\Elements\ISector.h">
       <Filter>Mocks\Elements</Filter>
     </ClInclude>
+    <ClInclude Include="Mocks\Camera\ICamera.h">
+      <Filter>Mocks\Camera</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">
@@ -882,6 +885,9 @@
     </Filter>
     <Filter Include="Mocks\Windows">
       <UniqueIdentifier>{bf510d34-b63f-4cfb-9448-1b62a72cdac3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Mocks\Camera">
+      <UniqueIdentifier>{77a62a69-05bf-4350-ba5d-849404977f4b}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/trview.input/IMouse.h
+++ b/trview.input/IMouse.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <trview.common/Event.h>
+#include <trview.common/Window.h>
 
 namespace trview
 {
@@ -8,6 +9,8 @@ namespace trview
     {
         struct IMouse
         {
+            using Source = std::function<std::shared_ptr<IMouse>(const Window& window)>;
+
             /// The mouse button that was pressed.
             enum class Button
             {

--- a/trview.input/IWindowTester.h
+++ b/trview.input/IWindowTester.h
@@ -9,6 +9,8 @@ namespace trview
         /// Used to check for Windows information.
         struct IWindowTester
         {
+            using Source = std::function<std::unique_ptr<IWindowTester>(const Window&)>;
+
             virtual ~IWindowTester() = 0;
 
             /// Is the window currently under the cursor?

--- a/trview.input/di.hpp
+++ b/trview.input/di.hpp
@@ -13,7 +13,22 @@ namespace trview
             using namespace boost;
             return di::make_injector(
                 di::bind<IWindowTester>.to<WindowTester>(),
-                di::bind<IMouse>.to<Mouse>()
+                di::bind<IWindowTester::Source>.to([](const auto& injector) -> IWindowTester::Source
+                    {
+                        return [&](auto&& window)
+                        {
+                            return std::make_unique<WindowTester>(window);
+                        };
+                    }),
+                di::bind<IMouse>.to<Mouse>(),
+                di::bind<IMouse::Source>.to([](const auto& injector) -> IMouse::Source
+                    {
+                        return [&](auto&& window)
+                        {
+                            return std::make_shared<Mouse>(window,
+                                injector.create<IWindowTester::Source>()(window));
+                        };
+                    })
             );
         }
     }

--- a/trview.ui/IInput.h
+++ b/trview.ui/IInput.h
@@ -19,7 +19,7 @@ namespace trview
             /// @returns The control, or nullptr if no control is focused.
             virtual Control* focus_control() const = 0;
 
-            virtual input::IMouse& mouse() = 0;
+            virtual std::shared_ptr<input::IMouse> mouse() = 0;
         };
     }
 }

--- a/trview.ui/Input.cpp
+++ b/trview.ui/Input.cpp
@@ -16,8 +16,9 @@ namespace trview
             }
         }
 
-        Input::Input(const trview::Window& window, Control& control, const std::shared_ptr<IShortcuts>& shortcuts, const std::shared_ptr<IClipboard>& clipboard)
-            : _mouse(window, std::make_unique<input::WindowTester>(window)), _keyboard(window), _window(window), _control(control), _shortcuts(shortcuts), _clipboard(clipboard)
+        Input::Input(const trview::Window& window, Control& control, const std::shared_ptr<IShortcuts>& shortcuts, const std::shared_ptr<IClipboard>& clipboard,
+            const std::shared_ptr<input::IMouse>& mouse)
+            : _mouse(mouse), _keyboard(window), _window(window), _control(control), _shortcuts(shortcuts), _clipboard(clipboard)
         {
             register_events();
         }
@@ -27,7 +28,7 @@ namespace trview
             return _focus_control;
         }
 
-        input::IMouse& Input::mouse()
+        std::shared_ptr<input::IMouse> Input::mouse()
         {
             return _mouse;
         }
@@ -38,11 +39,11 @@ namespace trview
 
             register_focus_controls(&_control);
 
-            _token_store += _mouse.mouse_move += [&](auto, auto) { process_mouse_move(); };
-            _token_store += _mouse.mouse_down += [&](input::IMouse::Button) { process_mouse_down(); };
-            _token_store += _mouse.mouse_up += [&](auto) { process_mouse_up(); };
-            _token_store += _mouse.mouse_click += [&](auto) { process_mouse_click(); };
-            _token_store += _mouse.mouse_wheel += [&](int16_t delta) { process_mouse_scroll(delta); };
+            _token_store += _mouse->mouse_move += [&](auto, auto) { process_mouse_move(); };
+            _token_store += _mouse->mouse_down += [&](input::IMouse::Button) { process_mouse_down(); };
+            _token_store += _mouse->mouse_up += [&](auto) { process_mouse_up(); };
+            _token_store += _mouse->mouse_click += [&](auto) { process_mouse_click(); };
+            _token_store += _mouse->mouse_wheel += [&](int16_t delta) { process_mouse_scroll(delta); };
             _token_store += _keyboard.on_key_down += [&](auto key, bool control, bool shift) { process_key_down(key, control, shift); };
             _token_store += _keyboard.on_char += [&](auto key) { process_char(key); };
             _token_store += _shortcuts->add_shortcut(true, 'V') += [&]() { process_paste(_clipboard->read(_window)); };

--- a/trview.ui/Input.h
+++ b/trview.ui/Input.h
@@ -19,10 +19,11 @@ namespace trview
         class Input final : public IInput
         {
         public:
-            explicit Input(const trview::Window& window, Control& control, const std::shared_ptr<IShortcuts>& shortcuts, const std::shared_ptr<IClipboard>& clipboard);
+            explicit Input(const trview::Window& window, Control& control, const std::shared_ptr<IShortcuts>& shortcuts, const std::shared_ptr<IClipboard>& clipboard,
+                const std::shared_ptr<input::IMouse>& mouse);
             virtual ~Input() = default;
             virtual Control* focus_control() const;
-            virtual input::IMouse& mouse() override;
+            virtual std::shared_ptr<input::IMouse> mouse() override;
         private:
             void     register_events();
             void     register_focus_controls(Control* control);
@@ -52,7 +53,7 @@ namespace trview
             void     set_focus_control(Control* control);
 
             TokenStore      _token_store;
-            input::Mouse    _mouse;
+            std::shared_ptr<input::IMouse> _mouse;
             input::Keyboard _keyboard;
             trview::Window  _window;
             Control&       _control;

--- a/trview.ui/Mocks/Input/IInput.h
+++ b/trview.ui/Mocks/Input/IInput.h
@@ -12,7 +12,7 @@ namespace trview
             {
                 virtual ~MockInput() = default;
                 MOCK_METHOD(Control*, focus_control, (), (const));
-                MOCK_METHOD(input::IMouse&, mouse, ());
+                MOCK_METHOD(std::shared_ptr<input::IMouse>, mouse, ());
             };
         }
     }

--- a/trview.ui/di.hpp
+++ b/trview.ui/di.hpp
@@ -16,11 +16,13 @@ namespace trview
                     {
                         return [&](auto&& window, auto&& control)
                         {
+                            auto mouse = injector.create<input::IMouse::Source>()(window);
                             return std::make_unique<Input>(
                                 window,
                                 control,
                                 injector.create<std::shared_ptr<IShortcuts>>(),
-                                injector.create<std::shared_ptr<IClipboard>>());
+                                injector.create<std::shared_ptr<IClipboard>>(),
+                                mouse);
                         };
                     })
             );


### PR DESCRIPTION
Add tests for most of the `Room` class.
Update the build to reliably fail when there are broken tests - previously it was sometimes ignoring failures.
Add some default values to some of the level types so they don't need to be explicitly set up when testing - just 0 in most cases.
Update `RoomWindowTests` to use the `.build()` style.
Remove reference returns in several places as it makes mocking them non-trivial and the cost is probably fine anyway.
Convert `IEntity` in `Room` to `shared_ptr/weak_ptr` instead of raw pointer.
Closes #797 