### PR TITLE
Add more accurate OCB adjustment for pickups

### DIFF
--- a/trview.app.tests/Elements/EntityTests.cpp
+++ b/trview.app.tests/Elements/EntityTests.cpp
@@ -1,0 +1,83 @@
+#include <trview.app/Elements/Entity.h>
+#include <trlevel/Mocks/ILevel.h>
+#include <trview.app/Mocks/Geometry/IMesh.h>
+#include <trview.app/Mocks/Graphics/IMeshStorage.h>
+
+using namespace trlevel::mocks;
+using namespace trview;
+using namespace trview::mocks;
+using testing::Return;
+
+namespace
+{
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            std::shared_ptr<trlevel::ILevel> level{ std::make_shared<trlevel::mocks::MockLevel>() };
+            IMesh::Source mesh_source = [](auto&&...) { return std::make_shared<MockMesh>(); };
+            std::shared_ptr<IMeshStorage> mesh_storage = std::make_shared<MockMeshStorage>();
+            trlevel::tr2_entity entity{};
+            uint32_t index{ 0u };
+            bool is_pickup{ false };
+
+            std::unique_ptr<Entity> build()
+            {
+                return std::make_unique<Entity>(mesh_source, *level, entity, *mesh_storage, index, is_pickup);
+            }
+
+            test_module& with_level(const std::shared_ptr<trlevel::ILevel>& level)
+            {
+                this->level = level;
+                return *this;
+            }
+
+            test_module& with_pickup(bool value)
+            {
+                this->is_pickup = value;
+                return *this;
+            }
+
+            test_module& with_entity(const trlevel::tr2_entity& entity)
+            {
+                this->entity = entity;
+                return *this;
+            }
+        };
+        return test_module{};
+    }
+}
+
+TEST(Entity, OcbAdjustmentTrueForPickup)
+{
+    auto level = std::make_shared<MockLevel>();
+    EXPECT_CALL(*level, get_version).WillRepeatedly(Return(trlevel::LevelVersion::Tomb4));
+    auto entity = register_test_module().with_level(level).with_pickup(true).build();
+    ASSERT_TRUE(entity->needs_ocb_adjustment());
+}
+
+TEST(Entity, OcbAdjustmentFalseForNonPickup)
+{
+    auto level = std::make_shared<MockLevel>();
+    EXPECT_CALL(*level, get_version).WillRepeatedly(Return(trlevel::LevelVersion::Tomb4));
+    auto entity = register_test_module().with_level(level).with_pickup(false).build();
+    ASSERT_FALSE(entity->needs_ocb_adjustment());
+}
+
+TEST(Entity, OcbAdjustmentFalseForPickupWithNonMatchingOCB)
+{
+    auto level = std::make_shared<MockLevel>();
+    EXPECT_CALL(*level, get_version).WillRepeatedly(Return(trlevel::LevelVersion::Tomb4));
+    trlevel::tr2_entity tr2_entity{};
+    tr2_entity.Intensity2 = 1;
+    auto entity = register_test_module().with_level(level).with_entity(tr2_entity).with_pickup(true).build();
+    ASSERT_FALSE(entity->needs_ocb_adjustment());
+}
+
+TEST(Entity, OcbAdjustmentNotDonePreTR4)
+{
+    auto level = std::make_shared<MockLevel>();
+    EXPECT_CALL(*level, get_version).WillRepeatedly(Return(trlevel::LevelVersion::Tomb3));
+    auto entity = register_test_module().with_level(level).with_pickup(true).build();
+    ASSERT_FALSE(entity->needs_ocb_adjustment());
+}

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -23,31 +23,65 @@ using testing::Return;
 
 namespace
 {
-    auto default_entity_source = [](auto&&...) { return std::make_shared<MockEntity>(); };
-    auto default_ai_source = [](auto&&...) { return std::make_shared<MockEntity>(); };
-    auto default_room_source = [](auto&&...) { return std::make_shared<MockRoom>(); };
-
-    auto register_test_module(std::unique_ptr<trlevel::ILevel> level, std::shared_ptr<ITypeNameLookup> type_name_lookup = nullptr, IEntity::EntitySource entity_source = default_entity_source,
-        IEntity::AiSource ai_source = default_ai_source, IRoom::Source room_source = default_room_source)
+    auto register_test_module()
     {
-        choose_mock<trlevel::mocks::MockLevel>(level);
-        choose_mock<MockTypeNameLookup>(type_name_lookup);
+        struct test_module
+        {
+            std::shared_ptr<ITypeNameLookup> type_name_lookup{ std::make_shared<MockTypeNameLookup>() };
+            IEntity::EntitySource entity_source{ [](auto&&...) { return std::make_shared<MockEntity>(); } };
+            IEntity::AiSource ai_source{ [](auto&&...) { return std::make_shared<MockEntity>(); } };
+            IRoom::Source room_source{ [](auto&&...) { return std::make_shared<MockRoom>(); } };
+            std::unique_ptr<trlevel::ILevel> level{ std::make_unique<trlevel::mocks::MockLevel>() };
 
-        return di::make_injector
-        (
-            di::bind<IDevice>.to<MockDevice>(),
-            di::bind<IShaderStorage>.to<MockShaderStorage>(),
-            di::bind<ITransparencyBuffer>.to<MockTransparencyBuffer>(),
-            di::bind<ISelectionRenderer>.to<MockSelectionRenderer>(),
-            di::bind<ITypeNameLookup>.to(type_name_lookup),
-            di::bind<ILevelTextureStorage>.to<MockLevelTextureStorage>(),
-            di::bind<trlevel::ILevel>.to([&](auto&&) { return std::move(level); }),
-            di::bind<IMeshStorage>.to<MockMeshStorage>(),
-            di::bind<IEntity::EntitySource>.to(entity_source),
-            di::bind<IEntity::AiSource>.to(ai_source),
-            di::bind<IRoom::Source>.to(room_source),
-            di::bind<Level>()
-        ).create<std::unique_ptr<Level>>();
+            std::unique_ptr<Level> build()
+            {
+                return di::make_injector(
+                    di::bind<IDevice>.to<MockDevice>(),
+                    di::bind<IShaderStorage>.to<MockShaderStorage>(),
+                    di::bind<ITransparencyBuffer>.to<MockTransparencyBuffer>(),
+                    di::bind<ISelectionRenderer>.to<MockSelectionRenderer>(),
+                    di::bind<ITypeNameLookup>.to(type_name_lookup),
+                    di::bind<ILevelTextureStorage>.to<MockLevelTextureStorage>(),
+                    di::bind<trlevel::ILevel>.to([&](auto&&) { return std::move(level); }),
+                    di::bind<IMeshStorage>.to<MockMeshStorage>(),
+                    di::bind<IEntity::EntitySource>.to(entity_source),
+                    di::bind<IEntity::AiSource>.to(ai_source),
+                    di::bind<IRoom::Source>.to(room_source),
+                    di::bind<Level>()).create<std::unique_ptr<Level>>();
+            }
+
+            test_module& with_type_name_lookup(const std::shared_ptr<ITypeNameLookup>& type_name_lookup)
+            {
+                this->type_name_lookup = type_name_lookup;
+                return *this;
+            }
+
+            test_module& with_level(std::unique_ptr<trlevel::ILevel>&& level)
+            {
+                this->level = std::move(level);
+                return *this;
+            }
+
+            test_module& with_entity_source(const IEntity::EntitySource& entity_source)
+            {
+                this->entity_source = entity_source;
+                return *this;
+            }
+
+            test_module& with_ai_source(const IEntity::AiSource& ai_source)
+            {
+                this->ai_source = ai_source;
+                return *this;
+            }
+
+            test_module& with_room_source(const IRoom::Source& room_source)
+            {
+                this->room_source = room_source;
+                return *this;
+            }
+        };
+
+        return test_module{};
     }
 }
 
@@ -66,7 +100,7 @@ TEST(Level, LoadTypeNames)
 
     auto mock_type_name_lookup = std::make_shared<MockTypeNameLookup>();
     EXPECT_CALL(*mock_type_name_lookup, lookup_type_name(LevelVersion::Tomb2, 123));
-    auto level = register_test_module(std::move(mock_level_ptr), mock_type_name_lookup);
+    auto level = register_test_module().with_level(std::move(mock_level_ptr)).with_type_name_lookup(mock_type_name_lookup).build();
 }
 
 TEST(Level, LoadFromEntitySources)
@@ -88,17 +122,19 @@ TEST(Level, LoadFromEntitySources)
     uint32_t entity_source_called = 0;
     uint32_t ai_source_called = 0;
 
-    auto level = register_test_module(std::move(mock_level_ptr), nullptr,
-        [&](auto&&...)
-        {
-            ++entity_source_called;
-            return std::make_shared<MockEntity>();
-        },
-        [&](auto&&...)
-        {
-            ++ai_source_called;
-            return std::make_shared<MockEntity>();
-        });
+    auto level = register_test_module().with_level(std::move(mock_level_ptr))
+        .with_entity_source(
+            [&](auto&&...)
+            {
+                ++entity_source_called;
+                return std::make_shared<MockEntity>();
+            })
+        .with_ai_source(
+            [&](auto&&...)
+            {
+                ++ai_source_called;
+                return std::make_shared<MockEntity>();
+            }).build();
 
     ASSERT_EQ(entity_source_called, 1);
     ASSERT_EQ(ai_source_called, 1);
@@ -112,12 +148,71 @@ TEST(Level, LoadRooms)
 
     int room_called = 0;
 
-    auto level = register_test_module(std::move(mock_level_ptr), nullptr, default_entity_source, default_ai_source, 
-        [&](auto&&...) 
-        { 
-            ++room_called;
-            return std::make_shared<MockRoom>(); 
-        });
+    auto level = register_test_module().with_level(std::move(mock_level_ptr))
+        .with_room_source(
+            [&](auto&&...)
+            {
+                ++room_called;
+                return std::make_shared<MockRoom>();
+            }).build();
 
     ASSERT_EQ(room_called, 3);
+}
+
+TEST(Level, OcbAdjustmentsPerformedWhenNeeded)
+{
+    auto [mock_level_ptr, mock_level] = create_mock<MockLevel>();
+    EXPECT_CALL(mock_level, num_rooms()).WillRepeatedly(Return(1));
+    EXPECT_CALL(mock_level, num_entities()).WillRepeatedly(Return(1));
+    int entity_source_called = 0;
+    auto level = register_test_module().with_level(std::move(mock_level_ptr))
+        .with_room_source(
+            [&](auto&&...)
+            {
+                auto room = std::make_shared<MockRoom>();
+                PickResult result{};
+                result.hit = true;
+                EXPECT_CALL(*room, pick).WillRepeatedly(Return(result));
+                return room;
+            })
+        .with_entity_source(
+            [&](auto&&...)
+            {
+                ++entity_source_called;
+                auto entity = std::make_shared<MockEntity>();
+                EXPECT_CALL(*entity, needs_ocb_adjustment).WillRepeatedly(Return(true));
+                EXPECT_CALL(*entity, adjust_y).Times(1);
+                return entity;
+            }).build();
+
+    ASSERT_EQ(entity_source_called, 1);
+}
+
+TEST(Level, OcbAdjustmentsNotPerformedWhenNotNeeded)
+{
+    auto [mock_level_ptr, mock_level] = create_mock<MockLevel>();
+    EXPECT_CALL(mock_level, num_rooms()).WillRepeatedly(Return(1));
+    EXPECT_CALL(mock_level, num_entities()).WillRepeatedly(Return(1));
+    int entity_source_called = 0;
+    auto level = register_test_module().with_level(std::move(mock_level_ptr))
+        .with_room_source(
+            [&](auto&&...)
+            {
+                auto room = std::make_shared<MockRoom>();
+                PickResult result{};
+                result.hit = true;
+                EXPECT_CALL(*room, pick).WillRepeatedly(Return(result));
+                return room;
+            })
+        .with_entity_source(
+            [&](auto&&...)
+            {
+                ++entity_source_called;
+                auto entity = std::make_shared<MockEntity>();
+                EXPECT_CALL(*entity, needs_ocb_adjustment).WillRepeatedly(Return(false));
+                EXPECT_CALL(*entity, adjust_y).Times(0);
+                return entity;
+            }).build();
+
+    ASSERT_EQ(entity_source_called, 1);
 }

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -317,7 +317,7 @@ TEST(Room, PickTestsEntities)
     EXPECT_CALL(*entity, pick).Times(1).WillOnce(Return(PickResult{ true, 0, {}, PickResult::Type::Entity, 10 }));
     room->add_entity(entity);
 
-    auto result = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), true, true);
+    auto result = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), PickFilter::Entities);
     ASSERT_EQ(result.hit, true);
     ASSERT_EQ(result.type, PickResult::Type::Entity);
     ASSERT_EQ(result.index, 10);
@@ -337,7 +337,7 @@ TEST(Room, PickTestsTriggers)
     EXPECT_CALL(*trigger, pick).Times(1).WillOnce(Return(PickResult{ true, 0, {}, PickResult::Type::Trigger, 10 }));
     room->add_trigger(trigger);
 
-    auto result = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), true, true);
+    auto result = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), PickFilter::Triggers);
     ASSERT_EQ(result.hit, true);
     ASSERT_EQ(result.type, PickResult::Type::Trigger);
     ASSERT_EQ(result.index, 10);
@@ -362,7 +362,7 @@ TEST(Room, PickChoosesClosest)
     EXPECT_CALL(*entity2, pick).Times(1).WillOnce(Return(PickResult{ true, 1.0f, {}, PickResult::Type::Entity, 10 }));
     room->add_entity(entity2);
 
-    auto result = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), true, true);
+    auto result = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), PickFilter::Entities | PickFilter::Triggers);
     ASSERT_EQ(result.hit, true);
     ASSERT_EQ(result.type, PickResult::Type::Entity);
     ASSERT_EQ(result.index, 5);
@@ -387,7 +387,7 @@ TEST(Room, PickChoosesEntityOverTrigger)
     EXPECT_CALL(*trigger, pick).Times(0);
     room->add_trigger(trigger);
 
-    auto result = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), true, true);
+    auto result = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), PickFilter::Entities | PickFilter::Triggers);
     ASSERT_EQ(result.hit, true);
     ASSERT_EQ(result.type, PickResult::Type::Entity);
     ASSERT_EQ(result.index, 5);

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="ApplicationTests.cpp" />
     <ClCompile Include="Camera\CameraInputTests.cpp" />
     <ClCompile Include="ContextMenuTests.cpp" />
+    <ClCompile Include="Elements\EntityTests.cpp" />
     <ClCompile Include="Elements\LevelTests.cpp" />
     <ClCompile Include="Elements\RoomTests.cpp" />
     <ClCompile Include="Elements\TypeNameLookupTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -74,6 +74,9 @@
     <ClCompile Include="Elements\RoomTests.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\EntityTests.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -35,7 +35,7 @@ namespace trview
         /// <returns>Whether the position needs adjustment.</returns>
         bool needs_adjustment_tr5(uint32_t ocb)
         {
-            return equals_any(ocb & 0x3f, 0u, 3u, 4u, 5u, 7u, 8u, 11u);
+            return equals_any(ocb & 0x3f, 0u, 3u, 4u, 5u, 6u, 7u, 8u, 11u);
         }
 
         /// <summary>

--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -300,22 +300,27 @@ namespace trview
 
     void Entity::apply_ocb_adjustment(uint32_t ocb)
     {
-        using namespace DirectX::SimpleMath;
-        const int flags = ocb & 0x3F;
-        // This assumes that pickups only have one mesh, as a general rule (it seems to work most of the time).
-        // Applying OCB adjustment without this test when OCB is 0 makes Lara and other entities move up, which
-        // isn't right.
-        if (_meshes.size() == 1 && equals_any(flags, 0, 3, 7, 11))
+        // If this isn't a pickup, don't adjust the position.
+        if (!has_any(ocb, 64)) 
         {
-            Matrix offset = Matrix::CreateTranslation(0, -_bounding_box.Extents.y, 0);
-            _world *= offset;
-
-            for (auto& obb : _oriented_boxes)
-            {
-                obb.Transform(obb, offset);
-            }
-            _bounding_box.Transform(_bounding_box, offset);
+            return;
         }
+
+        const int flags = ocb & 0x3F;
+        if (!equals_any(flags, 0, 3, 7, 11))
+        {
+            return;
+        }
+
+        using namespace DirectX::SimpleMath;
+        Matrix offset = Matrix::CreateTranslation(0, -_bounding_box.Extents.y, 0);
+        _world *= offset;
+
+        for (auto& obb : _oriented_boxes)
+        {
+            obb.Transform(obb, offset);
+        }
+        _bounding_box.Transform(_bounding_box, offset);
     }
 
     DirectX::BoundingBox Entity::bounding_box() const

--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -352,6 +352,7 @@ namespace trview
             obb.Transform(obb, offset);
         }
         _bounding_box.Transform(_bounding_box, offset);
+        _needs_ocb_adjustment = true;
     }
 
     DirectX::BoundingBox Entity::bounding_box() const
@@ -367,5 +368,22 @@ namespace trview
     void Entity::set_visible(bool value)
     {
         _visible = value;
+    }
+
+    void Entity::set_position(float height)
+    {
+        auto offset = Matrix::CreateTranslation(0, height, 0);
+        _world *= offset;
+
+        for (auto& obb : _oriented_boxes)
+        {
+            obb.Transform(obb, offset);
+        }
+        _bounding_box.Transform(_bounding_box, offset);
+    }
+
+    bool Entity::needs_ocb_adjustment() const
+    {
+        return _needs_ocb_adjustment;
     }
 }

--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -19,12 +19,23 @@ namespace trview
     namespace
     {
         /// <summary>
-        /// Determines whether the object type is a pickup based on object IDs from Tomb5. This should only
-        /// be called with Tomb4+ items.
+        /// Determines whether the object type is a pickup based on object IDs from Tomb4. This should only
+        /// be called with Tomb4 items.
         /// </summary>
         /// <param name="number">The object type id.</param>
         /// <returns>Whether this is a pickup.</returns>
-        bool is_pickup(uint32_t number)
+        bool is_pickup_tr4(uint32_t number)
+        {
+            return (number >= 246 && number <= 248) || (number >= 334 && number <= 373);
+        }
+
+        /// <summary>
+        /// Determines whether the object type is a pickup based on object IDs from Tomb5. This should only
+        /// be called with Tomb5 items.
+        /// </summary>
+        /// <param name="number">The object type id.</param>
+        /// <returns>Whether this is a pickup.</returns>
+        bool is_pickup_tr5(uint32_t number)
         {
             return (number >= 172 && number <= 241) || (number >= 334 && number <= 355);
         }
@@ -37,7 +48,7 @@ namespace trview
         /// <returns>Whether the position needs adjustment.</returns>
         bool needs_adjustment_tr4(uint32_t type_id, uint32_t ocb)
         {
-            return is_pickup(type_id) && equals_any(ocb & 0x3f, 0u, 3u, 4u);
+            return is_pickup_tr4(type_id) && equals_any(ocb & 0x3f, 0u, 3u, 4u);
         }
 
         /// <summary>
@@ -48,7 +59,7 @@ namespace trview
         /// <returns>Whether the position needs adjustment.</returns>
         bool needs_adjustment_tr5(uint32_t type_id, uint32_t ocb)
         {
-            return is_pickup(type_id) && equals_any(ocb & 0x3f, 0u, 3u, 4u, 5u, 7u, 8u, 11u);
+            return is_pickup_tr5(type_id) && equals_any(ocb & 0x3f, 0u, 3u, 4u, 5u, 7u, 8u, 11u);
         }
 
         /// <summary>

--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -370,9 +370,9 @@ namespace trview
         _visible = value;
     }
 
-    void Entity::set_position(float height)
+    void Entity::adjust_y(float amount)
     {
-        auto offset = Matrix::CreateTranslation(0, height, 0);
+        auto offset = Matrix::CreateTranslation(0, amount, 0);
         _world *= offset;
 
         for (auto& obb : _oriented_boxes)

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -42,6 +42,8 @@ namespace trview
 
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;
+        virtual void set_position(float height) override;
+        virtual bool needs_ocb_adjustment() const override;
     private:
         Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint32_t room, uint32_t index, uint32_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, bool is_pickup);
 
@@ -65,5 +67,6 @@ namespace trview
         DirectX::BoundingBox                      _bounding_box;
         std::vector<DirectX::BoundingOrientedBox> _oriented_boxes;
         bool                                      _visible{ true };
+        bool _needs_ocb_adjustment{ false };
     };
 }

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -28,7 +28,7 @@ namespace trview
     class Entity final : public IEntity
     {
     public:
-        explicit Entity(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, uint32_t index);
+        explicit Entity(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, uint32_t index, bool is_pickup);
         explicit Entity(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, uint32_t index);
         virtual ~Entity() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
@@ -43,12 +43,12 @@ namespace trview
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;
     private:
-        Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint32_t room, uint32_t index, uint32_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb);
+        Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint32_t room, uint32_t index, uint32_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, bool is_pickup);
 
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);
         void generate_bounding_box();
-        void apply_ocb_adjustment(trlevel::LevelVersion version, uint32_t type_id, uint32_t ocb);
+        void apply_ocb_adjustment(trlevel::LevelVersion version, uint32_t ocb, bool is_pickup);
 
         DirectX::SimpleMath::Matrix               _world;
         std::vector<std::shared_ptr<IMesh>>       _meshes;

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -48,7 +48,7 @@ namespace trview
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);
         void generate_bounding_box();
-        void apply_ocb_adjustment(uint32_t ocb);
+        void apply_ocb_adjustment(trlevel::LevelVersion version, uint32_t type_id, uint32_t ocb);
 
         DirectX::SimpleMath::Matrix               _world;
         std::vector<std::shared_ptr<IMesh>>       _meshes;

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -42,7 +42,7 @@ namespace trview
 
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;
-        virtual void set_position(float height) override;
+        virtual void adjust_y(float amount) override;
         virtual bool needs_ocb_adjustment() const override;
     private:
         Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint32_t room, uint32_t index, uint32_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, bool is_pickup);

--- a/trview.app/Elements/IEntity.h
+++ b/trview.app/Elements/IEntity.h
@@ -21,5 +21,7 @@ namespace trview
         virtual uint16_t room() const = 0;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
         virtual DirectX::BoundingBox bounding_box() const = 0;
+        virtual void set_position(float height) = 0;
+        virtual bool needs_ocb_adjustment() const = 0;
     };
 }

--- a/trview.app/Elements/IEntity.h
+++ b/trview.app/Elements/IEntity.h
@@ -21,7 +21,15 @@ namespace trview
         virtual uint16_t room() const = 0;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
         virtual DirectX::BoundingBox bounding_box() const = 0;
-        virtual void set_position(float height) = 0;
+        /// <summary>
+        /// Adjust the y position of the entity by the specified amount.
+        /// </summary>
+        /// <param name="amount">The amount to translate byin the Y axis.</param>
+        virtual void adjust_y(float amount) = 0;
+        /// <summary>
+        /// Determines whether the entity needs y adjustment based on the ocb value.
+        /// </summary>
+        /// <returns>True if the y needs to be adjusted.</returns>
         virtual bool needs_ocb_adjustment() const = 0;
     };
 }

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -9,6 +9,7 @@
 #include <trview.app/Elements/ISector.h>
 #include <trview.app/Elements/ITrigger.h>
 #include <trview.app/Elements/RoomInfo.h>
+#include <trview.app/Elements/PickFilter.h>
 #include <trview.app/Geometry/ITransparencyBuffer.h>
 #include <trview.app/Geometry/PickInfo.h>
 #include <trview.app/Graphics/ILevelTextureStorage.h>
@@ -159,12 +160,9 @@ namespace trview
         /// </summary>
         /// <param name="position">The world space position of the source of the ray.</param>
         /// <param name="direction">The direction of the ray.</param>
-        /// <param name="include_entities">Whether to include contained entities in the pick operation.</param>
-        /// <param name="include_triggers">Whether to include contained triggers in the pick operation.</param>
-        /// <param name="include_hidden_geometry">Whether hidden geometry should be included in the pick operation. This requires include_room_geometry to be set as well.</param>
-        /// <param name="include_room_geometry">Whether regular room geometry should be included in the pick operation.</param>
+        /// <param name="filters">The types of objects to include the picking operation.</param>
         /// <returns>The <see cref="PickResult"/>.</returns>
-        virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, bool include_entities, bool include_triggers, bool include_hidden_geometry = false, bool include_room_geometry = true) const = 0;
+        virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, PickFilter filters = PickFilter::Default) const = 0;
         /// <summary>
         /// Gets whether the room is a quicksand room based on the room flags. This can only be true if the game is TR3 or later.
         /// </summary>

--- a/trview.app/Elements/IStaticMesh.h
+++ b/trview.app/Elements/IStaticMesh.h
@@ -19,7 +19,6 @@ namespace trview
         virtual ~IStaticMesh() = 0;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) = 0;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) = 0;
-        virtual std::shared_ptr<IMesh> mesh() const = 0;
-        virtual DirectX::SimpleMath::Matrix world() const = 0;
+        virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
     };
 }

--- a/trview.app/Elements/IStaticMesh.h
+++ b/trview.app/Elements/IStaticMesh.h
@@ -19,5 +19,7 @@ namespace trview
         virtual ~IStaticMesh() = 0;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) = 0;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) = 0;
+        virtual std::shared_ptr<IMesh> mesh() const = 0;
+        virtual DirectX::SimpleMath::Matrix world() const = 0;
     };
 }

--- a/trview.app/Elements/ITypeNameLookup.h
+++ b/trview.app/Elements/ITypeNameLookup.h
@@ -11,5 +11,6 @@ namespace trview
     public:
         virtual ~ITypeNameLookup() = 0;
         virtual std::wstring lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id) const = 0;
+        virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const = 0;
     };
 }

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -478,11 +478,14 @@ namespace trview
         auto rooms = get_rooms_to_render(camera);
         for (auto& room : rooms)
         {
-            choose(room.room.pick(position, direction, true, _show_triggers, _show_hidden_geometry));
+            choose(room.room.pick(position, direction,
+                PickFilter::Entities |
+                filter_flag(PickFilter::Triggers, _show_triggers) |
+                filter_flag(PickFilter::HiddenGeometry, _show_hidden_geometry)));
             if (!is_alternate_mismatch(room.room) && room.room.alternate_mode() == IRoom::AlternateMode::IsAlternate)
             {
                 auto& original_room = _rooms[room.room.alternate_room()];
-                choose(original_room->pick(position, direction, true, false, false, false));
+                choose(original_room->pick(position, direction, PickFilter::Entities));
             }
         }
         return final_result;
@@ -691,7 +694,7 @@ namespace trview
             }
 
             const auto entity_pos = entity->bounding_box().Center;
-            const auto result = _rooms[entity->room()]->pick(Vector3(entity_pos.x, entity_pos.y, entity_pos.z), Vector3(0, 1, 0), false, false);
+            const auto result = _rooms[entity->room()]->pick(Vector3(entity_pos.x, entity_pos.y, entity_pos.z), Vector3(0, 1, 0), PickFilter::Geometry | PickFilter::HiddenGeometry | PickFilter::StaticMeshes);
             if (result.hit)
             {
                 const auto new_height = result.position.y - entity->bounding_box().Extents.y;

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -59,6 +59,22 @@ namespace trview
         {
             room->update_bounding_box();
         }
+
+        for (auto& entity : _entities)
+        {
+            if (!entity->needs_ocb_adjustment())
+            {
+                continue;
+            }
+            
+            // Adjust for OCB.
+            const auto& room = _rooms[entity->room()];
+            auto entity_pos = entity->bounding_box().Center;
+            auto result = room->pick(Vector3(entity_pos.x, entity_pos.y, entity_pos.z), Vector3(0, 1, 0), false, false);
+            auto new_height = result.position.y - entity->bounding_box().Extents.y;
+            entity->set_position(new_height - entity_pos.y);
+            continue;
+        }
     }
 
     std::vector<RoomInfo> Level::room_info() const

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -119,6 +119,7 @@ namespace trview
         bool is_alternate_mismatch(const IRoom& room) const;
 
         bool is_alternate_group_set(uint16_t group) const;
+        void apply_ocb_adjustment();
 
         std::shared_ptr<graphics::IDevice> _device;
         std::vector<std::shared_ptr<IRoom>>   _rooms;

--- a/trview.app/Elements/PickFilter.cpp
+++ b/trview.app/Elements/PickFilter.cpp
@@ -1,0 +1,32 @@
+#include "PickFilter.h"
+
+namespace trview
+{
+    PickFilter operator & (PickFilter left, PickFilter right)
+    {
+        using T = std::underlying_type_t<PickFilter>;
+        return static_cast<PickFilter>(static_cast<T>(left) & static_cast<T>(right));
+    }
+
+    PickFilter operator ~ (PickFilter left)
+    {
+        using T = std::underlying_type_t<PickFilter>;
+        return static_cast<PickFilter>(~static_cast<T>(left));
+    }
+
+    PickFilter operator | (PickFilter left, PickFilter right)
+    {
+        using T = std::underlying_type_t<PickFilter>;
+        return static_cast<PickFilter>(static_cast<T>(left) | static_cast<T>(right));
+    }
+
+    bool has_flag(PickFilter filter, PickFilter flag)
+    {
+        return (filter & flag) == flag;
+    }
+
+    PickFilter filter_flag(PickFilter filter, bool condition)
+    {
+        return condition ? filter : PickFilter::None;
+    }
+}

--- a/trview.app/Elements/PickFilter.h
+++ b/trview.app/Elements/PickFilter.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace trview
+{
+    /// <summary>
+    /// Target filters for picking.
+    /// </summary>
+    enum class PickFilter : uint32_t
+    {
+        None = 0x0,
+        Geometry = 0x1,
+        Entities = 0x2,
+        Triggers = 0x4,
+        HiddenGeometry = 0x8,
+        StaticMeshes = 0x10,
+        All = 0xffffffff,
+        Default = All & ~HiddenGeometry
+    };
+
+    PickFilter operator & (PickFilter left, PickFilter right);
+    PickFilter operator | (PickFilter left, PickFilter right);
+    PickFilter operator ~ (PickFilter left);
+    bool has_flag(PickFilter filter, PickFilter flag);
+    PickFilter filter_flag(PickFilter filter, bool condition);
+}

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -145,15 +145,11 @@ namespace trview
 
             for (const auto& static_mesh : _static_meshes)
             {
-                auto transform = (static_mesh->world()).Invert();
-                auto transformed_position = Vector3::Transform(position, transform);
-                PickResult static_mesh_result = static_mesh->mesh()->pick(transformed_position, direction);
+                PickResult static_mesh_result = static_mesh->pick(position, direction);
                 if (static_mesh_result.hit)
                 {
-                    // Transform the position back in to world space. Also mark it as a room pick result.
                     static_mesh_result.type = PickResult::Type::Room;
                     static_mesh_result.index = _index;
-                    static_mesh_result.position = Vector3::Transform(static_mesh_result.position, static_mesh->world());
                     pick_results.push_back(static_mesh_result);
                 }
             }

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -74,12 +74,7 @@ namespace trview
         return _neighbours;
     }
 
-    // Determine whether the specified ray hits any of the triangles in the room geometry.
-    // position: The world space position of the source of the ray.
-    // direction: The direction of the ray.
-    // Returns: The result of the operation. If 'hit' is true, distance and position contain
-    // how far along the ray the hit was and the position in world space.
-    PickResult Room::pick(const Vector3& position, const Vector3& direction, bool include_entities, bool include_triggers, bool include_hidden_geometry, bool include_room_geometry) const
+    PickResult Room::pick(const Vector3& position, const Vector3& direction, PickFilter filters) const
     {
         using namespace DirectX::TriangleTests;
 
@@ -92,7 +87,7 @@ namespace trview
 
         std::vector<PickResult> pick_results;
 
-        if (include_entities)
+        if (has_flag(filters, PickFilter::Entities))
         {
             // Pick against the entity geometry:
             for (const auto& entity : _entities)
@@ -111,7 +106,7 @@ namespace trview
             }
         }
 
-        if (include_triggers && pick_results.empty())
+        if (has_flag(filters, PickFilter::Triggers) && pick_results.empty())
         {
             for (const auto& trigger_pair : _triggers)
             {
@@ -129,7 +124,21 @@ namespace trview
             }
         }
 
-        if (include_room_geometry)
+        if (has_flag(filters, PickFilter::StaticMeshes))
+        {
+            for (const auto& static_mesh : _static_meshes)
+            {
+                PickResult static_mesh_result = static_mesh->pick(position, direction);
+                if (static_mesh_result.hit)
+                {
+                    static_mesh_result.type = PickResult::Type::Room;
+                    static_mesh_result.index = _index;
+                    pick_results.push_back(static_mesh_result);
+                }
+            }
+        }
+
+        if (has_flag(filters, PickFilter::Geometry))
         {
             // Pick against the room geometry:
             auto room_offset = Matrix::CreateTranslation(-_info.x / trlevel::Scale_X, 0, -_info.z / trlevel::Scale_Z);
@@ -143,18 +152,7 @@ namespace trview
                 pick_results.push_back(geometry_result);
             }
 
-            for (const auto& static_mesh : _static_meshes)
-            {
-                PickResult static_mesh_result = static_mesh->pick(position, direction);
-                if (static_mesh_result.hit)
-                {
-                    static_mesh_result.type = PickResult::Type::Room;
-                    static_mesh_result.index = _index;
-                    pick_results.push_back(static_mesh_result);
-                }
-            }
-
-            if (include_hidden_geometry)
+            if (has_flag(filters, PickFilter::HiddenGeometry))
             {
                 PickResult unmatched_result = _unmatched_mesh->pick(Vector3::Transform(position, room_offset), direction);
                 if (unmatched_result.hit)

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -143,6 +143,21 @@ namespace trview
                 pick_results.push_back(geometry_result);
             }
 
+            for (const auto& static_mesh : _static_meshes)
+            {
+                auto transform = (static_mesh->world()).Invert();
+                auto transformed_position = Vector3::Transform(position, transform);
+                PickResult static_mesh_result = static_mesh->mesh()->pick(transformed_position, direction);
+                if (static_mesh_result.hit)
+                {
+                    // Transform the position back in to world space. Also mark it as a room pick result.
+                    static_mesh_result.type = PickResult::Type::Room;
+                    static_mesh_result.index = _index;
+                    static_mesh_result.position = Vector3::Transform(static_mesh_result.position, static_mesh->world());
+                    pick_results.push_back(static_mesh_result);
+                }
+            }
+
             if (include_hidden_geometry)
             {
                 PickResult unmatched_result = _unmatched_mesh->pick(Vector3::Transform(position, room_offset), direction);

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -38,7 +38,7 @@ namespace trview
         Room& operator=(const Room&) = delete;
         virtual RoomInfo info() const override;
         virtual std::set<uint16_t> neighbours() const override;
-        virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, bool include_entities, bool include_triggers, bool include_hidden_geometry = false, bool include_room_geometry = true) const override;
+        virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, PickFilter filters = PickFilter::Default) const override;
         virtual void render(const ICamera& camera, SelectionMode selected, bool show_hidden_geometry, bool show_water) override;
         virtual void render_contained(const ICamera& camera, SelectionMode selected, bool show_water) override;
         virtual void add_entity(const std::weak_ptr<IEntity>& entity) override;

--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -58,17 +58,15 @@ namespace trview
         }
     }
 
-    std::shared_ptr<IMesh> StaticMesh::mesh() const
+    PickResult StaticMesh::pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const
     {
-        if (_sprite_mesh) 
+        if (_sprite_mesh)
         {
-            return _sprite_mesh;
+            return {};
         }
-        return _mesh;
-    }
 
-    DirectX::SimpleMath::Matrix StaticMesh::world() const
-    {
-        return _world;
+        PickResult result = _mesh->pick(Vector3::Transform(position, _world.Invert()), direction);
+        result.position = Vector3::Transform(result.position, _world);
+        return result;
     }
 }

--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -57,4 +57,18 @@ namespace trview
             }
         }
     }
+
+    std::shared_ptr<IMesh> StaticMesh::mesh() const
+    {
+        if (_sprite_mesh) 
+        {
+            return _sprite_mesh;
+        }
+        return _mesh;
+    }
+
+    DirectX::SimpleMath::Matrix StaticMesh::world() const
+    {
+        return _world;
+    }
 }

--- a/trview.app/Elements/StaticMesh.h
+++ b/trview.app/Elements/StaticMesh.h
@@ -12,8 +12,7 @@ namespace trview
         virtual ~StaticMesh() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
-        virtual std::shared_ptr<IMesh> mesh() const override;
-        virtual DirectX::SimpleMath::Matrix world() const override;
+        virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
     private:
         float                        _rotation;
         DirectX::SimpleMath::Vector3 _position;

--- a/trview.app/Elements/StaticMesh.h
+++ b/trview.app/Elements/StaticMesh.h
@@ -12,6 +12,8 @@ namespace trview
         virtual ~StaticMesh() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
+        virtual std::shared_ptr<IMesh> mesh() const override;
+        virtual DirectX::SimpleMath::Matrix world() const override;
     private:
         float                        _rotation;
         DirectX::SimpleMath::Vector3 _position;

--- a/trview.app/Elements/TypeNameLookup.cpp
+++ b/trview.app/Elements/TypeNameLookup.cpp
@@ -1,21 +1,10 @@
 #include "TypeNameLookup.h"
+#include <trview.common/Json.h>
 
 using namespace trlevel;
 
 namespace trview
 {
-    namespace
-    {
-        template <typename T>
-        void read_setting(const nlohmann::json& json, T& destination, const std::string& attribute_name)
-        {
-            if (json.count(attribute_name) != 0)
-            {
-                destination = json[attribute_name].get<T>();
-            }
-        }
-    }
-
     TypeNameLookup::TypeNameLookup(const std::string& type_name_json)
     {
         auto json = nlohmann::json::parse(type_name_json.begin(), type_name_json.end());
@@ -47,12 +36,10 @@ namespace trview
             for (const auto& element : json["games"][game_name])
             {
                 auto name = element.at("name").get<std::string>();
-                bool pickup = false;
-                read_setting(element, pickup, "pickup");
                 type_names.insert({ element.at("id").get<uint32_t>(), 
                     {
                         std::wstring(name.begin(), name.end()),
-                        pickup
+                        read_attribute<bool>(element, "pickup")
                     } });
             }
             _type_names.insert({ version, type_names });

--- a/trview.app/Elements/TypeNameLookup.cpp
+++ b/trview.app/Elements/TypeNameLookup.cpp
@@ -4,6 +4,18 @@ using namespace trlevel;
 
 namespace trview
 {
+    namespace
+    {
+        template <typename T>
+        void read_setting(const nlohmann::json& json, T& destination, const std::string& attribute_name)
+        {
+            if (json.count(attribute_name) != 0)
+            {
+                destination = json[attribute_name].get<T>();
+            }
+        }
+    }
+
     TypeNameLookup::TypeNameLookup(const std::string& type_name_json)
     {
         auto json = nlohmann::json::parse(type_name_json.begin(), type_name_json.end());
@@ -31,11 +43,17 @@ namespace trview
                 return;
             }
 
-            std::unordered_map<uint32_t, std::wstring> type_names;
+            std::unordered_map<uint32_t, Type> type_names;
             for (const auto& element : json["games"][game_name])
             {
                 auto name = element.at("name").get<std::string>();
-                type_names.insert({ element.at("id").get<uint32_t>(), std::wstring(name.begin(), name.end()) });
+                bool pickup = false;
+                read_setting(element, pickup, "pickup");
+                type_names.insert({ element.at("id").get<uint32_t>(), 
+                    {
+                        std::wstring(name.begin(), name.end()),
+                        pickup
+                    } });
             }
             _type_names.insert({ version, type_names });
         };
@@ -60,6 +78,22 @@ namespace trview
         {
             return std::to_wstring(type_id);
         }
-        return found_type->second;
+        return found_type->second.name;
+    }
+
+    bool TypeNameLookup::is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const
+    {
+        const auto& game_types = _type_names.find(level_version);
+        if (game_types == _type_names.end())
+        {
+            return false;
+        }
+
+        const auto found_type = game_types->second.find(type_id);
+        if (found_type == game_types->second.end())
+        {
+            return false;
+        }
+        return found_type->second.pickup;
     }
 }

--- a/trview.app/Elements/TypeNameLookup.h
+++ b/trview.app/Elements/TypeNameLookup.h
@@ -10,8 +10,15 @@ namespace trview
     public:
         explicit TypeNameLookup(const std::string& type_name_json);
         virtual ~TypeNameLookup() = default;
-        std::wstring lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id) const override;
+        virtual std::wstring lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id) const override;
+        virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const override;
     private:
-        std::unordered_map<trlevel::LevelVersion, std::unordered_map<uint32_t, std::wstring>> _type_names;
+        struct Type
+        {
+            std::wstring name;
+            bool pickup{ false };
+        };
+
+        std::unordered_map<trlevel::LevelVersion, std::unordered_map<uint32_t, Type>> _type_names;
     };
 }

--- a/trview.app/Elements/di.hpp
+++ b/trview.app/Elements/di.hpp
@@ -28,7 +28,8 @@ namespace trview
                 {
                     return [&](auto&& level, auto&& entity, auto&& index, auto&& mesh_storage)
                     {
-                        return std::make_shared<Entity>(injector.create<IMesh::Source>(), level, entity, mesh_storage, index);
+                        const auto type_names = injector.create<std::shared_ptr<ITypeNameLookup>>();
+                        return std::make_shared<Entity>(injector.create<IMesh::Source>(), level, entity, mesh_storage, index, type_names->is_pickup(level.get_version(), entity.TypeID));
                     };
                 }),
             di::bind<IEntity::AiSource>.to(

--- a/trview.app/Geometry/PickResult.h
+++ b/trview.app/Geometry/PickResult.h
@@ -15,7 +15,8 @@ namespace trview
             Mesh,
             Trigger,
             Waypoint,
-            Compass
+            Compass,
+            StaticMesh
         };
 
         bool                         hit{ false };

--- a/trview.app/Mocks/Elements/IEntity.h
+++ b/trview.app/Mocks/Elements/IEntity.h
@@ -9,13 +9,15 @@ namespace trview
         struct MockEntity final : public IEntity
         {
             virtual ~MockEntity() = default;
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&));
-            MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&));
-            MOCK_METHOD(bool, visible, (), (const));
-            MOCK_METHOD(void, set_visible, (bool));
-            MOCK_METHOD(uint16_t, room, (), (const));
-            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const));
-            MOCK_METHOD(DirectX::BoundingBox, bounding_box, (), (const));
+            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(bool, visible, (), (const, override));
+            MOCK_METHOD(void, set_visible, (bool), (override));
+            MOCK_METHOD(uint16_t, room, (), (const, override));
+            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
+            MOCK_METHOD(DirectX::BoundingBox, bounding_box, (), (const, override));
+            MOCK_METHOD(void, adjust_y, (float), (override));
+            MOCK_METHOD(bool, needs_ocb_adjustment, (), (const, override));
         };
     }
 }

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -25,7 +25,7 @@ namespace trview
             MOCK_METHOD(uint16_t, num_z_sectors, (), (const, override));
             MOCK_METHOD(uint32_t, number, (), (const, override));
             MOCK_METHOD(bool, outside, (), (const, override));
-            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, bool, bool, bool, bool), (const, override));
+            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, PickFilter), (const, override));
             MOCK_METHOD(bool, quicksand, (), (const, override));
             MOCK_METHOD(void, render, (const ICamera&, SelectionMode, bool, bool), (override));
             MOCK_METHOD(void, render_contained, (const ICamera&, SelectionMode, bool), (override));;

--- a/trview.app/Mocks/Elements/IStaticMesh.h
+++ b/trview.app/Mocks/Elements/IStaticMesh.h
@@ -11,6 +11,7 @@ namespace trview
             virtual ~MockStaticMesh() = default;
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
         };
     }
 }

--- a/trview.app/Mocks/Elements/ITypeNameLookup.h
+++ b/trview.app/Mocks/Elements/ITypeNameLookup.h
@@ -11,6 +11,7 @@ namespace trview
         public:
             virtual ~MockTypeNameLookup() = default;
             MOCK_METHOD(std::wstring, lookup_type_name, (trlevel::LevelVersion, uint32_t), (const, override));
+            MOCK_METHOD(bool, is_pickup, (trlevel::LevelVersion, uint32_t), (const, override));
         };
     }
 }

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -2552,46 +2552,60 @@
 				"pickup": true
 			}, {
 				"id": 187,
-				"name": "Puzzle 1 Combo 1"
+				"name": "Puzzle 1 Combo 1",
+				"pickup": true
 			}, {
 				"id": 188,
-				"name": "Puzzle 1 Combo 2"
+				"name": "Puzzle 1 Combo 2",
+				"pickup": true
 			}, {
 				"id": 189,
-				"name": "Puzzle 2 Combo 1"
+				"name": "Puzzle 2 Combo 1",
+				"pickup": true
 			}, {
 				"id": 190,
-				"name": "Puzzle 2 Combo 2"
+				"name": "Puzzle 2 Combo 2",
+				"pickup": true
 			}, {
 				"id": 193,
-				"name": "Puzzle 4 Combo 1"
+				"name": "Puzzle 4 Combo 1",
+				"pickup": true
 			}, {
 				"id": 194,
-				"name": "Puzzle 4 Combo 2"
+				"name": "Puzzle 4 Combo 2",
+				"pickup": true
 			}, {
 				"id": 195,
-				"name": "Puzzle 5 Combo 1"
+				"name": "Puzzle 5 Combo 1",
+				"pickup": true
 			}, {
 				"id": 196,
-				"name": "Puzzle 5 Combo 2"
+				"name": "Puzzle 5 Combo 2",
+				"pickup": true
 			}, {
 				"id": 197,
-				"name": "Puzzle 6 Combo 1"
+				"name": "Puzzle 6 Combo 1",
+				"pickup": true
 			}, {
 				"id": 198,
-				"name": "Puzzle 6 Combo 2"
+				"name": "Puzzle 6 Combo 2",
+				"pickup": true
 			}, {
 				"id": 199,
-				"name": "Puzzle 7 Combo 1"
+				"name": "Puzzle 7 Combo 1",
+				"pickup": true
 			}, {
 				"id": 200,
-				"name": "Puzzle 7 Combo 2"
+				"name": "Puzzle 7 Combo 2",
+				"pickup": true
 			}, {
 				"id": 201,
-				"name": "Puzzle 8 Combo 1"
+				"name": "Puzzle 8 Combo 1",
+				"pickup": true
 			}, {
 				"id": 202,
-				"name": "Puzzle 8 Combo 2"
+				"name": "Puzzle 8 Combo 2",
+				"pickup": true
 			}, {
 				"id": 203,
 				"name": "Key 1",
@@ -2761,10 +2775,12 @@
 				"name": "Lock 12"
 			}, {
 				"id": 296,
-				"name": "Waterskin 1"
+				"name": "Waterskin 1",
+				"pickup": true
 			}, {
 				"id": 300,
-				"name": "Waterskin 2"
+				"name": "Waterskin 2",
+				"pickup": true
 			}, {
 				"id": 306,
 				"name": "Switch 1"

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -3363,91 +3363,120 @@
 				"name": "Suitcase"
 			}, {
 				"id": 172,
-				"name": "Puzzle 1"
+				"name": "Puzzle 1",
+				"pickup": true
 			}, {
 				"id": 173,
-				"name": "Puzzle 2"
+				"name": "Puzzle 2",
+				"pickup": true
 			}, {
 				"id": 174,
-				"name": "Puzzle 3"
+				"name": "Puzzle 3",
+				"pickup": true
 			}, {
 				"id": 175,
-				"name": "Puzzle 4"
+				"name": "Puzzle 4",
+				"pickup": true
 			}, {
 				"id": 176,
-				"name": "Puzzle 5"
+				"name": "Puzzle 5",
+				"pickup": true
 			}, {
 				"id": 180,
-				"name": "Puzzle 1 Combo 1"
+				"name": "Puzzle 1 Combo 1",
+				"pickup": true
 			}, {
 				"id": 181,
-				"name": "Puzzle 1 Combo 2"
+				"name": "Puzzle 1 Combo 2",
+				"pickup": true
 			}, {
 				"id": 182,
-				"name": "Puzzle 2 Combo 1"
+				"name": "Puzzle 2 Combo 1",
+				"pickup": true
 			}, {
 				"id": 183,
-				"name": "Puzzle 2 Combo 2"
+				"name": "Puzzle 2 Combo 2",
+				"pickup": true
 			}, {
 				"id": 184,
-				"name": "Puzzle 3 Combo 1"
+				"name": "Puzzle 3 Combo 1",
+				"pickup": true
 			}, {
 				"id": 185,
-				"name": "Puzzle 3 Combo 2"
+				"name": "Puzzle 3 Combo 2",
+				"pickup": true
 			}, {
 				"id": 186,
-				"name": "Puzzle 4 Combo 1"
+				"name": "Puzzle 4 Combo 1",
+				"pickup": true
 			}, {
 				"id": 187,
-				"name": "Puzzle 4 Combo 2"
+				"name": "Puzzle 4 Combo 2",
+				"pickup": true
 			}, {
 				"id": 196,
-				"name": "Key 1"
+				"name": "Key 1",
+				"pickup": true
 			}, {
 				"id": 197,
-				"name": "Key 2"
+				"name": "Key 2",
+				"pickup": true
 			}, {
 				"id": 198,
-				"name": "Key 3"
+				"name": "Key 3",
+				"pickup": true
 			}, {
 				"id": 199,
-				"name": "Key 4"
+				"name": "Key 4",
+				"pickup": true
 			}, {
 				"id": 200,
-				"name": "Key 5"
+				"name": "Key 5",
+				"pickup": true
 			}, {
 				"id": 201,
-				"name": "Key 6"
+				"name": "Key 6",
+				"pickup": true
 			}, {
 				"id": 202,
-				"name": "Key 7"
+				"name": "Key 7",
+				"pickup": true
 			}, {
 				"id": 203,
-				"name": "Key 8"
+				"name": "Key 8",
+				"pickup": true
 			}, {
 				"id": 220,
-				"name": "Pickup 1"
+				"name": "Pickup 1",
+				"pickup": true
 			}, {
 				"id": 221,
-				"name": "Pickup 2"
+				"name": "Pickup 2",
+				"pickup": true
 			}, {
 				"id": 222,
-				"name": "Pickup 3"
+				"name": "Pickup 3",
+				"pickup": true
 			}, {
 				"id": 223,
-				"name": "Secret"
+				"name": "Secret",
+				"pickup": true
 			}, {
 				"id": 235,
-				"name": "Bottle"
+				"name": "Bottle",
+				"pickup": true
 			}, {
 				"id": 236,
-				"name": "Cloth"
+				"name": "Cloth",
+				"pickup": true
 			}, {
 				"id": 240,
-				"name": "Crowbar"
+				"name": "Crowbar",
+				"pickup": true
 			}, {
 				"id": 241,
-				"name": "Torch"
+				"name": "Torch",
+				"pickup": true
 			}, {
 				"id": 242,
 				"name": "Slot 1"
@@ -3630,58 +3659,76 @@
 				"name": "Steel Door"
 			}, {
 				"id": 334,
-				"name": "Pistols"
+				"name": "Pistols",
+				"pickup": true
 			}, {
 				"id": 335,
-				"name": "Pistol  Ammo"
+				"name": "Pistol  Ammo",
+				"pickup": true
 			}, {
 				"id": 336,
-				"name": "Uzis"
+				"name": "Uzis",
+				"pickup": true
 			}, {
 				"id": 337,
-				"name": "Uzi Ammo"
+				"name": "Uzi Ammo",
+				"pickup": true
 			}, {
 				"id": 338,
-				"name": "Shotgun"
+				"name": "Shotgun",
+				"pickup": true
 			}, {
 				"id": 339,
-				"name": "Shotgun ammo (red)"
+				"name": "Shotgun ammo (red)",
+				"pickup": true
 			}, {
 				"id": 340,
-				"name": "Shotgun ammo (blue)"
+				"name": "Shotgun ammo (blue)",
+				"pickup": true
 			}, {
 				"id": 341,
-				"name": "Grappling Gun"
+				"name": "Grappling Gun",
+				"pickup": true
 			}, {
 				"id": 342,
-				"name": "Grappling Ammo"
+				"name": "Grappling Ammo",
+				"pickup": true
 			}, {
 				"id": 345,
-				"name": "HK"
+				"name": "HK",
+				"pickup": true
 			}, {
 				"id": 346,
-				"name": "HK Ammo"
+				"name": "HK Ammo",
+				"pickup": true
 			}, {
 				"id": 347,
-				"name": "Revolver"
+				"name": "Revolver",
+				"pickup": true
 			}, {
 				"id": 348,
-				"name": "Revolver ammo"
+				"name": "Revolver ammo",
+				"pickup": true
 			},  {
 				"id": 349,
-				"name": "Large medipack"
+				"name": "Large medipack",
+				"pickup": true
 			}, {
 				"id": 350,
-				"name": "Small medipack"
+				"name": "Small medipack",
+				"pickup": true
 			}, {
 				"id": 351,
-				"name": "Lasersight"
+				"name": "Lasersight",
+				"pickup": true
 			}, {
 				"id": 354,
-				"name": "Flare"
+				"name": "Flare",
+				"pickup": true
 			}, {
 				"id": 355,
-				"name": "Flares"
+				"name": "Flares",
+				"pickup": true
 			}, {
 				"id": 356,
 				"name": "Compass"

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -2504,40 +2504,52 @@
 				"name": "Element Puzzle"
 			}, {
 				"id": 175,
-				"name": "Puzzle 1"
+				"name": "Puzzle 1",
+				"pickup": true
 			}, {
 				"id": 176,
-				"name": "Puzzle 2"
+				"name": "Puzzle 2",
+				"pickup": true
 			}, {
 				"id": 177,
-				"name": "Puzzle 3"
+				"name": "Puzzle 3",
+				"pickup": true
 			}, {
 				"id": 178,
-				"name": "Puzzle 4"
+				"name": "Puzzle 4",
+				"pickup": true
 			}, {
 				"id": 179,
-				"name": "Puzzle 5"
+				"name": "Puzzle 5",
+				"pickup": true
 			}, {
 				"id": 180,
-				"name": "Puzzle 6"
+				"name": "Puzzle 6",
+				"pickup": true
 			}, {
 				"id": 181,
-				"name": "Puzzle 7"
+				"name": "Puzzle 7",
+				"pickup": true
 			}, {
 				"id": 182,
-				"name": "Puzzle 8"
+				"name": "Puzzle 8",
+				"pickup": true
 			}, {
 				"id": 183,
-				"name": "Puzzle 9"
+				"name": "Puzzle 9",
+				"pickup": true
 			}, {
 				"id": 184,
-				"name": "Puzzle 10"
+				"name": "Puzzle 10",
+				"pickup": true
 			}, {
 				"id": 185,
-				"name": "Puzzle 11"
+				"name": "Puzzle 11",
+				"pickup": true
 			}, {
 				"id": 186,
-				"name": "Puzzle 12"
+				"name": "Puzzle 12",
+				"pickup": true
 			}, {
 				"id": 187,
 				"name": "Puzzle 1 Combo 1"
@@ -2582,40 +2594,52 @@
 				"name": "Puzzle 8 Combo 2"
 			}, {
 				"id": 203,
-				"name": "Key 1"
+				"name": "Key 1",
+				"pickup": true
 			}, {
 				"id": 204,
-				"name": "Key 2"
+				"name": "Key 2",
+				"pickup": true
 			}, {
 				"id": 205,
-				"name": "Key 3"
+				"name": "Key 3",
+				"pickup": true
 			}, {
 				"id": 206,
-				"name": "Key 4"
+				"name": "Key 4",
+				"pickup": true
 			}, {
 				"id": 207,
-				"name": "Key 5"
+				"name": "Key 5",
+				"pickup": true
 			}, {
 				"id": 208,
-				"name": "Key 6"
+				"name": "Key 6",
+				"pickup": true
 			}, {
 				"id": 209,
-				"name": "Key 7"
+				"name": "Key 7",
+				"pickup": true
 			}, {
 				"id": 210,
-				"name": "Key 8"
+				"name": "Key 8",
+				"pickup": true
 			}, {
 				"id": 211,
-				"name": "Key 9"
+				"name": "Key 9",
+				"pickup": true
 			}, {
 				"id": 212,
-				"name": "Key 10"
+				"name": "Key 10",
+				"pickup": true
 			}, {
 				"id": 213,
-				"name": "Key 11"
+				"name": "Key 11",
+				"pickup": true
 			}, {
 				"id": 214,
-				"name": "Key 12"
+				"name": "Key 12",
+				"pickup": true
 			}, {
 				"id": 231,
 				"name": "Item 1"
@@ -2633,10 +2657,12 @@
 				"name": "Examine 3"
 			}, {
 				"id": 246,
-				"name": "Crowbar"
+				"name": "Crowbar",
+				"pickup": true
 			}, {
 				"id": 247,
-				"name": "Torch"
+				"name": "Torch",
+				"pickup": true
 			}, {
 				"id": 249,
 				"name": "Winding Key"
@@ -2855,67 +2881,88 @@
 				"name": "Plinth"
 			}, {
 				"id": 349,
-				"name": "Pistols"
+				"name": "Pistols",
+				"pickup": true
 			}, {
 				"id": 350,
-				"name": "Pistol Ammo"
+				"name": "Pistol Ammo",
+				"pickup": true
 			}, {
 				"id": 351,
-				"name": "Uzis"
+				"name": "Uzis",
+				"pickup": true
 			}, {
 				"id": 352,
-				"name": "Uzi Ammo"
+				"name": "Uzi Ammo",
+				"pickup": true
 			}, {
 				"id": 353,
-				"name": "Shotgun"
+				"name": "Shotgun",
+				"pickup": true
 			}, {
 				"id": 354,
-				"name": "Shotgun ammo (red)"
+				"name": "Shotgun ammo (red)",
+				"pickup": true
 			}, {
 				"id": 355,
-				"name": "Shotgun ammo (blue)"
+				"name": "Shotgun ammo (blue)",
+				"pickup": true
 			}, {
 				"id": 356,
-				"name": "Crossbow"
+				"name": "Crossbow",
+				"pickup": true
 			}, {
 				"id": 357,
-				"name": "Bolts"
+				"name": "Bolts",
+				"pickup": true
 			}, {
 				"id": 358,
-				"name": "Bolts (poison)"
+				"name": "Bolts (poison)",
+				"pickup": true
 			}, {
 				"id": 359,
-				"name": "Bolts (explosive)"
+				"name": "Bolts (explosive)",
+				"pickup": true
 			}, {
 				"id": 361,
-				"name": "Grenade Launcher"
+				"name": "Grenade Launcher",
+				"pickup": true
 			}, {
 				"id": 362,
-				"name": "Grenades"
+				"name": "Grenades",
+				"pickup": true
 			}, {
 				"id": 363,
-				"name": "Grenades (super)"
+				"name": "Grenades (super)",
+				"pickup": true
 			}, {
 				"id": 364,
-				"name": "Grenades (flash)"
+				"name": "Grenades (flash)",
+				"pickup": true
 			}, {
 				"id": 368,
-				"name": "Large medipack"
+				"name": "Large medipack",
+				"pickup": true
 			}, {
 				"id": 366,
-				"name": "Revolver"
+				"name": "Revolver",
+				"pickup": true
 			}, {
 				"id": 367,
-				"name": "Revolver ammo"
+				"name": "Revolver ammo",
+				"pickup": true
 			}, {
 				"id": 369,
-				"name": "Small medipack"
+				"name": "Small medipack",
+				"pickup": true
 			}, {
 				"id": 370,
-				"name": "Lasersight"
+				"name": "Lasersight",
+				"pickup": true
 			}, {
 				"id": 373,
-				"name": "Flares"
+				"name": "Flares",
+				"pickup": true
 			}, {
 				"id": 375,
 				"name": "Compass"

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -1,4 +1,5 @@
 #include "SettingsLoader.h"
+#include <trview.common/Json.h>
 
 namespace trview
 {
@@ -15,15 +16,6 @@ namespace trview
                 }
             }
         };
-
-        template <typename T>
-        void read_setting(const nlohmann::json& json, T& destination, const std::string& attribute_name)
-        {
-            if (json.count(attribute_name) != 0)
-            {
-                destination = json[attribute_name].get<T>();
-            }
-        }
     }
 
     UserSettings SettingsLoader::load_user_settings() const
@@ -51,20 +43,20 @@ namespace trview
             nlohmann::json json;
             file >> json;
 
-            read_setting(json, settings.camera_sensitivity, "camera");
-            read_setting(json, settings.camera_movement_speed, "movement");
-            read_setting(json, settings.vsync, "vsync");
-            read_setting(json, settings.go_to_lara, "gotolara");
-            read_setting(json, settings.invert_map_controls, "invertmapcontrols");
-            read_setting(json, settings.items_startup, "itemsstartup");
-            read_setting(json, settings.triggers_startup, "triggersstartup");
-            read_setting(json, settings.auto_orbit, "autoorbit");
-            read_setting(json, settings.recent_files, "recent");
-            read_setting(json, settings.invert_vertical_pan, "invertverticalpan");
-            read_setting(json, settings.background_colour, "background");
-            read_setting(json, settings.rooms_startup, "roomsstartup");
-            read_setting(json, settings.camera_acceleration, "cameraacceleration");
-            read_setting(json, settings.camera_acceleration_rate, "cameraaccelerationrate");
+            read_attribute(json, settings.camera_sensitivity, "camera");
+            read_attribute(json, settings.camera_movement_speed, "movement");
+            read_attribute(json, settings.vsync, "vsync");
+            read_attribute(json, settings.go_to_lara, "gotolara");
+            read_attribute(json, settings.invert_map_controls, "invertmapcontrols");
+            read_attribute(json, settings.items_startup, "itemsstartup");
+            read_attribute(json, settings.triggers_startup, "triggersstartup");
+            read_attribute(json, settings.auto_orbit, "autoorbit");
+            read_attribute(json, settings.recent_files, "recent");
+            read_attribute(json, settings.invert_vertical_pan, "invertverticalpan");
+            read_attribute(json, settings.background_colour, "background");
+            read_attribute(json, settings.rooms_startup, "roomsstartup");
+            read_attribute(json, settings.camera_acceleration, "cameraacceleration");
+            read_attribute(json, settings.camera_acceleration_rate, "cameraaccelerationrate");
         }
         catch (...)
         {

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -46,6 +46,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Elements\ITypeNameLookup.cpp" />
     <ClCompile Include="Elements\ILevel.cpp" />
     <ClCompile Include="Elements\Level.cpp" />
+    <ClCompile Include="Elements\PickFilter.cpp" />
     <ClCompile Include="Elements\Room.cpp" />
     <ClCompile Include="Elements\Sector.cpp" />
     <ClCompile Include="Elements\StaticMesh.cpp" />
@@ -162,6 +163,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Elements\ITrigger.h" />
     <ClInclude Include="Elements\ITypeNameLookup.h" />
     <ClInclude Include="Elements\Level.h" />
+    <ClInclude Include="Elements\PickFilter.h" />
     <ClInclude Include="Elements\Room.h" />
     <ClInclude Include="Elements\RoomInfo.h" />
     <ClInclude Include="Elements\Sector.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -311,10 +311,10 @@
       <Filter>Elements</Filter>
     </ClCompile>
     <ClCompile Include="Elements\ITypeNameLookup.cpp">
-      <Filter>Elements\TypeLookup</Filter>
+      <Filter>Elements</Filter>
     </ClCompile>
     <ClCompile Include="Elements\TypeNameLookup.cpp">
-      <Filter>Elements\TypeLookup</Filter>
+      <Filter>Elements</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -807,10 +807,10 @@
       <Filter>Mocks\Camera</Filter>
     </ClInclude>
     <ClInclude Include="Elements\ITypeNameLookup.h">
-      <Filter>Elements\TypeLookup</Filter>
+      <Filter>Elements</Filter>
     </ClInclude>
     <ClInclude Include="Elements\TypeNameLookup.h">
-      <Filter>Elements\TypeLookup</Filter>
+      <Filter>Elements</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -888,9 +888,6 @@
     </Filter>
     <Filter Include="Mocks\Camera">
       <UniqueIdentifier>{77a62a69-05bf-4350-ba5d-849404977f4b}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Elements\TypeLookup">
-      <UniqueIdentifier>{84e7cebe-d753-4454-9ddf-44b41fdac0a8}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -316,6 +316,9 @@
     <ClCompile Include="Elements\ISector.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\PickFilter.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -811,6 +814,9 @@
     </ClInclude>
     <ClInclude Include="Mocks\Camera\ICamera.h">
       <Filter>Mocks\Camera</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\PickFilter.h">
+      <Filter>Elements</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -175,6 +175,12 @@
     <ClCompile Include="Graphics\MeshStorage.cpp">
       <Filter>Graphics</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\TypeNameLookup.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
+    <ClCompile Include="Elements\ITypeNameLookup.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
     <ClCompile Include="Menus\MenuDetector.cpp">
       <Filter>Menus</Filter>
     </ClCompile>
@@ -308,12 +314,6 @@
       <Filter>Elements</Filter>
     </ClCompile>
     <ClCompile Include="Elements\ISector.cpp">
-      <Filter>Elements</Filter>
-    </ClCompile>
-    <ClCompile Include="Elements\ITypeNameLookup.cpp">
-      <Filter>Elements</Filter>
-    </ClCompile>
-    <ClCompile Include="Elements\TypeNameLookup.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
   </ItemGroup>
@@ -509,6 +509,12 @@
     </ClInclude>
     <ClInclude Include="Graphics\MeshStorage.h">
       <Filter>Graphics</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\TypeNameLookup.h">
+      <Filter>Elements</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\ITypeNameLookup.h">
+      <Filter>Elements</Filter>
     </ClInclude>
     <ClInclude Include="Menus\MenuDetector.h">
       <Filter>Menus</Filter>
@@ -805,12 +811,6 @@
     </ClInclude>
     <ClInclude Include="Mocks\Camera\ICamera.h">
       <Filter>Mocks\Camera</Filter>
-    </ClInclude>
-    <ClInclude Include="Elements\ITypeNameLookup.h">
-      <Filter>Elements</Filter>
-    </ClInclude>
-    <ClInclude Include="Elements\TypeNameLookup.h">
-      <Filter>Elements</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -175,12 +175,6 @@
     <ClCompile Include="Graphics\MeshStorage.cpp">
       <Filter>Graphics</Filter>
     </ClCompile>
-    <ClCompile Include="Elements\TypeNameLookup.cpp">
-      <Filter>Elements</Filter>
-    </ClCompile>
-    <ClCompile Include="Elements\ITypeNameLookup.cpp">
-      <Filter>Elements</Filter>
-    </ClCompile>
     <ClCompile Include="Menus\MenuDetector.cpp">
       <Filter>Menus</Filter>
     </ClCompile>
@@ -315,6 +309,12 @@
     </ClCompile>
     <ClCompile Include="Elements\ISector.cpp">
       <Filter>Elements</Filter>
+    </ClCompile>
+    <ClCompile Include="Elements\ITypeNameLookup.cpp">
+      <Filter>Elements\TypeLookup</Filter>
+    </ClCompile>
+    <ClCompile Include="Elements\TypeNameLookup.cpp">
+      <Filter>Elements\TypeLookup</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -509,12 +509,6 @@
     </ClInclude>
     <ClInclude Include="Graphics\MeshStorage.h">
       <Filter>Graphics</Filter>
-    </ClInclude>
-    <ClInclude Include="Elements\TypeNameLookup.h">
-      <Filter>Elements</Filter>
-    </ClInclude>
-    <ClInclude Include="Elements\ITypeNameLookup.h">
-      <Filter>Elements</Filter>
     </ClInclude>
     <ClInclude Include="Menus\MenuDetector.h">
       <Filter>Menus</Filter>
@@ -812,6 +806,12 @@
     <ClInclude Include="Mocks\Camera\ICamera.h">
       <Filter>Mocks\Camera</Filter>
     </ClInclude>
+    <ClInclude Include="Elements\ITypeNameLookup.h">
+      <Filter>Elements\TypeLookup</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\TypeNameLookup.h">
+      <Filter>Elements\TypeLookup</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">
@@ -888,6 +888,9 @@
     </Filter>
     <Filter Include="Mocks\Camera">
       <UniqueIdentifier>{77a62a69-05bf-4350-ba5d-849404977f4b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Elements\TypeLookup">
+      <UniqueIdentifier>{84e7cebe-d753-4454-9ddf-44b41fdac0a8}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/trview.common/Algorithms.h
+++ b/trview.common/Algorithms.h
@@ -7,6 +7,12 @@ namespace trview
 
     template <typename T1, typename T2, typename... Args>
     bool equals_any(T1&& value, T2&& other, Args&&... set);
+
+    template <typename T1, typename T2>
+    bool has_any(T1&& value, T2&& other);
+
+    template <typename T1, typename T2, typename... Args>
+    bool has_any(T1&& value, T2&& other, Args&&... set);
 }
 
 #include "Algorithms.hpp"

--- a/trview.common/Algorithms.h
+++ b/trview.common/Algorithms.h
@@ -7,12 +7,6 @@ namespace trview
 
     template <typename T1, typename T2, typename... Args>
     bool equals_any(T1&& value, T2&& other, Args&&... set);
-
-    template <typename T1, typename T2>
-    bool has_any(T1&& value, T2&& other);
-
-    template <typename T1, typename T2, typename... Args>
-    bool has_any(T1&& value, T2&& other, Args&&... set);
 }
 
 #include "Algorithms.hpp"

--- a/trview.common/Algorithms.hpp
+++ b/trview.common/Algorithms.hpp
@@ -13,16 +13,4 @@ namespace trview
     {
         return equals_any(value, other) || equals_any(value, set...);
     }
-
-    template <typename T1, typename T2>
-    bool has_any(T1&& value, T2&& other)
-    {
-        return value & other;
-    }
-
-    template <typename T1, typename T2, typename... Args>
-    bool has_any(T1&& value, T2&& other, Args&&... set)
-    {
-        return has_any(value, other) || has_any(value, set...);
-    }
 }

--- a/trview.common/Algorithms.hpp
+++ b/trview.common/Algorithms.hpp
@@ -13,4 +13,16 @@ namespace trview
     {
         return equals_any(value, other) || equals_any(value, set...);
     }
+
+    template <typename T1, typename T2>
+    bool has_any(T1&& value, T2&& other)
+    {
+        return value & other;
+    }
+
+    template <typename T1, typename T2, typename... Args>
+    bool has_any(T1&& value, T2&& other, Args&&... set)
+    {
+        return has_any(value, other) || has_any(value, set...);
+    }
 }

--- a/trview.common/Json.h
+++ b/trview.common/Json.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#pragma warning(push)
+#pragma warning(disable : 4127)
+#include <external/nlohmann/json.hpp>
+#pragma warning(pop)
+
+namespace trview
+{
+    template <typename T>
+    T read_attribute(const nlohmann::json& json, const std::string& attribute_name);
+
+    template <typename T>
+    void read_attribute(const nlohmann::json& json, T& destination, const std::string& attribute_name);
+}
+
+#include "Json.hpp"

--- a/trview.common/Json.hpp
+++ b/trview.common/Json.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace trview
+{
+    template <typename T>
+    T read_attribute(const nlohmann::json& json, const std::string& attribute_name)
+    {
+        if (json.count(attribute_name) != 0)
+        {
+            return json[attribute_name].get<T>();
+        }
+        return {};
+    }
+
+    template <typename T>
+    void read_attribute(const nlohmann::json& json, T& destination, const std::string& attribute_name)
+    {
+        if (json.count(attribute_name) != 0)
+        {
+            destination = json[attribute_name].get<T>();
+        }
+    }
+}

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -24,6 +24,8 @@
     <ClInclude Include="Colour.h" />
     <ClInclude Include="Event.h" />
     <ClInclude Include="FileLoader.h" />
+    <ClInclude Include="Json.h" />
+    <ClInclude Include="Json.hpp" />
     <ClInclude Include="MessageHandler.h" />
     <ClInclude Include="Mocks\Windows\IClipboard.h" />
     <ClInclude Include="Mocks\Windows\IShortcuts.h" />
@@ -137,7 +139,7 @@
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -159,7 +161,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -183,7 +185,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -209,7 +211,7 @@
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/trview.common/trview.common.vcxproj.filters
+++ b/trview.common/trview.common.vcxproj.filters
@@ -38,6 +38,8 @@
     <ClInclude Include="Mocks\Windows\IClipboard.h">
       <Filter>Mocks\Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Json.h" />
+    <ClInclude Include="Json.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FileLoader.cpp" />


### PR DESCRIPTION
Use what should be an accurate version of pickup height adjustment based on the OCB value.
Also does a secondary downwards raycast to find the point where the item should be placed after it has been adjusted upwards, as I couldn't get the formula to work consistently otherwise.
Mark all pickup items as pickups in the type names file.
Add tests.
Closes #766 