### PR TITLE
Create waypoints using DI

### DIFF
--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -87,8 +87,8 @@ TEST(RouteWindow, WaypointRoomPositionCalculatedCorrectly)
     auto room = std::make_shared<MockRoom>();
     EXPECT_CALL(*room, info).WillRepeatedly(Return(info));
 
-    auto [mesh_ptr, mesh] = create_mock<MockMesh>();
-    Waypoint waypoint(&mesh, waypoint_pos, 0);
+    auto mesh = std::make_shared<MockMesh>();
+    Waypoint waypoint(mesh, waypoint_pos, 0);
 
     MockRoute route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
@@ -130,8 +130,8 @@ TEST(RouteWindow, PositionValuesCopiedToClipboard)
     auto window = register_test_module().with_clipboard(clipboard).build();
 
     const Vector3 waypoint_pos{ 130, 250, 325 };
-    auto [mesh_ptr, mesh] = create_mock<MockMesh>();
-    Waypoint waypoint(&mesh, waypoint_pos, 0);
+    auto mesh = std::make_shared<MockMesh>();
+    Waypoint waypoint(mesh, waypoint_pos, 0);
 
     MockRoute route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
@@ -159,8 +159,8 @@ TEST(RouteWindow, RoomPositionValuesCopiedToClipboard)
     auto window = register_test_module().with_clipboard(clipboard).build();
 
     const Vector3 waypoint_pos{ 130, 250, 325 };
-    auto [mesh_ptr, mesh] = create_mock<MockMesh>();
-    Waypoint waypoint(&mesh, waypoint_pos, 0);
+    auto mesh = std::make_shared<MockMesh>();
+    Waypoint waypoint(mesh, waypoint_pos, 0);
 
     MockRoute route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
@@ -183,8 +183,8 @@ TEST(RouteWindow, RoomPositionValuesCopiedToClipboard)
 TEST(RouteWindow, AddingWaypointNotesMarksRouteUnsaved)
 {
     const Vector3 waypoint_pos{ 130, 250, 325 };
-    auto [mesh_ptr, mesh] = create_mock<MockMesh>();
-    Waypoint waypoint(&mesh, waypoint_pos, 0);
+    auto mesh = std::make_shared<MockMesh>();
+    Waypoint waypoint(mesh, waypoint_pos, 0);
 
     MockRoute route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
@@ -203,8 +203,8 @@ TEST(RouteWindow, AddingWaypointNotesMarksRouteUnsaved)
 TEST(RouteWindow, ClearSaveMarksRouteUnsaved)
 {
     const Vector3 waypoint_pos{ 130, 250, 325 };
-    auto [mesh_ptr, mesh] = create_mock<MockMesh>();
-    Waypoint waypoint(&mesh, waypoint_pos, 0);
+    auto mesh = std::make_shared<MockMesh>();
+    Waypoint waypoint(mesh, waypoint_pos, 0);
     waypoint.set_save_file({ 0, 1, 2 });
 
     MockRoute route;
@@ -308,7 +308,7 @@ TEST(RouteWindow, ExportSaveButtonSavesFile)
     EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::vector<uint8_t>&>())).Times(1);
 
     auto mesh = std::make_shared<MockMesh>();
-    Waypoint waypoint{ mesh.get(), Vector3::Zero, 0 };
+    Waypoint waypoint{ mesh, Vector3::Zero, 0 };
     waypoint.set_save_file({ 0x1 });
     MockRoute route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
@@ -333,7 +333,7 @@ TEST(RouteWindow, ExportSaveButtonShowsErrorOnFailure)
     EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::vector<uint8_t>&>())).Times(1).WillRepeatedly(Throw(std::exception()));
 
     auto mesh = std::make_shared<MockMesh>();
-    Waypoint waypoint{ mesh.get(), Vector3::Zero, 0 };
+    Waypoint waypoint{ mesh, Vector3::Zero, 0 };
     waypoint.set_save_file({ 0x1 });
     MockRoute route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
@@ -357,7 +357,7 @@ TEST(RouteWindow, ExportSaveButtonDoesNotSaveFileWhenCancelled)
     EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::vector<uint8_t>&>())).Times(0);
 
     auto mesh = std::make_shared<MockMesh>();
-    Waypoint waypoint{ mesh.get(), Vector3::Zero, 0 };
+    Waypoint waypoint{ mesh, Vector3::Zero, 0 };
     waypoint.set_save_file({ 0x1 });
     MockRoute route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
@@ -381,7 +381,7 @@ TEST(RouteWindow, AttachSaveButtonLoadsSave)
     EXPECT_CALL(*files, load_file).Times(1).WillRepeatedly(Return(std::vector<uint8_t>{ 0x1, 0x2 }));
 
     auto mesh = std::make_shared<MockMesh>();
-    Waypoint waypoint{ mesh.get(), Vector3::Zero, 0 };
+    Waypoint waypoint{ mesh, Vector3::Zero, 0 };
     MockRoute route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
@@ -410,7 +410,7 @@ TEST(RouteWindow, AttachSaveButtonShowsMessageOnError)
     EXPECT_CALL(*files, load_file).Times(1).WillRepeatedly(Throw(std::exception()));
 
     auto mesh = std::make_shared<MockMesh>();
-    Waypoint waypoint{ mesh.get(), Vector3::Zero, 0 };
+    Waypoint waypoint{ mesh, Vector3::Zero, 0 };
     MockRoute route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
@@ -436,7 +436,7 @@ TEST(RouteWindow, AttachSaveButtonDoesNotLoadFileWhenCancelled)
     EXPECT_CALL(*files, load_file).Times(0);
 
     auto mesh = std::make_shared<MockMesh>();
-    Waypoint waypoint{ mesh.get(), Vector3::Zero, 0 };
+    Waypoint waypoint{ mesh, Vector3::Zero, 0 };
     MockRoute route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
@@ -460,7 +460,7 @@ TEST(RouteWindow, ClickStatShowsBubble)
     auto window = register_test_module().with_bubble_source([&](auto&&...) { return std::move(bubble); }).build();
 
     auto mesh = std::make_shared<MockMesh>();
-    Waypoint waypoint{ mesh.get(), Vector3::Zero, 0 };
+    Waypoint waypoint{ mesh, Vector3::Zero, 0 };
     MockRoute route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -45,7 +45,7 @@ namespace
     /// <returns>Waypoint source.</returns>
     IWaypoint::Source indexed_source(uint32_t& test_index)
     {
-        return [&](auto&& position, auto&& room, auto&& type, auto&& index, auto&& colour)
+        return [&](auto&&...)
         {
             auto waypoint = std::make_unique<MockWaypoint>();
             waypoint->test_index = test_index++;

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -1,6 +1,5 @@
 #include <trview.app/Routing/Route.h>
 #include <trview.app/Mocks/Graphics/ISelectionRenderer.h>
-#include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.app/Mocks/Routing/IWaypoint.h>
 
 using namespace trview;
@@ -14,7 +13,6 @@ namespace
         struct test_module
         {
             std::unique_ptr<ISelectionRenderer> selection_renderer = std::make_unique<MockSelectionRenderer>();
-            IMesh::Source mesh_source = [](auto&&...) { return std::make_shared<MockMesh>(); };
             IWaypoint::Source waypoint_source = [](auto&&...) { return std::make_unique<MockWaypoint>(); };
 
             test_module& with_waypoint_source(IWaypoint::Source waypoint_source)
@@ -25,7 +23,7 @@ namespace
 
             std::unique_ptr<Route> build()
             {
-                return std::make_unique<Route>(std::move(selection_renderer), mesh_source, waypoint_source);
+                return std::make_unique<Route>(std::move(selection_renderer), waypoint_source);
             }
         };
         return test_module{};

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -32,7 +32,7 @@ TEST(Route, Add)
     route->add(Vector3(0, 1, 0), 10);
     ASSERT_TRUE(route->is_unsaved());
     ASSERT_EQ(route->waypoints(), 1);
-    auto waypoint = route->waypoint(0);
+    auto& waypoint = route->waypoint(0);
     ASSERT_EQ(waypoint.position(), Vector3(0, 1, 0));
     ASSERT_EQ(waypoint.room(), 10);
     ASSERT_EQ(waypoint.type(), Waypoint::Type::Position);
@@ -44,7 +44,7 @@ TEST(Route, AddSpecificType)
     route->add(Vector3(0, 1, 0), 10, Waypoint::Type::Trigger, 100);
     ASSERT_TRUE(route->is_unsaved());
     ASSERT_EQ(route->waypoints(), 1);
-    auto waypoint = route->waypoint(0);
+    auto& waypoint = route->waypoint(0);
     ASSERT_EQ(waypoint.position(), Vector3(0, 1, 0));
     ASSERT_EQ(waypoint.room(), 10);
     ASSERT_EQ(waypoint.type(), Waypoint::Type::Trigger);
@@ -77,7 +77,7 @@ TEST(Route, InsertAtPosition)
     route->insert(Vector3(0, 1, 0), 2, 1);
     ASSERT_TRUE(route->is_unsaved());
     ASSERT_EQ(route->waypoints(), 3);
-    auto waypoint = route->waypoint(1);
+    auto& waypoint = route->waypoint(1);
     ASSERT_EQ(waypoint.position(), Vector3(0, 1, 0));
     ASSERT_EQ(waypoint.room(), 2);
     ASSERT_EQ(waypoint.type(), Waypoint::Type::Position);
@@ -92,7 +92,7 @@ TEST(Route, InsertSpecificTypeAtPosition)
     route->insert(Vector3(0, 1, 0), 2, 1, Waypoint::Type::Entity, 100);
     ASSERT_TRUE(route->is_unsaved());
     ASSERT_EQ(route->waypoints(), 3);
-    auto waypoint = route->waypoint(1);
+    auto& waypoint = route->waypoint(1);
     ASSERT_EQ(waypoint.position(), Vector3(0, 1, 0));
     ASSERT_EQ(waypoint.room(), 2);
     ASSERT_EQ(waypoint.type(), Waypoint::Type::Entity);
@@ -110,7 +110,7 @@ TEST(Route, Insert)
     ASSERT_EQ(index, 2);
     ASSERT_TRUE(route->is_unsaved());
     ASSERT_EQ(route->waypoints(), 3);
-    auto waypoint = route->waypoint(2);
+    auto& waypoint = route->waypoint(2);
     ASSERT_EQ(waypoint.position(), Vector3(0, 1, 0));
     ASSERT_EQ(waypoint.room(), 2);
     ASSERT_EQ(waypoint.type(), Waypoint::Type::Position);

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -56,10 +56,10 @@ namespace
     }
 
     /// <summary>
-    /// 
+    /// Get the test index values of the waypoints in the order they are in the list.
     /// </summary>
-    /// <param name="route"></param>
-    /// <returns></returns>
+    /// <param name="route">The route to test.</param>
+    /// <returns>The ordered index values.</returns>
     std::vector<uint32_t> get_order(Route& route)
     {
         std::vector<uint32_t> waypoints;

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -1,6 +1,7 @@
 #include <trview.app/Routing/Route.h>
 #include <trview.app/Mocks/Graphics/ISelectionRenderer.h>
 #include <trview.app/Mocks/Geometry/IMesh.h>
+#include <trview.app/Mocks/Routing/IWaypoint.h>
 
 using namespace trview;
 using namespace trview::mocks;
@@ -14,10 +15,11 @@ namespace
         {
             std::unique_ptr<ISelectionRenderer> selection_renderer = std::make_unique<MockSelectionRenderer>();
             IMesh::Source mesh_source = [](auto&&...) { return std::make_shared<MockMesh>(); };
+            IWaypoint::Source waypoint_source = [](auto&&...) { return std::make_unique<MockWaypoint>(); };
 
             std::unique_ptr<Route> build()
             {
-                return std::make_unique<Route>(std::move(selection_renderer), mesh_source);
+                return std::make_unique<Route>(std::move(selection_renderer), mesh_source, waypoint_source);
             }
         };
         return test_module{};

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -45,7 +45,7 @@ namespace
     /// </summary>
     /// <param name="test_index">Initial number, should be 0 and live as long or longer than the source.</param>
     /// <returns>Waypoint source.</returns>
-    IWaypoint::Source indexed_source(uint32_t test_index)
+    IWaypoint::Source indexed_source(uint32_t& test_index)
     {
         return [&](auto&& position, auto&& room, auto&& type, auto&& index, auto&& colour)
         {

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -98,7 +98,7 @@ TEST(Route, AddSpecificType)
         return std::make_unique<MockWaypoint>();
     };
     auto route = register_test_module().with_waypoint_source(source).build();
-    route->add(Vector3(0, 1, 0), 10, Waypoint::Type::Trigger, 100);
+    route->add(Vector3(0, 1, 0), 10, IWaypoint::Type::Trigger, 100);
     ASSERT_TRUE(route->is_unsaved());
     ASSERT_EQ(route->waypoints(), 1);
     ASSERT_EQ(waypoint_values.value().position, Vector3(0, 1, 0));
@@ -147,7 +147,7 @@ TEST(Route, InsertSpecificTypeAtPosition)
     route->add(Vector3::Zero, 0);
     route->add(Vector3::Zero, 1);
     route->set_unsaved(false);
-    route->insert(Vector3(0, 1, 0), 2, 1, Waypoint::Type::Entity, 100);
+    route->insert(Vector3(0, 1, 0), 2, 1, IWaypoint::Type::Entity, 100);
     ASSERT_TRUE(route->is_unsaved());
     ASSERT_EQ(route->waypoints(), 3);
     auto& waypoint = route->waypoint(1);

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -61,7 +61,7 @@ namespace
     std::vector<uint32_t> get_order(Route& route)
     {
         std::vector<uint32_t> waypoints;
-        for (auto i = 0; i < route.waypoints(); ++i)
+        for (auto i = 0u; i < route.waypoints(); ++i)
         {
             waypoints.push_back(static_cast<const MockWaypoint&>(route.waypoint(i)).test_index);
         }

--- a/trview.app.tests/Routing/WaypointTests.cpp
+++ b/trview.app.tests/Routing/WaypointTests.cpp
@@ -1,0 +1,49 @@
+#include <trview.app/Routing/Waypoint.h>
+#include <trview.app/Mocks/Geometry/IMesh.h>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace DirectX::SimpleMath;
+
+TEST(Waypoint, EmptySave)
+{
+    Waypoint waypoint(std::make_shared<MockMesh>(), Vector3::Zero, 0, IWaypoint::Type::Position, 0, Colour::Red);
+    ASSERT_FALSE(waypoint.has_save());
+    waypoint.set_save_file({});
+    ASSERT_FALSE(waypoint.has_save());
+}
+
+TEST(Waypoint, ConstructorProperties)
+{
+    Waypoint waypoint(std::make_shared<MockMesh>(), Vector3(1, 2, 3), 12, IWaypoint::Type::Trigger, 23, Colour::Red);
+    ASSERT_EQ(waypoint.position(), Vector3(1, 2, 3));
+    ASSERT_EQ(waypoint.room(), 12);
+    ASSERT_EQ(waypoint.type(), IWaypoint::Type::Trigger);
+    ASSERT_EQ(waypoint.index(), 23);
+}
+
+TEST(Waypoint, Notes)
+{
+    Waypoint waypoint(std::make_shared<MockMesh>(), Vector3(1, 2, 3), 12, IWaypoint::Type::Trigger, 23, Colour::Red);
+    waypoint.set_notes(L"Test notes\nNew line");
+    ASSERT_EQ(waypoint.notes(), L"Test notes\nNew Line");
+}
+
+TEST(Waypoint, SaveFile)
+{
+    Waypoint waypoint(std::make_shared<MockMesh>(), Vector3::Zero, 0, IWaypoint::Type::Position, 0, Colour::Red);
+    ASSERT_FALSE(waypoint.has_save());
+    waypoint.set_save_file({ 0x1 });
+    ASSERT_TRUE(waypoint.has_save());
+    ASSERT_EQ(waypoint.save_file(), std::vector<uint8_t>{ 0x1 });
+}
+
+TEST(Waypoint, Visibility)
+{
+    Waypoint waypoint(std::make_shared<MockMesh>(), Vector3::Zero, 0, IWaypoint::Type::Position, 0, Colour::Red);
+    ASSERT_TRUE(waypoint.visible());
+    waypoint.set_visible(false);
+    ASSERT_FALSE(waypoint.visible());
+    waypoint.set_visible(true);
+    ASSERT_TRUE(waypoint.visible());
+}

--- a/trview.app.tests/Routing/WaypointTests.cpp
+++ b/trview.app.tests/Routing/WaypointTests.cpp
@@ -26,7 +26,7 @@ TEST(Waypoint, Notes)
 {
     Waypoint waypoint(std::make_shared<MockMesh>(), Vector3(1, 2, 3), 12, IWaypoint::Type::Trigger, 23, Colour::Red);
     waypoint.set_notes(L"Test notes\nNew line");
-    ASSERT_EQ(waypoint.notes(), L"Test notes\nNew Line");
+    ASSERT_EQ(waypoint.notes(), L"Test notes\nNew line");
 }
 
 TEST(Waypoint, SaveFile)

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -17,6 +17,7 @@
 #include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.app/Mocks/Graphics/ISectorHighlight.h>
 #include <trlevel/Mocks/ILevel.h>
+#include <trview.app/Mocks/Routing/IWaypoint.h>
 
 using testing::Return;
 using namespace trview;
@@ -297,8 +298,8 @@ TEST(Viewer, AddWaypointRaised)
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
     viewer->open(&level);
 
-    std::optional<std::tuple<Vector3, uint32_t, Waypoint::Type, uint32_t>> added_waypoint;
-    auto token = viewer->on_waypoint_added += [&added_waypoint](const auto& position, uint32_t room, Waypoint::Type type, uint32_t index)
+    std::optional<std::tuple<Vector3, uint32_t, IWaypoint::Type, uint32_t>> added_waypoint;
+    auto token = viewer->on_waypoint_added += [&added_waypoint](const auto& position, uint32_t room, IWaypoint::Type type, uint32_t index)
     {
         added_waypoint = { position, room, type, index };
     };
@@ -309,7 +310,7 @@ TEST(Viewer, AddWaypointRaised)
 
     ASSERT_TRUE(added_waypoint.has_value());
     ASSERT_EQ(std::get<1>(added_waypoint.value()), 10u);
-    ASSERT_EQ(std::get<2>(added_waypoint.value()), Waypoint::Type::Entity);
+    ASSERT_EQ(std::get<2>(added_waypoint.value()), IWaypoint::Type::Entity);
     ASSERT_EQ(std::get<3>(added_waypoint.value()), 50u);
 }
 
@@ -421,8 +422,7 @@ TEST(Viewer, OrbitEnabledWhenWaypointSelectedAndAutoOrbitEnabled)
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 
     auto mesh = std::make_shared<MockMesh>();
-    Waypoint waypoint(mesh, Vector3::Zero, 0);
-    viewer->select_waypoint(waypoint);
+    viewer->select_waypoint(MockWaypoint{});
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Orbit);
 }
 
@@ -442,8 +442,7 @@ TEST(Viewer, OrbitNotEnabledWhenWaypointSelectedAndAutoOrbitDisabled)
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 
     auto mesh = std::make_shared<MockMesh>();
-    Waypoint waypoint(mesh, Vector3::Zero, 0);
-    viewer->select_waypoint(waypoint);
+    viewer->select_waypoint(MockWaypoint{});
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 }
 

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -420,8 +420,8 @@ TEST(Viewer, OrbitEnabledWhenWaypointSelectedAndAutoOrbitEnabled)
     viewer->set_camera_mode(CameraMode::Free);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 
-    MockMesh mesh;
-    Waypoint waypoint(&mesh, Vector3::Zero, 0);
+    auto mesh = std::make_shared<MockMesh>();
+    Waypoint waypoint(mesh, Vector3::Zero, 0);
     viewer->select_waypoint(waypoint);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Orbit);
 }
@@ -441,8 +441,8 @@ TEST(Viewer, OrbitNotEnabledWhenWaypointSelectedAndAutoOrbitDisabled)
     viewer->set_camera_mode(CameraMode::Free);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 
-    MockMesh mesh;
-    Waypoint waypoint(&mesh, Vector3::Zero, 0);
+    auto mesh = std::make_shared<MockMesh>();
+    Waypoint waypoint(mesh, Vector3::Zero, 0);
     viewer->select_waypoint(waypoint);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 }

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -43,6 +43,7 @@
     <ClCompile Include="Routing\ActionsTests.cpp" />
     <ClCompile Include="Routing\ActionTests.cpp" />
     <ClCompile Include="Routing\RouteTests.cpp" />
+    <ClCompile Include="Routing\WaypointTests.cpp" />
     <ClCompile Include="SettingsWindowTests.cpp" />
     <ClCompile Include="Settings\StartupOptionsTests.cpp" />
     <ClCompile Include="stdafx.cpp">

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -95,6 +95,9 @@
     <ClCompile Include="UI\BubbleTests.cpp">
       <Filter>UI</Filter>
     </ClCompile>
+    <ClCompile Include="Routing\WaypointTests.cpp">
+      <Filter>Routing</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -349,7 +349,7 @@ namespace trview
         _token_store += _items_windows->on_trigger_selected += [this](const auto& trigger) { select_trigger(trigger); };
         _token_store += _items_windows->on_add_to_route += [this](const auto& item)
         {
-            uint32_t new_index = _route->insert(item.position(), item.room(), Waypoint::Type::Entity, item.number());
+            uint32_t new_index = _route->insert(item.position(), item.room(), IWaypoint::Type::Entity, item.number());
             _route_window->set_route(_route.get());
             select_waypoint(new_index);
         };
@@ -368,7 +368,7 @@ namespace trview
         {
             if (auto trigger_ptr = trigger.lock())
             {
-                add_waypoint(trigger_ptr->position(), trigger_ptr->room(), Waypoint::Type::Trigger, trigger_ptr->number());
+                add_waypoint(trigger_ptr->position(), trigger_ptr->room(), IWaypoint::Type::Trigger, trigger_ptr->number());
             }
         };
     }
@@ -428,7 +428,7 @@ namespace trview
         add_shortcut(false, VK_DELETE, [&]() { remove_waypoint(_route->selected_waypoint()); });
     }
 
-    void Application::add_waypoint(const Vector3& position, uint32_t room, Waypoint::Type type, uint32_t index)
+    void Application::add_waypoint(const Vector3& position, uint32_t room, IWaypoint::Type type, uint32_t index)
     {
         uint32_t new_index = _route->insert(position, room, type, index);
         _route_window->set_route(_route.get());

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -70,7 +70,7 @@ namespace trview
         void setup_route_window();
         void setup_shortcuts();
         // Entity manipulation
-        void add_waypoint(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t index);
+        void add_waypoint(const DirectX::SimpleMath::Vector3& position, uint32_t room, IWaypoint::Type type, uint32_t index);
         void remove_waypoint(uint32_t index);
         void select_item(const Item& item);
         void select_room(uint32_t room);

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -11,13 +11,13 @@ namespace trview
         public:
             virtual ~MockRoute() = default;
             MOCK_METHOD(void, add, (const DirectX::SimpleMath::Vector3&, uint32_t), (override));
-            MOCK_METHOD(void, add, (const DirectX::SimpleMath::Vector3&, uint32_t, Waypoint::Type, uint32_t), (override));
+            MOCK_METHOD(void, add, (const DirectX::SimpleMath::Vector3&, uint32_t, IWaypoint::Type, uint32_t), (override));
             MOCK_METHOD(void, clear, (), (override));
             MOCK_METHOD(Colour, colour, (), (const, override));
             MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t), (override));
             MOCK_METHOD(uint32_t, insert, (const DirectX::SimpleMath::Vector3&, uint32_t), (override));
-            MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t, Waypoint::Type, uint32_t), (override));
-            MOCK_METHOD(uint32_t, insert, (const DirectX::SimpleMath::Vector3&, uint32_t, Waypoint::Type, uint32_t), (override));
+            MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t, IWaypoint::Type, uint32_t), (override));
+            MOCK_METHOD(uint32_t, insert, (const DirectX::SimpleMath::Vector3&, uint32_t, IWaypoint::Type, uint32_t), (override));
             MOCK_METHOD(bool, is_unsaved, (), (const, override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
             MOCK_METHOD(void, remove, (uint32_t), (override));

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -26,8 +26,8 @@ namespace trview
             MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
             MOCK_METHOD(void, set_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_unsaved, (bool), (override));
-            MOCK_METHOD(const Waypoint&, waypoint, (uint32_t), (const, override));
-            MOCK_METHOD(Waypoint&, waypoint, (uint32_t), (override));
+            MOCK_METHOD(const IWaypoint&, waypoint, (uint32_t), (const, override));
+            MOCK_METHOD(IWaypoint&, waypoint, (uint32_t), (override));
             MOCK_METHOD(uint32_t, waypoints, (), (const, override));
         };
     }

--- a/trview.app/Mocks/Routing/IWaypoint.h
+++ b/trview.app/Mocks/Routing/IWaypoint.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <trview.app/Routing/IWaypoint.h>
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockWaypoint final : public IWaypoint
+        {
+            virtual ~MockWaypoint() = default;
+            MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
+            MOCK_METHOD(Type, type, (), (const, override));
+            MOCK_METHOD(bool, has_save, (), (const, override));
+            MOCK_METHOD(uint32_t, index, (), (const, override));
+            MOCK_METHOD(uint32_t, room, (), (const, override));
+            MOCK_METHOD(std::wstring, notes, (), (const, override));
+            MOCK_METHOD(std::vector<uint8_t>, save_file, (), (const, override));
+            MOCK_METHOD(void, set_notes, (const std::wstring&), (override));
+            MOCK_METHOD(void, set_route_colour, (const Colour&), (override));
+            MOCK_METHOD(void, set_save_file, (const std::vector<uint8_t>&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(bool, visible, (), (const, override));
+            MOCK_METHOD(void, set_visible, (bool), (override));
+        };
+    }
+}
+

--- a/trview.app/Mocks/Routing/IWaypoint.h
+++ b/trview.app/Mocks/Routing/IWaypoint.h
@@ -9,6 +9,7 @@ namespace trview
         struct MockWaypoint final : public IWaypoint
         {
             virtual ~MockWaypoint() = default;
+            MOCK_METHOD(DirectX::BoundingBox, bounding_box, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(Type, type, (), (const, override));
             MOCK_METHOD(bool, has_save, (), (const, override));
@@ -20,11 +21,12 @@ namespace trview
             MOCK_METHOD(void, set_route_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_save_file, (const std::vector<uint8_t>&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, render_join, (const IWaypoint&, const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(bool, visible, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));
             /// <summary>
-            /// Index used in a test.
+            /// Index used for testing ordering.
             /// </summary>
             uint32_t test_index;
         };

--- a/trview.app/Mocks/Routing/IWaypoint.h
+++ b/trview.app/Mocks/Routing/IWaypoint.h
@@ -23,6 +23,10 @@ namespace trview
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(bool, visible, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));
+            /// <summary>
+            /// Index used in a test.
+            /// </summary>
+            uint32_t test_index;
         };
     }
 }

--- a/trview.app/Mocks/Windows/IViewer.h
+++ b/trview.app/Mocks/Windows/IViewer.h
@@ -16,7 +16,7 @@ namespace trview
             MOCK_METHOD(void, select_item, (const Item&));
             MOCK_METHOD(void, select_room, (uint32_t));
             MOCK_METHOD(void, select_trigger, (const std::weak_ptr<ITrigger>&));
-            MOCK_METHOD(void, select_waypoint, (const Waypoint&));
+            MOCK_METHOD(void, select_waypoint, (const IWaypoint&));
             MOCK_METHOD(void, set_camera_mode, (CameraMode), (override));
             MOCK_METHOD(void, set_route, (const std::shared_ptr<IRoute>&));
             MOCK_METHOD(void, set_show_compass, (bool));

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include <trview.app/Routing/Waypoint.h>
+#include <trview.app/Routing/IWaypoint.h>
 
 namespace trview
 {
@@ -25,7 +25,7 @@ namespace trview
         /// <param name="room">The room that waypoint is in.</param>
         /// <param name="type">The type of the waypoint.</param>
         /// <param name="type_index">The index of the referred to entity or trigger.</param>
-        virtual void add(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index) = 0;
+        virtual void add(const DirectX::SimpleMath::Vector3& position, uint32_t room, IWaypoint::Type type, uint32_t type_index) = 0;
         /// <summary>
         /// Remove all of the waypoints from the route.
         /// </summary>
@@ -57,7 +57,7 @@ namespace trview
         /// <param name="index">The index in the route list to put the waypoint.</param>
         /// <param name="type">The type of waypoint.</param>
         /// <param name="type_index">The index of the trigger or entity to reference.</param>
-        virtual void insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index) = 0;
+        virtual void insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, IWaypoint::Type type, uint32_t type_index) = 0;
         /// <summary>
         /// Insert a new non-positional waypoint based on the currently selected waypoint.
         /// </summary>
@@ -66,7 +66,7 @@ namespace trview
         /// <param name="type">The type of waypoint.</param>
         /// <param name="type_index">The index of the trigger or entity to reference.</param>
         /// <returns>The index of the new waypoint.</returns>
-        virtual uint32_t insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index) = 0;
+        virtual uint32_t insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, IWaypoint::Type type, uint32_t type_index) = 0;
         /// <summary>
         /// Determines whether the route has any unsaved changes.
         /// </summary>

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -115,13 +115,13 @@ namespace trview
         /// </summary>
         /// <param name="index">The index to get.</param>
         /// <returns>The waypoint.</returns>
-        virtual const Waypoint& waypoint(uint32_t index) const = 0;
+        virtual const IWaypoint& waypoint(uint32_t index) const = 0;
         /// <summary>
         /// Get the waypoint at the specified index.
         /// </summary>
         /// <param name="index">The index to get.</param>
         /// <returns>The waypoint.</returns>
-        virtual Waypoint& waypoint(uint32_t index) = 0;
+        virtual IWaypoint& waypoint(uint32_t index) = 0;
         /// <summary>
         /// Get the number of waypoints in the route.
         /// </summary>

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <trview.app/Routing/IWaypoint.h>
+#include <trview.app/Geometry/PickResult.h>
 
 namespace trview
 {

--- a/trview.app/Routing/IWaypoint.cpp
+++ b/trview.app/Routing/IWaypoint.cpp
@@ -1,0 +1,37 @@
+#include "IWaypoint.h"
+
+namespace trview
+{
+    IWaypoint::~IWaypoint()
+    {
+    }
+
+    IWaypoint::Type waypoint_type_from_string(const std::string& value)
+    {
+        if (value == "Trigger")
+        {
+            return IWaypoint::Type::Trigger;
+        }
+
+        if (value == "Entity")
+        {
+            return IWaypoint::Type::Entity;
+        }
+
+        return IWaypoint::Type::Position;
+    }
+
+    std::wstring waypoint_type_to_string(IWaypoint::Type type)
+    {
+        switch (type)
+        {
+            case IWaypoint::Type::Entity:
+                return L"Entity";
+            case IWaypoint::Type::Position:
+                return L"Position";
+            case IWaypoint::Type::Trigger:
+                return L"Trigger";
+        }
+        return L"Unknown";
+    }
+}

--- a/trview.app/Routing/IWaypoint.h
+++ b/trview.app/Routing/IWaypoint.h
@@ -22,36 +22,39 @@ namespace trview
         using Source = std::function<std::unique_ptr<IWaypoint>(const DirectX::SimpleMath::Vector3&, uint32_t, Type, uint32_t, const Colour&)>;
 
         virtual ~IWaypoint() = 0;
-
+        /// <summary>
+        /// Get the bounding box for the waypoint.
+        /// </summary>
+        /// <returns>The bounding box.</returns>
+        virtual DirectX::BoundingBox bounding_box() const = 0;
         /// Get the position of the waypoint in the 3D view.
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
-
         /// Get the type of the waypoint.
         virtual Type type() const = 0;
-
         /// Get whether the waypoint has an attached save file.
         virtual bool has_save() const = 0;
-
         /// Gets the index of the entity or trigger that the waypoint refers to.
         virtual uint32_t index() const = 0;
-
         /// Gets the room that the waypoint is in.
         virtual uint32_t room() const = 0;
-
         /// Get any notes associated with the waypoint.
         virtual std::wstring notes() const = 0;
-
+        /// <summary>
+        /// Render the join between this waypoint and another.
+        /// </summary>
+        /// <param name="next_waypoint">The waypoint to join to.</param>
+        /// <param name="camera">The camera to use to render.</param>
+        /// <param name="texture_storage">The texture storage to use to render.</param>
+        /// <param name="colour">The colour for the join.</param>
+        virtual void render_join(const IWaypoint& next_waypoint, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) = 0;
         /// Get the contents of the attached save file.
         virtual std::vector<uint8_t> save_file() const = 0;
-
         /// Set the notes associated with the waypoint.
         /// @param notes The notes to save.
         virtual void set_notes(const std::wstring& notes) = 0;
-
         /// Set the route colour for the waypoint blob.
         /// @param colour The colour of the route.
         virtual void set_route_colour(const Colour& colour) = 0;
-
         /// Set the contents of the attached save file.
         virtual void set_save_file(const std::vector<uint8_t>& data) = 0;
     };

--- a/trview.app/Routing/IWaypoint.h
+++ b/trview.app/Routing/IWaypoint.h
@@ -19,8 +19,7 @@ namespace trview
             Trigger
         };
 
-        using Source = std::function<std::unique_ptr<IWaypoint>(const DirectX::SimpleMath::Vector3&, uint32_t)>;
-        using IndexSource = std::function<std::unique_ptr<IWaypoint>(const DirectX::SimpleMath::Vector3&, uint32_t, Type, uint32_t, const Colour&)>;
+        using Source = std::function<std::unique_ptr<IWaypoint>(const DirectX::SimpleMath::Vector3&, uint32_t, Type, uint32_t, const Colour&)>;
 
         virtual ~IWaypoint() = 0;
 

--- a/trview.app/Routing/IWaypoint.h
+++ b/trview.app/Routing/IWaypoint.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <SimpleMath.h>
+#include <trview.common/Colour.h>
+#include <trview.app/Geometry/IRenderable.h>
+
+namespace trview
+{
+    struct IWaypoint : public IRenderable
+    {
+        /// Defines the type of waypoint.
+        enum class Type
+        {
+            /// The waypoint is to a position in the world.
+            Position,
+            /// The waypoint is to an entity in the world.
+            Entity,
+            /// The waypoint is to a trigger in the world.
+            Trigger
+        };
+
+        using Source = std::function<std::unique_ptr<IWaypoint>(const DirectX::SimpleMath::Vector3&, uint32_t)>;
+        using IndexSource = std::function<std::unique_ptr<IWaypoint>(const DirectX::SimpleMath::Vector3&, uint32_t, Type, uint32_t, const Colour&)>;
+
+        virtual ~IWaypoint() = 0;
+
+        /// Get the position of the waypoint in the 3D view.
+        virtual DirectX::SimpleMath::Vector3 position() const = 0;
+
+        /// Get the type of the waypoint.
+        virtual Type type() const = 0;
+
+        /// Get whether the waypoint has an attached save file.
+        virtual bool has_save() const = 0;
+
+        /// Gets the index of the entity or trigger that the waypoint refers to.
+        virtual uint32_t index() const = 0;
+
+        /// Gets the room that the waypoint is in.
+        virtual uint32_t room() const = 0;
+
+        /// Get any notes associated with the waypoint.
+        virtual std::wstring notes() const = 0;
+
+        /// Get the contents of the attached save file.
+        virtual std::vector<uint8_t> save_file() const = 0;
+
+        /// Set the notes associated with the waypoint.
+        /// @param notes The notes to save.
+        virtual void set_notes(const std::wstring& notes) = 0;
+
+        /// Set the route colour for the waypoint blob.
+        /// @param colour The colour of the route.
+        virtual void set_route_colour(const Colour& colour) = 0;
+
+        /// Set the contents of the attached save file.
+        virtual void set_save_file(const std::vector<uint8_t>& data) = 0;
+    };
+
+    IWaypoint::Type waypoint_type_from_string(const std::string& value);
+    std::wstring waypoint_type_to_string(IWaypoint::Type type);
+}

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -43,8 +43,8 @@ namespace trview
         }
     }
 
-    Route::Route(std::unique_ptr<ISelectionRenderer> selection_renderer, const IMesh::Source& mesh_source)
-        : _waypoint_mesh(create_cube_mesh(mesh_source)), _selection_renderer(std::move(selection_renderer))
+    Route::Route(std::unique_ptr<ISelectionRenderer> selection_renderer, const IMesh::Source& mesh_source, const IWaypoint::Source& waypoint_source)
+        : _waypoint_mesh(create_cube_mesh(mesh_source)), _selection_renderer(std::move(selection_renderer)), _waypoint_source(waypoint_source)
     {
     }
 
@@ -63,7 +63,7 @@ namespace trview
 
     void Route::add(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index)
     {
-        _waypoints.emplace_back(_waypoint_mesh.get(), position, room, type, type_index, _colour);
+        _waypoints.emplace_back(_waypoint_mesh, position, room, type, type_index, _colour);
         set_unsaved(true);
     }
 
@@ -101,7 +101,7 @@ namespace trview
 
     void Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index)
     {
-        _waypoints.insert(_waypoints.begin() + index, Waypoint(_waypoint_mesh.get(), position, room, type, type_index, _colour));
+        _waypoints.insert(_waypoints.begin() + index, Waypoint(_waypoint_mesh, position, room, type, type_index, _colour));
         set_unsaved(true);
     }
 

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -55,10 +55,10 @@ namespace trview
 
     void Route::add(const Vector3& position, uint32_t room)
     {
-        add(position, room, Waypoint::Type::Position, 0u);
+        add(position, room, IWaypoint::Type::Position, 0u);
     }
 
-    void Route::add(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index)
+    void Route::add(const DirectX::SimpleMath::Vector3& position, uint32_t room, IWaypoint::Type type, uint32_t type_index)
     {
         _waypoints.push_back(_waypoint_source(position, room, type, type_index, _colour));
         set_unsaved(true);
@@ -83,9 +83,9 @@ namespace trview
     {
         if (index >= _waypoints.size())
         {
-            return add(position, room, Waypoint::Type::Position, 0u);
+            return add(position, room, IWaypoint::Type::Position, 0u);
         }
-        insert(position, room, index, Waypoint::Type::Position, 0u);
+        insert(position, room, index, IWaypoint::Type::Position, 0u);
         set_unsaved(true);
     }
 
@@ -96,13 +96,13 @@ namespace trview
         return index;
     }
 
-    void Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index)
+    void Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, IWaypoint::Type type, uint32_t type_index)
     {
         _waypoints.insert(_waypoints.begin() + index, _waypoint_source(position, room, type, type_index, _colour));
         set_unsaved(true);
     }
 
-    uint32_t Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index)
+    uint32_t Route::insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, IWaypoint::Type type, uint32_t type_index)
     {
         uint32_t index = next_index();
         insert(position, room, index, type, type_index);
@@ -245,7 +245,7 @@ namespace trview
             for (const auto& waypoint : json["waypoints"])
             {
                 auto type_string = waypoint["type"].get<std::string>();
-                Waypoint::Type type = waypoint_type_from_string(type_string);
+                IWaypoint::Type type = waypoint_type_from_string(type_string);
  
                 auto position_string = waypoint["position"].get<std::string>();
 

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -13,7 +13,7 @@ namespace trview
     class Route final : public IRoute
     {
     public:
-        explicit Route(const std::unique_ptr<ISelectionRenderer> selection_renderer, const IMesh::Source& mesh_source);
+        explicit Route(const std::unique_ptr<ISelectionRenderer> selection_renderer, const IMesh::Source& mesh_source, const IWaypoint::Source& waypoint_source);
         virtual ~Route() = default;
         Route& operator=(const Route& other);
         virtual void add(const DirectX::SimpleMath::Vector3& position, uint32_t room) override;
@@ -38,6 +38,7 @@ namespace trview
     private:
         uint32_t next_index() const;
 
+        IWaypoint::Source _waypoint_source;
         std::vector<Waypoint> _waypoints;
         std::shared_ptr<IMesh> _waypoint_mesh;
         std::unique_ptr<ISelectionRenderer> _selection_renderer;

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -16,14 +16,14 @@ namespace trview
         virtual ~Route() = default;
         Route& operator=(const Route& other);
         virtual void add(const DirectX::SimpleMath::Vector3& position, uint32_t room) override;
-        virtual void add(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index) override;
+        virtual void add(const DirectX::SimpleMath::Vector3& position, uint32_t room, IWaypoint::Type type, uint32_t type_index) override;
         virtual void clear() override;
         virtual Colour colour() const override;
         virtual void insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index) override;
         virtual uint32_t insert(const DirectX::SimpleMath::Vector3& position, uint32_t room) override;
-        virtual void insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, Waypoint::Type type, uint32_t type_index) override;
+        virtual void insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, uint32_t index, IWaypoint::Type type, uint32_t type_index) override;
         virtual bool is_unsaved() const override;
-        virtual uint32_t insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, Waypoint::Type type, uint32_t type_index) override;
+        virtual uint32_t insert(const DirectX::SimpleMath::Vector3& position, uint32_t room, IWaypoint::Type type, uint32_t type_index) override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
         virtual void remove(uint32_t index) override;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage) override;

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -32,14 +32,14 @@ namespace trview
         virtual void select_waypoint(uint32_t index) override;
         virtual void set_colour(const Colour& colour) override;
         virtual void set_unsaved(bool value) override;
-        virtual const Waypoint& waypoint(uint32_t index) const override;
-        virtual Waypoint& waypoint(uint32_t index) override;
+        virtual const IWaypoint& waypoint(uint32_t index) const override;
+        virtual IWaypoint& waypoint(uint32_t index) override;
         virtual uint32_t waypoints() const override;
     private:
         uint32_t next_index() const;
 
         IWaypoint::Source _waypoint_source;
-        std::vector<Waypoint> _waypoints;
+        std::vector<std::shared_ptr<IWaypoint>> _waypoints;
         std::shared_ptr<IMesh> _waypoint_mesh;
         std::unique_ptr<ISelectionRenderer> _selection_renderer;
         uint32_t _selected_index{ 0u };

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <trview.app/Geometry/IMesh.h>
 #include <trview.app/Graphics/ISelectionRenderer.h>
 #include <trview.app/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Routing/IRoute.h>
@@ -13,7 +12,7 @@ namespace trview
     class Route final : public IRoute
     {
     public:
-        explicit Route(const std::unique_ptr<ISelectionRenderer> selection_renderer, const IMesh::Source& mesh_source, const IWaypoint::Source& waypoint_source);
+        explicit Route(const std::unique_ptr<ISelectionRenderer> selection_renderer, const IWaypoint::Source& waypoint_source);
         virtual ~Route() = default;
         Route& operator=(const Route& other);
         virtual void add(const DirectX::SimpleMath::Vector3& position, uint32_t room) override;
@@ -40,7 +39,6 @@ namespace trview
 
         IWaypoint::Source _waypoint_source;
         std::vector<std::shared_ptr<IWaypoint>> _waypoints;
-        std::shared_ptr<IMesh> _waypoint_mesh;
         std::unique_ptr<ISelectionRenderer> _selection_renderer;
         uint32_t _selected_index{ 0u };
         Colour _colour{ Colour::Green };

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -8,6 +8,7 @@ namespace trview
     namespace
     {
         const float PoleThickness = 0.05f;
+        const float RopeThickness = 0.015f;
     }
 
     Waypoint::Waypoint(std::shared_ptr<IMesh> mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room)
@@ -36,8 +37,24 @@ namespace trview
         _mesh->render(blob_wvp, texture_storage, _route_colour);
     }
 
+    void Waypoint::render_join(const IWaypoint& next_waypoint, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour)
+    {
+        const auto current = position() - Vector3(0, 0.5f + PoleThickness * 0.5f, 0);
+        const auto next_waypoint_pos = next_waypoint.position() - Vector3(0, 0.5f + PoleThickness * 0.5f, 0);
+        const auto mid = Vector3::Lerp(current, next_waypoint_pos, 0.5f);
+        const auto matrix = Matrix(DirectX::XMMatrixLookAtRH(mid, next_waypoint_pos, Vector3::Up)).Invert();
+        const auto length = (next_waypoint_pos - current).Length();
+        const auto to_wvp = Matrix::CreateScale(RopeThickness, RopeThickness, length) * matrix * camera.view_projection();
+        _mesh->render(to_wvp, texture_storage, colour);
+    }
+
     void Waypoint::get_transparent_triangles(ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&)
     {
+    }
+
+    DirectX::BoundingBox Waypoint::bounding_box() const
+    {
+        return DirectX::BoundingBox(position() - Vector3(0, 0.25f, 0), Vector3(PoleThickness, 0.5f, PoleThickness) * 0.5f);
     }
 
     DirectX::SimpleMath::Vector3 Waypoint::position() const

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -10,12 +10,12 @@ namespace trview
         const float PoleThickness = 0.05f;
     }
 
-    Waypoint::Waypoint(IMesh* mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room)
+    Waypoint::Waypoint(std::shared_ptr<IMesh> mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room)
         : _mesh(mesh), _position(position), _type(Type::Position), _index(0u), _room(room)
     {
     }
 
-    Waypoint::Waypoint(IMesh* mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room, Type type, uint32_t index, const Colour& route_colour)
+    Waypoint::Waypoint(std::shared_ptr<IMesh> mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room, Type type, uint32_t index, const Colour& route_colour)
         : _mesh(mesh), _position(position), _type(type), _index(index), _room(room), _route_colour(route_colour)
     {
     }

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -99,34 +99,5 @@ namespace trview
     {
         _visible = value;
     }
-
-    Waypoint::Type waypoint_type_from_string(const std::string& value)
-    {
-        if (value == "Trigger")
-        {
-            return Waypoint::Type::Trigger;
-        }
-
-        if (value == "Entity")
-        {
-            return Waypoint::Type::Entity;
-        }
-
-        return Waypoint::Type::Position;
-    }
-
-    std::wstring waypoint_type_to_string(Waypoint::Type type)
-    {
-        switch (type)
-        {
-        case Waypoint::Type::Entity:
-            return L"Entity";
-        case Waypoint::Type::Position:
-            return L"Position";
-        case Waypoint::Type::Trigger:
-            return L"Trigger";
-        }
-        return L"Unknown";
-    }
 }
 

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -11,11 +11,6 @@ namespace trview
         const float RopeThickness = 0.015f;
     }
 
-    Waypoint::Waypoint(std::shared_ptr<IMesh> mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room)
-        : _mesh(mesh), _position(position), _type(Type::Position), _index(0u), _room(room)
-    {
-    }
-
     Waypoint::Waypoint(std::shared_ptr<IMesh> mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room, Type type, uint32_t index, const Colour& route_colour)
         : _mesh(mesh), _position(position), _type(type), _index(index), _room(room), _route_colour(route_colour)
     {
@@ -62,7 +57,7 @@ namespace trview
         return _position;
     }
 
-    Waypoint::Type Waypoint::type() const
+    IWaypoint::Type Waypoint::type() const
     {
         return _type;
     }

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -26,18 +26,10 @@ namespace trview
 
         /// Destructor for waypoint.
         virtual ~Waypoint() = default;
-
-        /// Render the waypoint in the 3D view.
-        /// @param camera The current camera being used for rendering.
-        /// @param texture_storage The current texture storage instance.
-        /// @param colour The colour to render this object.
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
-
-        /// Get the transparent triangles that are contained in this object.
-        /// @param transparency The transparency buffer to add triangles to.
-        /// @param camera The current camera being used for rendering.
-        /// @param colour The colour to render the triangles.
+        virtual void render_join(const IWaypoint& next_waypoint, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
+        virtual DirectX::BoundingBox bounding_box() const override;
         virtual DirectX::SimpleMath::Vector3 position() const override;
         virtual Type type() const override;
         virtual bool has_save() const override;
@@ -48,7 +40,6 @@ namespace trview
         virtual void set_notes(const std::wstring& notes) override;
         virtual void set_route_colour(const Colour& colour) override;
         virtual void set_save_file(const std::vector<uint8_t>& data) override;
-
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;
     private:

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -1,27 +1,14 @@
 #pragma once
 
-#include <SimpleMath.h>
-#include <trview.app/Geometry/IRenderable.h>
 #include <trview.app/Geometry/IMesh.h>
-#include <trview.common/Colour.h>
+#include "IWaypoint.h"
 
 namespace trview
 {
     /// A waypoint is an entry in a route.
-    class Waypoint final : public IRenderable
+    class Waypoint final : public IWaypoint
     {
     public:
-        /// Defines the type of waypoint.
-        enum class Type
-        {
-            /// The waypoint is to a position in the world.
-            Position,
-            /// The waypoint is to an entity in the world.
-            Entity,
-            /// The waypoint is to a trigger in the world.
-            Trigger
-        };
-
         /// Create a new waypoint of position type.
         /// @param mesh The waypoint mesh.
         /// @param position The position of the waypoint in the world.
@@ -51,38 +38,16 @@ namespace trview
         /// @param camera The current camera being used for rendering.
         /// @param colour The colour to render the triangles.
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
-
-        /// Get the position of the waypoint in the 3D view.
-        DirectX::SimpleMath::Vector3 position() const;
-
-        /// Get the type of the waypoint.
-        Type type() const;
-
-        /// Get whether the waypoint has an attached save file.
-        bool has_save() const;
-
-        /// Gets the index of the entity or trigger that the waypoint refers to.
-        uint32_t index() const;
-
-        /// Gets the room that the waypoint is in.
-        uint32_t room() const;
-
-        /// Get any notes associated with the waypoint.
-        std::wstring notes() const;
-
-        /// Get the contents of the attached save file.
-        std::vector<uint8_t> save_file() const;
-
-        /// Set the notes associated with the waypoint.
-        /// @param notes The notes to save.
-        void set_notes(const std::wstring& notes);
-
-        /// Set the route colour for the waypoint blob.
-        /// @param colour The colour of the route.
-        void set_route_colour(const Colour& colour);
-
-        /// Set the contents of the attached save file.
-        void set_save_file(const std::vector<uint8_t>& data);
+        virtual DirectX::SimpleMath::Vector3 position() const override;
+        virtual Type type() const override;
+        virtual bool has_save() const override;
+        virtual uint32_t index() const override;
+        virtual uint32_t room() const override;
+        virtual std::wstring notes() const override;
+        virtual std::vector<uint8_t> save_file() const override;
+        virtual void set_notes(const std::wstring& notes) override;
+        virtual void set_route_colour(const Colour& colour) override;
+        virtual void set_save_file(const std::vector<uint8_t>& data) override;
 
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;
@@ -96,8 +61,5 @@ namespace trview
         uint32_t                     _room;
         Colour                       _route_colour;
         bool                         _visible{ true };
-    };
-
-    Waypoint::Type waypoint_type_from_string(const std::string& value);
-    std::wstring waypoint_type_to_string(Waypoint::Type type);
+    };    
 }

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -13,7 +13,7 @@ namespace trview
         /// @param mesh The waypoint mesh.
         /// @param position The position of the waypoint in the world.
         /// @param room The room that the waypoint is in.
-        explicit Waypoint(IMesh* mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room);
+        explicit Waypoint(std::shared_ptr<IMesh> mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room);
 
         /// Create a new waypoint.
         /// @param mesh The waypoint mesh.
@@ -22,7 +22,7 @@ namespace trview
         /// @param type The type of waypoint.
         /// @param index The index of the entity or trigger being referenced if this is a non-position type.
         /// @param route_colour The colour of the route.
-        explicit Waypoint(IMesh* mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room, Type type, uint32_t index, const Colour& route_colour);
+        explicit Waypoint(std::shared_ptr<IMesh> mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room, Type type, uint32_t index, const Colour& route_colour);
 
         /// Destructor for waypoint.
         virtual ~Waypoint() = default;
@@ -55,7 +55,7 @@ namespace trview
         std::wstring                 _notes;
         std::vector<uint8_t>         _save_data;
         DirectX::SimpleMath::Vector3 _position;
-        IMesh*                       _mesh;
+        std::shared_ptr<IMesh>       _mesh;
         Type                         _type;
         uint32_t                     _index;
         uint32_t                     _room;

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -5,20 +5,22 @@
 
 namespace trview
 {
+    /// <summary>
     /// A waypoint is an entry in a route.
+    /// </summary>
     class Waypoint final : public IWaypoint
     {
-    public:
+    public:       
+        /// <summary>
         /// Create a new waypoint.
-        /// @param mesh The waypoint mesh.
-        /// @param position The position of the waypoint in the world.
-        /// @param room The room that waypoint is in.
-        /// @param type The type of waypoint.
-        /// @param index The index of the entity or trigger being referenced if this is a non-position type.
-        /// @param route_colour The colour of the route.
+        /// </summary>
+        /// <param name="mesh">The waypoint mesh.</param>
+        /// <param name="position">The position of the waypoint in the world.</param>
+        /// <param name="room">The room that waypoint is in.</param>
+        /// <param name="type">The type of waypoint.</param>
+        /// <param name="index">The index of the entity or trigger being referenced if this is a non-position type.</param>
+        /// <param name="route_colour">The colour of the route.</param>
         explicit Waypoint(std::shared_ptr<IMesh> mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room, Type type, uint32_t index, const Colour& route_colour);
-
-        /// Destructor for waypoint.
         virtual ~Waypoint() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual void render_join(const IWaypoint& next_waypoint, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -9,12 +9,6 @@ namespace trview
     class Waypoint final : public IWaypoint
     {
     public:
-        /// Create a new waypoint of position type.
-        /// @param mesh The waypoint mesh.
-        /// @param position The position of the waypoint in the world.
-        /// @param room The room that the waypoint is in.
-        explicit Waypoint(std::shared_ptr<IMesh> mesh, const DirectX::SimpleMath::Vector3& position, uint32_t room);
-
         /// Create a new waypoint.
         /// @param mesh The waypoint mesh.
         /// @param position The position of the waypoint in the world.

--- a/trview.app/Routing/di.hpp
+++ b/trview.app/Routing/di.hpp
@@ -20,9 +20,9 @@ namespace trview
                 [](const auto& injector) -> IWaypoint::Source
                 {
                     const auto mesh = create_cube_mesh(injector.create<IMesh::Source>());
-                    return [=](auto&& pos, auto&& room, auto&& type, auto&& index, auto&& route_colour)
+                    return [=](auto&&... args)
                     {
-                        return std::make_unique<Waypoint>(mesh, pos, room, type, index, route_colour);
+                        return std::make_unique<Waypoint>(mesh, args...);
                     };
                 }),
             di::bind<IRoute>.to<Route>(),

--- a/trview.app/Routing/di.hpp
+++ b/trview.app/Routing/di.hpp
@@ -2,6 +2,7 @@
 
 #include <external/boost/di.hpp>
 #include "Route.h"
+#include "Waypoint.h"
 #include "Actions.h"
 
 namespace trview

--- a/trview.app/Routing/di.hpp
+++ b/trview.app/Routing/di.hpp
@@ -16,6 +16,15 @@ namespace trview
                     Resource type_list = get_resource_memory(IDR_ACTIONS, L"TEXT");
                     return std::make_shared<Actions>(std::string(type_list.data, type_list.data + type_list.size));
                 }),
+            di::bind<IWaypoint::Source>.to(
+                [](const auto& injector) -> IWaypoint::Source
+                {
+                    const auto mesh = create_cube_mesh(injector.create<IMesh::Source>());
+                    return [=](auto&& pos, auto&& room, auto&& type, auto&& index, auto&& route_colour)
+                    {
+                        return std::make_unique<Waypoint>(mesh, pos, room, type, index, route_colour);
+                    };
+                }),
             di::bind<IRoute>.to<Route>(),
             di::bind<IRoute::Source>.to(
                 [](const auto& injector) -> IRoute::Source

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -75,7 +75,7 @@ namespace trview
         /// Select the specified waypoint
         /// @param index The waypoint to select.
         /// @remarks This will not raise the on_waypoint_selected event.
-        virtual void select_waypoint(const Waypoint& waypoint) = 0;
+        virtual void select_waypoint(const IWaypoint& waypoint) = 0;
 
         virtual void set_camera_mode(CameraMode camera_mode) = 0;
 

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -7,8 +7,7 @@
 #include <trview.app/Elements/Item.h>
 #include <trview.app/Elements/ITrigger.h>
 #include <trview.app/Elements/ILevel.h>
-#include <trview.app/Routing/Route.h>
-#include <trview.app/Routing/Waypoint.h>
+#include <trview.app/Routing/IRoute.h>
 #include <trview.app/Settings/UserSettings.h>
 #include <trview.app/Camera/CameraMode.h>
 
@@ -44,7 +43,7 @@ namespace trview
         Event<uint32_t> on_waypoint_removed;
 
         /// Event raised when the viewer wants to add a waypoint.
-        Event<DirectX::SimpleMath::Vector3, uint32_t, Waypoint::Type, uint32_t> on_waypoint_added;
+        Event<DirectX::SimpleMath::Vector3, uint32_t, IWaypoint::Type, uint32_t> on_waypoint_added;
 
         virtual CameraMode camera_mode() const = 0;
 

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -185,13 +185,13 @@ namespace trview
             const auto index = _route->waypoint(_selected_index).index();
             switch (_selected_type)
             {
-            case Waypoint::Type::Entity:
+            case IWaypoint::Type::Entity:
                 if (index < _all_items.size())
                 {
                     on_item_selected(_all_items[index]);
                 }
                 break;
-            case Waypoint::Type::Trigger:
+            case IWaypoint::Type::Trigger:
                 if (index < _all_triggers.size())
                 {
                     on_trigger_selected(_all_triggers[index]);
@@ -309,7 +309,7 @@ namespace trview
     Listbox::Item RouteWindow::create_listbox_item(uint32_t index, const IWaypoint& waypoint)
     {
         std::wstring type = waypoint_type_to_string(waypoint.type());
-        if (waypoint.type() == Waypoint::Type::Entity)
+        if (waypoint.type() == IWaypoint::Type::Entity)
         {
             if (waypoint.index() < _all_items.size())
             {
@@ -320,7 +320,7 @@ namespace trview
                 type = L"Invalid entity";
             }
         }
-        else if (waypoint.type() == Waypoint::Type::Trigger)
+        else if (waypoint.type() == IWaypoint::Type::Trigger)
         {
             if (waypoint.index() < _all_triggers.size())
             {
@@ -381,10 +381,10 @@ namespace trview
         _selected_type = waypoint.type();
         _selected_index = index;
 
-        if (waypoint.type() != Waypoint::Type::Position)
+        if (waypoint.type() != IWaypoint::Type::Position)
         {
             stats.push_back(make_item(L"Target Index", std::to_wstring(waypoint.index())));
-            if (waypoint.type() == Waypoint::Type::Entity)
+            if (waypoint.type() == IWaypoint::Type::Entity)
             {
                 std::wstring type = L"Invalid entity";
                 if (waypoint.index() < _all_items.size())
@@ -393,7 +393,7 @@ namespace trview
                 }
                 stats.push_back(make_item(L"Entity", type));
             }
-            else if (waypoint.type() == Waypoint::Type::Trigger)
+            else if (waypoint.type() == IWaypoint::Type::Trigger)
             {
                 std::wstring type = L"Invalid trigger";
                 if (waypoint.index() < _all_triggers.size())

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -306,7 +306,7 @@ namespace trview
         return right_panel;
     }
 
-    Listbox::Item RouteWindow::create_listbox_item(uint32_t index, const Waypoint& waypoint)
+    Listbox::Item RouteWindow::create_listbox_item(uint32_t index, const IWaypoint& waypoint)
     {
         std::wstring type = waypoint_type_to_string(waypoint.type());
         if (waypoint.type() == Waypoint::Type::Entity)

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -52,7 +52,7 @@ namespace trview
         void load_waypoint_details(uint32_t index);
         std::unique_ptr<ui::Control> create_left_panel();
         std::unique_ptr<ui::Control> create_right_panel();
-        ui::Listbox::Item create_listbox_item(uint32_t index, const Waypoint& waypoint);
+        ui::Listbox::Item create_listbox_item(uint32_t index, const IWaypoint& waypoint);
 
         ui::Dropdown* _colour;
         ui::Listbox* _waypoints;

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -6,7 +6,7 @@
 #include <trview.ui/Dropdown.h>
 #include "CollapsiblePanel.h"
 #include <trview.common/Event.h>
-#include <trview.app/Routing/Waypoint.h>
+#include <trview.app/Routing/IWaypoint.h>
 #include <trview.app/Elements/Item.h>
 #include <trview.app/Elements/Room.h>
 #include <trview.common/Windows/IClipboard.h>
@@ -65,7 +65,7 @@ namespace trview
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;
-        Waypoint::Type _selected_type{ Waypoint::Type::Position };
+        IWaypoint::Type _selected_type{ IWaypoint::Type::Position };
         uint32_t       _selected_index{ 0u };
         std::shared_ptr<IClipboard> _clipboard;
         std::shared_ptr<IDialogs> _dialogs;

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -663,7 +663,7 @@ namespace trview
         _scene_changed = true;
     }
 
-    void Viewer::select_waypoint(const Waypoint& waypoint)
+    void Viewer::select_waypoint(const IWaypoint& waypoint)
     {
         _target = waypoint.position();
         if (_settings.auto_orbit)

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -86,7 +86,7 @@ namespace trview
         };
         _token_store += _ui->on_add_waypoint += [&]()
         {
-            auto type = _context_pick.type == PickResult::Type::Entity ? Waypoint::Type::Entity : _context_pick.type == PickResult::Type::Trigger ? Waypoint::Type::Trigger : Waypoint::Type::Position;
+            auto type = _context_pick.type == PickResult::Type::Entity ? IWaypoint::Type::Entity : _context_pick.type == PickResult::Type::Trigger ? IWaypoint::Type::Trigger : IWaypoint::Type::Position;
             on_waypoint_added(_context_pick.position, room_from_pick(_context_pick), type, _context_pick.index);
         };
         _token_store += _ui->on_remove_waypoint += [&]() { on_waypoint_removed(_context_pick.index); };

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -73,7 +73,7 @@ namespace trview
         virtual void select_item(const Item& item) override;
         virtual void select_room(uint32_t room_number) override;
         virtual void select_trigger(const std::weak_ptr<ITrigger>& trigger) override;
-        virtual void select_waypoint(const Waypoint& waypoint) override;
+        virtual void select_waypoint(const IWaypoint& waypoint) override;
         virtual void set_camera_mode(CameraMode camera_mode) override;
         virtual void set_route(const std::shared_ptr<IRoute>& route) override;
         virtual void set_show_compass(bool value) override;

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -93,6 +93,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Routing\Actions.cpp" />
     <ClCompile Include="Routing\IActions.cpp" />
     <ClCompile Include="Routing\IRoute.cpp" />
+    <ClCompile Include="Routing\IWaypoint.cpp" />
     <ClCompile Include="Routing\Route.cpp" />
     <ClCompile Include="Routing\Waypoint.cpp" />
     <ClCompile Include="Settings\ISettingsLoader.cpp" />
@@ -268,6 +269,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Routing\di.hpp" />
     <ClInclude Include="Routing\IActions.h" />
     <ClInclude Include="Routing\IRoute.h" />
+    <ClInclude Include="Routing\IWaypoint.h" />
     <ClInclude Include="Routing\Route.h" />
     <ClInclude Include="Routing\Waypoint.h" />
     <ClInclude Include="Settings\di.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -241,6 +241,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\Menus\IRecentFiles.h" />
     <ClInclude Include="Mocks\Menus\IUpdateChecker.h" />
     <ClInclude Include="Mocks\Routing\IRoute.h" />
+    <ClInclude Include="Mocks\Routing\IWaypoint.h" />
     <ClInclude Include="Mocks\Settings\ISettingsLoader.h" />
     <ClInclude Include="Mocks\Settings\IStartupOptions.h" />
     <ClInclude Include="Mocks\Tools\ICompass.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -337,6 +337,9 @@
     <ClCompile Include="UI\IBubble.cpp">
       <Filter>UI</Filter>
     </ClCompile>
+    <ClCompile Include="Routing\IWaypoint.cpp">
+      <Filter>Routing</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -862,6 +865,9 @@
     </ClInclude>
     <ClInclude Include="Mocks\Windows\IRouteWindow.h">
       <Filter>Mocks\Windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Routing\IWaypoint.h">
+      <Filter>Routing</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -869,6 +869,9 @@
     <ClInclude Include="Routing\IWaypoint.h">
       <Filter>Routing</Filter>
     </ClInclude>
+    <ClInclude Include="Mocks\Routing\IWaypoint.h">
+      <Filter>Mocks\Routing</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">


### PR DESCRIPTION
Create `Waypoint`s using DI.
Add an `IWaypoint` interface and use that everywhere instead of `Waypoint`.
Update tests that previously used `Waypoint` to use the new `MockWaypoint`.
Move all rendering of waypoints and joins into the `Waypoint` class.
Add some tests for `Waypoint`.
Closes #791 