### PR TITLE
Check camera position and rotation input for inf/nan

### DIFF
--- a/trview.app.tests/UI/CameraPositionTests.cpp
+++ b/trview.app.tests/UI/CameraPositionTests.cpp
@@ -129,9 +129,22 @@ TEST(CameraPosition, RotationNotUpdatedWithInvalidValues)
     auto subject = CameraPosition(window);
 
     auto area_yaw = window.find<TextArea>("Yaw");
-    auto area_pitch = window.find<TextArea>("Pitch");
+    area_yaw->gained_focus();
+    area_yaw->set_text(L"inf");
+    area_yaw->key_char(0xD);
 
-    FAIL();
+    auto area_pitch = window.find<TextArea>("Pitch");
+    area_pitch->gained_focus();
+    area_pitch->set_text(L"nan");
+    area_pitch->key_char(0xD);
+
+    bool raised = false;
+    auto token = subject.on_rotation_changed += [&](auto&&...)
+    {
+        raised = true;
+    };
+
+    ASSERT_FALSE(raised);
 }
 
 TEST(CameraPosition, CoordinatesNotUpdatedWithInvalidValues)
@@ -140,8 +153,25 @@ TEST(CameraPosition, CoordinatesNotUpdatedWithInvalidValues)
     auto subject = CameraPosition(window);
 
     auto area_x = window.find<TextArea>("X");
-    auto area_y = window.find<TextArea>("Y");
-    auto area_z = window.find<TextArea>("Z");
+    area_x->gained_focus();
+    area_x->set_text(L"inf");
+    area_x->key_char(0xD);
 
-    FAIL();
+    auto area_y = window.find<TextArea>("Y");
+    area_y->gained_focus();
+    area_y->set_text(L"nan");
+    area_y->key_char(0xD);
+
+    auto area_z = window.find<TextArea>("Z");
+    area_z->gained_focus();
+    area_z->set_text(L"nan");
+    area_z->key_char(0xD);
+
+    bool raised = false;
+    auto token = subject.on_rotation_changed += [&](auto&&...)
+    {
+        raised = true;
+    };
+
+    ASSERT_FALSE(raised);
 }

--- a/trview.app.tests/UI/CameraPositionTests.cpp
+++ b/trview.app.tests/UI/CameraPositionTests.cpp
@@ -122,3 +122,26 @@ TEST(CameraPosition, RotationShowRadians)
     EXPECT_THAT(area_yaw->text(), HasSubstr(L"3.1416"));
     EXPECT_THAT(area_pitch->text(), HasSubstr(L"1.5708"));
 }
+
+TEST(CameraPosition, RotationNotUpdatedWithInvalidValues)
+{
+    ui::Window window(Point(), Size(100, 100), Colour::Transparent);
+    auto subject = CameraPosition(window);
+
+    auto area_yaw = window.find<TextArea>("Yaw");
+    auto area_pitch = window.find<TextArea>("Pitch");
+
+    FAIL();
+}
+
+TEST(CameraPosition, CoordinatesNotUpdatedWithInvalidValues)
+{
+    ui::Window window(Point(), Size(100, 100), Colour::Transparent);
+    auto subject = CameraPosition(window);
+
+    auto area_x = window.find<TextArea>("X");
+    auto area_y = window.find<TextArea>("Y");
+    auto area_z = window.find<TextArea>("Z");
+
+    FAIL();
+}

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -136,7 +136,7 @@ namespace trview
         try
         {
             const auto value = std::stof(text);
-            if (isnan(value) || isinf(value))
+            if (!std::isfinite(value))
             {
                 return;
             }
@@ -154,7 +154,7 @@ namespace trview
         try
         {
             const auto value = std::stof(text);
-            if (isnan(value) || isinf(value))
+            if (!std::isfinite(value))
             {
                 return;
             }

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -135,7 +135,12 @@ namespace trview
     {
         try
         {
-            coordinate = std::stof(text) / trlevel::Scale_X;
+            const auto value = std::stof(text);
+            if (isnan(value) || isinf(value))
+            {
+                return;
+            }
+            coordinate = value / trlevel::Scale_X;
             on_position_changed(_position);
         }
         catch (...)
@@ -148,7 +153,11 @@ namespace trview
     {
         try
         {
-            float value = std::stof(text);
+            const auto value = std::stof(text);
+            if (isnan(value) || isinf(value))
+            {
+                return;
+            }
             coordinate = _display_degrees ? DirectX::XMConvertToRadians(value) : value;
             on_rotation_changed(_rotation_yaw, _rotation_pitch);
         }


### PR DESCRIPTION
Reject camera position and rotation input if the input is not finite (is nan/inf).
Add tests for the camera position class to cover this.
Closes #811