### PR TITLE
Add file dialogs to IDialogs and add interface for loading a file #807

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -16,6 +16,7 @@
 #include <trview.common/Mocks/Windows/IDialogs.h>
 #include <trlevel/Mocks/ILevelLoader.h>
 #include <trlevel/Mocks/ILevel.h>
+#include <trview.app/Resources/resource.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -368,5 +369,30 @@ TEST(Application, ClosingEventCalled)
 
 TEST(Application, FileOpenOpensFile)
 {
-    FAIL();
+    auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
+    EXPECT_CALL(level_loader, load_level).Times(1);
+    auto dialogs = std::make_shared<MockDialogs>();
+    EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return("filename"));
+
+    auto application = register_test_module()
+        .with_level_loader(std::move(level_loader_ptr))
+        .with_dialogs(dialogs)
+        .build();
+
+    application->process_message(WM_COMMAND, MAKEWPARAM(ID_FILE_OPEN, 0), 0);
+}
+
+TEST(Application, FileOpenAcceleratorOpensFile)
+{
+    auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
+    EXPECT_CALL(level_loader, load_level).Times(1);
+    auto dialogs = std::make_shared<MockDialogs>();
+    EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return("filename"));
+
+    auto application = register_test_module()
+        .with_level_loader(std::move(level_loader_ptr))
+        .with_dialogs(dialogs)
+        .build();
+
+    application->process_message(WM_COMMAND, MAKEWPARAM(ID_ACCEL_FILE_OPEN, 0), 0);
 }

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -441,14 +441,15 @@ TEST(Application, ImportRouteLoadsFile)
     auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
     EXPECT_CALL(route_window_manager, set_route).Times(1);
     auto files = std::make_shared<MockFiles>();
-    EXPECT_CALL(*files, load_file).Times(1);
+    EXPECT_CALL(*files, load_file).Times(1).WillRepeatedly(Return<std::vector<uint8_t>>({ 0x7b, 0x7d }));;
     auto route = std::make_shared<MockRoute>();
     EXPECT_CALL(*route, set_unsaved(false)).Times(1);
 
     auto application = register_test_module()
         .with_route_window_manager(std::move(route_window_manager_ptr))
         .with_route_source([&](auto&&...) {return route; })
+        .with_viewer(std::move(viewer_ptr))
         .with_files(files).build();
 
-    // route_window_manager.on_route_import("filename");
+    route_window_manager.on_route_import("filename");
 }

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -374,11 +374,18 @@ TEST(Application, FileOpenOpensFile)
     auto dialogs = std::make_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return("filename"));
 
-    auto application = register_test_module()
-        .with_level_loader(std::move(level_loader_ptr))
-        .with_dialogs(dialogs)
-        .build();
+    auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_dialogs(dialogs).build();
+    application->process_message(WM_COMMAND, MAKEWPARAM(ID_FILE_OPEN, 0), 0);
+}
 
+TEST(Application, FileOpenDoesNotOpenFileWhenCancelled)
+{
+    auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
+    EXPECT_CALL(level_loader, load_level).Times(0);
+    auto dialogs = std::make_shared<MockDialogs>();
+    EXPECT_CALL(*dialogs, open_file).Times(1);
+
+    auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_dialogs(dialogs).build();
     application->process_message(WM_COMMAND, MAKEWPARAM(ID_FILE_OPEN, 0), 0);
 }
 
@@ -389,10 +396,18 @@ TEST(Application, FileOpenAcceleratorOpensFile)
     auto dialogs = std::make_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return("filename"));
 
-    auto application = register_test_module()
-        .with_level_loader(std::move(level_loader_ptr))
-        .with_dialogs(dialogs)
-        .build();
-
+    auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_dialogs(dialogs).build();
     application->process_message(WM_COMMAND, MAKEWPARAM(ID_ACCEL_FILE_OPEN, 0), 0);
 }
+
+TEST(Application, FileOpenAcceleratorDoesNotOpenFileWhenCancelled)
+{
+    auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
+    EXPECT_CALL(level_loader, load_level).Times(0);
+    auto dialogs = std::make_shared<MockDialogs>();
+    EXPECT_CALL(*dialogs, open_file).Times(1);
+
+    auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_dialogs(dialogs).build();
+    application->process_message(WM_COMMAND, MAKEWPARAM(ID_ACCEL_FILE_OPEN, 0), 0);
+}
+

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -365,3 +365,8 @@ TEST(Application, ClosingEventCalled)
     application->process_message(WM_CLOSE, 0, 0);
     ASSERT_TRUE(closing_called);
 }
+
+TEST(Application, FileOpenOpensFile)
+{
+    FAIL();
+}

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -48,7 +48,7 @@ namespace
             std::unique_ptr<IRoomsWindowManager> rooms_window_manager{ std::make_unique<MockRoomsWindowManager>() };
             ILevel::Source level_source{ [](auto&&...) { return std::make_unique<trview::mocks::MockLevel>(); } };
             std::shared_ptr<IStartupOptions> startup_options{ std::make_shared<MockStartupOptions>() };
-            std::unique_ptr<IDialogs> dialogs{ std::make_unique<MockDialogs>() };
+            std::shared_ptr<IDialogs> dialogs{ std::make_shared<MockDialogs>() };
 
             std::unique_ptr<Application> build()
             {
@@ -59,9 +59,9 @@ namespace
                     level_source, startup_options, std::move(dialogs));
             }
 
-            test_module& with_dialogs(std::unique_ptr<IDialogs> dialogs)
+            test_module& with_dialogs(std::shared_ptr<IDialogs> dialogs)
             {
-                this->dialogs = std::move(dialogs);
+                this->dialogs = dialogs;
                 return *this;
             }
 
@@ -296,11 +296,11 @@ TEST(Application, FileNotOpenedWhenNotSpecified)
 TEST(Application, DialogShownOnCloseWithUnsavedRouteBlocksClose)
 {
     auto [route_ptr, route] = create_mock<MockRoute>();
-    auto [dialogs_ptr, dialogs] = create_mock<MockDialogs>();
+    auto dialogs = std::make_shared<MockDialogs>();
     auto route_ptr_actual = std::move(route_ptr);
 
     EXPECT_CALL(route, is_unsaved).WillRepeatedly(Return(true));
-    auto application = register_test_module().with_route_source([&](auto&&...) {return std::move(route_ptr_actual); }).with_dialogs(std::move(dialogs_ptr)).build();
+    auto application = register_test_module().with_route_source([&](auto&&...) {return std::move(route_ptr_actual); }).with_dialogs(dialogs).build();
     bool closing_called = false;
     auto token = application->on_closing += [&]() { closing_called = true; };
     application->process_message(WM_CLOSE, 0, 0);
@@ -310,12 +310,12 @@ TEST(Application, DialogShownOnCloseWithUnsavedRouteBlocksClose)
 TEST(Application, DialogShownOnCloseWithUnsavedRouteAllowsClose)
 {
     auto [route_ptr, route] = create_mock<MockRoute>();
-    auto [dialogs_ptr, dialogs] = create_mock<MockDialogs>();
+    auto dialogs = std::make_shared<MockDialogs>();
     auto route_ptr_actual = std::move(route_ptr);
 
     EXPECT_CALL(route, is_unsaved).WillRepeatedly(Return(true));
-    EXPECT_CALL(dialogs, message_box).WillRepeatedly(Return(true));
-    auto application = register_test_module().with_route_source([&](auto&&...) {return std::move(route_ptr_actual); }).with_dialogs(std::move(dialogs_ptr)).build();
+    EXPECT_CALL(*dialogs, message_box).WillRepeatedly(Return(true));
+    auto application = register_test_module().with_route_source([&](auto&&...) {return std::move(route_ptr_actual); }).with_dialogs(dialogs).build();
     bool closing_called = false;
     auto token = application->on_closing += [&]() { closing_called = true; };
     application->process_message(WM_CLOSE, 0, 0);
@@ -325,7 +325,7 @@ TEST(Application, DialogShownOnCloseWithUnsavedRouteAllowsClose)
 TEST(Application, DialogShownOnOpenWithUnsavedRouteBlocksOpen)
 {
     auto [route_ptr, route] = create_mock<MockRoute>();
-    auto [dialogs_ptr, dialogs] = create_mock<MockDialogs>();
+    auto dialogs = std::make_shared<MockDialogs>();
     auto route_ptr_actual = std::move(route_ptr);
     auto [level_loader_ptr, level_loader] = create_mock<trlevel::mocks::MockLevelLoader>();
 
@@ -333,7 +333,7 @@ TEST(Application, DialogShownOnOpenWithUnsavedRouteBlocksOpen)
     EXPECT_CALL(level_loader, load_level).Times(0);
     auto application = register_test_module()
         .with_route_source([&](auto&&...) {return std::move(route_ptr_actual); })
-        .with_dialogs(std::move(dialogs_ptr))
+        .with_dialogs(dialogs)
         .with_level_loader(std::move(level_loader_ptr))
         .build();
     application->open("");
@@ -342,16 +342,16 @@ TEST(Application, DialogShownOnOpenWithUnsavedRouteBlocksOpen)
 TEST(Application, DialogShownOnOpenWithUnsavedRouteAllowsOpen)
 {
     auto [route_ptr, route] = create_mock<MockRoute>();
-    auto [dialogs_ptr, dialogs] = create_mock<MockDialogs>();
+    auto dialogs = std::make_shared<MockDialogs>();
     auto route_ptr_actual = std::move(route_ptr);
     auto [level_loader_ptr, level_loader] = create_mock<trlevel::mocks::MockLevelLoader>();
 
     EXPECT_CALL(route, is_unsaved).WillRepeatedly(Return(true));
-    EXPECT_CALL(dialogs, message_box).WillRepeatedly(Return(true));
+    EXPECT_CALL(*dialogs, message_box).WillRepeatedly(Return(true));
     EXPECT_CALL(level_loader, load_level).Times(1);
     auto application = register_test_module()
         .with_route_source([&](auto&&...) {return std::move(route_ptr_actual); })
-        .with_dialogs(std::move(dialogs_ptr))
+        .with_dialogs(dialogs)
         .with_level_loader(std::move(level_loader_ptr))
         .build();
     application->open("");

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -9,6 +9,7 @@
 #include <trview.common/Mocks/Windows/IClipboard.h>
 #include <trview.ui/Mocks/Input/IInput.h>
 #include <external/boost/di.hpp>
+#include <trview.common/Mocks/Windows/IDialogs.h>
 
 using namespace DirectX::SimpleMath;
 using namespace testing;
@@ -31,7 +32,8 @@ namespace
             di::bind<ui::IInput::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockInput>(); }; }),
             di::bind<Window>.to(create_test_window(L"RouteWindowTests")),
             di::bind<RouteWindow>(),
-            di::bind<IClipboard>.to(clipboard ? clipboard : std::make_shared<MockClipboard>())
+            di::bind<IClipboard>.to(clipboard ? clipboard : std::make_shared<MockClipboard>()),
+            di::bind<IDialogs>.to(std::make_shared<MockDialogs>())
         );
     }
 }

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -10,6 +10,7 @@
 #include <trview.ui/Mocks/Input/IInput.h>
 #include <external/boost/di.hpp>
 #include <trview.common/Mocks/Windows/IDialogs.h>
+#include <trview.common/Mocks/IFiles.h>
 
 using namespace DirectX::SimpleMath;
 using namespace testing;
@@ -33,7 +34,8 @@ namespace
             di::bind<Window>.to(create_test_window(L"RouteWindowTests")),
             di::bind<RouteWindow>(),
             di::bind<IClipboard>.to(clipboard ? clipboard : std::make_shared<MockClipboard>()),
-            di::bind<IDialogs>.to(std::make_shared<MockDialogs>())
+            di::bind<IDialogs>.to(std::make_shared<MockDialogs>()),
+            di::bind<IFiles>.to(std::make_shared<MockFiles>())
         );
     }
 }
@@ -186,4 +188,24 @@ TEST(RouteWindow, ClearSaveMarksRouteUnsaved)
     ASSERT_NE(clear_save, nullptr);
 
     clear_save->on_click();
+}
+
+TEST(RouteWindow, ExportRouteButtonRaisesEvent)
+{
+    FAIL();
+}
+
+TEST(RouteWindow, ImportRouteButtonRaisesEvent)
+{
+    FAIL();
+}
+
+TEST(RouteWindow, ExportSaveButtonSavesFile)
+{
+    FAIL();
+}
+
+TEST(RouteWindow, AttachSaveButtonLoadsSave)
+{
+    FAIL();
 }

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -297,7 +297,7 @@ TEST(RouteWindow, ExportSaveButtonSavesFile)
     EXPECT_CALL(*dialogs, save_file).Times(1).WillRepeatedly(Return("filename"));
 
     auto files = std::make_shared<MockFiles>();
-    EXPECT_CALL(*files, save_file).Times(1);
+    EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::vector<uint8_t>&>())).Times(1);
 
     auto mesh = std::make_shared<MockMesh>();
     Waypoint waypoint{ mesh.get(), Vector3::Zero, 0 };
@@ -321,7 +321,7 @@ TEST(RouteWindow, ExportSaveButtonDoesNotSaveFileWhenCancelled)
     EXPECT_CALL(*dialogs, save_file).Times(1);
 
     auto files = std::make_shared<MockFiles>();
-    EXPECT_CALL(*files, save_file).Times(0);
+    EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::vector<uint8_t>&>())).Times(0);
 
     auto mesh = std::make_shared<MockMesh>();
     Waypoint waypoint{ mesh.get(), Vector3::Zero, 0 };

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -29,6 +29,7 @@
 #include <trview.common/windows/Clipboard.h>
 #include <trview.common/Windows/Dialogs.h>
 #include <trview.app/Settings/IStartupOptions.h>
+#include <trview.common/Files.h>
 
 using namespace DirectX::SimpleMath;
 
@@ -596,6 +597,7 @@ namespace trview
             di::bind<IShortcuts>.to<Shortcuts>(),
             di::bind<IApplication>.to<Application>(),
             di::bind<IDialogs>.to<Dialogs>(),
+            di::bind<IFiles>.to<Files>(),
             di::bind<IStartupOptions::CommandLine>.to(command_line)
         );
 

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -122,13 +122,13 @@ namespace trview
         std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
         const ILevel::Source& level_source,
         std::shared_ptr<IStartupOptions> startup_options,
-        std::unique_ptr<IDialogs> dialogs)
+        std::shared_ptr<IDialogs> dialogs)
         : MessageHandler(application_window), _instance(GetModuleHandle(nullptr)),
         _file_dropper(std::move(file_dropper)), _level_switcher(std::move(level_switcher)), _recent_files(std::move(recent_files)), _update_checker(std::move(update_checker)),
         _view_menu(window()), _settings_loader(std::move(settings_loader)), _level_loader(std::move(level_loader)), _viewer(std::move(viewer)), _route_source(route_source),
         _route(route_source()), _shortcuts(shortcuts), _items_windows(std::move(items_window_manager)),
         _triggers_windows(std::move(triggers_window_manager)), _route_window(std::move(route_window_manager)), _rooms_windows(std::move(rooms_window_manager)), _level_source(level_source),
-        _dialogs(std::move(dialogs))
+        _dialogs(dialogs)
     {
         _update_checker->check_for_updates();
         _settings = _settings_loader->load_user_settings();
@@ -218,26 +218,10 @@ namespace trview
                     case ID_FILE_OPEN:
                     case ID_ACCEL_FILE_OPEN:
                     {
-                        wchar_t cd[MAX_PATH];
-                        GetCurrentDirectoryW(MAX_PATH, cd);
-
-                        OPENFILENAME ofn;
-                        memset(&ofn, 0, sizeof(ofn));
-
-                        wchar_t path[MAX_PATH];
-                        memset(&path, 0, sizeof(path));
-
-                        ofn.lStructSize = sizeof(ofn);
-                        ofn.lpstrFile = path;
-                        ofn.nMaxFile = MAX_PATH;
-                        ofn.lpstrTitle = L"Open level";
-                        ofn.lpstrFilter = L"All Tomb Raider Files\0*.tr*;*.phd\0";
-                        ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
-
-                        if (GetOpenFileName(&ofn))
+                        const auto filename = _dialogs->open_file(L"Open level", L"All Tomb Raider Files", { L"*.tr*", L"*.phd" }, OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST);
+                        if (filename.has_value())
                         {
-                            SetCurrentDirectory(cd);
-                            open(trview::to_utf8(ofn.lpstrFile));
+                            open(filename.value());
                         }
                         break;
                     }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -1,8 +1,5 @@
 #include "Application.h"
 
-#include <shellapi.h>
-#include <commdlg.h>
-
 #include <trview.common/Strings.h>
 
 #include "Resources/resource.h"

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -1,7 +1,5 @@
 #include "Application.h"
 
-#include <trview.common/Strings.h>
-
 #include "Resources/resource.h"
 #include "Resources/DefaultShaders.h"
 #include "Resources/DefaultFonts.h"
@@ -23,10 +21,10 @@
 #include <trview.app/Tools/di.h>
 #include <trview.app/UI/di.h>
 #include <trview.app/Windows/di.h>
+#include <trview.common/Files.h>
 #include <trview.common/windows/Clipboard.h>
 #include <trview.common/Windows/Dialogs.h>
 #include <trview.app/Settings/IStartupOptions.h>
-#include <trview.common/Files.h>
 
 using namespace DirectX::SimpleMath;
 

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -120,13 +120,14 @@ namespace trview
         std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
         const ILevel::Source& level_source,
         std::shared_ptr<IStartupOptions> startup_options,
-        std::shared_ptr<IDialogs> dialogs)
+        std::shared_ptr<IDialogs> dialogs,
+        std::shared_ptr<IFiles> files)
         : MessageHandler(application_window), _instance(GetModuleHandle(nullptr)),
         _file_dropper(std::move(file_dropper)), _level_switcher(std::move(level_switcher)), _recent_files(std::move(recent_files)), _update_checker(std::move(update_checker)),
         _view_menu(window()), _settings_loader(std::move(settings_loader)), _level_loader(std::move(level_loader)), _viewer(std::move(viewer)), _route_source(route_source),
         _route(route_source()), _shortcuts(shortcuts), _items_windows(std::move(items_window_manager)),
         _triggers_windows(std::move(triggers_window_manager)), _route_window(std::move(route_window_manager)), _rooms_windows(std::move(rooms_window_manager)), _level_source(level_source),
-        _dialogs(dialogs)
+        _dialogs(dialogs), _files(files)
     {
         _update_checker->check_for_updates();
         _settings = _settings_loader->load_user_settings();
@@ -393,17 +394,17 @@ namespace trview
         _token_store += _route_window->on_trigger_selected += [&](const auto& trigger) { select_trigger(trigger); };
         _token_store += _route_window->on_route_import += [&](const std::string& path)
         {
-            auto route = import_route(_route_source, path);
+            auto route = import_route(_route_source, _files, path);
             if (route)
             {
-                _route = std::move(route);
+                _route = route;
                 _route_window->set_route(_route.get());
                 _viewer->set_route(_route);
             }
         };
         _token_store += _route_window->on_route_export += [&](const std::string& path)
         {
-            export_route(*_route, path); 
+            export_route(*_route, _files, path); 
             _route->set_unsaved(false);
         };
         _token_store += _route_window->on_waypoint_deleted += [&](auto index) { remove_waypoint(index); };

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -50,7 +50,7 @@ namespace trview
             std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
             const ILevel::Source& level_source,
             std::shared_ptr<IStartupOptions> startup_options,
-            std::unique_ptr<IDialogs> dialogs);
+            std::shared_ptr<IDialogs> dialogs);
         virtual ~Application();
         /// Attempt to open the specified level file.
         /// @param filename The level file to open.
@@ -95,7 +95,7 @@ namespace trview
         std::unique_ptr<IUpdateChecker> _update_checker;
         ViewMenu _view_menu;
         std::shared_ptr<IShortcuts> _shortcuts;
-        std::unique_ptr<IDialogs> _dialogs;
+        std::shared_ptr<IDialogs> _dialogs;
         HINSTANCE _instance{ nullptr };
 
         // Level data components

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -50,7 +50,8 @@ namespace trview
             std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
             const ILevel::Source& level_source,
             std::shared_ptr<IStartupOptions> startup_options,
-            std::shared_ptr<IDialogs> dialogs);
+            std::shared_ptr<IDialogs> dialogs,
+            std::shared_ptr<IFiles> files);
         virtual ~Application();
         /// Attempt to open the specified level file.
         /// @param filename The level file to open.
@@ -96,6 +97,7 @@ namespace trview
         ViewMenu _view_menu;
         std::shared_ptr<IShortcuts> _shortcuts;
         std::shared_ptr<IDialogs> _dialogs;
+        std::shared_ptr<IFiles> _files;
         HINSTANCE _instance{ nullptr };
 
         // Level data components

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -10,7 +10,7 @@ namespace trview
     /// </summary>
     struct IRoute
     {
-        using Source = std::function<std::unique_ptr<IRoute>()>;
+        using Source = std::function<std::shared_ptr<IRoute>()>;
         virtual ~IRoute() = 0;
         /// <summary>
         /// Add a new waypoint to the end of the route.

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -245,13 +245,12 @@ namespace trview
         try
         {
             auto data = files->load_file(filename);
-            // if (!data.has_value())
-            if (false)
+            if (!data.has_value())
             {
                 return nullptr;
             }
 
-            auto json = nlohmann::json::parse(data.begin(), data.end());
+            auto json = nlohmann::json::parse(data.value().begin(), data.value().end());
 
             auto route = route_source();
             if (json["colour"].is_string())

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -236,7 +236,7 @@ namespace trview
         return _waypoints.empty() ? 0 : _selected_index + 1;
     }
 
-    std::unique_ptr<IRoute> import_route(const IRoute::Source& route_source, const std::string& filename)
+    std::shared_ptr<IRoute> import_route(const IRoute::Source& route_source, const std::shared_ptr<IFiles>& files, const std::string& filename)
     {
         try
         {
@@ -250,6 +250,7 @@ namespace trview
             auto route = route_source();
 
             nlohmann::json json;
+            
             file >> json;
 
             if (json["colour"].is_string())
@@ -296,7 +297,7 @@ namespace trview
         }
     }
 
-    void export_route(const IRoute& route, const std::string& filename)
+    void export_route(const IRoute& route, std::shared_ptr<IFiles>& files, const std::string& filename)
     {
         try
         {
@@ -330,8 +331,7 @@ namespace trview
 
             json["waypoints"] = waypoints;
 
-            std::ofstream file(to_utf16(filename));
-            file << json;
+            files->save_file(filename, json.dump());
         }
         catch (...)
         {

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -2,10 +2,6 @@
 #include <trview.app/Camera/ICamera.h>
 #include <trview.common/Strings.h>
 
-#include <fstream>
-#include <external/nlohmann/json.hpp>
-#include <sstream>
-
 using namespace DirectX;
 using namespace DirectX::SimpleMath;
 

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -2,6 +2,10 @@
 #include <trview.app/Camera/ICamera.h>
 #include <trview.common/Strings.h>
 
+#include <fstream>
+#include <external/nlohmann/json.hpp>
+#include <sstream>
+
 using namespace DirectX;
 using namespace DirectX::SimpleMath;
 
@@ -240,19 +244,16 @@ namespace trview
     {
         try
         {
-            std::ifstream file(to_utf16(filename));
-            file.exceptions(std::ifstream::failbit | std::ifstream::badbit | std::ifstream::eofbit);
-            if (!file.is_open())
+            auto data = files->load_file(filename);
+            // if (!data.has_value())
+            if (false)
             {
                 return nullptr;
             }
 
+            auto json = nlohmann::json::parse(data.begin(), data.end());
+
             auto route = route_source();
-
-            nlohmann::json json;
-            
-            file >> json;
-
             if (json["colour"].is_string())
             {
                 route->set_colour(named_colour(to_utf16(json["colour"].get<std::string>())));

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -5,6 +5,7 @@
 #include <trview.app/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Routing/IRoute.h>
 #include <trview.app/Camera/ICamera.h>
+#include <trview.common/IFiles.h>
 
 namespace trview
 {
@@ -45,6 +46,6 @@ namespace trview
         bool _is_unsaved{ false };
     };
 
-    std::unique_ptr<IRoute> import_route(const IRoute::Source& route_source, const std::string& filename);
-    void export_route(const IRoute& route, const std::string& filename);
+    std::shared_ptr<IRoute> import_route(const IRoute::Source& route_source, const std::shared_ptr<IFiles>& files, const std::string& filename);
+    void export_route(const IRoute& route, std::shared_ptr<IFiles>& files, const std::string& filename);
 }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -212,18 +212,11 @@ namespace trview
                     // Load bytes from file.
                     try
                     {
-                        std::ifstream infile;
-                        infile.open(filename.value(), std::ios::in | std::ios::binary | std::ios::ate);
-                        auto length = infile.tellg();
-                        infile.seekg(0, std::ios::beg);
-
-                        if (length)
+                        const auto bytes = _files->load_file(filename.value());
+                        if (!bytes.empty())
                         {
-                            std::vector<uint8_t> bytes(static_cast<uint32_t>(length));
-                            infile.read(reinterpret_cast<char*>(&bytes[0]), length);
                             _route->waypoint(_selected_index).set_save_file(bytes);
                             _route->set_unsaved(true);
-
                             _select_save->set_text(L"SAVEGAME.0");
                         }
                     }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -44,8 +44,8 @@ namespace trview
 
     RouteWindow::RouteWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
         const ui::IInput::Source& input_source, const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard,
-        const std::shared_ptr<IDialogs>& dialogs)
-        : CollapsiblePanel(device_window_source, renderer_source(Size(470, 400)), parent, L"trview.route", L"Route", input_source, Size(470, 400)), _clipboard(clipboard), _dialogs(dialogs)
+        const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files)
+        : CollapsiblePanel(device_window_source, renderer_source(Size(470, 400)), parent, L"trview.route", L"Route", input_source, Size(470, 400)), _clipboard(clipboard), _dialogs(dialogs), _files(files)
     {
         CollapsiblePanel::on_window_closed += IRouteWindow::on_window_closed;
         set_panels(create_left_panel(), create_right_panel());
@@ -240,11 +240,7 @@ namespace trview
                 {
                     try
                     {
-                        std::ofstream outfile;
-                        outfile.open(filename.value(), std::ios::out | std::ios::binary);
-
-                        auto bytes = _route->waypoint(_selected_index).save_file();
-                        outfile.write(reinterpret_cast<char*>(&bytes[0]), bytes.size());
+                        _files->save_file(filename.value(), _route->waypoint(_selected_index).save_file());
                     }
                     catch (...)
                     {

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -25,10 +25,11 @@ namespace trview
         };
     }
 
+    const std::string RouteWindow::Names::export_button = "export_button";
+    const std::string RouteWindow::Names::import_button = "import_button";
     const std::string RouteWindow::Names::clear_save = "clear_save";
     const std::string RouteWindow::Names::notes_area = "notes_area";
     const std::string RouteWindow::Names::waypoint_stats = "waypoint_stats";
-    
 
     namespace Colours
     {
@@ -107,6 +108,7 @@ namespace trview
         };
 
         auto import = buttons->add_child(std::make_unique<Button>(Size(90, 20), L"Import"));
+        import->set_name(Names::import_button);
         _token_store += import->on_click += [&]()
         {
             const auto filename = _dialogs->open_file(L"Import route", L"trview route", { L"*.tvr" }, OFN_FILEMUSTEXIST);
@@ -116,6 +118,7 @@ namespace trview
             }
         };
         auto export_button = buttons->add_child(std::make_unique<Button>(Size(90, 20), L"Export"));
+        export_button->set_name(Names::export_button);
         _token_store += export_button->on_click += [&]()
         {
             const auto filename = _dialogs->save_file(L"Export route", L"trview route", { L"*.tvr" });

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -118,21 +118,10 @@ namespace trview
         auto export_button = buttons->add_child(std::make_unique<Button>(Size(90, 20), L"Export"));
         _token_store += export_button->on_click += [&]()
         {
-            OPENFILENAME ofn;
-            memset(&ofn, 0, sizeof(ofn));
-
-            wchar_t path[MAX_PATH];
-            memset(&path, 0, sizeof(path));
-
-            ofn.lStructSize = sizeof(ofn);
-            ofn.lpstrFilter = L"trview route\0*.tvr\0";
-            ofn.nMaxFile = MAX_PATH;
-            ofn.lpstrTitle = L"Export route";
-            ofn.lpstrFile = path;
-            ofn.lpstrDefExt = L"tvr";
-            if (GetSaveFileName(&ofn))
+            const auto filename = _dialogs->save_file(L"Export route", L"trview route", { L"*.tvr" });
+            if (filename.has_value())
             {
-                on_route_export(trview::to_utf8(ofn.lpstrFile));
+                on_route_export(filename.value());
             }
         };
         auto _buttons = left_panel->add_child(std::move(buttons));
@@ -246,25 +235,13 @@ namespace trview
             }
             else
             {
-                OPENFILENAME ofn;
-                memset(&ofn, 0, sizeof(ofn));
-
-                wchar_t path[MAX_PATH];
-                memset(&path, 0, sizeof(path));
-
-                ofn.lStructSize = sizeof(ofn);
-                ofn.lpstrFilter = L"Savegame File\0*.*\0";
-                ofn.nMaxFile = MAX_PATH;
-                ofn.lpstrTitle = L"Export Save";
-                ofn.lpstrFile = path;
-                ofn.lpstrDefExt = L"0";
-                if (GetSaveFileName(&ofn))
+                const auto filename = _dialogs->save_file(L"Export Save", L"Savegame File", { L"*.*" });
+                if (filename.has_value())
                 {
-                    auto filename = trview::to_utf8(ofn.lpstrFile);
                     try
                     {
                         std::ofstream outfile;
-                        outfile.open(filename, std::ios::out | std::ios::binary);
+                        outfile.open(filename.value(), std::ios::out | std::ios::binary);
 
                         auto bytes = _route->waypoint(_selected_index).save_file();
                         outfile.write(reinterpret_cast<char*>(&bytes[0]), bytes.size());

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -29,6 +29,7 @@ namespace trview
     const std::string RouteWindow::Names::import_button = "import_button";
     const std::string RouteWindow::Names::clear_save = "clear_save";
     const std::string RouteWindow::Names::notes_area = "notes_area";
+    const std::string RouteWindow::Names::select_save_button = "select_save_button";
     const std::string RouteWindow::Names::waypoint_stats = "waypoint_stats";
 
     namespace Colours
@@ -200,6 +201,7 @@ namespace trview
         auto save_area = details_panel->add_child(std::make_unique<StackPanel>(Size(panel_width - 20, 20), Colours::ItemDetails, Size(), StackPanel::Direction::Horizontal, SizeMode::Manual));
 
         _select_save = save_area->add_child(std::make_unique<Button>(Size(panel_width - 40, 20), L"Attach Save"));
+        _select_save->set_name(Names::select_save_button);
         _token_store += _select_save->on_click += [&]()
         {
             if (!(_route && _selected_index < _route->waypoints()))

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -227,7 +227,7 @@ namespace trview
                     }
                     catch (...)
                     {
-                        MessageBox(window(), L"Failed to attach save", L"Error", MB_OK);
+                        _dialogs->message_box(window(), L"Failed to attach save", L"Error", IDialogs::Buttons::OK);
                     }
                 }
             }
@@ -242,7 +242,7 @@ namespace trview
                     }
                     catch (...)
                     {
-                        MessageBox(window(), L"Failed to export save", L"Error", MB_OK);
+                        _dialogs->message_box(window(), L"Failed to export save", L"Error", IDialogs::Buttons::OK);
                     }
                 }
             }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -218,9 +218,9 @@ namespace trview
                     try
                     {
                         const auto bytes = _files->load_file(filename.value());
-                        if (!bytes.empty())
+                        if (bytes.has_value() && !bytes.value().empty())
                         {
-                            _route->waypoint(_selected_index).set_save_file(bytes);
+                            _route->waypoint(_selected_index).set_save_file(bytes.value());
                             _route->set_unsaved(true);
                             _select_save->set_text(L"SAVEGAME.0");
                         }

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -10,6 +10,7 @@
 #include <trview.app/Elements/Item.h>
 #include <trview.app/Elements/Room.h>
 #include <trview.common/Windows/IClipboard.h>
+#include <trview.common/Windows/IDialogs.h>
 #include "IRouteWindow.h"
 
 namespace trview
@@ -31,7 +32,8 @@ namespace trview
         /// @param renderer_source The function to call to get a renderer.
         /// @param parent The parent window.
         explicit RouteWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
-            const ui::IInput::Source& input_source, const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard);
+            const ui::IInput::Source& input_source, const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard,
+            const std::shared_ptr<IDialogs>& dialogs);
         virtual ~RouteWindow() = default;
         virtual void render(bool vsync) override;
         virtual void set_route(IRoute* route) override;
@@ -60,5 +62,6 @@ namespace trview
         Waypoint::Type _selected_type{ Waypoint::Type::Position };
         uint32_t       _selected_index{ 0u };
         std::shared_ptr<IClipboard> _clipboard;
+        std::shared_ptr<IDialogs> _dialogs;
     };
 }

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -27,6 +27,7 @@ namespace trview
             static const std::string import_button;
             static const std::string clear_save;
             static const std::string notes_area;
+            static const std::string select_save_button;
             static const std::string waypoint_stats;
         };
 

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -23,6 +23,8 @@ namespace trview
     public:
         struct Names
         {
+            static const std::string export_button;
+            static const std::string import_button;
             static const std::string clear_save;
             static const std::string notes_area;
             static const std::string waypoint_stats;

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -11,6 +11,7 @@
 #include <trview.app/Elements/Room.h>
 #include <trview.common/Windows/IClipboard.h>
 #include <trview.common/Windows/IDialogs.h>
+#include <trview.common/IFiles.h>
 #include "IRouteWindow.h"
 
 namespace trview
@@ -33,7 +34,7 @@ namespace trview
         /// @param parent The parent window.
         explicit RouteWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
             const ui::IInput::Source& input_source, const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard,
-            const std::shared_ptr<IDialogs>& dialogs);
+            const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
         virtual ~RouteWindow() = default;
         virtual void render(bool vsync) override;
         virtual void set_route(IRoute* route) override;
@@ -63,5 +64,6 @@ namespace trview
         uint32_t       _selected_index{ 0u };
         std::shared_ptr<IClipboard> _clipboard;
         std::shared_ptr<IDialogs> _dialogs;
+        std::shared_ptr<IFiles> _files;
     };
 }

--- a/trview.app/Windows/di.hpp
+++ b/trview.app/Windows/di.hpp
@@ -58,7 +58,8 @@ namespace trview
                             injector.create<ui::render::IRenderer::Source>(),
                             injector.create<ui::IInput::Source>(),
                             window,
-                            injector.create<std::shared_ptr<IClipboard>>());
+                            injector.create<std::shared_ptr<IClipboard>>(),
+                            injector.create<std::shared_ptr<IDialogs>>());
                     };
                 }
             ),

--- a/trview.app/Windows/di.hpp
+++ b/trview.app/Windows/di.hpp
@@ -59,7 +59,8 @@ namespace trview
                             injector.create<ui::IInput::Source>(),
                             window,
                             injector.create<std::shared_ptr<IClipboard>>(),
-                            injector.create<std::shared_ptr<IDialogs>>());
+                            injector.create<std::shared_ptr<IDialogs>>(),
+                            injector.create<std::shared_ptr<IFiles>>());
                     };
                 }
             ),

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -985,6 +985,8 @@
     <Text Include="Resources\Files\fontlist.txt">
       <Filter>Resources\Files</Filter>
     </Text>
-    <Text Include="Resources\Files\actions.json" />
+    <Text Include="Resources\Files\actions.json">
+      <Filter>Resources\Files</Filter>
+    </Text>
   </ItemGroup>
 </Project>

--- a/trview.common/Files.cpp
+++ b/trview.common/Files.cpp
@@ -7,6 +7,7 @@ namespace trview
     {
         std::ifstream infile;
         infile.open(to_utf16(filename), std::ios::in | std::ios::binary | std::ios::ate);
+        infile.exceptions(std::ifstream::failbit | std::ifstream::badbit | std::ifstream::eofbit);
 
         if (!infile.is_open())
         {

--- a/trview.common/Files.cpp
+++ b/trview.common/Files.cpp
@@ -1,0 +1,11 @@
+#include "Files.h"
+
+namespace trview
+{
+    void Files::save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const
+    {
+        std::ofstream outfile;
+        outfile.open(filename, std::ios::out | std::ios::binary);
+        outfile.write(reinterpret_cast<const char*>(&bytes[0]), bytes.size());
+    }
+}

--- a/trview.common/Files.cpp
+++ b/trview.common/Files.cpp
@@ -1,11 +1,12 @@
 #include "Files.h"
+#include "Strings.h"
 
 namespace trview
 {
     std::vector<uint8_t> Files::load_file(const std::string& filename) const
     {
         std::ifstream infile;
-        infile.open(filename, std::ios::in | std::ios::binary | std::ios::ate);
+        infile.open(to_utf16(filename), std::ios::in | std::ios::binary | std::ios::ate);
 
         const auto length = infile.tellg();
         if (!length)
@@ -22,7 +23,14 @@ namespace trview
     void Files::save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const
     {
         std::ofstream outfile;
-        outfile.open(filename, std::ios::out | std::ios::binary);
+        outfile.open(to_utf16(filename), std::ios::out | std::ios::binary);
         outfile.write(reinterpret_cast<const char*>(&bytes[0]), bytes.size());
+    }
+
+    void Files::save_file(const std::string& filename, const std::string& text) const
+    {
+        std::ofstream outfile;
+        outfile.open(to_utf16(filename), std::ios::out);
+        outfile << text;
     }
 }

--- a/trview.common/Files.cpp
+++ b/trview.common/Files.cpp
@@ -3,15 +3,20 @@
 
 namespace trview
 {
-    std::vector<uint8_t> Files::load_file(const std::string& filename) const
+    std::optional<std::vector<uint8_t>> Files::load_file(const std::string& filename) const
     {
         std::ifstream infile;
         infile.open(to_utf16(filename), std::ios::in | std::ios::binary | std::ios::ate);
 
+        if (!infile.is_open())
+        {
+            return {};
+        }
+
         const auto length = infile.tellg();
         if (!length)
         {
-            return {};
+            return {{}};
         }
 
         infile.seekg(0, std::ios::beg);

--- a/trview.common/Files.cpp
+++ b/trview.common/Files.cpp
@@ -2,6 +2,23 @@
 
 namespace trview
 {
+    std::vector<uint8_t> Files::load_file(const std::string& filename) const
+    {
+        std::ifstream infile;
+        infile.open(filename, std::ios::in | std::ios::binary | std::ios::ate);
+
+        const auto length = infile.tellg();
+        if (!length)
+        {
+            return {};
+        }
+
+        infile.seekg(0, std::ios::beg);
+        std::vector<uint8_t> bytes(static_cast<uint32_t>(length));
+        infile.read(reinterpret_cast<char*>(&bytes[0]), length);
+        return bytes;
+    }
+
     void Files::save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const
     {
         std::ofstream outfile;

--- a/trview.common/Files.h
+++ b/trview.common/Files.h
@@ -8,7 +8,7 @@ namespace trview
     {
     public:
         virtual ~Files() = default;
-        virtual std::vector<uint8_t> load_file(const std::string& filename) const override;
+        virtual std::optional<std::vector<uint8_t>> load_file(const std::string& filename) const override;
         virtual void save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const override;
         virtual void save_file(const std::string& filename, const std::string& text) const override;
     };

--- a/trview.common/Files.h
+++ b/trview.common/Files.h
@@ -10,5 +10,6 @@ namespace trview
         virtual ~Files() = default;
         virtual std::vector<uint8_t> load_file(const std::string& filename) const override;
         virtual void save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const override;
+        virtual void save_file(const std::string& filename, const std::string& text) const override;
     };
 }

--- a/trview.common/Files.h
+++ b/trview.common/Files.h
@@ -10,7 +10,5 @@ namespace trview
         virtual ~Files() = default;
         virtual std::vector<uint8_t> load_file(const std::string& filename) const override;
         virtual void save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const override;
-    private:
-
     };
 }

--- a/trview.common/Files.h
+++ b/trview.common/Files.h
@@ -8,6 +8,7 @@ namespace trview
     {
     public:
         virtual ~Files() = default;
+        virtual std::vector<uint8_t> load_file(const std::string& filename) const override;
         virtual void save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const override;
     private:
 

--- a/trview.common/Files.h
+++ b/trview.common/Files.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "IFiles.h"
+
+namespace trview
+{
+    class Files final : public IFiles
+    {
+    public:
+        virtual ~Files() = default;
+        virtual void save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const override;
+    private:
+
+    };
+}

--- a/trview.common/IFiles.cpp
+++ b/trview.common/IFiles.cpp
@@ -1,0 +1,8 @@
+#include "IFiles.h"
+
+namespace trview
+{
+    IFiles::~IFiles()
+    {
+    }
+}

--- a/trview.common/IFiles.h
+++ b/trview.common/IFiles.h
@@ -8,6 +8,7 @@ namespace trview
     struct IFiles
     {
         virtual ~IFiles() = 0;
+        virtual std::vector<uint8_t> load_file(const std::string& filename) const = 0;
         virtual void save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const = 0;
     };
 }

--- a/trview.common/IFiles.h
+++ b/trview.common/IFiles.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <cstdint>
+#include <vector>
 
 namespace trview
 {

--- a/trview.common/IFiles.h
+++ b/trview.common/IFiles.h
@@ -11,5 +11,6 @@ namespace trview
         virtual ~IFiles() = 0;
         virtual std::vector<uint8_t> load_file(const std::string& filename) const = 0;
         virtual void save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const = 0;
+        virtual void save_file(const std::string& filename, const std::string& text) const = 0;
     };
 }

--- a/trview.common/IFiles.h
+++ b/trview.common/IFiles.h
@@ -3,13 +3,14 @@
 #include <string>
 #include <cstdint>
 #include <vector>
+#include <optional>
 
 namespace trview
 {
     struct IFiles
     {
         virtual ~IFiles() = 0;
-        virtual std::vector<uint8_t> load_file(const std::string& filename) const = 0;
+        virtual std::optional<std::vector<uint8_t>> load_file(const std::string& filename) const = 0;
         virtual void save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const = 0;
         virtual void save_file(const std::string& filename, const std::string& text) const = 0;
     };

--- a/trview.common/IFiles.h
+++ b/trview.common/IFiles.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+#include <cstdint>
+
+namespace trview
+{
+    struct IFiles
+    {
+        virtual ~IFiles() = 0;
+        virtual void save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const = 0;
+    };
+}

--- a/trview.common/Mocks/IFiles.h
+++ b/trview.common/Mocks/IFiles.h
@@ -5,7 +5,7 @@ namespace trview
     struct MockFiles final : public IFiles
     {
         virtual ~MockFiles() = default;
-        MOCK_METHOD(std::vector<uint8_t>, load_file, (const std::string&), (const, override));
+        MOCK_METHOD(std::optional<std::vector<uint8_t>>, load_file, (const std::string&), (const, override));
         MOCK_METHOD(void, save_file, (const std::string&, const std::vector<uint8_t>&), (const, override));
         MOCK_METHOD(void, save_file, (const std::string&, const std::string&), (const, override));
     };

--- a/trview.common/Mocks/IFiles.h
+++ b/trview.common/Mocks/IFiles.h
@@ -5,6 +5,7 @@ namespace trview
     struct MockFiles final : public IFiles
     {
         virtual ~MockFiles() = default;
+        MOCK_METHOD(std::vector<uint8_t>, load_file, (const std::string&), (const, override));
         MOCK_METHOD(void, save_file, (const std::string&, const std::vector<uint8_t>&), (const, override));
     };
 }

--- a/trview.common/Mocks/IFiles.h
+++ b/trview.common/Mocks/IFiles.h
@@ -1,0 +1,10 @@
+#include "../IFiles.h"
+
+namespace trview
+{
+    struct MockFiles final : public IFiles
+    {
+        virtual ~MockFiles() = default;
+        MOCK_METHOD(void, save_file, (const std::string&, const std::vector<uint8_t>&), (const, override));
+    };
+}

--- a/trview.common/Mocks/IFiles.h
+++ b/trview.common/Mocks/IFiles.h
@@ -7,5 +7,6 @@ namespace trview
         virtual ~MockFiles() = default;
         MOCK_METHOD(std::vector<uint8_t>, load_file, (const std::string&), (const, override));
         MOCK_METHOD(void, save_file, (const std::string&, const std::vector<uint8_t>&), (const, override));
+        MOCK_METHOD(void, save_file, (const std::string&, const std::string&), (const, override));
     };
 }

--- a/trview.common/Mocks/Windows/IDialogs.h
+++ b/trview.common/Mocks/Windows/IDialogs.h
@@ -9,7 +9,8 @@ namespace trview
         struct MockDialogs final : public IDialogs
         {
             virtual ~MockDialogs() = default;
-            MOCK_METHOD(bool, message_box, (const Window&, const std::wstring&, const std::wstring&, Buttons), (override));
+            MOCK_METHOD(bool, message_box, (const Window&, const std::wstring&, const std::wstring&, Buttons), (const, override));
+            MOCK_METHOD(std::optional<std::string>, open_file, (const std::wstring&, const std::wstring&, const std::vector<std::wstring>&, uint32_t), (const, override));
         };
     }
 }

--- a/trview.common/Mocks/Windows/IDialogs.h
+++ b/trview.common/Mocks/Windows/IDialogs.h
@@ -11,6 +11,7 @@ namespace trview
             virtual ~MockDialogs() = default;
             MOCK_METHOD(bool, message_box, (const Window&, const std::wstring&, const std::wstring&, Buttons), (const, override));
             MOCK_METHOD(std::optional<std::string>, open_file, (const std::wstring&, const std::wstring&, const std::vector<std::wstring>&, uint32_t), (const, override));
+            MOCK_METHOD(std::optional<std::string>, save_file, (const std::wstring&, const std::wstring&, const std::vector<std::wstring>&), (const, override));
         };
     }
 }

--- a/trview.common/Windows/Dialogs.cpp
+++ b/trview.common/Windows/Dialogs.cpp
@@ -51,7 +51,7 @@ namespace trview
         OPENFILENAME ofn;
         memset(&ofn, 0, sizeof(ofn));
 
-        wchar_t path[MAX_PATH + 1];
+        wchar_t path[MAX_PATH];
         memset(&path, 0, sizeof(path));
 
         const auto final_filters = combine_filters(filter, file_types);

--- a/trview.common/Windows/Dialogs.cpp
+++ b/trview.common/Windows/Dialogs.cpp
@@ -69,4 +69,28 @@ namespace trview
         }
         return {};
     }
+
+    std::optional<std::string> Dialogs::save_file(const std::wstring& title, const std::wstring& filter, const std::vector<std::wstring>& file_types) const
+    {
+        OPENFILENAME ofn;
+        memset(&ofn, 0, sizeof(ofn));
+
+        wchar_t path[MAX_PATH];
+        memset(&path, 0, sizeof(path));
+
+        const auto final_filters = combine_filters(filter, file_types);
+
+        ofn.lStructSize = sizeof(ofn);
+        ofn.lpstrFilter = final_filters.c_str();
+        ofn.nMaxFile = MAX_PATH;
+        ofn.lpstrTitle = title.c_str();
+        ofn.lpstrFile = path;
+        ofn.lpstrDefExt = L"0";
+
+        if (GetSaveFileName(&ofn))
+        {
+            return trview::to_utf8(ofn.lpstrFile);
+        }
+        return {};
+    }
 }

--- a/trview.common/Windows/Dialogs.cpp
+++ b/trview.common/Windows/Dialogs.cpp
@@ -1,4 +1,6 @@
 #include "Dialogs.h"
+#include "Strings.h"
+#include <commdlg.h>
 
 namespace trview
 {
@@ -22,10 +24,49 @@ namespace trview
         {
             return response == IDOK || response == IDYES;
         }
+
+        std::wstring combine_filters(const std::wstring& filter, const std::vector<std::wstring>& file_types)
+        {
+            std::wstring final_filter = filter + L'\0';
+            for (auto i = 0; i < file_types.size(); ++i)
+            {
+                final_filter += file_types[i];
+                if (i < file_types.size() - 1)
+                {
+                    final_filter += L';';
+                }
+            }
+            final_filter += L'\0';
+            return final_filter;
+        }
     }
 
-    bool Dialogs::message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons)
+    bool Dialogs::message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons) const
     {
         return convert_response(MessageBox(window, message.c_str(), title.c_str(), convert_button(buttons)));
+    }
+
+    std::optional<std::string> Dialogs::open_file(const std::wstring& title, const std::wstring& filter, const std::vector<std::wstring>& file_types, uint32_t flags) const
+    {
+        OPENFILENAME ofn;
+        memset(&ofn, 0, sizeof(ofn));
+
+        wchar_t path[MAX_PATH + 1];
+        memset(&path, 0, sizeof(path));
+
+        const auto final_filters = combine_filters(filter, file_types);
+
+        ofn.lStructSize = sizeof(ofn);
+        ofn.lpstrFile = path;
+        ofn.nMaxFile = MAX_PATH;
+        ofn.lpstrTitle = title.c_str();
+        ofn.lpstrFilter = final_filters.c_str();
+        ofn.Flags = flags;
+
+        if (GetOpenFileName(&ofn))
+        {
+            return to_utf8(ofn.lpstrFile);
+        }
+        return {};
     }
 }

--- a/trview.common/Windows/Dialogs.h
+++ b/trview.common/Windows/Dialogs.h
@@ -8,6 +8,7 @@ namespace trview
     {
     public:
         virtual ~Dialogs() = default;
-        virtual bool message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons) override;
+        virtual bool message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons) const override;
+        virtual std::optional<std::string> open_file(const std::wstring& title, const std::wstring& filter, const std::vector<std::wstring>& file_types, uint32_t flags) const override;
     };
 }

--- a/trview.common/Windows/Dialogs.h
+++ b/trview.common/Windows/Dialogs.h
@@ -10,5 +10,6 @@ namespace trview
         virtual ~Dialogs() = default;
         virtual bool message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons) const override;
         virtual std::optional<std::string> open_file(const std::wstring& title, const std::wstring& filter, const std::vector<std::wstring>& file_types, uint32_t flags) const override;
+        virtual std::optional<std::string> save_file(const std::wstring& title, const std::wstring& filter, const std::vector<std::wstring>& file_types) const override;
     };
 }

--- a/trview.common/Windows/IDialogs.h
+++ b/trview.common/Windows/IDialogs.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include "../Window.h"
 
@@ -23,6 +24,15 @@ namespace trview
         /// <param name="title">The title of the message box.</param>
         /// <param name="buttons">The buttons to show on the message box.</param>
         /// <returns>True if the positive result was chosen.</returns>
-        virtual bool message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons) = 0;
+        virtual bool message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons) const = 0;
+        /// <summary>
+        /// Prompt the user to select a file to open.
+        /// </summary>
+        /// <param name="title">The title of the dialog box.</param>
+        /// <param name="filter">The display text for the file filters.</param>
+        /// <param name="file_types">The file types to allow.</param>
+        /// <param name="flags">The flags for the dialog.</param>
+        /// <returns>The filename if one was selected or an empty optional.</returns>
+        virtual std::optional<std::string> open_file(const std::wstring& title, const std::wstring& filter, const std::vector<std::wstring>& file_types, uint32_t flags) const = 0;
     };
 }

--- a/trview.common/Windows/IDialogs.h
+++ b/trview.common/Windows/IDialogs.h
@@ -34,5 +34,13 @@ namespace trview
         /// <param name="flags">The flags for the dialog.</param>
         /// <returns>The filename if one was selected or an empty optional.</returns>
         virtual std::optional<std::string> open_file(const std::wstring& title, const std::wstring& filter, const std::vector<std::wstring>& file_types, uint32_t flags) const = 0;
+        /// <summary>
+        /// Prompt the user to select a file to save.
+        /// </summary>
+        /// <param name="title">The title of the dialog box.</param>
+        /// <param name="filter">The display text for the file filters.</param>
+        /// <param name="file_types">The file types to allow.</param>
+        /// <returns>The filename if one was selected or an empty optional.</returns>
+        virtual std::optional<std::string> save_file(const std::wstring& title, const std::wstring& filter, const std::vector<std::wstring>& file_types) const = 0;
     };
 }

--- a/trview.common/Windows/IDialogs.h
+++ b/trview.common/Windows/IDialogs.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 #include "../Window.h"
 
 namespace trview

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -24,9 +24,12 @@
     <ClInclude Include="Colour.h" />
     <ClInclude Include="Event.h" />
     <ClInclude Include="FileLoader.h" />
+    <ClInclude Include="Files.h" />
+    <ClInclude Include="IFiles.h" />
     <ClInclude Include="Json.h" />
     <ClInclude Include="Json.hpp" />
     <ClInclude Include="MessageHandler.h" />
+    <ClInclude Include="Mocks\IFiles.h" />
     <ClInclude Include="Mocks\Windows\IClipboard.h" />
     <ClInclude Include="Mocks\Windows\IDialogs.h" />
     <ClInclude Include="Mocks\Windows\IShortcuts.h" />
@@ -48,6 +51,8 @@
     <ClCompile Include="Colour.cpp" />
     <ClCompile Include="EventToken.cpp" />
     <ClCompile Include="FileLoader.cpp" />
+    <ClCompile Include="Files.cpp" />
+    <ClCompile Include="IFiles.cpp" />
     <ClCompile Include="MessageHandler.cpp" />
     <ClCompile Include="Point.cpp" />
     <ClCompile Include="Size.cpp" />

--- a/trview.common/trview.common.vcxproj.filters
+++ b/trview.common/trview.common.vcxproj.filters
@@ -49,6 +49,11 @@
     <ClInclude Include="Mocks\Windows\IDialogs.h">
       <Filter>Mocks\Windows</Filter>
     </ClInclude>
+    <ClInclude Include="IFiles.h" />
+    <ClInclude Include="Files.h" />
+    <ClInclude Include="Mocks\IFiles.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="FileLoader.cpp" />
@@ -86,6 +91,8 @@
     <ClCompile Include="Windows\Dialogs.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
+    <ClCompile Include="Files.cpp" />
+    <ClCompile Include="IFiles.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">


### PR DESCRIPTION
Add file open/save dialogs to `IDialogs` and use them in `RouteWindow`.
Create `IFiles` with file load/save functions and use them in `Application` and `RouteWindow` to load routes and attachments.
Add a couple more usages of `IDialogs::message_box` instead of calling directly.
Add tests that were previously infeasible but can be written now that it uses the interface instead of files/direct win32 calls.
Closes #807 
