### PR TITLE
Show notification when copying from stat boxes

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -453,3 +453,46 @@ TEST(Application, ImportRouteLoadsFile)
 
     route_window_manager.on_route_import("filename");
 }
+
+TEST(Application, WindowManagersUpdated)
+{
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    EXPECT_CALL(route_window_manager, update).Times(1);
+    auto [items_window_manager_ptr, items_window_manager] = create_mock<MockItemsWindowManager>();
+    EXPECT_CALL(items_window_manager, update).Times(1);
+    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
+    EXPECT_CALL(rooms_window_manager, update).Times(1);
+    auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
+    EXPECT_CALL(triggers_window_manager, update).Times(1);
+
+    auto application = register_test_module()
+        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_items_window_manager(std::move(items_window_manager_ptr))
+        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
+        .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
+        .build();
+    application->render();
+}
+
+TEST(Application, WindowManagersAndViewerRendered)
+{
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    EXPECT_CALL(route_window_manager, render).Times(1);
+    auto [items_window_manager_ptr, items_window_manager] = create_mock<MockItemsWindowManager>();
+    EXPECT_CALL(items_window_manager, render).Times(1);
+    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
+    EXPECT_CALL(rooms_window_manager, render).Times(1);
+    auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
+    EXPECT_CALL(triggers_window_manager, render).Times(1);
+    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
+    EXPECT_CALL(viewer, render).Times(1);
+
+    auto application = register_test_module()
+        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_items_window_manager(std::move(items_window_manager_ptr))
+        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
+        .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
+        .with_viewer(std::move(viewer_ptr))
+        .build();
+    application->render();
+}

--- a/trview.app.tests/ItemsWindowManagerTests.cpp
+++ b/trview.app.tests/ItemsWindowManagerTests.cpp
@@ -221,3 +221,8 @@ TEST(ItemsWindowManager, CreateItemsWindowKeyboardShortcut)
     auto mock_window = std::make_shared<MockItemsWindow>();
     ItemsWindowManager manager(create_test_window(L"ItemsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
 }
+
+TEST(ItemsWindowManager, WindowsUpdated)
+{
+    FAIL();
+}

--- a/trview.app.tests/ItemsWindowManagerTests.cpp
+++ b/trview.app.tests/ItemsWindowManagerTests.cpp
@@ -9,18 +9,53 @@ using namespace trview;
 using namespace trview::tests;
 using namespace trview::mocks;
 
-TEST(ItemsWindowManager, AddToRouteEventRaised)
+namespace
 {
     Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>& { return shortcut_handler; });
-    auto mock_window = std::make_shared<MockItemsWindow>();
-    ItemsWindowManager manager(create_test_window(L"ItemsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            Window window{ create_test_window(L"ItemsWindowManagerTests") };
+            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<MockShortcuts>() };
+            ItemsWindow::Source window_source{ [](auto&&...) { return std::make_shared<MockItemsWindow>(); } };
+
+            test_module& with_window_source(const ItemsWindow::Source& source)
+            {
+                this->window_source = source;
+                return *this;
+            }
+
+            test_module& with_shortcuts(const std::shared_ptr<MockShortcuts>& shortcuts)
+            {
+                this->shortcuts = shortcuts;
+                return *this;
+            }
+
+            test_module()
+            {
+                EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
+            }
+
+            std::unique_ptr<ItemsWindowManager> build()
+            {
+                return std::make_unique<ItemsWindowManager>(window, shortcuts, window_source);
+            }
+        };
+
+        return test_module{};
+    }
+}
+
+TEST(ItemsWindowManager, AddToRouteEventRaised)
+{
+    auto manager = register_test_module().build();
 
     std::optional<Item> raised_item;
-    auto token = manager.on_add_to_route += [&raised_item](const auto& item) { raised_item = item; };
+    auto token = manager->on_add_to_route += [&raised_item](const auto& item) { raised_item = item; };
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
     Item test_item(100, 10, 1, L"Lara", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero);
@@ -32,16 +67,12 @@ TEST(ItemsWindowManager, AddToRouteEventRaised)
 
 TEST(ItemsWindowManager, ItemSelectedEventRaised)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto mock_window = std::make_shared<MockItemsWindow>();
-    ItemsWindowManager manager(create_test_window(L"ItemsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().build();
 
     std::optional<Item> raised_item;
-    auto token = manager.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
+    auto token = manager->on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
     Item test_item(100, 10, 1, L"Lara", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero);
@@ -53,16 +84,12 @@ TEST(ItemsWindowManager, ItemSelectedEventRaised)
 
 TEST(ItemsWindowManager, ItemVisibilityEventRaised)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto mock_window = std::make_shared<MockItemsWindow>();
-    ItemsWindowManager manager(create_test_window(L"ItemsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().build();
 
     std::optional<std::tuple<Item, bool>> raised_item;
-    auto token = manager.on_item_visibility += [&raised_item](const auto& item, bool state) { raised_item = { item, state }; };
+    auto token = manager->on_item_visibility += [&raised_item](const auto& item, bool state) { raised_item = { item, state }; };
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
     Item test_item(100, 10, 1, L"Lara", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero);
@@ -75,16 +102,12 @@ TEST(ItemsWindowManager, ItemVisibilityEventRaised)
 
 TEST(ItemsWindowManager, TriggerSelectedEventRaised)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto mock_window = std::make_shared<MockItemsWindow>();
-    ItemsWindowManager manager(create_test_window(L"ItemsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().build();
 
     std::optional<std::weak_ptr<ITrigger>> raised_trigger;
-    auto token = manager.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = manager->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
     auto test_trigger = std::make_shared<MockTrigger>();
@@ -96,14 +119,11 @@ TEST(ItemsWindowManager, TriggerSelectedEventRaised)
 
 TEST(ItemsWindowManager, SetItemsSetsItemsOnWindows)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockItemsWindow>();
     EXPECT_CALL(*mock_window, set_items).Times(2);
-    ItemsWindowManager manager(create_test_window(L"ItemsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
@@ -112,19 +132,16 @@ TEST(ItemsWindowManager, SetItemsSetsItemsOnWindows)
         Item(0, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
         Item(1, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero)
     };
-    manager.set_items(items);
+    manager->set_items(items);
 }
 
 TEST(ItemsWindowManager, SetItemVisibilityUpdatesWindows)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockItemsWindow>();
     EXPECT_CALL(*mock_window, update_items).Times(1);
-    ItemsWindowManager manager(create_test_window(L"ItemsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
@@ -132,73 +149,61 @@ TEST(ItemsWindowManager, SetItemVisibilityUpdatesWindows)
     {
         Item(0, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
     };
-    manager.set_items(items);
-    manager.set_item_visible(items[0], false);
+    manager->set_items(items);
+    manager->set_item_visible(items[0], false);
 }
 
 TEST(ItemsWindowManager, SetTriggersSetsTriggersOnWindows)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockItemsWindow>();
     EXPECT_CALL(*mock_window, set_triggers).Times(2);
-    ItemsWindowManager manager(create_test_window(L"ItemsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
     auto trigger = std::make_shared<MockTrigger>();
-    manager.set_triggers({ trigger });
+    manager->set_triggers({ trigger });
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
-    manager.set_triggers({ trigger });
+    manager->set_triggers({ trigger });
 }
 
 TEST(ItemsWindowManager, SetRoomSetsRoomOnWindows)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockItemsWindow>();
     EXPECT_CALL(*mock_window, set_current_room).Times(2);
-    ItemsWindowManager manager(create_test_window(L"ItemsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
-    manager.set_room(1);
+    manager->set_room(1);
 }
 
 TEST(ItemsWindowManager, SetSelectedItemSetsSelectedItemOnWindows)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockItemsWindow>();
     EXPECT_CALL(*mock_window, set_selected_item).Times(1);
-    ItemsWindowManager manager(create_test_window(L"ItemsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
     std::vector<Item> items
     {
         Item(0, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
         Item(1, 1, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero)
     };
-    manager.set_items(items);
+    manager->set_items(items);
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
-    manager.set_selected_item(items[1]);
+    manager->set_selected_item(items[1]);
 }
 
 TEST(ItemsWindowManager, CreateWindowCreatesNewWindowWithSavedValues)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockItemsWindow>();
     EXPECT_CALL(*mock_window, set_items).Times(1);
-    ItemsWindowManager manager(create_test_window(L"ItemsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
     std::vector<Item> items
     {
@@ -206,23 +211,25 @@ TEST(ItemsWindowManager, CreateWindowCreatesNewWindowWithSavedValues)
         Item(1, 1, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero)
     };
 
-    manager.set_items(items);
+    manager->set_items(items);
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 }
 
 TEST(ItemsWindowManager, CreateItemsWindowKeyboardShortcut)
 {
-    Event<> shortcut_handler;
     auto shortcuts = std::make_shared<MockShortcuts>();
     EXPECT_CALL(*shortcuts, add_shortcut).Times(1).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto mock_window = std::make_shared<MockItemsWindow>();
-    ItemsWindowManager manager(create_test_window(L"ItemsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_shortcuts(shortcuts).build();
 }
 
 TEST(ItemsWindowManager, WindowsUpdated)
 {
-    FAIL();
+    auto mock_window = std::make_shared<MockItemsWindow>();
+    EXPECT_CALL(*mock_window, update(1.0f)).Times(1);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+    manager->update(1.0f);
 }

--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -10,6 +10,7 @@
 #include <trview.ui/Mocks/Input/IInput.h>
 #include <external/boost/di.hpp>
 #include <trview.app/Mocks/Elements/ITrigger.h>
+#include <trview.app/Mocks/UI/IBubble.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -30,6 +31,10 @@ namespace
             di::bind<ui::IInput::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockInput>(); }; }),
             di::bind<Window>.to(create_test_window(L"ItemsWindowTests")),
             di::bind<IClipboard>.to<MockClipboard>(),
+            di::bind<IBubble::Source>.to([&](auto&&)
+                {
+                    return [&](auto&&...) { return std::make_unique<MockBubble>(); };
+                }),
             di::bind<ItemsWindow>()
         );
     }

--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -32,3 +32,8 @@ TEST(RoomsWindowManager, SetTriggersClearsSelectedTrigger)
     manager.set_triggers({});
     ASSERT_EQ(manager.selected_trigger().lock(), nullptr);
 }
+
+TEST(RoomsWindowManager, WindowsUpdated)
+{
+    FAIL();
+}

--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -9,31 +9,71 @@ using namespace trview;
 using namespace trview::mocks;
 using namespace trview::tests;
 
-TEST(RoomsWindowManager, SetTriggersClearsSelectedTrigger)
+namespace
 {
     Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
+
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            Window window{ create_test_window(L"RoomsWindowManagerTests") };
+            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<MockShortcuts>() };
+            RoomsWindow::Source window_source{ [](auto&&...) { return std::make_shared<MockRoomsWindow>(); } };
+
+            test_module& with_window_source(const RoomsWindow::Source& source)
+            {
+                this->window_source = source;
+                return *this;
+            }
+
+            test_module& with_shortcuts(const std::shared_ptr<MockShortcuts>& shortcuts)
+            {
+                this->shortcuts = shortcuts;
+                return *this;
+            }
+
+            test_module()
+            {
+                EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
+            }
+
+            std::unique_ptr<RoomsWindowManager> build()
+            {
+                return std::make_unique<RoomsWindowManager>(window, shortcuts, window_source);
+            }
+        };
+
+        return test_module{};
+    }
+}
+
+TEST(RoomsWindowManager, SetTriggersClearsSelectedTrigger)
+{
     auto mock_window = std::make_shared<MockRoomsWindow>();
     EXPECT_CALL(*mock_window, set_triggers).Times(3);
     EXPECT_CALL(*mock_window, clear_selected_trigger).Times(2);
-    RoomsWindowManager manager(create_test_window(L"RoomsWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
     auto trigger = std::make_shared<MockTrigger>();
-    manager.set_triggers({ trigger });
+    manager->set_triggers({ trigger });
 
-    ASSERT_EQ(manager.selected_trigger().lock(), nullptr);
-    manager.set_selected_trigger(trigger);
-    ASSERT_EQ(manager.selected_trigger().lock(), trigger);
-    manager.set_triggers({});
-    ASSERT_EQ(manager.selected_trigger().lock(), nullptr);
+    ASSERT_EQ(manager->selected_trigger().lock(), nullptr);
+    manager->set_selected_trigger(trigger);
+    ASSERT_EQ(manager->selected_trigger().lock(), trigger);
+    manager->set_triggers({});
+    ASSERT_EQ(manager->selected_trigger().lock(), nullptr);
 }
 
 TEST(RoomsWindowManager, WindowsUpdated)
 {
-    FAIL();
+    auto mock_window = std::make_shared<MockRoomsWindow>();
+    EXPECT_CALL(*mock_window, update(1.0f)).Times(1);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+    manager->update(1.0f);
 }

--- a/trview.app.tests/RoomsWindowTests.cpp
+++ b/trview.app.tests/RoomsWindowTests.cpp
@@ -10,6 +10,7 @@
 #include <trview.input/Mocks/IMouse.h>
 #include <external/boost/di.hpp>
 #include <trview.app/Mocks/Elements/ITrigger.h>
+#include <trview.common/Mocks/Windows/IClipboard.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -44,6 +45,7 @@ namespace
                         };
                         }),
                     di::bind<Window>.to(create_test_window(L"ItemsWindowTests")),
+                    di::bind<IClipboard>.to<MockClipboard>(),
                     di::bind<RoomsWindow>()
                 ).create<std::unique_ptr<RoomsWindow>>();
             }

--- a/trview.app.tests/RoomsWindowTests.cpp
+++ b/trview.app.tests/RoomsWindowTests.cpp
@@ -11,6 +11,7 @@
 #include <external/boost/di.hpp>
 #include <trview.app/Mocks/Elements/ITrigger.h>
 #include <trview.common/Mocks/Windows/IClipboard.h>
+#include <trview.app/Mocks/UI/IBubble.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -46,6 +47,10 @@ namespace
                         }),
                     di::bind<Window>.to(create_test_window(L"ItemsWindowTests")),
                     di::bind<IClipboard>.to<MockClipboard>(),
+                    di::bind<IBubble::Source>.to([&](auto&&)
+                        {
+                            return [&](auto&&...) { return std::make_unique<MockBubble>(); };
+                        }),
                     di::bind<RoomsWindow>()
                 ).create<std::unique_ptr<RoomsWindow>>();
             }

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -477,9 +477,3 @@ TEST(RouteWindow, ClickStatShowsBubble)
     ASSERT_NE(value, nullptr);
     value->clicked(Point());
 }
-
-TEST(RouteWindowManager, WindowsUpdated)
-{
-    FAIL();
-}
-

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -10,6 +10,7 @@
 #include <trview.ui/Mocks/Input/IInput.h>
 #include <trview.common/Mocks/Windows/IDialogs.h>
 #include <trview.common/Mocks/IFiles.h>
+#include <trview.app/Mocks/UI/IBubble.h>
 
 using namespace DirectX::SimpleMath;
 using namespace testing;
@@ -34,6 +35,7 @@ namespace
             std::shared_ptr<IClipboard> clipboard{ std::make_shared<MockClipboard>() };
             std::shared_ptr<IDialogs> dialogs{ std::make_shared<MockDialogs>() };
             std::shared_ptr<IFiles> files{ std::make_shared<MockFiles>() };
+            IBubble::Source bubble_source{ [](auto&&...) { return std::make_unique<MockBubble>(); }};
 
             test_module& with_clipboard(const std::shared_ptr<IClipboard>& clipboard)
             {
@@ -56,7 +58,7 @@ namespace
             std::unique_ptr<RouteWindow> build()
             {
                 return std::make_unique<RouteWindow>(device_window_source, renderer_source, input_source,
-                    parent, clipboard, dialogs, files);
+                    parent, clipboard, dialogs, files, bubble_source);
             }
         };
         return test_module{};

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -446,3 +446,7 @@ TEST(RouteWindow, AttachSaveButtonDoesNotLoadFileWhenCancelled)
     ASSERT_FALSE(waypoint.has_save());
 }
 
+TEST(RouteWindow, ClickStatShowsBubble)
+{
+    FAIL();
+}

--- a/trview.app.tests/TriggersWindowManagerTests.cpp
+++ b/trview.app.tests/TriggersWindowManagerTests.cpp
@@ -8,64 +8,91 @@ using namespace trview;
 using namespace trview::mocks;
 using namespace trview::tests;
 
-TEST(TriggersWindowManager, CreateTriggersWindowKeyboardShortcut)
+namespace
 {
     Event<> shortcut_handler;
+
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            Window window{ create_test_window(L"TriggersWindowManagerTests") };
+            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<MockShortcuts>() };
+            TriggersWindow::Source window_source{ [](auto&&...) { return std::make_shared<MockTriggersWindow>(); } };
+
+            test_module& with_window_source(const TriggersWindow::Source& source)
+            {
+                this->window_source = source;
+                return *this;
+            }
+
+            test_module& with_shortcuts(const std::shared_ptr<MockShortcuts>& shortcuts)
+            {
+                this->shortcuts = shortcuts;
+                return *this;
+            }
+
+            test_module()
+            {
+                EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
+            }
+
+            std::unique_ptr<TriggersWindowManager> build()
+            {
+                return std::make_unique<TriggersWindowManager>(window, shortcuts, window_source);
+            }
+        };
+
+        return test_module{};
+    }
+}
+
+TEST(TriggersWindowManager, CreateTriggersWindowKeyboardShortcut)
+{
     auto shortcuts = std::make_shared<MockShortcuts>();
     EXPECT_CALL(*shortcuts, add_shortcut).Times(1).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto mock_window = std::make_shared<MockTriggersWindow>();
-    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_shortcuts(shortcuts).build();
 }
 
 TEST(TriggersWindowManager, CreateTriggersWindowCreatesNewWindowWithSavedValues)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).Times(1).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_triggers).Times(1);
-    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
     auto trigger1 = std::make_shared<MockTrigger>();
     auto trigger2 = std::make_shared<MockTrigger>();
-    manager.set_triggers({ trigger1, trigger2 });
+    manager->set_triggers({ trigger1, trigger2 });
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 }
 
 TEST(TriggersWindowManager, CreateTriggersWindowSetsSelectedTriggerOnWindows)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_selected_trigger).Times(1);
-    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
     auto trigger1 = std::make_shared<MockTrigger>();
     auto trigger2 = std::make_shared<MockTrigger>();
-    manager.set_triggers({ trigger1, trigger2 });
-    manager.set_selected_trigger(trigger2);
+    manager->set_triggers({ trigger1, trigger2 });
+    manager->set_selected_trigger(trigger2);
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 }
 
 TEST(TriggersWindowManager, ItemSelectedEventRaised)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto mock_window = std::make_shared<MockTriggersWindow>();
-    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().build();
 
     std::optional<Item> raised_item;
-    auto token = manager.on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
+    auto token = manager->on_item_selected += [&raised_item](const auto& item) { raised_item = item; };
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
     Item test_item(100, 10, 1, L"Lara", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero);
@@ -77,16 +104,12 @@ TEST(TriggersWindowManager, ItemSelectedEventRaised)
 
 TEST(TriggersWindowManager, TriggerSelectedEventRaised)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto mock_window = std::make_shared<MockTriggersWindow>();
-    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().build();
 
     std::optional<std::weak_ptr<ITrigger>> raised_trigger;
-    auto token = manager.on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = manager->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
     auto trigger = std::make_shared<MockTrigger>();
@@ -98,16 +121,12 @@ TEST(TriggersWindowManager, TriggerSelectedEventRaised)
 
 TEST(TriggersWindowManager, TriggerVisibilityEventRaised)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto mock_window = std::make_shared<MockTriggersWindow>();
-    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().build();
 
     std::optional<std::tuple<std::weak_ptr<ITrigger>, bool>> raised_trigger;
-    auto token = manager.on_trigger_visibility += [&raised_trigger](const auto& trigger, bool state) { raised_trigger = { trigger, state }; };
+    auto token = manager->on_trigger_visibility += [&raised_trigger](const auto& trigger, bool state) { raised_trigger = { trigger, state }; };
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
     auto trigger = std::make_shared<MockTrigger>();
@@ -120,16 +139,12 @@ TEST(TriggersWindowManager, TriggerVisibilityEventRaised)
 
 TEST(TriggersWindowManager, AddToRouteEventRaised)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-    auto mock_window = std::make_shared<MockTriggersWindow>();
-    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().build();
 
     std::optional<std::weak_ptr<ITrigger>> raised_trigger;
-    auto token = manager.on_add_to_route += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
+    auto token = manager->on_add_to_route += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
     auto trigger = std::make_shared<MockTrigger>();
@@ -141,14 +156,11 @@ TEST(TriggersWindowManager, AddToRouteEventRaised)
 
 TEST(TriggersWindowManager, SetItemsSetsItemsOnWindows)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_items).Times(2);
-    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
@@ -156,105 +168,94 @@ TEST(TriggersWindowManager, SetItemsSetsItemsOnWindows)
     {
         Item(0, 0, 0, L"Test Object", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
     };
-    manager.set_items(items);
+    manager->set_items(items);
 }
 
 TEST(TriggersWindowManager, SetTriggersSetsTriggersOnWindows)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_triggers).Times(2);
-    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
     auto trigger1 = std::make_shared<MockTrigger>();
     auto trigger2 = std::make_shared<MockTrigger>();
-    manager.set_triggers({ trigger1, trigger2 });
+    manager->set_triggers({ trigger1, trigger2 });
 }
 
 TEST(TriggersWindowManager, SetTriggersClearsSelectedTrigger)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_triggers).Times(3);
     EXPECT_CALL(*mock_window, clear_selected_trigger).Times(2);
-    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
     auto trigger = std::make_shared<MockTrigger>();
-    manager.set_triggers({ trigger });
+    manager->set_triggers({ trigger });
 
-    ASSERT_EQ(manager.selected_trigger().lock(), nullptr);
-    manager.set_selected_trigger(trigger);
-    ASSERT_EQ(manager.selected_trigger().lock(), trigger);
-    manager.set_triggers({});
-    ASSERT_EQ(manager.selected_trigger().lock(), nullptr);
+    ASSERT_EQ(manager->selected_trigger().lock(), nullptr);
+    manager->set_selected_trigger(trigger);
+    ASSERT_EQ(manager->selected_trigger().lock(), trigger);
+    manager->set_triggers({});
+    ASSERT_EQ(manager->selected_trigger().lock(), nullptr);
 }
 
 TEST(TriggersWindowManager, SetTriggerVisibilityUpdatesWindows)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, update_triggers).Times(1);
-    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
     auto trigger = std::make_shared<MockTrigger>();
-    manager.set_triggers({ trigger });
-    manager.set_trigger_visible(trigger, false);
+    manager->set_triggers({ trigger });
+    manager->set_trigger_visible(trigger, false);
 }
 
 TEST(TriggersWindowManager, SetRoomSetsRoomOnWindows)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_current_room).Times(2);
-    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
-    manager.set_room(1);
+    manager->set_room(1);
 }
 
 TEST(TriggersWindowManager, SetSelectedTriggerSetsSelectedTriggerOnWindows)
 {
-    Event<> shortcut_handler;
-    auto shortcuts = std::make_shared<MockShortcuts>();
-    EXPECT_CALL(*shortcuts, add_shortcut).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto mock_window = std::make_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_selected_trigger).Times(2);
-    TriggersWindowManager manager(create_test_window(L"TriggersWindowManagerTests"), shortcuts, [&mock_window](...) { return mock_window; });
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    auto created_window = manager.create_window().lock();
+    auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
     auto trigger1 = std::make_shared<MockTrigger>();
     auto trigger2 = std::make_shared<MockTrigger>();
-    manager.set_triggers({ trigger1, trigger2 });
-    manager.set_selected_trigger(trigger2);
+    manager->set_triggers({ trigger1, trigger2 });
+    manager->set_selected_trigger(trigger2);
 }
 
 TEST(TriggersWindowManager, WindowsUpdated)
 {
-    FAIL();
+    auto mock_window = std::make_shared<MockTriggersWindow>();
+    EXPECT_CALL(*mock_window, update(1.0f)).Times(1);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+    manager->update(1.0f);
 }
 

--- a/trview.app.tests/TriggersWindowManagerTests.cpp
+++ b/trview.app.tests/TriggersWindowManagerTests.cpp
@@ -252,3 +252,9 @@ TEST(TriggersWindowManager, SetSelectedTriggerSetsSelectedTriggerOnWindows)
     manager.set_triggers({ trigger1, trigger2 });
     manager.set_selected_trigger(trigger2);
 }
+
+TEST(TriggersWindowManager, WindowsUpdated)
+{
+    FAIL();
+}
+

--- a/trview.app.tests/TriggersWindowTests.cpp
+++ b/trview.app.tests/TriggersWindowTests.cpp
@@ -8,7 +8,6 @@
 #include <trview.graphics/mocks/IDeviceWindow.h>
 #include <trview.common/Mocks/Windows/IClipboard.h>
 #include <trview.ui/Mocks/Input/IInput.h>
-#include <external/boost/di.hpp>
 #include <trview.app/Mocks/Elements/ITrigger.h>
 #include <trview.app/Mocks/UI/IBubble.h>
 

--- a/trview.app.tests/TriggersWindowTests.cpp
+++ b/trview.app.tests/TriggersWindowTests.cpp
@@ -10,6 +10,7 @@
 #include <trview.ui/Mocks/Input/IInput.h>
 #include <external/boost/di.hpp>
 #include <trview.app/Mocks/Elements/ITrigger.h>
+#include <trview.app/Mocks/UI/IBubble.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -31,6 +32,10 @@ namespace
             di::bind<ui::IInput::Source>.to([](auto&&) { return [](auto&&...) { return std::make_unique<MockInput>(); }; }),
             di::bind<Window>.to(create_test_window(L"TriggersWindowTests")),
             di::bind<IClipboard>.to<MockClipboard>(),
+            di::bind<IBubble::Source>.to([&](auto&&)
+                {
+                    return [&](auto&&...) { return std::make_unique<MockBubble>(); };
+                }),
             di::bind<TriggersWindow>()
         );
     }

--- a/trview.app.tests/UI/BubbleTests.cpp
+++ b/trview.app.tests/UI/BubbleTests.cpp
@@ -1,0 +1,39 @@
+#include <trview.app/UI/Bubble.h>
+
+using namespace trview;
+using namespace trview::ui;
+
+TEST(Bubble, ShowMakesBubbleVisible)
+{
+    ui::Window control(Size(), Colour::White);
+    Bubble bubble(control);
+
+    auto bubble_control = control.find<ui::Control>(Bubble::Names::Bubble);
+    ASSERT_NE(bubble_control, nullptr);
+    ASSERT_FALSE(bubble_control->visible());
+
+    bubble.show(Point());
+    ASSERT_TRUE(bubble_control->visible());
+}
+
+TEST(Bubble, BubbleFadesToInvisibleOverTime)
+{
+    ui::Window control(Size(), Colour::White);
+    Bubble bubble(control);
+
+    auto bubble_control = control.find<ui::Label>(Bubble::Names::Bubble);
+    ASSERT_NE(bubble_control, nullptr);
+    ASSERT_FALSE(bubble_control->visible());
+
+    bubble.show(Point());
+    ASSERT_TRUE(bubble_control->visible());
+    ASSERT_FLOAT_EQ(bubble_control->background_colour().a, 1.0f);
+    ASSERT_FLOAT_EQ(bubble_control->text_colour().a, 1.0f);
+
+    control.update(Bubble::FadeTime * 0.5f);
+    ASSERT_FLOAT_EQ(bubble_control->background_colour().a, 0.5f);
+    ASSERT_FLOAT_EQ(bubble_control->text_colour().a, 0.5f);
+
+    control.update(Bubble::FadeTime * 0.5f);
+    ASSERT_FALSE(bubble_control->visible());
+}

--- a/trview.app.tests/Windows/RouteWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/RouteWindowManagerTests.cpp
@@ -1,0 +1,58 @@
+#include <trview.app/Windows/RouteWindowManager.h>
+#include <trview.app/Elements/Types.h>
+#include <trview.app/Mocks/Windows/IRouteWindow.h>
+#include <trview.common/Mocks/Windows/IShortcuts.h>
+#include <trview.app/Mocks/Geometry/IMesh.h>
+#include <trview.app/Mocks/Elements/ITrigger.h>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace trview::tests;
+
+namespace
+{
+    Event<> shortcut_handler;
+
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            Window window{ create_test_window(L"RouteWindowManagerTests") };
+            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<MockShortcuts>() };
+            RouteWindow::Source window_source{ [](auto&&...) { return std::make_shared<MockRouteWindow>(); } };
+
+            test_module& with_window_source(const RouteWindow::Source& source)
+            {
+                this->window_source = source;
+                return *this;
+            }
+
+            test_module& with_shortcuts(const std::shared_ptr<MockShortcuts>& shortcuts)
+            {
+                this->shortcuts = shortcuts;
+                return *this;
+            }
+
+            test_module()
+            {
+                EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
+            }
+
+            std::unique_ptr<RouteWindowManager> build()
+            {
+                return std::make_unique<RouteWindowManager>(window, shortcuts, window_source);
+            }
+        };
+
+        return test_module{};
+    }
+}
+
+TEST(RouteWindowManager, WindowsUpdated)
+{
+    auto mock_window = std::make_shared<MockRouteWindow>();
+    EXPECT_CALL(*mock_window, update(1.0f)).Times(1);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+    manager->update(1.0f);
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -53,6 +53,7 @@
     </ClCompile>
     <ClCompile Include="TriggersWindowManagerTests.cpp" />
     <ClCompile Include="TriggersWindowTests.cpp" />
+    <ClCompile Include="UI\BubbleTests.cpp" />
     <ClCompile Include="UI\CameraPositionTests.cpp" />
     <ClCompile Include="UI\ViewerUITests.cpp" />
     <ClCompile Include="ViewMenuTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -57,6 +57,7 @@
     <ClCompile Include="UI\ViewerUITests.cpp" />
     <ClCompile Include="ViewMenuTests.cpp" />
     <ClCompile Include="WindowResizerTests.cpp" />
+    <ClCompile Include="Windows\RouteWindowManagerTests.cpp" />
     <ClCompile Include="Windows\ViewerTests.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -89,6 +89,9 @@
     <ClCompile Include="UI\ViewerUITests.cpp">
       <Filter>UI</Filter>
     </ClCompile>
+    <ClCompile Include="Windows\RouteWindowManagerTests.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -92,6 +92,9 @@
     <ClCompile Include="Windows\RouteWindowManagerTests.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
+    <ClCompile Include="UI\BubbleTests.cpp">
+      <Filter>UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -125,7 +125,7 @@ namespace trview
         _view_menu(window()), _settings_loader(std::move(settings_loader)), _level_loader(std::move(level_loader)), _viewer(std::move(viewer)), _route_source(route_source),
         _route(route_source()), _shortcuts(shortcuts), _items_windows(std::move(items_window_manager)),
         _triggers_windows(std::move(triggers_window_manager)), _route_window(std::move(route_window_manager)), _rooms_windows(std::move(rooms_window_manager)), _level_source(level_source),
-        _dialogs(dialogs), _files(files)
+        _dialogs(dialogs), _files(files), _timer(default_time_source())
     {
         _update_checker->check_for_updates();
         _settings = _settings_loader->load_user_settings();
@@ -551,6 +551,9 @@ namespace trview
             Sleep(1);
             return;
         }
+
+        _timer.update();
+        _items_windows->update(_timer.elapsed());
 
         _viewer->render();
         _items_windows->render(_settings.vsync);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -556,6 +556,7 @@ namespace trview
         const auto elapsed = _timer.elapsed();
         _items_windows->update(elapsed);
         _triggers_windows->update(elapsed);
+        _rooms_windows->update(elapsed);
         _route_window->update(elapsed);
 
         _viewer->render();

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -553,8 +553,10 @@ namespace trview
         }
 
         _timer.update();
-        _items_windows->update(_timer.elapsed());
-        _triggers_windows->update(_timer.elapsed());
+        const auto elapsed = _timer.elapsed();
+        _items_windows->update(elapsed);
+        _triggers_windows->update(elapsed);
+        _route_window->update(elapsed);
 
         _viewer->render();
         _items_windows->render(_settings.vsync);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -554,6 +554,7 @@ namespace trview
 
         _timer.update();
         _items_windows->update(_timer.elapsed());
+        _triggers_windows->update(_timer.elapsed());
 
         _viewer->render();
         _items_windows->render(_settings.vsync);

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <trview.common/Window.h>
+#include <trview.common/Timer.h>
 
 #include <trlevel/ILevelLoader.h>
 
@@ -115,6 +116,8 @@ namespace trview
         std::unique_ptr<ITriggersWindowManager> _triggers_windows;
         std::unique_ptr<IRouteWindowManager> _route_window;
         std::unique_ptr<IRoomsWindowManager> _rooms_windows;
+
+        Timer _timer;
     };
 
     std::unique_ptr<IApplication> create_application(HINSTANCE instance, const std::wstring& command_line, int command_show);

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -59,6 +59,7 @@ namespace trview
         void open(const std::string& filename);
         virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         virtual int run() override;
+        void render();
     private:
         // Window setup functions.
         void setup_view_menu();
@@ -79,8 +80,6 @@ namespace trview
         void select_previous_waypoint();
         void set_item_visibility(const Item& item, bool visible);
         void set_trigger_visibility(const std::weak_ptr<ITrigger>& trigger, bool visible);
-        // Rendering
-        void render();
         // Lua
         void register_lua();
         bool should_discard_changes();

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -116,7 +116,6 @@ namespace trview
         std::unique_ptr<ITriggersWindowManager> _triggers_windows;
         std::unique_ptr<IRouteWindowManager> _route_window;
         std::unique_ptr<IRoomsWindowManager> _rooms_windows;
-
         Timer _timer;
     };
 

--- a/trview.app/Mocks/UI/IBubble.h
+++ b/trview.app/Mocks/UI/IBubble.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <trview.app/UI/IBubble.h>
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockBubble final : public IBubble
+        {
+            virtual ~MockBubble() = default;
+            MOCK_METHOD(void, show, (const Point&), (override));
+        };
+    }
+}

--- a/trview.app/Mocks/Windows/IItemsWindow.h
+++ b/trview.app/Mocks/Windows/IItemsWindow.h
@@ -18,6 +18,7 @@ namespace trview
             MOCK_METHOD(void, set_current_room, (uint32_t));
             MOCK_METHOD(void, set_selected_item, (const Item&));
             MOCK_METHOD(std::optional<Item>, selected_item, (), (const));
+            MOCK_METHOD(void, update, (float), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IItemsWindowManager.h
+++ b/trview.app/Mocks/Windows/IItemsWindowManager.h
@@ -9,13 +9,13 @@ namespace trview
         class MockItemsWindowManager final : public IItemsWindowManager
         {
         public:
-            MOCK_METHOD(void, render, (bool));
-            MOCK_METHOD(void, set_items, (const std::vector<Item>&));
-            MOCK_METHOD(void, set_item_visible, (const Item&, bool));
-            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
-            MOCK_METHOD(void, set_room, (uint32_t));
-            MOCK_METHOD(void, set_selected_item, (const Item&));
-            MOCK_METHOD(std::weak_ptr<IItemsWindow>, create_window, ());
+            MOCK_METHOD(void, render, (bool), (override));
+            MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
+            MOCK_METHOD(void, set_item_visible, (const Item&, bool), (override));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
+            MOCK_METHOD(void, set_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_selected_item, (const Item&), (override));
+            MOCK_METHOD(std::weak_ptr<IItemsWindow>, create_window, (), (override));
             MOCK_METHOD(void, update, (float), (override));
         };
     }

--- a/trview.app/Mocks/Windows/IItemsWindowManager.h
+++ b/trview.app/Mocks/Windows/IItemsWindowManager.h
@@ -16,6 +16,7 @@ namespace trview
             MOCK_METHOD(void, set_room, (uint32_t));
             MOCK_METHOD(void, set_selected_item, (const Item&));
             MOCK_METHOD(std::weak_ptr<IItemsWindow>, create_window, ());
+            MOCK_METHOD(void, update, (float), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRoomsWindow.h
+++ b/trview.app/Mocks/Windows/IRoomsWindow.h
@@ -9,14 +9,15 @@ namespace trview
         struct MockRoomsWindow : public IRoomsWindow
         {
             virtual ~MockRoomsWindow() = default;
-            MOCK_METHOD(void, clear_selected_trigger, ());
-            MOCK_METHOD(void, render, (bool));
-            MOCK_METHOD(void, set_current_room, (uint32_t));
-            MOCK_METHOD(void, set_items, (const std::vector<Item>&));
-            MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&));
-            MOCK_METHOD(void, set_selected_item, (const Item&));;
-            MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&));
-            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
+            MOCK_METHOD(void, clear_selected_trigger, (), (override));
+            MOCK_METHOD(void, render, (bool), (override));
+            MOCK_METHOD(void, set_current_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
+            MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&), (override));
+            MOCK_METHOD(void, set_selected_item, (const Item&), (override));
+            MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&), (override));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
+            MOCK_METHOD(void, update, (float), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRoomsWindowManager.h
+++ b/trview.app/Mocks/Windows/IRoomsWindowManager.h
@@ -9,14 +9,15 @@ namespace trview
         class MockRoomsWindowManager final : public IRoomsWindowManager
         {
         public:
-            MOCK_METHOD(void, render, (bool));
-            MOCK_METHOD(void, set_items, (const std::vector<Item>&));
-            MOCK_METHOD(void, set_room, (uint32_t));
-            MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&));
-            MOCK_METHOD(void, set_selected_item, (const Item&));
-            MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>& ));
-            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
-            MOCK_METHOD(std::weak_ptr<IRoomsWindow>, create_window, ());
+            MOCK_METHOD(void, render, (bool), (override));
+            MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
+            MOCK_METHOD(void, set_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&), (override));
+            MOCK_METHOD(void, set_selected_item, (const Item&), (override));
+            MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>& ), (override));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
+            MOCK_METHOD(std::weak_ptr<IRoomsWindow>, create_window, (), (override));
+            MOCK_METHOD(void, update, (float), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRouteWindow.h
+++ b/trview.app/Mocks/Windows/IRouteWindow.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <trview.app/Windows/IRouteWindow.h>
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockRouteWindow : public IRouteWindow
+        {
+            virtual ~MockRouteWindow() = default;
+            MOCK_METHOD(void, render, (bool), (override));
+            MOCK_METHOD(void, set_route, (IRoute*), (override));
+            MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
+            MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
+            MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&), (override));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
+            MOCK_METHOD(void, focus, (), (override));
+            MOCK_METHOD(void, update, (float), (override));
+        };
+    }
+}

--- a/trview.app/Mocks/Windows/IRouteWindowManager.h
+++ b/trview.app/Mocks/Windows/IRouteWindowManager.h
@@ -9,13 +9,14 @@ namespace trview
         class MockRouteWindowManager final : public IRouteWindowManager
         {
         public:
-            MOCK_METHOD(void, render, (bool));
-            MOCK_METHOD(void, set_route, (IRoute*));
-            MOCK_METHOD(void, create_window, ());
-            MOCK_METHOD(void, set_items, (const std::vector<Item>&));
-            MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&) );
-            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
-            MOCK_METHOD(void, select_waypoint, (uint32_t));
+            MOCK_METHOD(void, render, (bool), (override));
+            MOCK_METHOD(void, set_route, (IRoute*), (override));
+            MOCK_METHOD(void, create_window, (), (override));
+            MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
+            MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&), (override));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
+            MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
+            MOCK_METHOD(void, update, (float), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/ITriggersWindow.h
+++ b/trview.app/Mocks/Windows/ITriggersWindow.h
@@ -9,14 +9,14 @@ namespace trview
         class MockTriggersWindow final : public ITriggersWindow
         {
         public:
-            MOCK_METHOD(void, clear_selected_trigger, ());
-            MOCK_METHOD(void, render, (bool));
-            MOCK_METHOD(std::weak_ptr<ITrigger>, selected_trigger, (), (const));
-            MOCK_METHOD(void, set_current_room, (uint32_t));
-            MOCK_METHOD(void, set_items, (const std::vector<Item>&));
-            MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&));
-            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
-            MOCK_METHOD(void, update_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
+            MOCK_METHOD(void, clear_selected_trigger, (), (override));
+            MOCK_METHOD(void, render, (bool), (override));
+            MOCK_METHOD(std::weak_ptr<ITrigger>, selected_trigger, (), (const, override));
+            MOCK_METHOD(void, set_current_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
+            MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&), (override));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
+            MOCK_METHOD(void, update_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(void, update, (float), (override));
         };
     }

--- a/trview.app/Mocks/Windows/ITriggersWindow.h
+++ b/trview.app/Mocks/Windows/ITriggersWindow.h
@@ -17,6 +17,7 @@ namespace trview
             MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
             MOCK_METHOD(void, update_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
+            MOCK_METHOD(void, update, (float), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/ITriggersWindowManager.h
+++ b/trview.app/Mocks/Windows/ITriggersWindowManager.h
@@ -9,13 +9,14 @@ namespace trview
         class MockTriggersWindowManager final : public ITriggersWindowManager
         {
         public:
-            MOCK_METHOD(void, render, (bool));
-            MOCK_METHOD(void, set_items, (const std::vector<Item>&));
-            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&));
-            MOCK_METHOD(void, set_trigger_visible, (const std::weak_ptr<ITrigger>& trigger, bool));
-            MOCK_METHOD(void, set_room, (uint32_t));
-            MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&));
-            MOCK_METHOD(std::weak_ptr<ITriggersWindow>, create_window, ());
+            MOCK_METHOD(void, render, (bool), (override));
+            MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
+            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
+            MOCK_METHOD(void, set_trigger_visible, (const std::weak_ptr<ITrigger>& trigger, bool), (override));
+            MOCK_METHOD(void, set_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&), (override));
+            MOCK_METHOD(std::weak_ptr<ITriggersWindow>, create_window, (), (override));
+            MOCK_METHOD(void, update, (float), (override));
         };
     }
 }

--- a/trview.app/UI/Bubble.cpp
+++ b/trview.app/UI/Bubble.cpp
@@ -5,9 +5,14 @@ using namespace trview::graphics;
 
 namespace trview
 {
+    namespace
+    {
+        const Colour Background{ Colour::Grey };
+    }
+
     Bubble::Bubble(Control& control)
     {
-        _label = control.add_child(std::make_unique<Label>(Size(40, 20), Colour::Black, L"Copied", 8, TextAlignment::Centre, ParagraphAlignment::Centre));
+        _label = control.add_child(std::make_unique<Label>(Size(40, 20), Background, L"Copied", 8, TextAlignment::Centre, ParagraphAlignment::Centre));
         _label->set_visible(false);
         _label->set_z(-1);
 
@@ -15,10 +20,12 @@ namespace trview
         {
             if (_label->visible())
             {
+                const float speed = 1.5f;
+
                 auto bg = _label->background_colour();
-                bg.a = std::max(bg.a - delta, 0.0f);
+                bg.a = std::max(bg.a - delta * speed, 0.0f);
                 auto fg = _label->text_colour();
-                fg.a = std::max(fg.a - delta, 0.0f);
+                fg.a = std::max(fg.a - delta * speed, 0.0f);
 
                 _label->set_text_colour(fg);
                 _label->set_background_colour(bg);
@@ -31,9 +38,10 @@ namespace trview
         };
     }
 
-    void Bubble::show()
+    void Bubble::show(const Point& position)
     {
-        _label->set_background_colour(Colour::Black);
+        _label->set_position(position - Point(_label->size().width * 0.5f, 0));
+        _label->set_background_colour(Background);
         _label->set_text_colour(Colour::White);
         _label->set_visible(true);
     }

--- a/trview.app/UI/Bubble.cpp
+++ b/trview.app/UI/Bubble.cpp
@@ -1,0 +1,40 @@
+#include "Bubble.h"
+
+using namespace trview::ui;
+using namespace trview::graphics;
+
+namespace trview
+{
+    Bubble::Bubble(Control& control)
+    {
+        _label = control.add_child(std::make_unique<Label>(Size(40, 20), Colour::Black, L"Copied", 8, TextAlignment::Centre, ParagraphAlignment::Centre));
+        _label->set_visible(false);
+        _label->set_z(-1);
+
+        _token_store += control.on_update += [&](float delta)
+        {
+            if (_label->visible())
+            {
+                auto bg = _label->background_colour();
+                bg.a = std::max(bg.a - delta, 0.0f);
+                auto fg = _label->text_colour();
+                fg.a = std::max(fg.a - delta, 0.0f);
+
+                _label->set_text_colour(fg);
+                _label->set_background_colour(bg);
+
+                if (bg.a == 0.0f || fg.a == 0.0f)
+                {
+                    _label->set_visible(false);
+                }
+            }
+        };
+    }
+
+    void Bubble::show()
+    {
+        _label->set_background_colour(Colour::Black);
+        _label->set_text_colour(Colour::White);
+        _label->set_visible(true);
+    }
+}

--- a/trview.app/UI/Bubble.cpp
+++ b/trview.app/UI/Bubble.cpp
@@ -10,9 +10,13 @@ namespace trview
         const Colour Background{ Colour::Grey };
     }
 
+    const float Bubble::FadeTime{ 0.66666666666666666666666666666667f };
+    const std::string Bubble::Names::Bubble{ "Bubble" };
+
     Bubble::Bubble(Control& control)
     {
         _label = control.add_child(std::make_unique<Label>(Size(40, 20), Background, L"Copied", 8, TextAlignment::Centre, ParagraphAlignment::Centre));
+        _label->set_name(Names::Bubble);
         _label->set_visible(false);
         _label->set_z(-1);
 
@@ -20,7 +24,7 @@ namespace trview
         {
             if (_label->visible())
             {
-                const float speed = 1.5f;
+                const float speed = 1.0f / FadeTime;
 
                 auto bg = _label->background_colour();
                 bg.a = std::max(bg.a - delta * speed, 0.0f);

--- a/trview.app/UI/Bubble.h
+++ b/trview.app/UI/Bubble.h
@@ -9,7 +9,7 @@ namespace trview
     {
     public:
         explicit Bubble(ui::Control& control);
-        void show();
+        void show(const Point& position);
     private:
         TokenStore _token_store;
         ui::Label* _label{ nullptr };

--- a/trview.app/UI/Bubble.h
+++ b/trview.app/UI/Bubble.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "IBubble.h"
-#include <trview.ui/Control.h>
 #include <trview.ui/Label.h>
 
 namespace trview
@@ -9,9 +8,16 @@ namespace trview
     class Bubble final : public IBubble
     {
     public:
+        static const float FadeTime;
+
+        struct Names
+        {
+            static const std::string Bubble;
+        };
+
         explicit Bubble(ui::Control& control);
         virtual ~Bubble() = default;
-        void show(const Point& position);
+        virtual void show(const Point& position) override;
     private:
         TokenStore _token_store;
         ui::Label* _label{ nullptr };

--- a/trview.app/UI/Bubble.h
+++ b/trview.app/UI/Bubble.h
@@ -1,14 +1,16 @@
 #pragma once
 
+#include "IBubble.h"
 #include <trview.ui/Control.h>
 #include <trview.ui/Label.h>
 
 namespace trview
 {
-    class Bubble final
+    class Bubble final : public IBubble
     {
     public:
         explicit Bubble(ui::Control& control);
+        virtual ~Bubble() = default;
         void show(const Point& position);
     private:
         TokenStore _token_store;

--- a/trview.app/UI/Bubble.h
+++ b/trview.app/UI/Bubble.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <trview.ui/Control.h>
+#include <trview.ui/Label.h>
+
+namespace trview
+{
+    class Bubble final
+    {
+    public:
+        explicit Bubble(ui::Control& control);
+        void show();
+    private:
+        TokenStore _token_store;
+        ui::Label* _label{ nullptr };
+    };
+}

--- a/trview.app/UI/IBubble.cpp
+++ b/trview.app/UI/IBubble.cpp
@@ -1,0 +1,8 @@
+#include "IBubble.h"
+
+namespace trview
+{
+    IBubble::~IBubble()
+    {
+    }
+}

--- a/trview.app/UI/IBubble.h
+++ b/trview.app/UI/IBubble.h
@@ -5,11 +5,17 @@
 
 namespace trview
 {
+    /// <summary>
+    /// Shows a short lived notification bubble.
+    /// </summary>
     struct IBubble
     {
         using Source = std::function<std::unique_ptr<IBubble>(ui::Control&)>;
-
         virtual ~IBubble() = 0;
+        /// <summary>
+        /// Show the notification bubble at the specified position.
+        /// </summary>
+        /// <param name="position">The point to show the notification bubble.</param>
         virtual void show(const Point& position) = 0;
     };
 }

--- a/trview.app/UI/IBubble.h
+++ b/trview.app/UI/IBubble.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <trview.common/Point.h>
+
+namespace trview
+{
+    struct IBubble
+    {
+        virtual ~IBubble() = 0;
+        virtual void show(const Point& position) = 0;
+    };
+}

--- a/trview.app/UI/IBubble.h
+++ b/trview.app/UI/IBubble.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include <trview.common/Point.h>
+#include <trview.ui/Control.h>
 
 namespace trview
 {
     struct IBubble
     {
+        using Source = std::function<std::unique_ptr<IBubble>(ui::Control&)>;
+
         virtual ~IBubble() = 0;
         virtual void show(const Point& position) = 0;
     };

--- a/trview.app/UI/di.hpp
+++ b/trview.app/UI/di.hpp
@@ -3,6 +3,7 @@
 #include <external/boost/di.hpp>
 #include "ViewerUI.h"
 #include "SettingsWindow.h"
+#include "Bubble.h"
 
 namespace trview
 {
@@ -11,11 +12,19 @@ namespace trview
         using namespace boost;
         return di::make_injector(
             di::bind<ISettingsWindow::Source>.to(
-                [](const auto& injector) -> ISettingsWindow::Source
+                [](const auto&) -> ISettingsWindow::Source
                 {
                     return [&](ui::Control& parent)
                     {
                         return std::make_unique<SettingsWindow>(parent);
+                    };
+                }),
+            di::bind<IBubble::Source>.to(
+                [](const auto&) -> IBubble::Source
+                {
+                    return [&](ui::Control& parent)
+                    {
+                        return std::make_unique<Bubble>(parent);
                     };
                 }),
             di::bind<IViewerUI>.to<ViewerUI>()

--- a/trview.app/Windows/IItemsWindow.h
+++ b/trview.app/Windows/IItemsWindow.h
@@ -58,6 +58,8 @@ namespace trview
         /// Get the selected item.
         /// @returns The selected item, if present.
         virtual std::optional<Item> selected_item() const = 0;
+
+        virtual void update(float delta) = 0;
     };
 }
 

--- a/trview.app/Windows/IItemsWindow.h
+++ b/trview.app/Windows/IItemsWindow.h
@@ -58,7 +58,10 @@ namespace trview
         /// Get the selected item.
         /// @returns The selected item, if present.
         virtual std::optional<Item> selected_item() const = 0;
-
+        /// <summary>
+        /// Update the window.
+        /// </summary>
+        /// <param name="delta">Elapsed time since previous update.</param>
         virtual void update(float delta) = 0;
     };
 }

--- a/trview.app/Windows/IItemsWindowManager.h
+++ b/trview.app/Windows/IItemsWindowManager.h
@@ -48,7 +48,10 @@ namespace trview
 
         /// Create a new items window.
         virtual std::weak_ptr<IItemsWindow> create_window() = 0;
-
+        /// <summary>
+        /// Update the windows.
+        /// </summary>
+        /// <param name="delta">Elapsed time since previous update.</param>
         virtual void update(float delta) = 0;
     };
 }

--- a/trview.app/Windows/IItemsWindowManager.h
+++ b/trview.app/Windows/IItemsWindowManager.h
@@ -48,5 +48,7 @@ namespace trview
 
         /// Create a new items window.
         virtual std::weak_ptr<IItemsWindow> create_window() = 0;
+
+        virtual void update(float delta) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -56,7 +56,10 @@ namespace trview
         /// Set the triggers in the level.
         /// @param triggers The triggers in the level.
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
-
+        /// <summary>
+        /// Update the window.
+        /// </summary>
+        /// <param name="delta">Elapsed time since previous update.</param>
         virtual void update(float delta) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -56,5 +56,7 @@ namespace trview
         /// Set the triggers in the level.
         /// @param triggers The triggers in the level.
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
+
+        virtual void update(float delta) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -46,7 +46,10 @@ namespace trview
 
         /// Create a new rooms window.
         virtual std::weak_ptr<IRoomsWindow> create_window() = 0;
-
+        /// <summary>
+        /// Update the windows.
+        /// </summary>
+        /// <param name="delta">Elapsed time since previous update.</param>
         virtual void update(float delta) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -46,5 +46,7 @@ namespace trview
 
         /// Create a new rooms window.
         virtual std::weak_ptr<IRoomsWindow> create_window() = 0;
+
+        virtual void update(float delta) = 0;
     };
 }

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -61,6 +61,7 @@ namespace trview
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& trigger) = 0;
 
         virtual void focus() = 0;
+        virtual void update(float delta) = 0;
     };
 }
 

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -61,6 +61,10 @@ namespace trview
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& trigger) = 0;
 
         virtual void focus() = 0;
+        /// <summary>
+        /// Update the window.
+        /// </summary>
+        /// <param name="delta">Elapsed time since previous update.</param>
         virtual void update(float delta) = 0;
     };
 }

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -52,5 +52,7 @@ namespace trview
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
 
         virtual void select_waypoint(uint32_t index) = 0;
+
+        virtual void update(float delta) = 0;
     };
 }

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -52,7 +52,10 @@ namespace trview
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
 
         virtual void select_waypoint(uint32_t index) = 0;
-
+        /// <summary>
+        /// Update the windows.
+        /// </summary>
+        /// <param name="delta">Elapsed time since previous update.</param>
         virtual void update(float delta) = 0;
     };
 }

--- a/trview.app/Windows/ITriggersWindow.h
+++ b/trview.app/Windows/ITriggersWindow.h
@@ -56,6 +56,8 @@ namespace trview
 
         /// Update the trigers - this doesn't reset the filters.
         virtual void update_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
+
+        virtual void update(float delta) = 0;
     };
 }
 

--- a/trview.app/Windows/ITriggersWindow.h
+++ b/trview.app/Windows/ITriggersWindow.h
@@ -56,7 +56,10 @@ namespace trview
 
         /// Update the trigers - this doesn't reset the filters.
         virtual void update_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
-
+        /// <summary>
+        /// Update the window.
+        /// </summary>
+        /// <param name="delta">Elapsed time since previous update.</param>
         virtual void update(float delta) = 0;
     };
 }

--- a/trview.app/Windows/ITriggersWindowManager.h
+++ b/trview.app/Windows/ITriggersWindowManager.h
@@ -46,5 +46,7 @@ namespace trview
 
         /// Create a new triggers window.
         virtual std::weak_ptr<ITriggersWindow> create_window() = 0;
+
+        virtual void update(float delta) = 0;
     };
 }

--- a/trview.app/Windows/ITriggersWindowManager.h
+++ b/trview.app/Windows/ITriggersWindowManager.h
@@ -46,7 +46,10 @@ namespace trview
 
         /// Create a new triggers window.
         virtual std::weak_ptr<ITriggersWindow> create_window() = 0;
-
+        /// <summary>
+        /// Update the windows.
+        /// </summary>
+        /// <param name="delta">Elapsed time since previous update.</param>
         virtual void update(float delta) = 0;
     };
 }

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -42,7 +42,8 @@ namespace trview
 
     ItemsWindow::ItemsWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const ui::IInput::Source& input_source, const Window& parent,
         const std::shared_ptr<IClipboard>& clipboard)
-        : CollapsiblePanel(device_window_source, renderer_source(Size(450, Height)), parent, L"trview.items", L"Items", input_source, Size(450, Height)), _clipboard(clipboard)
+        : CollapsiblePanel(device_window_source, renderer_source(Size(450, Height)), parent, L"trview.items", L"Items", input_source, Size(450, Height)), _clipboard(clipboard),
+        _bubble(std::make_unique<Bubble>(*_ui))
     {
         CollapsiblePanel::on_window_closed += IItemsWindow::on_window_closed;
         set_panels(create_left_panel(), create_right_panel());
@@ -202,6 +203,7 @@ namespace trview
         _token_store += _stats_list->on_item_selected += [this](const ui::Listbox::Item& item)
         {
             _clipboard->write(window(), item.value(L"Value"));
+            _bubble->show();
         };
 
         auto add_to_route = details_panel->add_child(std::make_unique<Button>(Size(180, 20), L"Add to Route"));

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -355,4 +355,9 @@ namespace trview
     {
         CollapsiblePanel::render(vsync);
     }
+
+    void ItemsWindow::update(float delta)
+    {
+        _ui->update(delta);
+    }
 }

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -203,7 +203,7 @@ namespace trview
         _token_store += _stats_list->on_item_selected += [this](const ui::Listbox::Item& item)
         {
             _clipboard->write(window(), item.value(L"Value"));
-            _bubble->show();
+            _bubble->show(client_cursor_position(window()) - Point(0, 20));
         };
 
         auto add_to_route = details_panel->add_child(std::make_unique<Button>(Size(180, 20), L"Add to Route"));

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -41,9 +41,9 @@ namespace trview
     const std::string ItemsWindow::Names::triggers_listbox{ "Triggers" };
 
     ItemsWindow::ItemsWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const ui::IInput::Source& input_source, const Window& parent,
-        const std::shared_ptr<IClipboard>& clipboard)
+        const std::shared_ptr<IClipboard>& clipboard, const IBubble::Source& bubble_source)
         : CollapsiblePanel(device_window_source, renderer_source(Size(450, Height)), parent, L"trview.items", L"Items", input_source, Size(450, Height)), _clipboard(clipboard),
-        _bubble(std::make_unique<Bubble>(*_ui))
+        _bubble(bubble_source(*_ui))
     {
         CollapsiblePanel::on_window_closed += IItemsWindow::on_window_closed;
         set_panels(create_left_panel(), create_right_panel());

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -8,6 +8,7 @@
 #include "CollapsiblePanel.h"
 #include "IItemsWindow.h"
 #include <trview.common/Windows/IClipboard.h>
+#include <trview.app/UI/Bubble.h>
 
 namespace trview
 {
@@ -75,5 +76,6 @@ namespace trview
         bool _sync_item{ true };
         std::optional<Item> _selected_item;
         std::shared_ptr<IClipboard> _clipboard;
+        std::unique_ptr<Bubble> _bubble;
     };
 }

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -49,6 +49,7 @@ namespace trview
         virtual void set_current_room(uint32_t room) override;
         virtual void set_selected_item(const Item& item) override;
         virtual std::optional<Item> selected_item() const override;
+        virtual void update(float delta) override;
     protected:
         /// After the window has been resized, adjust the sizes of the child elements.
         virtual void update_layout() override;

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -8,7 +8,7 @@
 #include "CollapsiblePanel.h"
 #include "IItemsWindow.h"
 #include <trview.common/Windows/IClipboard.h>
-#include <trview.app/UI/Bubble.h>
+#include <trview.app/UI/IBubble.h>
 
 namespace trview
 {
@@ -39,7 +39,8 @@ namespace trview
             const ui::render::IRenderer::Source& renderer_source,
             const ui::IInput::Source& input_source,
             const Window& parent,
-            const std::shared_ptr<IClipboard>& clipboard);
+            const std::shared_ptr<IClipboard>& clipboard,
+            const IBubble::Source& bubble_source);
         virtual ~ItemsWindow() = default;
         virtual void render(bool vsync) override;
         virtual void set_items(const std::vector<Item>& items) override;
@@ -77,6 +78,6 @@ namespace trview
         bool _sync_item{ true };
         std::optional<Item> _selected_item;
         std::shared_ptr<IClipboard> _clipboard;
-        std::unique_ptr<Bubble> _bubble;
+        std::unique_ptr<IBubble> _bubble;
     };
 }

--- a/trview.app/Windows/ItemsWindowManager.cpp
+++ b/trview.app/Windows/ItemsWindowManager.cpp
@@ -110,4 +110,12 @@ namespace trview
             window->set_selected_item(item);
         }
     }
+
+    void ItemsWindowManager::update(float delta)
+    {
+        for (const auto& window : _windows)
+        {
+            window->update(delta);
+        }
+    }
 }

--- a/trview.app/Windows/ItemsWindowManager.h
+++ b/trview.app/Windows/ItemsWindowManager.h
@@ -32,6 +32,7 @@ namespace trview
         virtual void set_room(uint32_t room) override;
         virtual void set_selected_item(const Item& item) override;
         virtual std::weak_ptr<IItemsWindow> create_window() override;
+        virtual void update(float delta) override;
     private:
         std::vector<std::shared_ptr<IItemsWindow>> _windows;
         std::vector<std::weak_ptr<IItemsWindow>> _closing_windows;

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -63,6 +63,7 @@ namespace trview
 
     const std::string RoomsWindow::Names::rooms_listbox{ "Rooms" };
     const std::string RoomsWindow::Names::triggers_listbox{ "Triggers" };
+    const std::string RoomsWindow::Names::stats_listbox{ "Stats" };
 
     RoomsWindow::RoomsWindow(const graphics::IDeviceWindow::Source& device_window_source,
         const ui::render::IRenderer::Source& renderer_source,
@@ -483,6 +484,7 @@ namespace trview
         auto lower_left = std::make_unique<StackPanel>(Size(190, 300), Colours::ItemDetails, Size(0, 2), StackPanel::Direction::Vertical, SizeMode::Manual);
         auto room_stats = std::make_unique<GroupBox>(Size(190, 150), Colours::ItemDetails, Colours::DetailsBorder, L"Room Details");
         _stats_box = room_stats->add_child(std::make_unique<Listbox>(Size(180, 150 - 21), Colours::LeftPanel));
+        _stats_box->set_name(Names::stats_listbox);
         _stats_box->set_columns(
             {
                 { Listbox::Column::Type::String, L"Name", 100 },

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -69,9 +69,10 @@ namespace trview
         const ui::render::IMapRenderer::Source& map_renderer_source,
         const ui::IInput::Source& input_source,
         const std::shared_ptr<IClipboard>& clipboard,
+        const IBubble::Source& bubble_source,
         const Window& parent)
         : CollapsiblePanel(device_window_source, renderer_source(Size(630, 680)), parent, L"trview.rooms", L"Rooms", input_source, Size(630, 680)), _map_renderer(map_renderer_source(Size(341, 341))),
-        _bubble(std::make_unique<Bubble>(*_ui)), _clipboard(clipboard)
+        _bubble(bubble_source(*_ui)), _clipboard(clipboard)
     {
         CollapsiblePanel::on_window_closed += IRoomsWindow::on_window_closed;
 

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -68,8 +68,10 @@ namespace trview
         const ui::render::IRenderer::Source& renderer_source,
         const ui::render::IMapRenderer::Source& map_renderer_source,
         const ui::IInput::Source& input_source,
+        const std::shared_ptr<IClipboard>& clipboard,
         const Window& parent)
-        : CollapsiblePanel(device_window_source, renderer_source(Size(630, 680)), parent, L"trview.rooms", L"Rooms", input_source, Size(630, 680)), _map_renderer(map_renderer_source(Size(341, 341)))
+        : CollapsiblePanel(device_window_source, renderer_source(Size(630, 680)), parent, L"trview.rooms", L"Rooms", input_source, Size(630, 680)), _map_renderer(map_renderer_source(Size(341, 341))),
+        _bubble(std::make_unique<Bubble>(*_ui)), _clipboard(clipboard)
     {
         CollapsiblePanel::on_window_closed += IRoomsWindow::on_window_closed;
 
@@ -494,6 +496,11 @@ namespace trview
             {
                 on_room_selected(std::stoi(item.value(L"Value")));
             }
+            else
+            {
+                _clipboard->write(window(), item.value(L"Value"));
+                _bubble->show(client_cursor_position(window()) - Point(0, 20));
+            }
         };
         lower_left->add_child(std::move(room_stats));
         create_neighbours_list(*lower_left);
@@ -563,5 +570,10 @@ namespace trview
     {
         _selected_trigger.reset();
         _triggers_list->clear_selection();
+    }
+
+    void RoomsWindow::update(float delta)
+    {
+        _ui->update(delta);
     }
 }

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -21,6 +21,7 @@ namespace trview
         {
             static const std::string rooms_listbox;
             static const std::string triggers_listbox;
+            static const std::string stats_listbox;
         };
 
         /// Create a rooms window as a child of the specified window.

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -9,7 +9,7 @@
 #include <trview.app/Elements/Item.h>
 #include <trview.ui.render/MapRenderer.h>
 #include "IRoomsWindow.h"
-#include <trview.app/UI/Bubble.h>
+#include <trview.app/UI/IBubble.h>
 #include <trview.common/Windows/IClipboard.h>
 
 namespace trview
@@ -32,6 +32,7 @@ namespace trview
             const ui::render::IMapRenderer::Source& map_renderer_source,
             const ui::IInput::Source& input_source,
             const std::shared_ptr<IClipboard>& clipboard,
+            const IBubble::Source& bubble_source,
             const Window& parent);
         virtual ~RoomsWindow() = default;
         virtual void clear_selected_trigger() override;
@@ -79,7 +80,7 @@ namespace trview
 
         std::unique_ptr<ui::render::IMapRenderer> _map_renderer;
         std::unique_ptr<Tooltip> _map_tooltip;
-        std::unique_ptr<Bubble> _bubble;
+        std::unique_ptr<IBubble> _bubble;
         std::shared_ptr<IClipboard> _clipboard;
     };
 }

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -9,6 +9,8 @@
 #include <trview.app/Elements/Item.h>
 #include <trview.ui.render/MapRenderer.h>
 #include "IRoomsWindow.h"
+#include <trview.app/UI/Bubble.h>
+#include <trview.common/Windows/IClipboard.h>
 
 namespace trview
 {
@@ -29,6 +31,7 @@ namespace trview
             const ui::render::IRenderer::Source& renderer_source,
             const ui::render::IMapRenderer::Source& map_renderer_source,
             const ui::IInput::Source& input_source,
+            const std::shared_ptr<IClipboard>& clipboard,
             const Window& parent);
         virtual ~RoomsWindow() = default;
         virtual void clear_selected_trigger() override;
@@ -39,6 +42,7 @@ namespace trview
         virtual void set_selected_item(const Item& item) override;
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
+        virtual void update(float delta) override;
     private:
         void load_room_details(const std::weak_ptr<IRoom>& room_ptr);
         std::unique_ptr<ui::Control> create_left_panel();
@@ -75,5 +79,7 @@ namespace trview
 
         std::unique_ptr<ui::render::IMapRenderer> _map_renderer;
         std::unique_ptr<Tooltip> _map_tooltip;
+        std::unique_ptr<Bubble> _bubble;
+        std::shared_ptr<IClipboard> _clipboard;
     };
 }

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -120,4 +120,12 @@ namespace trview
         _windows.push_back(rooms_window);
         return rooms_window;
     }
+
+    void RoomsWindowManager::update(float delta)
+    {
+        for (auto& window : _windows)
+        {
+            window->update(delta);
+        }
+    }
 }

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -37,6 +37,7 @@ namespace trview
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual std::weak_ptr<IRoomsWindow> create_window() override;
+        virtual void update(float delta) override;
     private:
         std::vector<std::shared_ptr<IRoomsWindow>> _windows;
         std::vector<std::weak_ptr<IRoomsWindow>> _closing_windows;

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -47,7 +47,8 @@ namespace trview
     RouteWindow::RouteWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
         const ui::IInput::Source& input_source, const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard,
         const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files)
-        : CollapsiblePanel(device_window_source, renderer_source(Size(470, 400)), parent, L"trview.route", L"Route", input_source, Size(470, 400)), _clipboard(clipboard), _dialogs(dialogs), _files(files)
+        : CollapsiblePanel(device_window_source, renderer_source(Size(470, 400)), parent, L"trview.route", L"Route", input_source, Size(470, 400)), _clipboard(clipboard), _dialogs(dialogs), _files(files),
+        _bubble(std::make_unique<Bubble>(*_ui))
     {
         CollapsiblePanel::on_window_closed += IRouteWindow::on_window_closed;
         set_panels(create_left_panel(), create_right_panel());
@@ -177,6 +178,7 @@ namespace trview
                 item.value(L"Name") == L"Position")
             {
                 _clipboard->write(window(), item.value(L"Value"));
+                _bubble->show(client_cursor_position(window()) - Point(0, 20));
                 return;
             }
 
@@ -455,5 +457,10 @@ namespace trview
     void RouteWindow::focus()
     {
         SetForegroundWindow(window());
+    }
+
+    void RouteWindow::update(float delta)
+    {
+        _ui->update(delta);
     }
 }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -46,9 +46,9 @@ namespace trview
 
     RouteWindow::RouteWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
         const ui::IInput::Source& input_source, const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard,
-        const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files)
+        const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files, const IBubble::Source& bubble_source)
         : CollapsiblePanel(device_window_source, renderer_source(Size(470, 400)), parent, L"trview.route", L"Route", input_source, Size(470, 400)), _clipboard(clipboard), _dialogs(dialogs), _files(files),
-        _bubble(std::make_unique<Bubble>(*_ui))
+        _bubble(bubble_source(*_ui))
     {
         CollapsiblePanel::on_window_closed += IRouteWindow::on_window_closed;
         set_panels(create_left_panel(), create_right_panel());

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -13,7 +13,7 @@
 #include <trview.common/Windows/IDialogs.h>
 #include <trview.common/IFiles.h>
 #include "IRouteWindow.h"
-#include <trview.app/UI/Bubble.h>
+#include <trview.app/UI/IBubble.h>
 
 namespace trview
 {
@@ -38,7 +38,7 @@ namespace trview
         /// @param parent The parent window.
         explicit RouteWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
             const ui::IInput::Source& input_source, const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard,
-            const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
+            const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files, const IBubble::Source& bubble_source);
         virtual ~RouteWindow() = default;
         virtual void render(bool vsync) override;
         virtual void set_route(IRoute* route) override;
@@ -70,6 +70,6 @@ namespace trview
         std::shared_ptr<IClipboard> _clipboard;
         std::shared_ptr<IDialogs> _dialogs;
         std::shared_ptr<IFiles> _files;
-        std::unique_ptr<Bubble> _bubble;
+        std::unique_ptr<IBubble> _bubble;
     };
 }

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -13,6 +13,7 @@
 #include <trview.common/Windows/IDialogs.h>
 #include <trview.common/IFiles.h>
 #include "IRouteWindow.h"
+#include <trview.app/UI/Bubble.h>
 
 namespace trview
 {
@@ -46,6 +47,7 @@ namespace trview
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& rooms) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void focus() override;
+        virtual void update(float delta) override;
     private:
         void load_waypoint_details(uint32_t index);
         std::unique_ptr<ui::Control> create_left_panel();
@@ -68,5 +70,6 @@ namespace trview
         std::shared_ptr<IClipboard> _clipboard;
         std::shared_ptr<IDialogs> _dialogs;
         std::shared_ptr<IFiles> _files;
+        std::unique_ptr<Bubble> _bubble;
     };
 }

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -108,4 +108,12 @@ namespace trview
             _route_window->select_waypoint(index);
         }
     }
+
+    void RouteWindowManager::update(float delta)
+    {
+        if (_route_window)
+        {
+            _route_window->update(delta);
+        }
+    }
 }

--- a/trview.app/Windows/RouteWindowManager.h
+++ b/trview.app/Windows/RouteWindowManager.h
@@ -21,6 +21,7 @@ namespace trview
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& rooms) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void select_waypoint(uint32_t index) override;
+        virtual void update(float delta) override;
     private:
         TokenStore _token_store;
         std::shared_ptr<IRouteWindow> _route_window;

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -53,7 +53,8 @@ namespace trview
 
     TriggersWindow::TriggersWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
         const ui::IInput::Source& input_source, const Window& parent, const std::shared_ptr<IClipboard>& clipboard)
-        : CollapsiblePanel(device_window_source, renderer_source(Size(520, 400)), parent, L"trview.triggers", L"Triggers", input_source, Size(520, 400)), _clipboard(clipboard)
+        : CollapsiblePanel(device_window_source, renderer_source(Size(520, 400)), parent, L"trview.triggers", L"Triggers", input_source, Size(520, 400)), _clipboard(clipboard),
+        _bubble(std::make_unique<Bubble>(*_ui))
     {
         CollapsiblePanel::on_window_closed += ITriggersWindow::on_window_closed;
         set_panels(create_left_panel(), create_right_panel());
@@ -179,6 +180,7 @@ namespace trview
         _token_store += _stats_list->on_item_selected += [this](const ui::Listbox::Item& item)
         {
             _clipboard->write(window(), item.value(L"Value"));
+            _bubble->show(client_cursor_position(window()) - Point(0, 20));
         };
 
         auto button = details_panel->add_child(std::make_unique<Button>(Size(panel_width - 20, 20), L"Add to Route"));
@@ -436,5 +438,10 @@ namespace trview
     void TriggersWindow::render(bool vsync)
     {
         CollapsiblePanel::render(vsync);
+    }
+
+    void TriggersWindow::update(float delta)
+    {
+        _ui->update(delta);
     }
 }

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -52,9 +52,9 @@ namespace trview
     using namespace graphics;
 
     TriggersWindow::TriggersWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
-        const ui::IInput::Source& input_source, const Window& parent, const std::shared_ptr<IClipboard>& clipboard)
+        const ui::IInput::Source& input_source, const Window& parent, const std::shared_ptr<IClipboard>& clipboard, const IBubble::Source& bubble_source)
         : CollapsiblePanel(device_window_source, renderer_source(Size(520, 400)), parent, L"trview.triggers", L"Triggers", input_source, Size(520, 400)), _clipboard(clipboard),
-        _bubble(std::make_unique<Bubble>(*_ui))
+        _bubble(bubble_source(*_ui))
     {
         CollapsiblePanel::on_window_closed += ITriggersWindow::on_window_closed;
         set_panels(create_left_panel(), create_right_panel());

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -9,7 +9,7 @@
 #include "ITriggersWindow.h"
 #include "CollapsiblePanel.h"
 #include <trview.common/Windows/IClipboard.h>
-#include <trview.app/UI/Bubble.h>
+#include <trview.app/UI/IBubble.h>
 
 namespace trview
 {
@@ -34,7 +34,7 @@ namespace trview
         };
 
         explicit TriggersWindow(const graphics::IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source,
-            const ui::IInput::Source& input_source, const Window& parent, const std::shared_ptr<IClipboard>& clipboard);
+            const ui::IInput::Source& input_source, const Window& parent, const std::shared_ptr<IClipboard>& clipboard, const IBubble::Source& bubble_source);
         virtual ~TriggersWindow() = default;
         virtual void render(bool vsync) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
@@ -76,6 +76,6 @@ namespace trview
         std::weak_ptr<ITrigger> _selected_trigger;
         std::vector<TriggerCommandType> _selected_commands;
         std::shared_ptr<IClipboard> _clipboard;
-        std::unique_ptr<Bubble> _bubble;
+        std::unique_ptr<IBubble> _bubble;
     };
 }

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -9,6 +9,7 @@
 #include "ITriggersWindow.h"
 #include "CollapsiblePanel.h"
 #include <trview.common/Windows/IClipboard.h>
+#include <trview.app/UI/Bubble.h>
 
 namespace trview
 {
@@ -43,6 +44,7 @@ namespace trview
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual void set_items(const std::vector<Item>& items) override;
         virtual std::weak_ptr<ITrigger> selected_trigger() const override;
+        virtual void update(float delta) override;
     protected:
         virtual void update_layout() override;
     private:
@@ -74,5 +76,6 @@ namespace trview
         std::weak_ptr<ITrigger> _selected_trigger;
         std::vector<TriggerCommandType> _selected_commands;
         std::shared_ptr<IClipboard> _clipboard;
+        std::unique_ptr<Bubble> _bubble;
     };
 }

--- a/trview.app/Windows/TriggersWindowManager.cpp
+++ b/trview.app/Windows/TriggersWindowManager.cpp
@@ -120,4 +120,12 @@ namespace trview
             window->set_selected_trigger(trigger);
         }
     }
+
+    void TriggersWindowManager::update(float delta)
+    {
+        for (const auto& window : _windows)
+        {
+            window->update(delta);
+        }
+    }
 }

--- a/trview.app/Windows/TriggersWindowManager.h
+++ b/trview.app/Windows/TriggersWindowManager.h
@@ -30,6 +30,7 @@ namespace trview
         virtual void set_room(uint32_t room) override;
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual std::weak_ptr<ITriggersWindow> create_window() override;
+        virtual void update(float delta) override;
     private:
         std::vector<std::shared_ptr<ITriggersWindow>> _windows;
         std::vector<std::weak_ptr<ITriggersWindow>> _closing_windows;

--- a/trview.app/Windows/di.hpp
+++ b/trview.app/Windows/di.hpp
@@ -75,6 +75,7 @@ namespace trview
                             injector.create<ui::render::IRenderer::Source>(),
                             injector.create<ui::render::IMapRenderer::Source>(),
                             injector.create<ui::IInput::Source>(),
+                            injector.create<std::shared_ptr<IClipboard>>(),
                             window);
                     };
                 }),

--- a/trview.app/Windows/di.hpp
+++ b/trview.app/Windows/di.hpp
@@ -30,7 +30,8 @@ namespace trview
                         injector.create<ui::render::IRenderer::Source>(),
                         injector.create<ui::IInput::Source>(),
                         window,
-                        injector.create<std::shared_ptr<IClipboard>>());
+                        injector.create<std::shared_ptr<IClipboard>>(),
+                        injector.create<IBubble::Source>());
                 };
             }),
             di::bind<IItemsWindowManager>.to<ItemsWindowManager>(),
@@ -44,7 +45,8 @@ namespace trview
                             injector.create<ui::render::IRenderer::Source>(),
                             injector.create<ui::IInput::Source>(),
                             window,
-                            injector.create<std::shared_ptr<IClipboard>>());
+                            injector.create<std::shared_ptr<IClipboard>>(),
+                            injector.create<IBubble::Source>());
                     };
                 }),
             di::bind<ITriggersWindowManager>.to<TriggersWindowManager>(),
@@ -60,7 +62,8 @@ namespace trview
                             window,
                             injector.create<std::shared_ptr<IClipboard>>(),
                             injector.create<std::shared_ptr<IDialogs>>(),
-                            injector.create<std::shared_ptr<IFiles>>());
+                            injector.create<std::shared_ptr<IFiles>>(),
+                            injector.create<IBubble::Source>());
                     };
                 }
             ),
@@ -76,6 +79,7 @@ namespace trview
                             injector.create<ui::render::IMapRenderer::Source>(),
                             injector.create<ui::IInput::Source>(),
                             injector.create<std::shared_ptr<IClipboard>>(),
+                            injector.create<IBubble::Source>(),
                             window);
                     };
                 }),

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -111,6 +111,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Tools\IMeasure.cpp" />
     <ClCompile Include="Tools\Measure.cpp" />
     <ClCompile Include="Tools\Toolbar.cpp" />
+    <ClCompile Include="UI\Bubble.cpp" />
     <ClCompile Include="UI\CameraControls.cpp" />
     <ClCompile Include="UI\CameraPosition.cpp" />
     <ClCompile Include="UI\Console.cpp" />
@@ -281,6 +282,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Tools\IMeasure.h" />
     <ClInclude Include="Tools\Measure.h" />
     <ClInclude Include="Tools\Toolbar.h" />
+    <ClInclude Include="UI\Bubble.h" />
     <ClInclude Include="UI\CameraControls.h" />
     <ClInclude Include="UI\CameraPosition.h" />
     <ClInclude Include="UI\Console.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -244,6 +244,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\Settings\IStartupOptions.h" />
     <ClInclude Include="Mocks\Tools\ICompass.h" />
     <ClInclude Include="Mocks\Tools\IMeasure.h" />
+    <ClInclude Include="Mocks\UI\IBubble.h" />
     <ClInclude Include="Mocks\UI\ISettingsWindow.h" />
     <ClInclude Include="Mocks\UI\IViewerUI.h" />
     <ClInclude Include="Mocks\Windows\IItemsWindow.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -117,6 +117,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="UI\Console.cpp" />
     <ClCompile Include="UI\ContextMenu.cpp" />
     <ClCompile Include="UI\GoTo.cpp" />
+    <ClCompile Include="UI\IBubble.cpp" />
     <ClCompile Include="UI\ISettingsWindow.cpp" />
     <ClCompile Include="UI\IViewerUI.cpp" />
     <ClCompile Include="UI\LevelInfo.cpp" />
@@ -290,6 +291,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="UI\di.h" />
     <ClInclude Include="UI\di.hpp" />
     <ClInclude Include="UI\GoTo.h" />
+    <ClInclude Include="UI\IBubble.h" />
     <ClInclude Include="UI\ISettingsWindow.h" />
     <ClInclude Include="UI\IViewerUI.h" />
     <ClInclude Include="UI\LevelInfo.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -251,6 +251,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\Windows\IItemsWindowManager.h" />
     <ClInclude Include="Mocks\Windows\IRoomsWindow.h" />
     <ClInclude Include="Mocks\Windows\IRoomsWindowManager.h" />
+    <ClInclude Include="Mocks\Windows\IRouteWindow.h" />
     <ClInclude Include="Mocks\Windows\IRouteWindowManager.h" />
     <ClInclude Include="Mocks\Windows\ITriggersWindow.h" />
     <ClInclude Include="Mocks\Windows\ITriggersWindowManager.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -860,6 +860,9 @@
     <ClInclude Include="Mocks\UI\IBubble.h">
       <Filter>Mocks\UI</Filter>
     </ClInclude>
+    <ClInclude Include="Mocks\Windows\IRouteWindow.h">
+      <Filter>Mocks\Windows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -857,6 +857,9 @@
     <ClInclude Include="UI\IBubble.h">
       <Filter>UI</Filter>
     </ClInclude>
+    <ClInclude Include="Mocks\UI\IBubble.h">
+      <Filter>Mocks\UI</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -331,6 +331,9 @@
     <ClCompile Include="UI\ISettingsWindow.cpp">
       <Filter>UI</Filter>
     </ClCompile>
+    <ClCompile Include="UI\Bubble.cpp">
+      <Filter>UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -844,6 +847,9 @@
     </ClInclude>
     <ClInclude Include="Mocks\UI\ISettingsWindow.h">
       <Filter>Mocks\UI</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\Bubble.h">
+      <Filter>UI</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -334,6 +334,9 @@
     <ClCompile Include="UI\Bubble.cpp">
       <Filter>UI</Filter>
     </ClCompile>
+    <ClCompile Include="UI\IBubble.cpp">
+      <Filter>UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -849,6 +852,9 @@
       <Filter>Mocks\UI</Filter>
     </ClInclude>
     <ClInclude Include="UI\Bubble.h">
+      <Filter>UI</Filter>
+    </ClInclude>
+    <ClInclude Include="UI\IBubble.h">
       <Filter>UI</Filter>
     </ClInclude>
   </ItemGroup>

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -286,15 +286,13 @@ namespace trview
             return _focused;
         }
 
-        Colour Control::colour() const
+        void Control::update(float delta)
         {
-            return _colour;
-        }
-
-        void Control::set_colour(const Colour& colour)
-        {
-            _colour = colour;
-            on_invalidate();
+            on_update(delta);
+            for (const auto& child : _child_elements)
+            {
+                child->update(delta);
+            }
         }
     }
 }

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -285,5 +285,16 @@ namespace trview
         {
             return _focused;
         }
+
+        Colour Control::colour() const
+        {
+            return _colour;
+        }
+
+        void Control::set_colour(const Colour& colour)
+        {
+            _colour = colour;
+            on_invalidate();
+        }
     }
 }

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -9,6 +9,7 @@
 #include <trview.common/Size.h>
 #include <trview.common/Point.h>
 #include <trview.common/TokenStore.h>
+#include <trview.common/Colour.h>
 #include "Align.h"
 #include "IInput.h"
 
@@ -145,8 +146,10 @@ namespace trview
             /// @returns The z order.
             int z() const;
 
-            /// Set the z order of the control.
-            /// @param value The new z order.
+            /// <summary>
+            /// Set the Z order of the control. Lower is on top.
+            /// </summary>
+            /// <param name="value">The new Z order</param>
             void set_z(int value);
 
             /// Remove the specified child element.
@@ -181,6 +184,8 @@ namespace trview
 
             /// Event raised when user has selected the control for text tinput.
             Event<> on_focused;
+
+            Event<float> on_update;
 
             /// To be called when the mouse has been pressed down over the element.
             /// @param position The position of the mouse down relative to the control.

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -184,7 +184,9 @@ namespace trview
 
             /// Event raised when user has selected the control for text tinput.
             Event<> on_focused;
-
+            /// <summary>
+            /// Event raised when the control has been updated. The elapsed time is passed as the parameter.
+            /// </summary>
             Event<float> on_update;
 
             /// To be called when the mouse has been pressed down over the element.
@@ -245,7 +247,10 @@ namespace trview
             void set_input(IInput* input);
 
             bool focused() const;
-
+            /// <summary>
+            /// Update the control.
+            /// </summary>
+            /// <param name="delta">The elapsed time since the previous update.</param>
             void update(float delta);
         protected:
             /// To be called after a child element has been added to the control.

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -245,6 +245,8 @@ namespace trview
             void set_input(IInput* input);
 
             bool focused() const;
+
+            void update(float delta);
         protected:
             /// To be called after a child element has been added to the control.
             /// @param child_element The element that was added.


### PR DESCRIPTION
Add a notification bubble to let the user know that they have copied some text from one of the stats boxes around the application. This is done by clicking on the stat box (this functionality was already there but no-one knew about it).
Had to add an update path through the application which wasn't really there before so quite a few files changed to pass this through from `Application` to the various windows.
Add tests where possible and update some older tests to use the new `with_` style.
Closes #754 