### PR TITLE
Warn if route has unsaved changes when switching levels or closing the application

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -288,3 +288,13 @@ TEST(Application, FileNotOpenedWhenNotSpecified)
     EXPECT_CALL(viewer, open).Times(0);
     auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_viewer(std::move(viewer_ptr)).build();
 }
+
+TEST(Application, DialogShownOnCloseWithUnsavedRoute)
+{
+    FAIL();
+}
+
+TEST(Application, DialogShownOnOpenWithUnsavedRoute)
+{
+    FAIL();
+}

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -30,49 +30,116 @@ namespace
 {
     Event<> shortcut_handler;
 
-    auto register_test_module(std::unique_ptr<IUpdateChecker> update_checker = nullptr, std::unique_ptr<ISettingsLoader> settings_loader = nullptr, std::unique_ptr<IFileDropper> file_dropper = nullptr,
-        std::unique_ptr<trlevel::ILevelLoader> level_loader = nullptr, std::unique_ptr<ILevelSwitcher> level_switcher = nullptr, std::unique_ptr<IRecentFiles> recent_files = nullptr,
-        std::unique_ptr<IViewer> viewer = nullptr, std::unique_ptr<IRoute> route = nullptr, std::unique_ptr<IItemsWindowManager> items_window_manager = nullptr, std::unique_ptr<ITriggersWindowManager> triggers_window_manager = nullptr,
-        std::unique_ptr<IRouteWindowManager> route_window_manager = nullptr, std::unique_ptr<IRoomsWindowManager> rooms_window_manager = nullptr,
-        std::shared_ptr<IStartupOptions> startup_options = nullptr, std::unique_ptr<IDialogs> dialogs = nullptr)
+    auto register_test_module()
     {
-        choose_mock<MockUpdateChecker>(update_checker);
-        choose_mock<MockSettingsLoader>(settings_loader);
-        choose_mock<MockFileDropper>(file_dropper);
-        choose_mock<MockLevelLoader>(level_loader);
-        choose_mock<MockLevelSwitcher>(level_switcher);
-        choose_mock<MockRecentFiles>(recent_files);
-        choose_mock<MockViewer>(viewer);
-        choose_mock<MockRoute>(route);
-        choose_mock<MockItemsWindowManager>(items_window_manager);
-        choose_mock<MockTriggersWindowManager>(triggers_window_manager);
-        choose_mock<MockRouteWindowManager>(route_window_manager);
-        choose_mock<MockRoomsWindowManager>(rooms_window_manager);
-        choose_mock<MockStartupOptions>(startup_options);
-        choose_mock<MockDialogs>(dialogs);
+        struct test_module
+        {
+            Window window{ create_test_window(L"ApplicationTests") };
+            std::unique_ptr<IUpdateChecker> update_checker{ std::make_unique<MockUpdateChecker>() };
+            std::unique_ptr<ISettingsLoader> settings_loader{ std::make_unique<MockSettingsLoader>() };
+            std::unique_ptr<IFileDropper> file_dropper{ std::make_unique<MockFileDropper>() };
+            std::unique_ptr<trlevel::ILevelLoader> level_loader{ std::make_unique<MockLevelLoader>() };
+            std::unique_ptr<ILevelSwitcher> level_switcher{ std::make_unique<MockLevelSwitcher>() };
+            std::unique_ptr<IRecentFiles> recent_files{ std::make_unique<MockRecentFiles>() };
+            std::unique_ptr<IViewer> viewer{ std::make_unique<MockViewer>() };
+            IRoute::Source route_source{ [](auto&&...) { return std::make_unique<MockRoute>(); } };
+            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<MockShortcuts>() };
+            std::unique_ptr<IItemsWindowManager> items_window_manager{ std::make_unique<MockItemsWindowManager>() };
+            std::unique_ptr<ITriggersWindowManager> triggers_window_manager{ std::make_unique<MockTriggersWindowManager>() };
+            std::unique_ptr<IRouteWindowManager> route_window_manager{ std::make_unique<MockRouteWindowManager>() };
+            std::unique_ptr<IRoomsWindowManager> rooms_window_manager{ std::make_unique<MockRoomsWindowManager>() };
+            ILevel::Source level_source{ [](auto&&...) { return std::make_unique<trview::mocks::MockLevel>(); } };
+            std::shared_ptr<IStartupOptions> startup_options{ std::make_shared<MockStartupOptions>() };
+            std::unique_ptr<IDialogs> dialogs{ std::make_unique<MockDialogs>() };
 
-        auto shortcuts = std::make_shared<MockShortcuts>();
-        EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
+            std::unique_ptr<Application> build()
+            {
+                EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
+                return std::make_unique<Application>(window, std::move(update_checker), std::move(settings_loader), std::move(file_dropper),
+                    std::move(level_loader), std::move(level_switcher), std::move(recent_files), std::move(viewer), route_source, shortcuts,
+                    std::move(items_window_manager), std::move(triggers_window_manager), std::move(route_window_manager), std::move(rooms_window_manager),
+                    level_source, startup_options, std::move(dialogs));
+            }
 
-        return di::make_injector(
-            di::bind<Window>.to(create_test_window(L"ApplicationTests")),
-            di::bind<IUpdateChecker>.to([&](auto&&) { return std::move(update_checker); }),
-            di::bind<ISettingsLoader>.to([&](auto&&) { return std::move(settings_loader); }),
-            di::bind<IFileDropper>.to([&](auto&&) { return std::move(file_dropper); }),
-            di::bind<trlevel::ILevelLoader>.to([&](auto&&) { return std::move(level_loader); }),
-            di::bind<ILevelSwitcher>.to([&](auto&&) { return std::move(level_switcher); }),
-            di::bind<IRecentFiles>.to([&](auto&&) { return std::move(recent_files); }),
-            di::bind<IViewer>.to([&](auto&&) { return std::move(viewer); }),
-            di::bind<IRoute::Source>.to([&](auto&&) { return [&](auto&&...) { return std::move(route); }; }),
-            di::bind<IShortcuts>.to(shortcuts),
-            di::bind<IItemsWindowManager>.to([&](auto&&) { return std::move(items_window_manager); }),
-            di::bind<ITriggersWindowManager>.to([&](auto&&) { return std::move(triggers_window_manager); }),
-            di::bind<IRouteWindowManager>.to([&](auto&&) { return std::move(route_window_manager); }),
-            di::bind<IRoomsWindowManager>.to([&](auto&&) { return std::move(rooms_window_manager); }),
-            di::bind<ILevel::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<trview::mocks::MockLevel>(); }; }),
-            di::bind<IStartupOptions>.to(startup_options),
-            di::bind<IDialogs>.to([&](auto&&) { return std::move(dialogs); })
-        ).create<std::unique_ptr<Application>>();
+            test_module& with_file_dropper(std::unique_ptr<IFileDropper> file_dropper)
+            {
+                this->file_dropper = std::move(file_dropper);
+                return *this;
+            }
+
+            test_module& with_items_window_manager(std::unique_ptr<IItemsWindowManager> items_window_manager)
+            {
+                this->items_window_manager = std::move(items_window_manager);
+                return *this;
+            }
+
+            test_module& with_level_loader(std::unique_ptr<trlevel::ILevelLoader> level_loader)
+            {
+                this->level_loader = std::move(level_loader);
+                return *this;
+            }
+
+            test_module& with_level_switcher(std::unique_ptr<ILevelSwitcher> level_switcher)
+            {
+                this->level_switcher = std::move(level_switcher);
+                return *this;
+            }
+
+            test_module& with_recent_files(std::unique_ptr<IRecentFiles> recent_files)
+            {
+                this->recent_files = std::move(recent_files);
+                return *this;
+            }
+
+            test_module& with_rooms_window_manager(std::unique_ptr<IRoomsWindowManager> rooms_window_manager)
+            {
+                this->rooms_window_manager = std::move(rooms_window_manager);
+                return *this;
+            }
+
+            test_module& with_route_source(IRoute::Source route_source)
+            {
+                this->route_source = route_source;
+                return *this;
+            }
+
+            test_module& with_route_window_manager(std::unique_ptr<IRouteWindowManager> route_window_manager)
+            {
+                this->route_window_manager = std::move(route_window_manager);
+                return *this;
+            }
+
+            test_module& with_settings_loader(std::unique_ptr<ISettingsLoader> settings_loader)
+            {
+                this->settings_loader = std::move(settings_loader);
+                return *this;
+            }
+
+            test_module& with_startup_options(std::shared_ptr<IStartupOptions> startup_options)
+            {
+                this->startup_options = startup_options;
+                return *this;
+            }
+
+            test_module& with_triggers_window_manager(std::unique_ptr<ITriggersWindowManager> triggers_window_manager)
+            {
+                this->triggers_window_manager = std::move(triggers_window_manager);
+                return *this;
+            }
+
+            test_module& with_update_checker(std::unique_ptr<IUpdateChecker> update_checker)
+            {
+                this->update_checker = std::move(update_checker);
+                return *this;
+            }
+
+            test_module& with_viewer(std::unique_ptr<IViewer> viewer)
+            {
+                this->viewer = std::move(viewer);
+                return *this;
+            }
+        };
+        return test_module{};
     }
 }
 
@@ -80,7 +147,7 @@ TEST(Application, ChecksForUpdates)
 {
     auto [update_checker_ptr, update_checker] = create_mock<MockUpdateChecker>();
     EXPECT_CALL(update_checker, check_for_updates).Times(1);
-    auto application = register_test_module(std::move(update_checker_ptr));
+    auto application = register_test_module().with_update_checker(std::move(update_checker_ptr)).build();
 }
 
 TEST(Application, SettingsLoadedAndSaved)
@@ -88,7 +155,7 @@ TEST(Application, SettingsLoadedAndSaved)
     auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
     EXPECT_CALL(settings_loader, load_user_settings).Times(1);
     EXPECT_CALL(settings_loader, save_user_settings).Times(1);
-    auto application = register_test_module(nullptr, std::move(settings_loader_ptr));
+    auto application = register_test_module().with_settings_loader(std::move(settings_loader_ptr)).build();
 }
 
 TEST(Application, FileDropperOpensFile)
@@ -96,7 +163,7 @@ TEST(Application, FileDropperOpensFile)
     auto [file_dropper_ptr, file_dropper] = create_mock<MockFileDropper>();
     auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
     EXPECT_CALL(level_loader, load_level("test_path.tr2")).Times(1).WillRepeatedly(Throw(std::exception()));
-    auto application = register_test_module(nullptr, nullptr, std::move(file_dropper_ptr), std::move(level_loader_ptr));
+    auto application = register_test_module().with_file_dropper(std::move(file_dropper_ptr)).with_level_loader(std::move(level_loader_ptr)).build();
     file_dropper.on_file_dropped("test_path.tr2");
 }
 
@@ -105,7 +172,7 @@ TEST(Application, LevelLoadedOnSwitchLevel)
     auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
     auto [level_switcher_ptr, level_switcher] = create_mock<MockLevelSwitcher>();
     EXPECT_CALL(level_loader, load_level("test_path.tr2")).Times(1).WillRepeatedly(Throw(std::exception()));
-    auto application = register_test_module(nullptr, nullptr, nullptr, std::move(level_loader_ptr), std::move(level_switcher_ptr));
+    auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_level_switcher(std::move(level_switcher_ptr)).build();
     level_switcher.on_switch_level("test_path.tr2");
 }
 
@@ -114,7 +181,7 @@ TEST(Application, LevelLoadedOnRecentFileOpen)
     auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
     auto [recent_files_ptr, recent_files] = create_mock<MockRecentFiles>();
     EXPECT_CALL(level_loader, load_level("test_path.tr2")).Times(1).WillRepeatedly(Throw(std::exception()));
-    auto application = register_test_module(nullptr, nullptr, nullptr, std::move(level_loader_ptr), nullptr, std::move(recent_files_ptr));
+    auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_recent_files(std::move(recent_files_ptr)).build();
     recent_files.on_file_open("test_path.tr2");
 }
 
@@ -125,7 +192,7 @@ TEST(Application, RecentFilesUpdatedOnFileOpen)
     EXPECT_CALL(recent_files, set_recent_files(std::list<std::string>{})).Times(1);
     EXPECT_CALL(recent_files, set_recent_files(std::list<std::string>{"test_path.tr2"})).Times(1);
     EXPECT_CALL(level_loader, load_level("test_path.tr2")).WillOnce(Return(ByMove(std::make_unique<trlevel::mocks::MockLevel>())));
-    auto application = register_test_module(nullptr, nullptr, nullptr, std::move(level_loader_ptr), nullptr, std::move(recent_files_ptr));
+    auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_recent_files(std::move(recent_files_ptr)).build();
     application->open("test_path.tr2");
 }
 
@@ -136,7 +203,7 @@ TEST(Application, FileOpenedInViewer)
     auto [level_ptr, level] = create_mock<trlevel::mocks::MockLevel>();
     EXPECT_CALL(level_loader, load_level("test_path.tr2")).WillOnce(Return(ByMove(std::move(level_ptr))));
     EXPECT_CALL(viewer, open(NotNull())).Times(1);
-    auto application = register_test_module(nullptr, nullptr, nullptr, std::move(level_loader_ptr), nullptr, nullptr, std::move(viewer_ptr));
+    auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_viewer(std::move(viewer_ptr)).build();
     application->open("test_path.tr2");
 }
 
@@ -150,6 +217,7 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
     auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
     auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
     auto [route_ptr, route] = create_mock<MockRoute>();
+    auto route_ptr_actual = std::move(route_ptr);
 
     std::vector<std::string> events;
 
@@ -170,8 +238,15 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
     EXPECT_CALL(route, set_unsaved(false)).Times(1);
     EXPECT_CALL(viewer, open(NotNull())).Times(1).WillOnce([&](auto) { events.push_back("viewer"); });
 
-    auto application = register_test_module(nullptr, nullptr, nullptr, std::move(level_loader_ptr), nullptr, nullptr, std::move(viewer_ptr), std::move(route_ptr),
-        std::move(items_window_manager_ptr), std::move(triggers_window_manager_ptr), std::move(route_window_manager_ptr), std::move(rooms_window_manager_ptr));
+    auto application = register_test_module()
+        .with_level_loader(std::move(level_loader_ptr))
+        .with_viewer(std::move(viewer_ptr))
+        .with_route_source([&](auto&&...) {return std::move(route_ptr_actual); })
+        .with_items_window_manager(std::move(items_window_manager_ptr))
+        .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
+        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
+        .build();
     application->open("test_path.tr2");
 
     ASSERT_EQ(events.size(), 13);
@@ -183,7 +258,7 @@ TEST(Application, PropagatesSettingsWhenUpdated)
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
     EXPECT_CALL(viewer, set_settings).Times(2);
 
-    auto application = register_test_module(nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, std::move(viewer_ptr));
+    auto application = register_test_module().with_viewer(std::move(viewer_ptr)).build();
     viewer.on_settings({});
 }
 
@@ -191,7 +266,7 @@ TEST(Application, SavesSettingsOnShutdown)
 {
     auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
     EXPECT_CALL(settings_loader, save_user_settings).Times(1);
-    auto application = register_test_module(nullptr, std::move(settings_loader_ptr));
+    auto application = register_test_module().with_settings_loader(std::move(settings_loader_ptr)).build();
 }
 
 TEST(Application, FileOpenedFromCommandLine)
@@ -202,8 +277,7 @@ TEST(Application, FileOpenedFromCommandLine)
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
     EXPECT_CALL(level_loader, load_level("test.tr2")).Times(1);
     EXPECT_CALL(viewer, open).Times(1);
-    auto application = register_test_module(nullptr, nullptr, nullptr, std::move(level_loader_ptr), nullptr, nullptr, std::move(viewer_ptr),
-        nullptr, nullptr, nullptr, nullptr, nullptr, startup_options);
+    auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_viewer(std::move(viewer_ptr)).with_startup_options(startup_options).build();
 }
 
 TEST(Application, FileNotOpenedWhenNotSpecified)
@@ -212,5 +286,5 @@ TEST(Application, FileNotOpenedWhenNotSpecified)
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
     EXPECT_CALL(level_loader, load_level("test.tr2")).Times(0);
     EXPECT_CALL(viewer, open).Times(0);
-    auto application = register_test_module(nullptr, nullptr, nullptr, std::move(level_loader_ptr), nullptr, nullptr, std::move(viewer_ptr));
+    auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_viewer(std::move(viewer_ptr)).build();
 }

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -16,7 +16,6 @@
 #include <trview.common/Mocks/Windows/IDialogs.h>
 #include <trlevel/Mocks/ILevelLoader.h>
 #include <trlevel/Mocks/ILevel.h>
-#include <external/boost/di.hpp>
 
 using namespace trview;
 using namespace trview::tests;
@@ -24,7 +23,6 @@ using namespace testing;
 using namespace trview::mocks;
 using namespace trlevel::mocks;
 using testing::_;
-using namespace boost;
 
 namespace
 {

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -164,3 +164,24 @@ TEST(RouteWindow, AddingWaypointNotesMarksRouteUnsaved)
 
     notes_area->on_text_changed(L"Test");
 }
+
+TEST(RouteWindow, ClearSaveMarksRouteUnsaved)
+{
+    const Vector3 waypoint_pos{ 130, 250, 325 };
+    auto [mesh_ptr, mesh] = create_mock<MockMesh>();
+    Waypoint waypoint(&mesh, waypoint_pos, 0);
+    waypoint.set_save_file({ 0, 1, 2 });
+
+    MockRoute route;
+    EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
+    EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
+    EXPECT_CALL(route, set_unsaved(true)).Times(1);
+
+    auto window = register_test_module().create<std::unique_ptr<RouteWindow>>();
+    window->set_route(&route);
+
+    auto clear_save = window->root_control()->find<ui::Button>(RouteWindow::Names::clear_save);
+    ASSERT_NE(clear_save, nullptr);
+
+    clear_save->on_click();
+}

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -154,7 +154,7 @@ TEST(RouteWindow, AddingWaypointNotesMarksRouteUnsaved)
     MockRoute route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
-    EXPECT_CALL(route, set_unsaved(true)).Times(2);
+    EXPECT_CALL(route, set_unsaved(true)).Times(1);
 
     auto window = register_test_module().create<std::unique_ptr<RouteWindow>>();
     window->set_route(&route);

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -144,3 +144,23 @@ TEST(RouteWindow, RoomPositionValuesCopiedToClipboard)
     ASSERT_NE(cell, nullptr);
     cell->clicked(Point());
 }
+
+TEST(RouteWindow, AddingWaypointNotesMarksRouteUnsaved)
+{
+    const Vector3 waypoint_pos{ 130, 250, 325 };
+    auto [mesh_ptr, mesh] = create_mock<MockMesh>();
+    Waypoint waypoint(&mesh, waypoint_pos, 0);
+
+    MockRoute route;
+    EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
+    EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
+    EXPECT_CALL(route, set_unsaved(true)).Times(2);
+
+    auto window = register_test_module().create<std::unique_ptr<RouteWindow>>();
+    window->set_route(&route);
+
+    auto notes_area = window->root_control()->find<ui::TextArea>(RouteWindow::Names::notes_area);
+    ASSERT_NE(notes_area, nullptr);
+
+    notes_area->on_text_changed(L"Test");
+}

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -1,0 +1,141 @@
+#include <trview.app/Routing/Route.h>
+#include <trview.app/Mocks/Graphics/ISelectionRenderer.h>
+#include <trview.app/Mocks/Geometry/IMesh.h>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace DirectX::SimpleMath;
+
+namespace
+{
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            std::unique_ptr<ISelectionRenderer> selection_renderer = std::make_unique<MockSelectionRenderer>();
+            IMesh::Source mesh_source = [](auto&&...) { return std::make_shared<MockMesh>(); };
+
+            std::unique_ptr<Route> build()
+            {
+                return std::make_unique<Route>(std::move(selection_renderer), mesh_source);
+            }
+        };
+        return test_module{};
+    }
+}
+
+TEST(Route, Add)
+{
+    auto route = register_test_module().build();
+    route->add(Vector3(0, 1, 0), 10);
+    ASSERT_TRUE(route->is_unsaved());
+    ASSERT_EQ(route->waypoints(), 1);
+    auto waypoint = route->waypoint(0);
+    ASSERT_EQ(waypoint.position(), Vector3(0, 1, 0));
+    ASSERT_EQ(waypoint.room(), 10);
+    ASSERT_EQ(waypoint.type(), Waypoint::Type::Position);
+}
+
+TEST(Route, AddSpecificType)
+{
+    auto route = register_test_module().build();
+    route->add(Vector3(0, 1, 0), 10, Waypoint::Type::Trigger, 100);
+    ASSERT_TRUE(route->is_unsaved());
+    ASSERT_EQ(route->waypoints(), 1);
+    auto waypoint = route->waypoint(0);
+    ASSERT_EQ(waypoint.position(), Vector3(0, 1, 0));
+    ASSERT_EQ(waypoint.room(), 10);
+    ASSERT_EQ(waypoint.type(), Waypoint::Type::Trigger);
+    ASSERT_EQ(waypoint.index(), 100);
+}
+
+TEST(Route, Clear)
+{
+    auto route = register_test_module().build();
+    route->add(Vector3::Zero, 0);
+    ASSERT_TRUE(route->is_unsaved());
+    route->set_unsaved(false);
+    route->clear();
+    ASSERT_TRUE(route->is_unsaved());
+}
+
+TEST(Route, ClearAlreadyEmpty)
+{
+    auto route = register_test_module().build();
+    route->clear();
+    ASSERT_FALSE(route->is_unsaved());
+}
+
+TEST(Route, InsertAtPosition)
+{
+    auto route = register_test_module().build();
+    route->add(Vector3::Zero, 0);
+    route->add(Vector3::Zero, 1);
+    route->set_unsaved(false);
+    route->insert(Vector3(0, 1, 0), 2, 1);
+    ASSERT_TRUE(route->is_unsaved());
+    ASSERT_EQ(route->waypoints(), 3);
+    auto waypoint = route->waypoint(1);
+    ASSERT_EQ(waypoint.position(), Vector3(0, 1, 0));
+    ASSERT_EQ(waypoint.room(), 2);
+    ASSERT_EQ(waypoint.type(), Waypoint::Type::Position);
+}
+
+TEST(Route, InsertSpecificTypeAtPosition)
+{
+    auto route = register_test_module().build();
+    route->add(Vector3::Zero, 0);
+    route->add(Vector3::Zero, 1);
+    route->set_unsaved(false);
+    route->insert(Vector3(0, 1, 0), 2, 1, Waypoint::Type::Entity, 100);
+    ASSERT_TRUE(route->is_unsaved());
+    ASSERT_EQ(route->waypoints(), 3);
+    auto waypoint = route->waypoint(1);
+    ASSERT_EQ(waypoint.position(), Vector3(0, 1, 0));
+    ASSERT_EQ(waypoint.room(), 2);
+    ASSERT_EQ(waypoint.type(), Waypoint::Type::Entity);
+    ASSERT_EQ(waypoint.index(), 100);
+}
+
+TEST(Route, Insert)
+{
+    auto route = register_test_module().build();
+    route->add(Vector3::Zero, 0);
+    route->add(Vector3::Zero, 1);
+    route->set_unsaved(false);
+    auto index = route->insert(Vector3(0, 1, 0), 2);
+    ASSERT_EQ(index, 2);
+    ASSERT_TRUE(route->is_unsaved());
+    ASSERT_EQ(route->waypoints(), 3);
+    auto waypoint = route->waypoint(2);
+    ASSERT_EQ(waypoint.position(), Vector3(0, 1, 0));
+    ASSERT_EQ(waypoint.room(), 2);
+    ASSERT_EQ(waypoint.type(), Waypoint::Type::Position);
+}
+
+TEST(Route, IsUnsaved)
+{
+    auto route = register_test_module().build();
+    ASSERT_FALSE(route->is_unsaved());
+    route->set_unsaved(true);
+    ASSERT_TRUE(route->is_unsaved());
+}
+
+TEST(Route, Remove)
+{
+    auto route = register_test_module().build();
+    route->add(Vector3::Zero, 0);
+    ASSERT_EQ(route->waypoints(), 1);
+    route->set_unsaved(false);
+    route->remove(0);
+    ASSERT_TRUE(route->is_unsaved());
+    ASSERT_EQ(route->waypoints(), 0);
+}
+
+TEST(Route, SetColour)
+{
+    auto route = register_test_module().build();
+    route->set_colour(Colour::Red);
+    ASSERT_TRUE(route->is_unsaved());
+    ASSERT_EQ(route->colour(), Colour::Red);
+}

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -103,6 +103,7 @@ TEST(Route, Insert)
     route->add(Vector3::Zero, 0);
     route->add(Vector3::Zero, 1);
     route->set_unsaved(false);
+    route->select_waypoint(1);
     auto index = route->insert(Vector3(0, 1, 0), 2);
     ASSERT_EQ(index, 2);
     ASSERT_TRUE(route->is_unsaved());
@@ -138,4 +139,28 @@ TEST(Route, SetColour)
     route->set_colour(Colour::Red);
     ASSERT_TRUE(route->is_unsaved());
     ASSERT_EQ(route->colour(), Colour::Red);
+}
+
+TEST(Route, SelectedWaypoint)
+{
+    auto route = register_test_module().build();
+    route->add(Vector3::Zero, 0);
+    route->add(Vector3::Zero, 0);
+    route->set_unsaved(false);
+    route->select_waypoint(1);
+    ASSERT_FALSE(route->is_unsaved());
+    ASSERT_EQ(route->selected_waypoint(), 1);
+}
+
+TEST(Route, SelectedWaypointAdjustedByRemove)
+{
+    auto route = register_test_module().build();
+    route->add(Vector3::Zero, 0);
+    route->add(Vector3::Zero, 0);
+    route->set_unsaved(false);
+    route->select_waypoint(1);
+    ASSERT_FALSE(route->is_unsaved());
+    ASSERT_EQ(route->selected_waypoint(), 1);
+    route->remove(1);
+    ASSERT_EQ(route->selected_waypoint(), 0);
 }

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -42,6 +42,7 @@
     <ClCompile Include="RouteWindowTests.cpp" />
     <ClCompile Include="Routing\ActionsTests.cpp" />
     <ClCompile Include="Routing\ActionTests.cpp" />
+    <ClCompile Include="Routing\RouteTests.cpp" />
     <ClCompile Include="SettingsWindowTests.cpp" />
     <ClCompile Include="Settings\StartupOptionsTests.cpp" />
     <ClCompile Include="stdafx.cpp">

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -83,6 +83,9 @@
     <ClCompile Include="Routing\ActionTests.cpp">
       <Filter>Routing</Filter>
     </ClCompile>
+    <ClCompile Include="Routing\RouteTests.cpp">
+      <Filter>Routing</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -170,10 +170,7 @@ namespace trview
         }
         catch (...)
         {
-            if (!is_message_only(window()))
-            {
-                MessageBox(window(), L"Failed to load level", L"Error", MB_OK);
-            }
+            _dialogs->message_box(window(), L"Failed to load level", L"Error", IDialogs::Buttons::OK);
             return;
         }
 
@@ -583,7 +580,7 @@ namespace trview
     {
         if (_route->is_unsaved())
         {
-            return _dialogs->message_box(window(), L"Uh-oh", L"It won't be easy", IDialogs::Buttons::OK_Cancel);
+            return _dialogs->message_box(window(), L"It won't be easy", L"Uh-oh", IDialogs::Buttons::OK_Cancel);
         }
         return true;
     }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -255,6 +255,7 @@ namespace trview
                     {
                         if (should_discard_changes())
                         {
+                            on_closing();
                             DestroyWindow(window());
                         }
                         break;
@@ -266,6 +267,7 @@ namespace trview
             {
                 if (should_discard_changes())
                 {
+                    on_closing();
                     DestroyWindow(window());
                 }
                 return 0;
@@ -580,7 +582,7 @@ namespace trview
     {
         if (_route->is_unsaved())
         {
-            return _dialogs->message_box(window(), L"It won't be easy", L"Uh-oh", IDialogs::Buttons::OK_Cancel);
+            return _dialogs->message_box(window(), L"Route has unsaved changes. Do you want to continue and lose changes?", L"Unsaved Route Changes", IDialogs::Buttons::Yes_No);
         }
         return true;
     }

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -19,6 +19,7 @@
 #include <trview.app/Windows/ITriggersWindowManager.h>
 #include <trview.app/Windows/IViewer.h>
 #include <trview.app/Lua/Lua.h>
+#include <trview.common/Windows/IDialogs.h>
 
 namespace trview
 {
@@ -47,7 +48,8 @@ namespace trview
             std::unique_ptr<IRouteWindowManager> route_window_manager,
             std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
             const ILevel::Source& level_source,
-            std::shared_ptr<IStartupOptions> startup_options);
+            std::shared_ptr<IStartupOptions> startup_options,
+            std::unique_ptr<IDialogs> dialogs);
         virtual ~Application();
         /// Attempt to open the specified level file.
         /// @param filename The level file to open.
@@ -92,6 +94,7 @@ namespace trview
         std::unique_ptr<IUpdateChecker> _update_checker;
         ViewMenu _view_menu;
         std::shared_ptr<IShortcuts> _shortcuts;
+        std::unique_ptr<IDialogs> _dialogs;
         HINSTANCE _instance{ nullptr };
 
         // Level data components

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -49,13 +49,10 @@ namespace trview
             const ILevel::Source& level_source,
             std::shared_ptr<IStartupOptions> startup_options);
         virtual ~Application();
-
         /// Attempt to open the specified level file.
         /// @param filename The level file to open.
         void open(const std::string& filename);
-
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
-
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         virtual int run() override;
     private:
         // Window setup functions.
@@ -66,7 +63,6 @@ namespace trview
         void setup_rooms_windows();
         void setup_route_window();
         void setup_shortcuts();
-
         // Entity manipulation
         void add_waypoint(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t index);
         void remove_waypoint(uint32_t index);
@@ -78,12 +74,11 @@ namespace trview
         void select_previous_waypoint();
         void set_item_visibility(const Item& item, bool visible);
         void set_trigger_visibility(const std::weak_ptr<ITrigger>& trigger, bool visible);
-
         // Rendering
         void render();
-
         // Lua
         void register_lua();
+        bool should_discard_changes();
 
         TokenStore _token_store;
 

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -27,6 +27,7 @@ namespace trview
     {
         virtual ~IApplication() = 0;
         virtual int run() = 0;
+        Event<> on_closing;
     };
 
     class Application final : public IApplication, public MessageHandler

--- a/trview.app/Menus/AlternateGroupToggler.cpp
+++ b/trview.app/Menus/AlternateGroupToggler.cpp
@@ -7,7 +7,7 @@ namespace trview
     {
     }
 
-    void AlternateGroupToggler::process_message(UINT message, WPARAM wParam, LPARAM)
+    std::optional<int> AlternateGroupToggler::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         if (message == WM_CHAR)
         {
@@ -17,5 +17,6 @@ namespace trview
                 on_alternate_group(value - L'0');
             }
         }
+        return {};
     }
 }

--- a/trview.app/Menus/AlternateGroupToggler.h
+++ b/trview.app/Menus/AlternateGroupToggler.h
@@ -21,7 +21,7 @@ namespace trview
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Event raised when an alternate group is toggled by the user. The group
         /// is passed as a parameter.

--- a/trview.app/Menus/FileDropper.cpp
+++ b/trview.app/Menus/FileDropper.cpp
@@ -10,7 +10,7 @@ namespace trview
         DragAcceptFiles(window, TRUE);
     }
 
-    void FileDropper::process_message(UINT message, WPARAM wParam, LPARAM)
+    std::optional<int> FileDropper::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         if(message == WM_DROPFILES)
         {
@@ -19,5 +19,6 @@ namespace trview
             DragQueryFile((HDROP)wParam, 0, filename, MAX_PATH);
             on_file_dropped(to_utf8(filename));
         }
+        return {};
     }
 }

--- a/trview.app/Menus/FileDropper.h
+++ b/trview.app/Menus/FileDropper.h
@@ -23,6 +23,6 @@ namespace trview
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
     };
 }

--- a/trview.app/Menus/LevelSwitcher.cpp
+++ b/trview.app/Menus/LevelSwitcher.cpp
@@ -52,7 +52,7 @@ namespace trview
     {
     }
 
-    void LevelSwitcher::process_message(UINT message, WPARAM wParam, LPARAM)
+    std::optional<int> LevelSwitcher::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         if (message == WM_COMMAND)
         {
@@ -63,6 +63,7 @@ namespace trview
                 on_switch_level(f.path);
             }
         }
+        return {};
     }
 
     void LevelSwitcher::open_file(const std::string& filepath)

--- a/trview.app/Menus/LevelSwitcher.h
+++ b/trview.app/Menus/LevelSwitcher.h
@@ -28,7 +28,7 @@ namespace trview
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Open the specified file. This will populate the switcher menu.
         /// @param filename The file that was opened.

--- a/trview.app/Menus/MenuDetector.cpp
+++ b/trview.app/Menus/MenuDetector.cpp
@@ -7,7 +7,7 @@ namespace trview
     {
     }
 
-    void MenuDetector::process_message(UINT message, WPARAM, LPARAM) 
+    std::optional<int> MenuDetector::process_message(UINT message, WPARAM, LPARAM)
     {
         if (message == WM_ENTERMENULOOP)
         {
@@ -17,5 +17,6 @@ namespace trview
         {
             on_menu_toggled(false);
         }
+        return {};
     }
 }

--- a/trview.app/Menus/MenuDetector.h
+++ b/trview.app/Menus/MenuDetector.h
@@ -19,7 +19,7 @@ namespace trview
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Event raised when the menu is toggled on or off.
         Event<bool> on_menu_toggled;

--- a/trview.app/Menus/RecentFiles.cpp
+++ b/trview.app/Menus/RecentFiles.cpp
@@ -34,7 +34,7 @@ namespace trview
     {
     }
 
-    void RecentFiles::process_message(UINT message, WPARAM wParam, LPARAM)
+    std::optional<int> RecentFiles::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         if (message == WM_COMMAND)
         {
@@ -48,6 +48,7 @@ namespace trview
                 }
             }
         }
+        return {};
     }
 
     void RecentFiles::set_recent_files(const std::list<std::string>& files)

--- a/trview.app/Menus/RecentFiles.h
+++ b/trview.app/Menus/RecentFiles.h
@@ -25,7 +25,7 @@ namespace trview
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Set the current list of recent files.
         /// @param files The list of recent files.

--- a/trview.app/Menus/UpdateChecker.cpp
+++ b/trview.app/Menus/UpdateChecker.cpp
@@ -107,11 +107,12 @@ namespace trview
         }, window(), _current_version);
     }
 
-    void UpdateChecker::process_message(UINT message, WPARAM wParam, LPARAM)
+    std::optional<int> UpdateChecker::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         if (message == WM_COMMAND && LOWORD(wParam) == id_update_available)
         {
             ShellExecute(0, 0, L"https://github.com/chreden/trview/releases/latest", 0, 0, SW_SHOW);
         }
+        return {};
     }
 }

--- a/trview.app/Menus/UpdateChecker.h
+++ b/trview.app/Menus/UpdateChecker.h
@@ -26,7 +26,7 @@ namespace trview
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
     private:
         std::thread _thread;
         std::string _current_version;

--- a/trview.app/Menus/ViewMenu.cpp
+++ b/trview.app/Menus/ViewMenu.cpp
@@ -56,11 +56,11 @@ namespace trview
         set_checked(menu, ID_APP_VIEW_TOOLS, true);
     }
 
-    void ViewMenu::process_message(UINT message, WPARAM wParam, LPARAM)
+    std::optional<int> ViewMenu::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         if (message != WM_COMMAND)
         {
-            return;
+            return {};
         }
 
         HMENU menu = GetMenu(window());
@@ -155,19 +155,20 @@ namespace trview
                     on_colour_change(Colour(GetRValue(rgb) / 255.0f, GetGValue(rgb) / 255.0f, GetBValue(rgb) / 255.0f));
                 }
 
-                return; // Do not set checked
+                return {}; // Do not set checked
             }
             case ID_APP_VIEW_UNHIDE_ALL:
             {
                 on_unhide_all();
-                return;
+                return {};
             }
             default:
             {
-                return;
+                return {};
             }
         }
 
         set_checked(menu, id, enable);
+        return {};
     }
 }

--- a/trview.app/Menus/ViewMenu.h
+++ b/trview.app/Menus/ViewMenu.h
@@ -11,7 +11,7 @@ namespace trview
     public:
         explicit ViewMenu(const Window& window);
         virtual ~ViewMenu() = default;
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Event raised when the show minimap option is toggled.
         Event<bool> on_show_minimap;

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -10,23 +10,25 @@ namespace trview
         {
         public:
             virtual ~MockRoute() = default;
-            MOCK_METHOD(void, add, (const DirectX::SimpleMath::Vector3&, uint32_t));
-            MOCK_METHOD(void, add, (const DirectX::SimpleMath::Vector3&, uint32_t, Waypoint::Type, uint32_t));
-            MOCK_METHOD(void, clear, ());
-            MOCK_METHOD(Colour, colour, (), (const));
-            MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t));
-            MOCK_METHOD(uint32_t, insert, (const DirectX::SimpleMath::Vector3&, uint32_t));
-            MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t, Waypoint::Type, uint32_t));
-            MOCK_METHOD(uint32_t, insert, (const DirectX::SimpleMath::Vector3&, uint32_t, Waypoint::Type, uint32_t));
-            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const));
-            MOCK_METHOD(void, remove, (uint32_t));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&));
-            MOCK_METHOD(uint32_t, selected_waypoint, (), (const));
-            MOCK_METHOD(void, select_waypoint, (uint32_t));
-            MOCK_METHOD(void, set_colour, (const Colour&));
-            MOCK_METHOD(const Waypoint&, waypoint, (uint32_t), (const));
-            MOCK_METHOD(Waypoint&, waypoint, (uint32_t));
-            MOCK_METHOD(uint32_t, waypoints, (), (const));
+            MOCK_METHOD(void, add, (const DirectX::SimpleMath::Vector3&, uint32_t), (override));
+            MOCK_METHOD(void, add, (const DirectX::SimpleMath::Vector3&, uint32_t, Waypoint::Type, uint32_t), (override));
+            MOCK_METHOD(void, clear, (), (override));
+            MOCK_METHOD(Colour, colour, (), (const, override));
+            MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t), (override));
+            MOCK_METHOD(uint32_t, insert, (const DirectX::SimpleMath::Vector3&, uint32_t), (override));
+            MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t, Waypoint::Type, uint32_t), (override));
+            MOCK_METHOD(uint32_t, insert, (const DirectX::SimpleMath::Vector3&, uint32_t, Waypoint::Type, uint32_t), (override));
+            MOCK_METHOD(bool, is_unsaved, (), (const, override));
+            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
+            MOCK_METHOD(void, remove, (uint32_t), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&), (override));
+            MOCK_METHOD(uint32_t, selected_waypoint, (), (const, override));
+            MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
+            MOCK_METHOD(void, set_colour, (const Colour&), (override));
+            MOCK_METHOD(void, set_unsaved, (bool), (override));
+            MOCK_METHOD(const Waypoint&, waypoint, (uint32_t), (const, override));
+            MOCK_METHOD(Waypoint&, waypoint, (uint32_t), (override));
+            MOCK_METHOD(uint32_t, waypoints, (), (const, override));
         };
     }
 }

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -5,92 +5,127 @@
 
 namespace trview
 {
+    /// <summary>
+    /// A route is a series of waypoints with notes.
+    /// </summary>
     struct IRoute
     {
         using Source = std::function<std::unique_ptr<IRoute>()>;
-
         virtual ~IRoute() = 0;
-        
+        /// <summary>
         /// Add a new waypoint to the end of the route.
-        /// @param position The new waypoint.
-        /// @param room The room the waypoint is in.
+        /// </summary>
+        /// <param name="position">The new waypoint.</param>
+        /// <param name="room">The room the waypoint is in.</param>
         virtual void add(const DirectX::SimpleMath::Vector3& position, uint32_t room) = 0;
-
+        /// <summary>
         /// Add a new waypoint to the end of the route.
-        /// @param position The position of the waypoint in the world.
-        /// @param room The room that waypoint is in.
-        /// @param type The type of the waypoint.
-        /// @param type_index The index of the referred to entity or trigger.
+        /// </summary>
+        /// <param name="position">The position of the waypoint in the world.</param>
+        /// <param name="room">The room that waypoint is in.</param>
+        /// <param name="type">The type of the waypoint.</param>
+        /// <param name="type_index">The index of the referred to entity or trigger.</param>
         virtual void add(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index) = 0;
-
+        /// <summary>
         /// Remove all of the waypoints from the route.
+        /// </summary>
         virtual void clear() = 0;
-
+        /// <summary>
         /// Get the colour of the route.
+        /// </summary>
+        /// <returns>The colour of the route.</returns>
         virtual Colour colour() const = 0;
-
+        /// <summary>
         /// Insert the new waypoint into the route.
-        /// @param position The new waypoint.
-        /// @param room The room that the waypoint is in.
-        /// @param index The index in the route list to put the waypoint.
+        /// </summary>
+        /// <param name="position">The new waypoint.</param>
+        /// <param name="room">The room that the waypoint is in.</param>
+        /// <param name="index">The index in the route list to put the waypoint.</param>
         virtual void insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index) = 0;
-
+        /// <summary>
         /// Insert the new waypoint into the route based on the currently selected waypoint.
-        /// @param position The new waypoint.
-        /// @param room The room that the waypoint is in.
-        /// @return The index of the new waypoint.
+        /// </summary>
+        /// <param name="position">The new waypoint.</param>
+        /// <param name="room">The room that the waypoint is in.</param>
+        /// <returns>The index of the new waypoint.</returns>
         virtual uint32_t insert(const DirectX::SimpleMath::Vector3& position, uint32_t room) = 0;
-
+        /// <summary>
         /// Insert a new non-positional waypoint.
-        /// @param position The position of the waypoint in the world.
-        /// @param room The room that the waypoint is in.
-        /// @param type The type of waypoint.
-        /// @param index The index in the route list to put the waypoint.
-        /// @param type_index The index of the trigger or entity to reference.
+        /// </summary>
+        /// <param name="position">The position of the waypoint in the world.</param>
+        /// <param name="room">The room that the waypoint is in.</param>
+        /// <param name="index">The index in the route list to put the waypoint.</param>
+        /// <param name="type">The type of waypoint.</param>
+        /// <param name="type_index">The index of the trigger or entity to reference.</param>
         virtual void insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index) = 0;
-
+        /// <summary>
         /// Insert a new non-positional waypoint based on the currently selected waypoint.
-        /// @param position The position of the waypoint in the world.
-        /// @param room The room that the waypoint is in.
-        /// @param type The type of waypoint.
-        /// @param type_index The index of the trigger or entity to reference.
-        /// @return The index of the new waypoint.
+        /// </summary>
+        /// <param name="position">The position of the waypoint in the world.</param>
+        /// <param name="room">The room that the waypoint is in.</param>
+        /// <param name="type">The type of waypoint.</param>
+        /// <param name="type_index">The index of the trigger or entity to reference.</param>
+        /// <returns>The index of the new waypoint.</returns>
         virtual uint32_t insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index) = 0;
-
+        /// <summary>
+        /// Determines whether the route has any unsaved changes.
+        /// </summary>
+        /// <returns>True if there are unsaved changes.</returns>
+        virtual bool is_unsaved() const = 0;
+        /// <summary>
         /// Pick against the waypoints in the route.
-        /// @param position The position of the camera.
-        /// @param direction The direction of the ray.
+        /// </summary>
+        /// <param name="position">The position of the camera.</param>
+        /// <param name="direction">The direction of the ray.</param>
+        /// <returns>The pcik result.</returns>
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
-
+        /// <summary>
         /// Remove the waypoint at the specified index.
-        /// @param index The index of the waypoint to remove.
+        /// </summary>
+        /// <param name="index">The index of the waypoint to remove.</param>
         virtual void remove(uint32_t index) = 0;
-
+        /// <summary>
         /// Render the route.
-        /// @param camera The camera to use to render.
-        /// @param texture_storage Texture storage for the mesh.
+        /// </summary>
+        /// <param name="camera">The camera to use to render.</param>
+        /// <param name="texture_storage">Texture storage for the mesh.</param>
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage) = 0;
-
+        /// <summary>
         /// Get the index of the currently selected waypoint.
+        /// </summary>
+        /// <returns>The index of the currently selected waypoint.</returns>
         virtual uint32_t selected_waypoint() const = 0;
-
+        /// <summary>
         /// Set the specified waypoint index to be the selected waypoint.
-        /// @param index The index to select.
+        /// </summary>
+        /// <param name="index">The index to select.</param>
         virtual void select_waypoint(uint32_t index) = 0;
-
+        /// <summary>
         /// Set the colour for the route.
-        /// @param colour The colour to use.
+        /// </summary>
+        /// <param name="colour">The colour to use.</param>
         virtual void set_colour(const Colour& colour) = 0;
-
+        /// <summary>
+        /// Set whether the route has unsaved changes.
+        /// </summary>
+        /// <param name="value">Whether the route has unsaved changes.</param>
+        virtual void set_unsaved(bool value) = 0;
+        /// <summary>
         /// Get the waypoint at the specified index.
-        /// @param index The index to get.
+        /// </summary>
+        /// <param name="index">The index to get.</param>
+        /// <returns>The waypoint.</returns>
         virtual const Waypoint& waypoint(uint32_t index) const = 0;
-
+        /// <summary>
         /// Get the waypoint at the specified index.
-        /// @param index The index to get.
+        /// </summary>
+        /// <param name="index">The index to get.</param>
+        /// <returns>The waypoint.</returns>
         virtual Waypoint& waypoint(uint32_t index) = 0;
-
+        /// <summary>
         /// Get the number of waypoints in the route.
+        /// </summary>
+        /// <returns>The number of waypoints in the route.</returns>
         virtual uint32_t waypoints() const = 0;
     };
 }

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -64,6 +64,7 @@ namespace trview
     void Route::add(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index)
     {
         _waypoints.emplace_back(_waypoint_mesh.get(), position, room, type, type_index, _colour);
+        set_unsaved(true);
     }
 
     Colour Route::colour() const
@@ -73,6 +74,10 @@ namespace trview
 
     void Route::clear()
     {
+        if (!_waypoints.empty())
+        {
+            set_unsaved(true);
+        }
         _waypoints.clear();
         _selected_index = 0u;
     }
@@ -84,6 +89,7 @@ namespace trview
             return add(position, room, Waypoint::Type::Position, 0u);
         }
         insert(position, room, index, Waypoint::Type::Position, 0u);
+        set_unsaved(true);
     }
 
     uint32_t Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room)
@@ -96,6 +102,7 @@ namespace trview
     void Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index)
     {
         _waypoints.insert(_waypoints.begin() + index, Waypoint(_waypoint_mesh.get(), position, room, type, type_index, _colour));
+        set_unsaved(true);
     }
 
     uint32_t Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index)
@@ -146,6 +153,7 @@ namespace trview
         {
             --_selected_index;
         }
+        set_unsaved(true);
     }
 
     void Route::render(const ICamera& camera, const ILevelTextureStorage& texture_storage)
@@ -192,6 +200,7 @@ namespace trview
         {
             waypoint.set_route_colour(colour);
         }
+        set_unsaved(true);
     }
 
     void Route::set_unsaved(bool value)

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -287,6 +287,7 @@ namespace trview
                 new_waypoint.set_save_file(from_base64(waypoint.value("save", "")));
             }
 
+            route->set_unsaved(false);
             return route;
         }
         catch (std::exception&)

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -105,6 +105,11 @@ namespace trview
         return index;
     }
 
+    bool Route::is_unsaved() const
+    {
+        return _is_unsaved;
+    }
+
     PickResult Route::pick(const Vector3& position, const Vector3& direction) const
     {
         PickResult result;
@@ -187,6 +192,11 @@ namespace trview
         {
             waypoint.set_route_colour(colour);
         }
+    }
+
+    void Route::set_unsaved(bool value)
+    {
+        _is_unsaved = value;
     }
 
     const Waypoint& Route::waypoint(uint32_t index) const

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -12,93 +12,27 @@ namespace trview
     class Route final : public IRoute
     {
     public:
-        /// Create a route.
         explicit Route(const std::unique_ptr<ISelectionRenderer> selection_renderer, const IMesh::Source& mesh_source);
-
         virtual ~Route() = default;
-
         Route& operator=(const Route& other);
-
-        /// Add a new waypoint to the end of the route.
-        /// @param position The new waypoint.
-        /// @param room The room the waypoint is in.
         virtual void add(const DirectX::SimpleMath::Vector3& position, uint32_t room) override;
-
-        /// Add a new waypoint to the end of the route.
-        /// @param position The position of the waypoint in the world.
-        /// @param room The room that waypoint is in.
-        /// @param type The type of the waypoint.
-        /// @param type_index The index of the referred to entity or trigger.
         virtual void add(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index) override;
-
-        /// Remove all of the waypoints from the route.
         virtual void clear() override;
-
-        /// Get the colour of the route.
         virtual Colour colour() const override;
-
-        /// Insert the new waypoint into the route.
-        /// @param position The new waypoint.
-        /// @param room The room that the waypoint is in.
-        /// @param index The index in the route list to put the waypoint.
         virtual void insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index) override;
-
-        /// Insert the new waypoint into the route based on the currently selected waypoint.
-        /// @param position The new waypoint.
-        /// @param room The room that the waypoint is in.
-        /// @return The index of the new waypoint.
         virtual uint32_t insert(const DirectX::SimpleMath::Vector3& position, uint32_t room) override;
-
-        /// Insert a new non-positional waypoint.
-        /// @param position The position of the waypoint in the world.
-        /// @param room The room that the waypoint is in.
-        /// @param type The type of waypoint.
-        /// @param index The index in the route list to put the waypoint.
-        /// @param type_index The index of the trigger or entity to reference.
         virtual void insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index) override;
-
-        /// Insert a new non-positional waypoint based on the currently selected waypoint.
-        /// @param position The position of the waypoint in the world.
-        /// @param room The room that the waypoint is in.
-        /// @param type The type of waypoint.
-        /// @param type_index The index of the trigger or entity to reference.
-        /// @return The index of the new waypoint.
+        virtual bool is_unsaved() const override;
         virtual uint32_t insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index) override;
-
-        /// Pick against the waypoints in the route.
-        /// @param position The position of the camera.
-        /// @param direction The direction of the ray.
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
-
-        /// Remove the waypoint at the specified index.
-        /// @param index The index of the waypoint to remove.
         virtual void remove(uint32_t index) override;
-
-        /// Render the route.
-        /// @param camera The camera to use to render.
-        /// @param texture_storage Texture storage for the mesh.
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage) override;
-
-        /// Get the index of the currently selected waypoint.
         virtual uint32_t selected_waypoint() const override;
-
-        /// Set the specified waypoint index to be the selected waypoint.
-        /// @param index The index to select.
         virtual void select_waypoint(uint32_t index) override;
-
-        /// Set the colour for the route.
-        /// @param colour The colour to use.
         virtual void set_colour(const Colour& colour) override;
-
-        /// Get the waypoint at the specified index.
-        /// @param index The index to get.
+        virtual void set_unsaved(bool value) override;
         virtual const Waypoint& waypoint(uint32_t index) const override;
-
-        /// Get the waypoint at the specified index.
-        /// @param index The index to get.
         virtual Waypoint& waypoint(uint32_t index) override;
-
-        /// Get the number of waypoints in the route.
         virtual uint32_t waypoints() const override;
     private:
         uint32_t next_index() const;
@@ -106,8 +40,9 @@ namespace trview
         std::vector<Waypoint> _waypoints;
         std::shared_ptr<IMesh> _waypoint_mesh;
         std::unique_ptr<ISelectionRenderer> _selection_renderer;
-        uint32_t              _selected_index{ 0u };
-        Colour                _colour{ Colour::Green };
+        uint32_t _selected_index{ 0u };
+        Colour _colour{ Colour::Green };
+        bool _is_unsaved{ false };
     };
 
     std::unique_ptr<IRoute> import_route(const IRoute::Source& route_source, const std::string& filename);

--- a/trview.app/Windows/CollapsiblePanel.cpp
+++ b/trview.app/Windows/CollapsiblePanel.cpp
@@ -103,7 +103,7 @@ namespace trview
         }
     }
 
-    void CollapsiblePanel::process_message(UINT message, WPARAM, LPARAM lParam)
+    std::optional<int> CollapsiblePanel::process_message(UINT message, WPARAM, LPARAM lParam)
     {
         if (message == WM_CLOSE)
         {
@@ -124,6 +124,7 @@ namespace trview
                 info->ptMaxTrackSize.y = rect.bottom - rect.top;
             }
         }
+        return {};
     }
 
     void CollapsiblePanel::render(bool vsync)

--- a/trview.app/Windows/CollapsiblePanel.h
+++ b/trview.app/Windows/CollapsiblePanel.h
@@ -42,7 +42,7 @@ namespace trview
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Render the window.
         /// @param device The device to render with.

--- a/trview.app/Windows/ItemsWindowManager.cpp
+++ b/trview.app/Windows/ItemsWindowManager.cpp
@@ -9,12 +9,13 @@ namespace trview
         _token_store += shortcuts->add_shortcut(true, 'I') += [&]() { create_window(); };
     }
 
-    void ItemsWindowManager::process_message(UINT message, WPARAM wParam, LPARAM)
+    std::optional<int> ItemsWindowManager::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         if (message == WM_COMMAND && LOWORD(wParam) == ID_APP_WINDOWS_ITEMS)
         {
             create_window();
         }
+        return {};
     }
 
     void ItemsWindowManager::render(bool vsync)

--- a/trview.app/Windows/ItemsWindowManager.h
+++ b/trview.app/Windows/ItemsWindowManager.h
@@ -24,7 +24,7 @@ namespace trview
         /// @param items_window_source Function to call to create a triggers window.
         explicit ItemsWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const IItemsWindow::Source& items_window_source);
         virtual ~ItemsWindowManager() = default;
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         virtual void render(bool vsync) override;
         virtual void set_items(const std::vector<Item>& items) override;
         virtual void set_item_visible(const Item& item, bool visible) override;

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -12,12 +12,13 @@ namespace trview
         _token_store += shortcuts->add_shortcut(true, 'M') += [&]() { create_window(); };
     }
 
-    void RoomsWindowManager::process_message(UINT message, WPARAM wParam, LPARAM)
+    std::optional<int> RoomsWindowManager::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         if (message == WM_COMMAND && LOWORD(wParam) == ID_APP_WINDOWS_ROOMS)
         {
             create_window();
         }
+        return {};
     }
 
     void RoomsWindowManager::render(bool vsync)

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -27,7 +27,7 @@ namespace trview
         /// @param rooms_window_source The function to call to get a rooms window.
         explicit RoomsWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const IRoomsWindow::Source& rooms_window_source);
         virtual ~RoomsWindowManager() = default;
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         virtual void render(bool vsync) override;
         std::weak_ptr<ITrigger> selected_trigger() const;
         virtual void set_items(const std::vector<Item>& items) override;

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -26,6 +26,7 @@ namespace trview
     }
 
     const std::string RouteWindow::Names::waypoint_stats = "waypoint_stats";
+    const std::string RouteWindow::Names::notes_area = "notes_area";
 
     namespace Colours
     {
@@ -327,21 +328,19 @@ namespace trview
         group_box->add_child(std::move(details_panel));
         right_panel->add_child(std::move(group_box));
 
-        // Notes area.
-        auto notes_box = std::make_unique<GroupBox>(Size(panel_width, window().size().height - 160), Colours::Notes, Colours::DetailsBorder, L"Notes");
-
-        auto notes_area = std::make_unique<TextArea>(Size(panel_width - 20, notes_box->size().height - 41), Colours::NotesTextArea, Colour(1.0f, 1.0f, 1.0f));
-        _notes_area = notes_box->add_child(std::move(notes_area));
-        _notes_area->set_scrollbar_visible(true);
-
         right_panel->add_child(std::make_unique<ui::Window>(Size(panel_width, 5), Colours::Notes));
-        right_panel->add_child(std::move(notes_box));
+        // Notes area.
+        auto notes_box = right_panel->add_child(std::make_unique<GroupBox>(Size(panel_width, window().size().height - 160), Colours::Notes, Colours::DetailsBorder, L"Notes"));
+        _notes_area = notes_box->add_child(std::move(std::make_unique<TextArea>(Size(panel_width - 20, notes_box->size().height - 41), Colours::NotesTextArea, Colour(1.0f, 1.0f, 1.0f))));
+        _notes_area->set_name(Names::notes_area);
+        _notes_area->set_scrollbar_visible(true);
 
         _token_store += _notes_area->on_text_changed += [&](const std::wstring& text)
         {
             if (_route && _selected_index < _route->waypoints())
             {
                 _route->waypoint(_selected_index).set_notes(text);
+                _route->set_unsaved(true);
             }
         };
 

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -339,8 +339,11 @@ namespace trview
         {
             if (_route && _selected_index < _route->waypoints())
             {
-                _route->waypoint(_selected_index).set_notes(text);
-                _route->set_unsaved(true);
+                if (_route->waypoint(_selected_index).notes() != text)
+                {
+                    _route->waypoint(_selected_index).set_notes(text);
+                    _route->set_unsaved(true);
+                }
             }
         };
 

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -25,8 +25,10 @@ namespace trview
         };
     }
 
-    const std::string RouteWindow::Names::waypoint_stats = "waypoint_stats";
+    const std::string RouteWindow::Names::clear_save = "clear_save";
     const std::string RouteWindow::Names::notes_area = "notes_area";
+    const std::string RouteWindow::Names::waypoint_stats = "waypoint_stats";
+    
 
     namespace Colours
     {
@@ -253,6 +255,7 @@ namespace trview
                             std::vector<uint8_t> bytes(static_cast<uint32_t>(length));
                             infile.read(reinterpret_cast<char*>(&bytes[0]), length);
                             _route->waypoint(_selected_index).set_save_file(bytes);
+                            _route->set_unsaved(true);
 
                             _select_save->set_text(L"SAVEGAME.0");
                         }
@@ -297,6 +300,7 @@ namespace trview
         };
 
         _clear_save = save_area->add_child(std::make_unique<Button>(Size(20, 20), L"X"));
+        _clear_save->set_name(Names::clear_save);
         _token_store += _clear_save->on_click += [&]()
         {
             if (!(_route && _selected_index < _route->waypoints()))
@@ -309,6 +313,7 @@ namespace trview
             {
                 waypoint.set_save_file({});
                 _select_save->set_text(L"Attach Save");
+                _route->set_unsaved(true);
             }
         };
 

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -21,8 +21,9 @@ namespace trview
     public:
         struct Names
         {
-            static const std::string waypoint_stats;
+            static const std::string clear_save;
             static const std::string notes_area;
+            static const std::string waypoint_stats;
         };
 
         /// Create a route window as a child of the specified window.

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -22,6 +22,7 @@ namespace trview
         struct Names
         {
             static const std::string waypoint_stats;
+            static const std::string notes_area;
         };
 
         /// Create a route window as a child of the specified window.

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -9,12 +9,13 @@ namespace trview
         _token_store += shortcuts->add_shortcut(true, 'R') += [&]() { create_window(); };
     }
 
-    void RouteWindowManager::process_message(UINT message, WPARAM wParam, LPARAM)
+    std::optional<int> RouteWindowManager::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         if (message == WM_COMMAND && LOWORD(wParam) == ID_APP_WINDOWS_ROUTE)
         {
             create_window();
         }
+        return {};
     }
 
     void RouteWindowManager::create_window()

--- a/trview.app/Windows/RouteWindowManager.h
+++ b/trview.app/Windows/RouteWindowManager.h
@@ -13,7 +13,7 @@ namespace trview
     public:
         explicit RouteWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const IRouteWindow::Source& route_window_source);
         virtual ~RouteWindowManager() = default;
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         virtual void render(bool vsync) override;
         virtual void set_route(IRoute* route) override;
         virtual void create_window() override;

--- a/trview.app/Windows/TriggersWindowManager.cpp
+++ b/trview.app/Windows/TriggersWindowManager.cpp
@@ -10,12 +10,13 @@ namespace trview
         _token_store += shortcuts->add_shortcut(true, 'T') += [&]() { create_window(); };
     }
 
-    void TriggersWindowManager::process_message(UINT message, WPARAM wParam, LPARAM)
+    std::optional<int> TriggersWindowManager::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         if (message == WM_COMMAND && LOWORD(wParam) == ID_APP_WINDOWS_TRIGGERS)
         {
             create_window();
         }
+        return {};
     }
 
     void TriggersWindowManager::render(bool vsync)

--- a/trview.app/Windows/TriggersWindowManager.h
+++ b/trview.app/Windows/TriggersWindowManager.h
@@ -21,7 +21,7 @@ namespace trview
         /// @param triggers_window_source Function to call to create a triggers window.
         explicit TriggersWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const ITriggersWindow::Source& triggers_window_source);
         virtual ~TriggersWindowManager() = default;
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         virtual void render(bool vsync) override;
         const std::weak_ptr<ITrigger> selected_trigger() const;
         virtual void set_items(const std::vector<Item>& items) override;

--- a/trview.app/Windows/WindowResizer.cpp
+++ b/trview.app/Windows/WindowResizer.cpp
@@ -10,7 +10,7 @@ namespace trview
     {
     }
 
-    void WindowResizer::process_message(UINT message, WPARAM wParam, LPARAM)
+    std::optional<int> WindowResizer::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         switch (message)
         {
@@ -47,6 +47,7 @@ namespace trview
                 break;
             }
         }
+        return {};
     }
 
     bool WindowResizer::has_size_changed()

--- a/trview.app/Windows/WindowResizer.h
+++ b/trview.app/Windows/WindowResizer.h
@@ -25,7 +25,7 @@ namespace trview
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         /// Event that is raised when the window has resized.
         Event<> on_resize;

--- a/trview.common/MessageHandler.cpp
+++ b/trview.common/MessageHandler.cpp
@@ -10,7 +10,11 @@ namespace trview
             MessageHandler* handler = reinterpret_cast<MessageHandler*>(dwRefData);
             if (handler)
             {
-                handler->process_message(message, wParam, lParam);
+                const auto code = handler->process_message(message, wParam, lParam);
+                if (code.has_value())
+                {
+                    return code.value();
+                }
             }
             return DefSubclassProc(hWnd, message, wParam, lParam);
         }

--- a/trview.common/MessageHandler.h
+++ b/trview.common/MessageHandler.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <optional>
 #include <cstdint>
 #include <Windows.h>
 #include "Window.h"
@@ -40,7 +41,7 @@ namespace trview
         /// @param message The message that was received.
         /// @param wParam The WPARAM for the message.
         /// @param lParam The LPARAM for the message.
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) = 0;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) = 0;
 
         /// Gets the window that the handler is listening to.
         /// @returns The window handle.

--- a/trview.common/Mocks/Windows/IDialogs.h
+++ b/trview.common/Mocks/Windows/IDialogs.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../../Windows/IDialogs.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockDialogs final : public IDialogs
+        {
+            virtual ~MockDialogs() = default;
+            MOCK_METHOD(bool, message_box, (const Window&, const std::wstring&, const std::wstring&, Buttons), (override));
+        };
+    }
+}

--- a/trview.common/Windows/Dialogs.cpp
+++ b/trview.common/Windows/Dialogs.cpp
@@ -1,0 +1,10 @@
+#include "Dialogs.h"
+
+namespace trview
+{
+    bool Dialogs::message_box(const Window& window, const std::wstring& title, const std::wstring& message, Buttons buttons)
+    {
+        const auto mode = buttons == Buttons::OK_Cancel ? MB_OKCANCEL : MB_OK;
+        return IDOK == MessageBox(window, title.c_str(), message.c_str(), mode);
+    }
+}

--- a/trview.common/Windows/Dialogs.cpp
+++ b/trview.common/Windows/Dialogs.cpp
@@ -17,10 +17,15 @@ namespace trview
                     return MB_OK;
             }
         }
+
+        bool convert_response(int response)
+        {
+            return response == IDOK || response == IDYES;
+        }
     }
 
     bool Dialogs::message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons)
     {
-        return IDOK == MessageBox(window, message.c_str(), title.c_str(), convert_button(buttons));
+        return convert_response(MessageBox(window, message.c_str(), title.c_str(), convert_button(buttons)));
     }
 }

--- a/trview.common/Windows/Dialogs.cpp
+++ b/trview.common/Windows/Dialogs.cpp
@@ -2,9 +2,23 @@
 
 namespace trview
 {
-    bool Dialogs::message_box(const Window& window, const std::wstring& title, const std::wstring& message, Buttons buttons)
+    namespace
     {
-        const auto mode = buttons == Buttons::OK_Cancel ? MB_OKCANCEL : MB_OK;
-        return IDOK == MessageBox(window, title.c_str(), message.c_str(), mode);
+        long convert_button(IDialogs::Buttons buttons)
+        {
+            switch (buttons)
+            {
+                case IDialogs::Buttons::OK_Cancel:
+                    return MB_OKCANCEL;
+                case IDialogs::Buttons::OK:
+                default:
+                    return MB_OK;
+            }
+        }
+    }
+
+    bool Dialogs::message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons)
+    {
+        return IDOK == MessageBox(window, message.c_str(), title.c_str(), convert_button(buttons));
     }
 }

--- a/trview.common/Windows/Dialogs.cpp
+++ b/trview.common/Windows/Dialogs.cpp
@@ -10,6 +10,8 @@ namespace trview
             {
                 case IDialogs::Buttons::OK_Cancel:
                     return MB_OKCANCEL;
+                case IDialogs::Buttons::Yes_No:
+                    return MB_YESNO;
                 case IDialogs::Buttons::OK:
                 default:
                     return MB_OK;

--- a/trview.common/Windows/Dialogs.h
+++ b/trview.common/Windows/Dialogs.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "IDialogs.h"
+
+namespace trview
+{
+    class Dialogs final : public IDialogs
+    {
+    public:
+        virtual ~Dialogs() = default;
+        virtual bool message_box(const Window& window, const std::wstring& title, const std::wstring& message, Buttons buttons) override;
+    };
+}

--- a/trview.common/Windows/Dialogs.h
+++ b/trview.common/Windows/Dialogs.h
@@ -8,6 +8,6 @@ namespace trview
     {
     public:
         virtual ~Dialogs() = default;
-        virtual bool message_box(const Window& window, const std::wstring& title, const std::wstring& message, Buttons buttons) override;
+        virtual bool message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons) override;
     };
 }

--- a/trview.common/Windows/IDialogs.cpp
+++ b/trview.common/Windows/IDialogs.cpp
@@ -1,0 +1,8 @@
+#include "IDialogs.h"
+
+namespace trview
+{
+    IDialogs::~IDialogs()
+    {
+    }
+}

--- a/trview.common/Windows/IDialogs.h
+++ b/trview.common/Windows/IDialogs.h
@@ -10,7 +10,8 @@ namespace trview
         enum class Buttons
         {
             OK,
-            OK_Cancel
+            OK_Cancel,
+            Yes_No
         };
 
         virtual ~IDialogs() = 0;

--- a/trview.common/Windows/IDialogs.h
+++ b/trview.common/Windows/IDialogs.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+#include "../Window.h"
+
+namespace trview
+{
+    struct IDialogs
+    {
+        enum class Buttons
+        {
+            OK_Cancel
+        };
+
+        virtual ~IDialogs() = 0;
+        /// <summary>
+        /// Show a modal message box.
+        /// </summary>
+        /// <param name="window">The window that owns the message box.</param>
+        /// <param name="title">The title of the message box.</param>
+        /// <param name="message">The message of the message box.</param>
+        /// <param name="buttons">The buttons to show on the message box.</param>
+        /// <returns>True if the positive result was chosen.</returns>
+        virtual bool message_box(const Window& window, const std::wstring& title, const std::wstring& message, Buttons buttons) = 0;
+    };
+}

--- a/trview.common/Windows/IDialogs.h
+++ b/trview.common/Windows/IDialogs.h
@@ -9,6 +9,7 @@ namespace trview
     {
         enum class Buttons
         {
+            OK,
             OK_Cancel
         };
 
@@ -17,10 +18,10 @@ namespace trview
         /// Show a modal message box.
         /// </summary>
         /// <param name="window">The window that owns the message box.</param>
-        /// <param name="title">The title of the message box.</param>
         /// <param name="message">The message of the message box.</param>
+        /// <param name="title">The title of the message box.</param>
         /// <param name="buttons">The buttons to show on the message box.</param>
         /// <returns>True if the positive result was chosen.</returns>
-        virtual bool message_box(const Window& window, const std::wstring& title, const std::wstring& message, Buttons buttons) = 0;
+        virtual bool message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons) = 0;
     };
 }

--- a/trview.common/Windows/Shortcuts.cpp
+++ b/trview.common/Windows/Shortcuts.cpp
@@ -52,13 +52,13 @@ namespace trview
         _accelerators = CreateAcceleratorTable(&shortcuts[0], static_cast<int>(shortcuts.size()));
     }
 
-    void Shortcuts::process_message(UINT message, WPARAM wParam, LPARAM lParam)
+    std::optional<int> Shortcuts::process_message(UINT message, WPARAM wParam, LPARAM lParam)
     {
         if (!_accelerators)
         {
             if (_shortcuts.empty())
             {
-                return;
+                return {};
             }
             create_accelerators();
         }
@@ -66,7 +66,7 @@ namespace trview
         MSG msg{ window(), message, wParam, lParam, GetTickCount(), 0 };
         if (TranslateAccelerator(window(), _accelerators, &msg))
         {
-            return;
+            return {};
         }
 
         if (message == WM_COMMAND)
@@ -81,5 +81,6 @@ namespace trview
                 }
             }
         }
+        return {};
     }
 }

--- a/trview.common/Windows/Shortcuts.h
+++ b/trview.common/Windows/Shortcuts.h
@@ -11,7 +11,7 @@ namespace trview
     public:
         explicit Shortcuts(const Window& window);
         virtual ~Shortcuts() = default;
-        virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
 
         virtual Event<>& add_shortcut(bool control, uint16_t key) override;
 

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -28,6 +28,7 @@
     <ClInclude Include="Json.hpp" />
     <ClInclude Include="MessageHandler.h" />
     <ClInclude Include="Mocks\Windows\IClipboard.h" />
+    <ClInclude Include="Mocks\Windows\IDialogs.h" />
     <ClInclude Include="Mocks\Windows\IShortcuts.h" />
     <ClInclude Include="Point.h" />
     <ClInclude Include="Size.h" />
@@ -37,7 +38,9 @@
     <ClInclude Include="TokenStore.h" />
     <ClInclude Include="Window.h" />
     <ClInclude Include="Windows\Clipboard.h" />
+    <ClInclude Include="Windows\Dialogs.h" />
     <ClInclude Include="Windows\IClipboard.h" />
+    <ClInclude Include="Windows\IDialogs.h" />
     <ClInclude Include="Windows\IShortcuts.h" />
     <ClInclude Include="Windows\Shortcuts.h" />
   </ItemGroup>
@@ -59,7 +62,9 @@
     <ClCompile Include="TokenStore.cpp" />
     <ClCompile Include="Window.cpp" />
     <ClCompile Include="Windows\Clipboard.cpp" />
+    <ClCompile Include="Windows\Dialogs.cpp" />
     <ClCompile Include="Windows\IClipboard.cpp" />
+    <ClCompile Include="Windows\IDialogs.cpp" />
     <ClCompile Include="Windows\IShortcuts.cpp" />
     <ClCompile Include="Windows\Shortcuts.cpp" />
   </ItemGroup>

--- a/trview.common/trview.common.vcxproj.filters
+++ b/trview.common/trview.common.vcxproj.filters
@@ -40,6 +40,15 @@
     </ClInclude>
     <ClInclude Include="Json.h" />
     <ClInclude Include="Json.hpp" />
+    <ClInclude Include="Windows\IDialogs.h">
+      <Filter>Windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Windows\Dialogs.h">
+      <Filter>Windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\Windows\IDialogs.h">
+      <Filter>Mocks\Windows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FileLoader.cpp" />
@@ -69,6 +78,12 @@
       <Filter>Windows</Filter>
     </ClCompile>
     <ClCompile Include="Windows\IClipboard.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Windows\IDialogs.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
+    <ClCompile Include="Windows\Dialogs.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
   </ItemGroup>

--- a/trview.input/Keyboard.cpp
+++ b/trview.input/Keyboard.cpp
@@ -23,7 +23,7 @@ namespace trview
             return GetKeyState(VK_SHIFT) & 0x8000;
         }
 
-        void Keyboard::process_message(UINT message, WPARAM wParam, LPARAM)
+        std::optional<int> Keyboard::process_message(UINT message, WPARAM wParam, LPARAM)
         {
             bool control_pressed = control();
             bool shift_pressed = shift();
@@ -45,6 +45,7 @@ namespace trview
                     break;
                 }
             }
+            return {};
         }
     }
 }

--- a/trview.input/Keyboard.h
+++ b/trview.input/Keyboard.h
@@ -50,7 +50,7 @@ namespace trview
             /// @param message The message that was received.
             /// @param wParam The WPARAM for the message.
             /// @param lParam The LPARAM for the message.
-            virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+            virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         };
     }
 }

--- a/trview.input/Mouse.cpp
+++ b/trview.input/Mouse.cpp
@@ -99,7 +99,7 @@ namespace trview
             _absolute_y = y;
         }
 
-        void Mouse::process_message(UINT message, WPARAM wParam, LPARAM lParam)
+        std::optional<int> Mouse::process_message(UINT message, WPARAM wParam, LPARAM lParam)
         {
             switch (message)
             {
@@ -146,6 +146,7 @@ namespace trview
                     break;
                 }
             }
+            return {};
         }
     }
 }

--- a/trview.input/Mouse.h
+++ b/trview.input/Mouse.h
@@ -45,7 +45,7 @@ namespace trview
             /// @param message The message that was received.
             /// @param wParam The WPARAM for the message.
             /// @param lParam The LPARAM for the message.
-            virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+            virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         private:
             void raise_absolute_mouse_move(long x, long y);
 

--- a/trview.input/WindowTester.cpp
+++ b/trview.input/WindowTester.cpp
@@ -24,7 +24,7 @@ namespace trview
             return GetSystemMetrics(rdp ? SM_CYVIRTUALSCREEN : SM_CYSCREEN);
         }
 
-        void WindowTester::process_message(UINT message, WPARAM, LPARAM)
+        std::optional<int> WindowTester::process_message(UINT message, WPARAM, LPARAM)
         {
             if (message == WM_MOUSEMOVE && !_mouse_in_window)
             {
@@ -38,6 +38,7 @@ namespace trview
             {
                 _mouse_in_window = false;
             }
+            return {};
         }
     }
 }

--- a/trview.input/WindowTester.h
+++ b/trview.input/WindowTester.h
@@ -15,7 +15,7 @@ namespace trview
             virtual bool is_window_under_cursor() const override;
             virtual int screen_width(bool rdp) const override;
             virtual int screen_height(bool rdp) const override;
-            virtual void process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+            virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         private:
             bool _mouse_in_window{ false };
         };


### PR DESCRIPTION
If there are unsaved changes to a route show a dialog:
- When opening a new level
- When closing the application

Update the `IMessageHander` interface to allow it to return a code in the case that it needs to override the default subclass behaviour. This affected a lot of files but they are small changes mainly, just to return default.
Add some tests for `Route` and `Application`.
Closes #764 
