### PR TITLE
Render static mesh collision boxes

### DIFF
--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -269,3 +269,9 @@ TEST(Level, PickUsesCorrectMinimalFilters)
     MockCamera camera;
     level->pick(camera, Vector3::Zero, Vector3::Forward);
 }
+
+TEST(Level, BoundingBoxesRendered)
+{
+    FAIL();
+}
+

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -342,4 +342,13 @@ TEST(Level, BoundingBoxesRenderedWhenEnabled)
     level->render(camera, false);
 }
 
+TEST(Level, SetShowBoundingBoxesRaisesLevelChangedEvent)
+{
+    auto level = register_test_module().build();
 
+    uint32_t times_called = 0;
+    auto token = level->on_level_changed += [&](auto&&...) { ++times_called; };
+
+    level->set_show_bounding_boxes(true);
+    ASSERT_EQ(times_called, 1u);
+}

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -564,3 +564,8 @@ TEST(Room, WaterDetected)
     auto room = register_test_module().with_room(level_room).build();
     ASSERT_EQ(room->water(), true);
 }
+
+TEST(Room, BoundingBoxesRendered)
+{
+    FAIL();
+}

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -567,5 +567,13 @@ TEST(Room, WaterDetected)
 
 TEST(Room, BoundingBoxesRendered)
 {
-    FAIL();
+    auto mesh = std::make_shared<MockStaticMesh>();
+    EXPECT_CALL(*mesh, render_bounding_box).Times(1);
+    trlevel::tr3_room level_room;
+    level_room.static_meshes.push_back({});
+    auto room = register_test_module()
+        .with_room(level_room)
+        .with_static_mesh_source([&](auto&&...) { return mesh; })
+        .build();
+    room->render_bounding_boxes(MockCamera{});
 }

--- a/trview.app.tests/Elements/StaticMeshTests.cpp
+++ b/trview.app.tests/Elements/StaticMeshTests.cpp
@@ -1,6 +1,18 @@
 #include <trview.app/Elements/StaticMesh.h>
+#include <trview.app/Mocks/Geometry/IMesh.h>
+#include <trview.app/Mocks/Camera/ICamera.h>
+#include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace DirectX::SimpleMath;
 
 TEST(StaticMesh, BoundingBoxRendered)
 {
-    FAIL();
+    auto actual_mesh = std::make_shared<MockMesh>();
+    auto bounding_mesh = std::make_shared<MockMesh>();
+    EXPECT_CALL(*bounding_mesh, render).Times(1);
+
+    StaticMesh mesh({}, {}, actual_mesh, bounding_mesh);
+    mesh.render_bounding_box(MockCamera{}, MockLevelTextureStorage{}, Colour::White);
 }

--- a/trview.app.tests/Elements/StaticMeshTests.cpp
+++ b/trview.app.tests/Elements/StaticMeshTests.cpp
@@ -1,0 +1,6 @@
+#include <trview.app/Elements/StaticMesh.h>
+
+TEST(StaticMesh, BoundingBoxRendered)
+{
+    FAIL();
+}

--- a/trview.app.tests/UI/ViewOptionsTests.cpp
+++ b/trview.app.tests/UI/ViewOptionsTests.cpp
@@ -1,0 +1,6 @@
+#include <trview.app/UI/ViewOptions.h>
+
+TEST(ViewOptions, BoundingBoxToggle)
+{
+    FAIL();
+}

--- a/trview.app.tests/UI/ViewOptionsTests.cpp
+++ b/trview.app.tests/UI/ViewOptionsTests.cpp
@@ -7,7 +7,7 @@ using namespace trview;
 using namespace trview::mocks;
 using namespace trview::ui;
 
-TEST(ViewOptions, BoundingBoxToggle)
+TEST(ViewOptions, BoundsCheckboxToggle)
 {
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, MockLevelTextureStorage{});
@@ -25,7 +25,7 @@ TEST(ViewOptions, BoundingBoxToggle)
     ASSERT_TRUE(clicked.value());
 }
 
-TEST(ViewOptions, CheckboxUpdated)
+TEST(ViewOptions, BoundsCheckboxUpdated)
 {
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, MockLevelTextureStorage{});

--- a/trview.app.tests/UI/ViewOptionsTests.cpp
+++ b/trview.app.tests/UI/ViewOptionsTests.cpp
@@ -1,6 +1,38 @@
 #include <trview.app/UI/ViewOptions.h>
+#include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
+#include <trview.ui/Window.h>
+#include <trview.ui/Checkbox.h>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace trview::ui;
 
 TEST(ViewOptions, BoundingBoxToggle)
 {
-    FAIL();
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    std::optional<bool> clicked;
+    auto token = view_options.on_show_bounding_boxes += [&](bool value)
+    {
+        clicked = value;
+    };
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::show_bounding_boxes);
+    ASSERT_FALSE(checkbox->state());
+    checkbox->clicked({});
+    ASSERT_TRUE(clicked.has_value());
+    ASSERT_TRUE(clicked.value());
+}
+
+TEST(ViewOptions, CheckboxUpdated)
+{
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::show_bounding_boxes);
+    ASSERT_FALSE(checkbox->state());
+    
+    view_options.set_show_bounding_boxes(true);
+    ASSERT_TRUE(checkbox->state());
 }

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -6,6 +6,7 @@
 #include <trview.ui/Mocks/Input/IInput.h>
 #include <trview.tests.common/Window.h>
 #include <trview.app/Mocks/UI/ISettingsWindow.h>
+#include <trview.app/Mocks/UI/IViewOptions.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -30,12 +31,13 @@ namespace
             IRenderer::Source ui_renderer_source{ [](auto&&...) { return std::make_unique<MockRenderer>(); }};
             IMapRenderer::Source map_renderer_source{ [](auto&&...) { return std::make_unique<MockMapRenderer>(); }};
             ISettingsWindow::Source settings_window_source{ [](auto&&...) { return std::make_unique<MockSettingsWindow>(); }};
+            IViewOptions::Source view_options_source{ [](auto&&...) { return std::make_unique<MockViewOptions>(); } };
 
             std::unique_ptr<ViewerUI> build()
             {
                 EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
                 return std::make_unique<ViewerUI>(window, texture_storage, shortcuts, std::move(input_source),
-                    ui_renderer_source, map_renderer_source, settings_window_source);
+                    ui_renderer_source, map_renderer_source, settings_window_source, view_options_source);
             }
 
             test_module& with_settings_window_source(const ISettingsWindow::Source& source)
@@ -72,5 +74,11 @@ TEST(ViewerUI, OnCameraDisplayDegreesEventRaised)
 
 TEST(ViewerUI, BoundingBoxUpdatesViewOptions)
 {
+    FAIL();
+}
+
+TEST(ViewerUI, ShowBoundingBoxesEventRaised)
+{
+
     FAIL();
 }

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -45,6 +45,12 @@ namespace
                 settings_window_source = source;
                 return *this;
             }
+
+            test_module& with_view_options_source(const IViewOptions::Source& source)
+            {
+                view_options_source = source;
+                return *this;
+            }
         };
         return test_module{};
     }
@@ -74,11 +80,28 @@ TEST(ViewerUI, OnCameraDisplayDegreesEventRaised)
 
 TEST(ViewerUI, BoundingBoxUpdatesViewOptions)
 {
-    FAIL();
+    auto [view_options_ptr, view_options] = create_mock<MockViewOptions>();
+    auto view_options_ptr_actual = std::move(view_options_ptr);
+    auto ui = register_test_module().with_view_options_source([&](auto&&...) { return std::move(view_options_ptr_actual); }).build();
+
+    EXPECT_CALL(view_options, set_show_bounding_boxes(true)).Times(1);
+
+    ui->set_show_bounding_boxes(true);
 }
 
 TEST(ViewerUI, ShowBoundingBoxesEventRaised)
 {
+    auto [view_options_ptr, view_options] = create_mock<MockViewOptions>();
+    auto view_options_ptr_actual = std::move(view_options_ptr);
+    auto ui = register_test_module().with_view_options_source([&](auto&&...) { return std::move(view_options_ptr_actual); }).build();
 
-    FAIL();
+    std::optional<bool> show;
+    auto token = ui->on_show_bounding_boxes += [&](const auto& value)
+    {
+        show = value;
+    };
+
+    view_options.on_show_bounding_boxes(true);
+    ASSERT_TRUE(show.has_value());
+    ASSERT_TRUE(show.value());
 }

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -69,3 +69,8 @@ TEST(ViewerUI, OnCameraDisplayDegreesEventRaised)
     ASSERT_TRUE(settings.has_value());
     ASSERT_FALSE(settings.value().camera_display_degrees);
 }
+
+TEST(ViewerUI, BoundingBoxUpdatesViewOptions)
+{
+    FAIL();
+}

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -528,5 +528,15 @@ TEST(Viewer, CameraRotationUpdated)
 
 TEST(Viewer, SetShowBoundingBox)
 {
-    FAIL();
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
+
+    EXPECT_CALL(level, set_show_bounding_boxes(false)).Times(1);
+    EXPECT_CALL(ui, set_show_bounding_boxes(true)).Times(1);
+    EXPECT_CALL(level, set_show_bounding_boxes(true)).Times(1);
+
+    viewer->open(&level);
+    ui.on_show_bounding_boxes(true);
 }
+

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -525,3 +525,8 @@ TEST(Viewer, CameraRotationUpdated)
     ASSERT_FLOAT_EQ(2.0f, camera.rotation_yaw());
     ASSERT_FLOAT_EQ(1.0f, camera.rotation_pitch());
 }
+
+TEST(Viewer, SetShowBoundingBox)
+{
+    FAIL();
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -26,6 +26,7 @@
     <ClCompile Include="Elements\EntityTests.cpp" />
     <ClCompile Include="Elements\LevelTests.cpp" />
     <ClCompile Include="Elements\RoomTests.cpp" />
+    <ClCompile Include="Elements\StaticMeshTests.cpp" />
     <ClCompile Include="Elements\TypeNameLookupTests.cpp" />
     <ClCompile Include="FileDropperTests.cpp" />
     <ClCompile Include="FreeCameraTests.cpp" />
@@ -57,6 +58,7 @@
     <ClCompile Include="UI\BubbleTests.cpp" />
     <ClCompile Include="UI\CameraPositionTests.cpp" />
     <ClCompile Include="UI\ViewerUITests.cpp" />
+    <ClCompile Include="UI\ViewOptionsTests.cpp" />
     <ClCompile Include="ViewMenuTests.cpp" />
     <ClCompile Include="WindowResizerTests.cpp" />
     <ClCompile Include="Windows\RouteWindowManagerTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -98,6 +98,12 @@
     <ClCompile Include="Routing\WaypointTests.cpp">
       <Filter>Routing</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\StaticMeshTests.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
+    <ClCompile Include="UI\ViewOptionsTests.cpp">
+      <Filter>UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -77,6 +77,7 @@ namespace trview
         virtual void set_show_triggers(bool show) = 0;
         virtual void set_show_water(bool show) = 0;
         virtual void set_show_wireframe(bool show) = 0;
+        virtual void set_show_bounding_boxes(bool show) = 0;
         virtual void set_trigger_visibility(uint32_t index, bool state) = 0;
         virtual void set_neighbour_depth(uint32_t depth) = 0;
         virtual void set_selected_room(uint16_t index) = 0;

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -177,6 +177,11 @@ namespace trview
         /// <param name="show_water">Whether to render water effects.</param>
         virtual void render(const ICamera& camera, SelectionMode selected, bool show_hidden_geometry, bool show_water) = 0;
         /// <summary>
+        /// Render the bounding boxes in the room.
+        /// </summary>
+        /// <param name="camera">The current viewpoint.</param>
+        virtual void render_bounding_boxes(const ICamera& camera) = 0;
+        /// <summary>
         /// Render the contents of the room.
         /// </summary>
         /// <param name="camera">The current viewpoint.</param>

--- a/trview.app/Elements/IStaticMesh.h
+++ b/trview.app/Elements/IStaticMesh.h
@@ -18,6 +18,7 @@ namespace trview
 
         virtual ~IStaticMesh() = 0;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) = 0;
+        virtual void render_bounding_box(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) = 0;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) = 0;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
     };

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -236,6 +236,21 @@ namespace trview
             }
         }
 
+        {
+            const auto context = _device->context();
+            graphics::RasterizerStateStore rasterizer_store(context);
+            if (!_show_wireframe)
+            {
+                context->RSSetState(_wireframe_rasterizer.Get());
+            }
+
+            // Render any bounding boxes
+            for (const auto& room : rooms)
+            {
+                room.room.render_bounding_boxes(camera);
+            }
+        }
+
         if (_regenerate_transparency)
         {
             // Sort the accumulated transparent triangles farthest to nearest.

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -244,7 +244,6 @@ namespace trview
                 context->RSSetState(_wireframe_rasterizer.Get());
             }
 
-            // Render any bounding boxes
             for (const auto& room : rooms)
             {
                 room.room.render_bounding_boxes(camera);

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -236,6 +236,7 @@ namespace trview
             }
         }
 
+        if (_show_bounding_boxes)
         {
             const auto context = _device->context();
             graphics::RasterizerStateStore rasterizer_store(context);
@@ -641,6 +642,13 @@ namespace trview
     void Level::set_show_wireframe(bool show)
     {
         _show_wireframe = show;
+        _regenerate_transparency = true;
+        on_level_changed();
+    }
+
+    void Level::set_show_bounding_boxes(bool show)
+    {
+        _show_bounding_boxes = show;
         _regenerate_transparency = true;
         on_level_changed();
     }

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -72,6 +72,7 @@ namespace trview
         virtual bool show_hidden_geometry() const override;
         virtual void set_show_water(bool show) override;
         virtual void set_show_wireframe(bool show) override;
+        virtual void set_show_bounding_boxes(bool show) override;
         virtual bool show_triggers() const override;
         virtual void set_selected_trigger(uint32_t number) override;
         virtual const ILevelTextureStorage& texture_storage() const override;
@@ -150,6 +151,7 @@ namespace trview
         bool _show_hidden_geometry{ false };
         bool _show_water{ true };
         bool _show_wireframe{ false };
+        bool _show_bounding_boxes{ false };
 
         std::unique_ptr<ISelectionRenderer> _selection_renderer;
         std::set<uint32_t> _alternate_groups;

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -200,6 +200,15 @@ namespace trview
         render_contained(camera, colour);
     }
 
+    void Room::render_bounding_boxes(const ICamera& camera)
+    {
+        Color colour = room_colour(false, SelectionMode::Selected);
+        for (const auto& mesh : _static_meshes)
+        {
+            mesh->render_bounding_box(camera, *_texture_storage, colour);
+        }
+    }
+
     void Room::render_contained(const ICamera& camera, SelectionMode selected, bool show_water)
     {
         Color colour = room_colour(water() && show_water, selected);

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -202,10 +202,9 @@ namespace trview
 
     void Room::render_bounding_boxes(const ICamera& camera)
     {
-        Color colour = room_colour(false, SelectionMode::Selected);
         for (const auto& mesh : _static_meshes)
         {
-            mesh->render_bounding_box(camera, *_texture_storage, colour);
+            mesh->render_bounding_box(camera, *_texture_storage, Colour::White);
         }
     }
 

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -40,6 +40,7 @@ namespace trview
         virtual std::set<uint16_t> neighbours() const override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, PickFilter filters = PickFilter::Default) const override;
         virtual void render(const ICamera& camera, SelectionMode selected, bool show_hidden_geometry, bool show_water) override;
+        virtual void render_bounding_boxes(const ICamera& camera) override;
         virtual void render_contained(const ICamera& camera, SelectionMode selected, bool show_water) override;
         virtual void add_entity(const std::weak_ptr<IEntity>& entity) override;
         virtual void add_trigger(const std::weak_ptr<ITrigger>& trigger) override;

--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -6,14 +6,15 @@ namespace trview
 {
     using namespace DirectX::SimpleMath;
 
-    StaticMesh::StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, const std::shared_ptr<IMesh>& mesh)
+    StaticMesh::StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, const std::shared_ptr<IMesh>& mesh, const std::shared_ptr<IMesh>& bounding_mesh)
         : _mesh(mesh),
         _visibility_min(level_static_mesh.VisibilityBox.MinX, level_static_mesh.VisibilityBox.MinY, level_static_mesh.VisibilityBox.MinZ),
         _visibility_max(level_static_mesh.VisibilityBox.MaxX, level_static_mesh.VisibilityBox.MaxY, level_static_mesh.VisibilityBox.MaxZ),
         _collision_min(level_static_mesh.CollisionBox.MinX, level_static_mesh.CollisionBox.MinY, level_static_mesh.CollisionBox.MinZ),
         _collision_max(level_static_mesh.CollisionBox.MaxX, level_static_mesh.CollisionBox.MaxY, level_static_mesh.CollisionBox.MaxZ),
         _position(static_mesh.x / trlevel::Scale_X, static_mesh.y / trlevel::Scale_Y, static_mesh.z / trlevel::Scale_Z),
-        _rotation(static_mesh.rotation / 16384.0f * DirectX::XM_PIDIV2)
+        _rotation(static_mesh.rotation / 16384.0f * DirectX::XM_PIDIV2),
+        _bounding_mesh(bounding_mesh)
     {
         using namespace DirectX::SimpleMath;
         _world = Matrix::CreateRotationY(_rotation) * Matrix::CreateTranslation(_position);
@@ -36,6 +37,7 @@ namespace trview
         else
         {
             _mesh->render(_world * camera.view_projection(), texture_storage, colour);
+            _bounding_mesh->render(_world * camera.view_projection(), texture_storage, Colour::Magenta);
         }
     }
 

--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -46,11 +46,8 @@ namespace trview
         {
             const auto size = (_collision_max - _collision_min);
             const auto adjust = _collision_min + size * 0.5f;
-            const auto wvp = Matrix::CreateScale(size) *
-                Matrix::CreateTranslation(adjust) *
-                _world *
-                camera.view_projection();
-            _bounding_mesh->render(wvp, texture_storage, Colour::Magenta);
+            const auto wvp = Matrix::CreateScale(size) * Matrix::CreateTranslation(adjust) * _world * camera.view_projection();
+            _bounding_mesh->render(wvp, texture_storage, colour);
         }
     }
 

--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -37,6 +37,13 @@ namespace trview
         else
         {
             _mesh->render(_world * camera.view_projection(), texture_storage, colour);
+        }
+    }
+
+    void StaticMesh::render_bounding_box(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour)
+    {
+        if (!_sprite_mesh)
+        {
             _bounding_mesh->render(_world * camera.view_projection(), texture_storage, Colour::Magenta);
         }
     }

--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -10,8 +10,8 @@ namespace trview
         : _mesh(mesh),
         _visibility_min(level_static_mesh.VisibilityBox.MinX, level_static_mesh.VisibilityBox.MinY, level_static_mesh.VisibilityBox.MinZ),
         _visibility_max(level_static_mesh.VisibilityBox.MaxX, level_static_mesh.VisibilityBox.MaxY, level_static_mesh.VisibilityBox.MaxZ),
-        _collision_min(level_static_mesh.CollisionBox.MinX, level_static_mesh.CollisionBox.MinY, level_static_mesh.CollisionBox.MinZ),
-        _collision_max(level_static_mesh.CollisionBox.MaxX, level_static_mesh.CollisionBox.MaxY, level_static_mesh.CollisionBox.MaxZ),
+        _collision_min(level_static_mesh.CollisionBox.MinX / trlevel::Scale_X, level_static_mesh.CollisionBox.MinY / trlevel::Scale_Y, level_static_mesh.CollisionBox.MinZ / trlevel::Scale_Z),
+        _collision_max(level_static_mesh.CollisionBox.MaxX / trlevel::Scale_X, level_static_mesh.CollisionBox.MaxY / trlevel::Scale_Y, level_static_mesh.CollisionBox.MaxZ / trlevel::Scale_Z),
         _position(static_mesh.x / trlevel::Scale_X, static_mesh.y / trlevel::Scale_Y, static_mesh.z / trlevel::Scale_Z),
         _rotation(static_mesh.rotation / 16384.0f * DirectX::XM_PIDIV2),
         _bounding_mesh(bounding_mesh)
@@ -44,7 +44,13 @@ namespace trview
     {
         if (!_sprite_mesh)
         {
-            _bounding_mesh->render(_world * camera.view_projection(), texture_storage, Colour::Magenta);
+            const auto size = (_collision_max - _collision_min);
+            const auto adjust = _collision_min + size * 0.5f;
+            const auto wvp = Matrix::CreateScale(size) *
+                Matrix::CreateTranslation(adjust) *
+                _world *
+                camera.view_projection();
+            _bounding_mesh->render(wvp, texture_storage, Colour::Magenta);
         }
     }
 

--- a/trview.app/Elements/StaticMesh.h
+++ b/trview.app/Elements/StaticMesh.h
@@ -11,6 +11,7 @@ namespace trview
         StaticMesh(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Matrix& scale, std::shared_ptr<IMesh> mesh);
         virtual ~StaticMesh() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
+        virtual void render_bounding_box(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
     private:

--- a/trview.app/Elements/StaticMesh.h
+++ b/trview.app/Elements/StaticMesh.h
@@ -7,7 +7,7 @@ namespace trview
     class StaticMesh final : public IStaticMesh
     {
     public:
-        StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, const std::shared_ptr<IMesh>& mesh);
+        StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, const std::shared_ptr<IMesh>& mesh, const std::shared_ptr<IMesh>& bounding_mesh);
         StaticMesh(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Matrix& scale, std::shared_ptr<IMesh> mesh);
         virtual ~StaticMesh() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
@@ -23,6 +23,7 @@ namespace trview
         DirectX::SimpleMath::Matrix  _world;
         std::shared_ptr<IMesh> _mesh;
         std::shared_ptr<IMesh> _sprite_mesh;
+        std::shared_ptr<IMesh> _bounding_mesh;
         DirectX::SimpleMath::Matrix _scale;
     };
 }

--- a/trview.app/Elements/di.hpp
+++ b/trview.app/Elements/di.hpp
@@ -58,11 +58,12 @@ namespace trview
                     };
                 }),
             di::bind<IStaticMesh::MeshSource>.to(
-                [](const auto&) -> IStaticMesh::MeshSource
+                [](const auto& injector) -> IStaticMesh::MeshSource
                 {
-                    return [&](auto&& room_mesh, auto&& level_mesh, auto&& mesh)
+                    auto bounding_mesh = create_cube_mesh(injector.create<IMesh::Source>());
+                    return [=](auto&& room_mesh, auto&& level_mesh, auto&& mesh)
                     {
-                        return std::make_shared<StaticMesh>(room_mesh, level_mesh, mesh);
+                        return std::make_shared<StaticMesh>(room_mesh, level_mesh, mesh, bounding_mesh);
                     };
                 }),
             di::bind<IStaticMesh::PositionSource>.to(

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -37,6 +37,7 @@ namespace trview
             MOCK_METHOD(void, set_show_triggers, (bool));
             MOCK_METHOD(void, set_show_water, (bool));
             MOCK_METHOD(void, set_show_wireframe, (bool));
+            MOCK_METHOD(void, set_show_bounding_boxes, (bool));
             MOCK_METHOD(void, set_trigger_visibility, (uint32_t, bool));
             MOCK_METHOD(void, set_neighbour_depth, (uint32_t));
             MOCK_METHOD(void, set_selected_room, (uint16_t));

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -28,6 +28,7 @@ namespace trview
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, PickFilter), (const, override));
             MOCK_METHOD(bool, quicksand, (), (const, override));
             MOCK_METHOD(void, render, (const ICamera&, SelectionMode, bool, bool), (override));
+            MOCK_METHOD(void, render_bounding_boxes, (const ICamera&), (override));
             MOCK_METHOD(void, render_contained, (const ICamera&, SelectionMode, bool), (override));;
             MOCK_METHOD(const std::vector<std::shared_ptr<ISector>>, sectors, (), (const, override));
             MOCK_METHOD(void, set_is_alternate, (int16_t), (override));

--- a/trview.app/Mocks/Elements/IStaticMesh.h
+++ b/trview.app/Mocks/Elements/IStaticMesh.h
@@ -10,6 +10,7 @@ namespace trview
         {
             virtual ~MockStaticMesh() = default;
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, render_bounding_box, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
         };

--- a/trview.app/Mocks/UI/IViewOptions.h
+++ b/trview.app/Mocks/UI/IViewOptions.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <trview.app/UI/IViewOptions.h>
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockViewOptions final : public IViewOptions
+        {
+            virtual ~MockViewOptions() = default;
+            MOCK_METHOD(void, set_alternate_group, (uint32_t, bool), (override));
+            MOCK_METHOD(void, set_alternate_groups, (const std::set<uint32_t>&), (override));
+            MOCK_METHOD(void, set_depth, (int32_t), (override));
+            MOCK_METHOD(void, set_depth_enabled, (bool), (override));
+            MOCK_METHOD(void, set_flip, (bool), (override));
+            MOCK_METHOD(void, set_flip_enabled, (bool), (override));
+            MOCK_METHOD(void, set_highlight, (bool), (override));
+            MOCK_METHOD(void, set_show_hidden_geometry, (bool), (override));
+            MOCK_METHOD(void, set_show_triggers, (bool), (override));
+            MOCK_METHOD(void, set_show_water, (bool), (override));
+            MOCK_METHOD(void, set_show_wireframe, (bool), (override));
+            MOCK_METHOD(void, set_use_alternate_groups, (bool), (override));
+            MOCK_METHOD(void, set_show_bounding_boxes, (bool), (override));
+            MOCK_METHOD(bool, show_hidden_geometry, (), (const, override));
+            MOCK_METHOD(bool, show_triggers, (), (const, override));
+            MOCK_METHOD(bool, show_water, (), (const, override));
+            MOCK_METHOD(bool, show_wireframe, (), (const, override));
+            MOCK_METHOD(bool, show_bounding_boxes, (), (const, override));
+        };
+    }
+}
+

--- a/trview.app/Mocks/UI/IViewerUI.h
+++ b/trview.app/Mocks/UI/IViewerUI.h
@@ -45,12 +45,14 @@ namespace trview
             MOCK_METHOD(void, set_show_triggers, (bool), (override));
             MOCK_METHOD(void, set_show_water, (bool), (override));
             MOCK_METHOD(void, set_show_wireframe, (bool), (override));
+            MOCK_METHOD(void, set_show_bounding_boxes, (bool), (override));
             MOCK_METHOD(void, set_use_alternate_groups, (bool), (override));
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(bool, show_hidden_geometry, (), (const, override));
             MOCK_METHOD(bool, show_triggers, (), (const, override));
             MOCK_METHOD(bool, show_water, (), (const, override));
             MOCK_METHOD(bool, show_wireframe, (), (const, override));
+            MOCK_METHOD(bool, show_bounding_boxes, (), (const, override));
             MOCK_METHOD(bool, show_context_menu, (), (const, override));
             MOCK_METHOD(void, toggle_settings_visibility, (), (override));
             MOCK_METHOD(void, print_console, (const std::wstring&), (override));

--- a/trview.app/UI/IViewOptions.cpp
+++ b/trview.app/UI/IViewOptions.cpp
@@ -1,0 +1,8 @@
+#include "IViewOptions.h"
+
+namespace trview
+{
+    IViewOptions::~IViewOptions()
+    {
+    }
+}

--- a/trview.app/UI/IViewOptions.h
+++ b/trview.app/UI/IViewOptions.h
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <functional>
+#include <cstdint>
+#include <trview.common/Event.h>
+#include <trview.ui/Control.h>
+#include <trview.app/Graphics/ITextureStorage.h>
+
+namespace trview
+{
+    struct IViewOptions
+    {
+        using Source = std::function<std::unique_ptr<IViewOptions>(ui::Control&, const ITextureStorage&)>;
+
+        virtual ~IViewOptions() = 0;
+        /// <summary>
+        /// Event raised when an alternate group is toggled. The group number and the new state are passed as parameters.
+        /// </summary>
+        Event<uint32_t, bool> on_alternate_group;
+        /// <summary>
+        /// Event raised when the user has changed the depth of neighbour to display. The newly selected depth is passed when the event is raised.
+        /// </summary>
+        Event<int32_t> on_depth_changed;
+        /// <summary>
+        /// Event raised when the user has enabled or disabled neighbour mode. The boolean passed to when the event is raised indicates whether neighbours mode is enabled.
+        /// </summary>
+        /// <remarks>This event is not raised when the set_enabled function is called.</remarks>
+        Event<bool> on_depth_enabled;
+        /// <summary>
+        /// Event raised when the user toggles the alternate mode. The boolean passed as a parameter when this event is raised indicates whether flip mode is enabled.
+        /// </summary>
+        /// <remarks>This event is not raised by the set_flip function.</remarks>
+        Event<bool> on_flip;
+        /// Event raised when the user toggles the highlight mode. The boolean passed as a parameter when this
+        /// event is raised indicates whether highlight mode is enabled.
+        /// @remarks This event is not raised by the set_highlight function.
+        Event<bool> on_highlight;
+        /// <summary>
+        /// Event raised when the user toggles the hidden geometry visibility. The boolean passed as a parameter when this event is raised indicates whether hidden geomety is visible.
+        /// </summary>
+        /// <remarks>This event is not raised by the set_show_hidden_geometry function.</remarks>
+        Event<bool> on_show_hidden_geometry;
+        /// <summary>
+        /// Event raised when the user toggles the trigger visibility. The boolean passed as a parameter when this event is raised indicates whether triggers are visible.
+        /// </summary>
+        /// <remarks>This event is not raised by the set_show_triggers function.</remarks>
+        Event<bool> on_show_triggers;
+        /// <summary>
+        /// Event raised when the user toggles showing water. The boolean passed as a paramter when this event is raised indicates whether water colouring is visible.
+        /// </summary>
+        /// <remarks>This event is not raised by the set_show_water function.</remarks>
+        Event<bool> on_show_water;
+        /// <summary>
+        /// Event raised when the user toggles wireframe mode. The boolean passed as a parameter when this event is raised indicates whether wireframe mode is used.
+        /// </summary>
+        /// <remarks>This event is not raised by the set_wireframe function.</remarks>
+        Event<bool> on_show_wireframe;
+        /// <summary>
+        /// Event raised when the user toggles bounding boxes. The boolean passed as a parameter when this event is raised.
+        /// </summary>
+        /// <remarks>This event is not raised by the set_show_bounding_boxes function.</remarks>
+        Event<bool> on_show_bounding_boxes;
+        /// <summary>
+        /// Set whether an alternate group is enabled. This will not raise the on_alternate_group event.
+        /// </summary>
+        /// <param name="value">The group to change.</param>
+        /// <param name="enabled">Whether the group is enabled.</param>
+        virtual void set_alternate_group(uint32_t value, bool enabled) = 0;
+        /// <summary>
+        /// Set the alternate groups that are in the level.
+        /// </summary>
+        /// <param name="groups">The groups in the level.</param>
+        virtual void set_alternate_groups(const std::set<uint32_t>& groups) = 0;
+        /// <summary>
+        /// Set the value of the depth control. This will not raise the on_depth_changed event.
+        /// </summary>
+        /// <param name="value">The neighbour depth to use.</param>
+        virtual void set_depth(int32_t value) = 0;
+        /// <summary>
+        /// Set whether neighbours are enabled. This will not raise the on_enabled_changed event.
+        /// </summary>
+        /// <param name="value">Whether neighbours are enabled.</param>
+        virtual void set_depth_enabled(bool value) = 0;
+        /// <summary>
+        /// Set the current flip mode. This will not raise the on_flip event but will update the user interface appropriately.
+        /// </summary>
+        /// <param name="flip">The new flip mode.</param>
+        virtual void set_flip(bool flip) = 0;
+        /// <summary>
+        /// Set whether the flip control is enabled or disabled.
+        /// </summary>
+        /// <param name="enabled">Whether the control is enabled.</param>
+        virtual void set_flip_enabled(bool enabled) = 0;
+        /// <summary>
+        /// Set the current highlight mode. This will not raise the on_highlight event but will update the user interface appropriately.
+        /// </summary>
+        /// <param name="highlight">Whether the highlight mode is enabled or disabled.</param>
+        virtual void set_highlight(bool highlight) = 0;
+        /// <summary>
+        /// Set whether hidden geometry is visible or not.
+        /// </summary>
+        /// <param name="show">Whether the hidden geometry is visible.</param>
+        virtual void set_show_hidden_geometry(bool show) = 0;
+        /// <summary>
+        /// Set whether triggers are visible or not.
+        /// </summary>
+        /// <param name="show">Whether the triggers are visible.</param>
+        virtual void set_show_triggers(bool show) = 0;
+        /// <summary>
+        /// Set whether water is visible or not.
+        /// </summary>
+        /// <param name="show">Whether water is visible.</param>
+        virtual void set_show_water(bool show) = 0;
+        /// <summary>
+        /// Set whether wireframe mode is enabled.
+        /// </summary>
+        /// <param name="show">Whether to use wireframe.</param>
+        virtual void set_show_wireframe(bool show) = 0;
+        /// <summary>
+        /// Set whether to use alternate groups method of flipmaps.
+        /// </summary>
+        /// <param name="value">Whether to use alternate groups or a single toggle.</param>
+        virtual void set_use_alternate_groups(bool value) = 0;
+        /// <summary>
+        /// Set whether to show bounding boxes.
+        /// </summary>
+        /// <param name="value">Whether to show bouding boxes.</param>
+        virtual void set_show_bounding_boxes(bool value) = 0;
+        /// <summary>
+        /// Get the current value of the show hidden geometry checkbox.
+        /// </summary>
+        /// <returns>The current value of the checkbox.</returns>
+        virtual bool show_hidden_geometry() const = 0;
+        /// <summary>
+        /// Get the current value of the show triggers checkbox.
+        /// </summary>
+        /// <returns>The current value of the checkbox.</returns>
+        virtual bool show_triggers() const = 0;
+        /// <summary>
+        /// Get the current value of the show water checkbox.
+        /// </summary>
+        /// <returns>The current value of the checkbox.</returns>
+        virtual bool show_water() const = 0;
+        /// <summary>
+        /// Get the current value of the wireframe checkbox.
+        /// </summary>
+        /// <returns>The current value of the checkbox.</returns>
+        virtual bool show_wireframe() const = 0;
+        /// <summary>
+        /// Get the current value of the bounding boxes checkbox.
+        /// </summary>
+        /// <returns>The current value of the checkbox.</returns>
+        virtual bool show_bounding_boxes() const = 0;
+    };
+}

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -95,6 +95,11 @@ namespace trview
         /// Event raised when the show wireframe setting is changed.
         Event<bool> on_show_wireframe;
 
+        /// <summary>
+        /// Event raised when the show bouding boxes setting is changed.
+        /// </summary>
+        Event<bool> on_show_bounding_boxes;
+
         /// Event raised when a tool is selected.
         Event<Tool> on_tool_selected;
 
@@ -241,6 +246,12 @@ namespace trview
         /// @param value Whether wireframe is visible.
         virtual void set_show_wireframe(bool value) = 0;
 
+        /// <summary>
+        /// Set whether to show bounding boxes.
+        /// </summary>
+        /// <param name="value">Whether bounding boxes are visible.</param>
+        virtual void set_show_bounding_boxes(bool value) = 0;
+
         /// Set whether the level uses alternate groups.
         /// @param value Whether alternate groups are used.
         virtual void set_use_alternate_groups(bool value) = 0;
@@ -260,6 +271,11 @@ namespace trview
 
         /// Get whether wireframe is visible.
         virtual bool show_wireframe() const = 0;
+
+        /// <summary>
+        /// Get whether bounding boxes are visible.
+        /// </summary>
+        virtual bool show_bounding_boxes() const = 0;
 
         /// Get whether the context menu is visible.
         virtual bool show_context_menu() const = 0;

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -10,6 +10,8 @@
 
 namespace trview
 {
+    const std::string ViewOptions::Names::show_bounding_boxes { "show_bounding_boxes" };
+
     namespace Colours
     {
         const Colour FlipOff{ 0.2f, 0.2f, 0.2f };
@@ -49,6 +51,7 @@ namespace trview
         _wireframe->on_state_changed += on_show_wireframe;
 
         _bounding_boxes = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Bounds"));
+        _bounding_boxes->set_name(Names::show_bounding_boxes);
         _bounding_boxes->on_state_changed += on_show_bounding_boxes;
 
         const auto panel_size = Size(140, 20);

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -47,7 +47,10 @@ namespace trview
 
         _wireframe = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Wireframe"));
         _wireframe->on_state_changed += on_show_wireframe;
-        
+
+        _bounding_boxes = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Bounds"));
+        _bounding_boxes->on_state_changed += on_show_bounding_boxes;
+
         const auto panel_size = Size(140, 20);
         auto flip_panel = rooms_area->add_child(std::make_unique<ui::Window>(panel_size, Colour::Transparent));
         _tr1_3_panel = flip_panel->add_child(std::make_unique<ui::Window>(panel_size, Colour::Transparent));
@@ -148,6 +151,11 @@ namespace trview
         _tr4_5_panel->set_visible(value);
     }
 
+    void ViewOptions::set_show_bounding_boxes(bool value)
+    {
+        _bounding_boxes->set_state(value);
+    }
+
     bool ViewOptions::show_hidden_geometry() const
     {
         return _hidden_geometry->state();
@@ -161,10 +169,15 @@ namespace trview
     bool ViewOptions::show_water() const
     {
         return _water->state();
-    }    
+    }
 
     bool ViewOptions::show_wireframe() const
     {
         return _wireframe->state();
+    }
+
+    bool ViewOptions::show_bounding_boxes() const
+    {
+        return _bounding_boxes->state();
     }
 }

--- a/trview.app/UI/ViewOptions.h
+++ b/trview.app/UI/ViewOptions.h
@@ -66,6 +66,12 @@ namespace trview
         /// @remarks This event is not raised by the set_wireframe function.
         Event<bool> on_show_wireframe;
 
+        /// <summary>
+        /// Event raised when the user toggles bounding boxes. The boolean passed as a parameter when this event is raised.
+        /// </summary>
+        /// <remarks>This event is not raised by the set_show_bounding_boxes function.</remarks>
+        Event<bool> on_show_bounding_boxes;
+
         /// Set whether an alternate group is enabled. This will not raise the on_alternate_group event.
         /// @param value The group to change.
         /// @param enabled Whether the group is enabled.
@@ -115,6 +121,12 @@ namespace trview
         /// @param value Whether to use alternate groups or a single toggle.
         void set_use_alternate_groups(bool value);
 
+        /// <summary>
+        /// Set whether to show bounding boxes.
+        /// </summary>
+        /// <param name="value">Whether to show bouding boxes.</param>
+        void set_show_bounding_boxes(bool value);
+
         /// Get the current value of the show hidden geometry checkbox.
         /// @returns The current value of the checkbox.
         bool show_hidden_geometry() const;
@@ -130,6 +142,12 @@ namespace trview
         /// Get the current value of the wireframe checkbox.
         /// @returns The current value of the checkbox.
         bool show_wireframe() const;
+
+        /// <summary>
+        /// Get the current value of the bounding boxes checkbox.
+        /// </summary>
+        /// <returns>The current value of the checkbox.</returns>
+        bool show_bounding_boxes() const;
     private:
         TokenStore _token_store;
         ui::Checkbox* _highlight;
@@ -139,6 +157,7 @@ namespace trview
         ui::Checkbox* _water;
         ui::Checkbox* _enabled;
         ui::Checkbox* _wireframe;
+        ui::Checkbox* _bounding_boxes;
         ui::NumericUpDown* _depth;
         ui::Window* _tr1_3_panel;
         ui::Window* _tr4_5_panel;

--- a/trview.app/UI/ViewOptions.h
+++ b/trview.app/UI/ViewOptions.h
@@ -6,6 +6,7 @@
 
 #include <trview.common/TokenStore.h>
 #include <trview.app/Graphics/ITextureStorage.h>
+#include "IViewOptions.h"
 
 namespace trview
 {
@@ -19,135 +20,34 @@ namespace trview
         class StackPanel;
     }
 
-    class ViewOptions final
+    class ViewOptions final : public IViewOptions
     {
     public:
+        struct Names
+        {
+            static const std::string show_bounding_boxes;
+        };
+
         explicit ViewOptions(ui::Control& parent, const ITextureStorage& texture_storage);
-
-        /// Event raised when an alternate group is toggled. The group number and the new state are passed as parameters.
-        Event<uint32_t, bool> on_alternate_group;
-
-        /// Event raised when the user has changed the depth of neighbour to display. The newly selected depth is passed
-        /// when the event is raised.
-        Event<int32_t> on_depth_changed;
-
-        /// Event raised when the user has enabled or disabled neighbour mode. The boolean passed to when the event is
-        /// raised indicates whether neighbours mode is enabled.
-        /// @remarks This event is not raised when the set_enabled function is called.
-        Event<bool> on_depth_enabled;
-
-        /// Event raised when the user toggles the alternate mode. The boolean passed as a parameter when this
-        /// event is raised indicates whether flip mode is enabled.
-        /// @remarks This event is not raised by the set_flip function.
-        Event<bool> on_flip;
-        
-        /// Event raised when the user toggles the highlight mode. The boolean passed as a parameter when this
-        /// event is raised indicates whether highlight mode is enabled.
-        /// @remarks This event is not raised by the set_highlight function.
-        Event<bool> on_highlight;
-
-        /// Event raised when the user toggles the hidden geometry visibility. The boolean passed as a parameter when
-        /// this event is raised indicates whether hidden geomety is visible.
-        /// @remarks This event is not raised by the set_show_hidden_geometry function.
-        Event<bool> on_show_hidden_geometry;
-
-        /// Event raised when the user toggles the trigger visibility. The boolean passed as a parameter when this
-        /// event is raised indicates whether triggers are visible.
-        /// @remarks This event is not raised by the set_show_triggers function.
-        Event<bool> on_show_triggers;
-
-        /// Event raised when the user toggles showing water. The boolean passed as a paramter when this event is raised
-        /// indicates whether water colouring is visible.
-        /// @remarks This event is not raised by the set_show_water function.
-        Event<bool> on_show_water;
-
-        /// Event raised when the user toggles wireframe mode. The boolean passed as a parameter when this event is raised
-        /// indicates whether wireframe mode is used.
-        /// @remarks This event is not raised by the set_wireframe function.
-        Event<bool> on_show_wireframe;
-
-        /// <summary>
-        /// Event raised when the user toggles bounding boxes. The boolean passed as a parameter when this event is raised.
-        /// </summary>
-        /// <remarks>This event is not raised by the set_show_bounding_boxes function.</remarks>
-        Event<bool> on_show_bounding_boxes;
-
-        /// Set whether an alternate group is enabled. This will not raise the on_alternate_group event.
-        /// @param value The group to change.
-        /// @param enabled Whether the group is enabled.
-        void set_alternate_group(uint32_t value, bool enabled);
-
-        /// Set the alternate groups that are in the level.
-        /// @param groups The groups in the level.
-        void set_alternate_groups(const std::set<uint32_t>& groups);
-
-        /// Set the value of the depth control. This will not raise the on_depth_changed event.
-        /// @param value The neighbour depth to use.
-        void set_depth(int32_t value);
-        
-        /// Set whether neighbours are enabled. This will not raise the on_enabled_changed event.
-        /// @param value Whether neighbours are enabled.
-        void set_depth_enabled(bool value);
-
-        /// Set the current flip mode. This will not raise the on_flip event but will update the user interface appropriately.
-        /// @param flip The new flip mode.
-        void set_flip(bool flip);
-
-        /// Set whether the flip control is enabled or disabled.
-        /// @param enabled Whether the control is enabled.
-        void set_flip_enabled(bool enabled);
-
-        /// Set the current highlight mode. This will not raise the on_highlight event but will update the user interface appropriately.
-        /// @param highlight Whether the highlight mode is enabled or disabled.
-        void set_highlight(bool highlight);
-
-        /// Set whether hidden geometry is visible or not.
-        /// @param show Whether the hidden geometry is visible.
-        void set_show_hidden_geometry(bool show);
-
-        /// Set whether triggers are visible or not.
-        /// @param show Whether the triggers are visible.
-        void set_show_triggers(bool show);
-
-        /// Set whether water is visible or not.
-        /// @param show Whether water is visible.
-        void set_show_water(bool show);
-
-        /// Set whether wireframe mode is enabled.
-        /// @param show Whether to use wireframe.
-        void set_show_wireframe(bool show);
-
-        /// Set whether to use alternate groups method of flipmaps.
-        /// @param value Whether to use alternate groups or a single toggle.
-        void set_use_alternate_groups(bool value);
-
-        /// <summary>
-        /// Set whether to show bounding boxes.
-        /// </summary>
-        /// <param name="value">Whether to show bouding boxes.</param>
-        void set_show_bounding_boxes(bool value);
-
-        /// Get the current value of the show hidden geometry checkbox.
-        /// @returns The current value of the checkbox.
-        bool show_hidden_geometry() const;
-        
-        /// Get the current value of the show triggers checkbox.
-        /// @returns The current value of the checkbox.
-        bool show_triggers() const;
-
-        /// Get the current value of the show water checkbox.
-        /// @returns The current value of the checkbox.
-        bool show_water() const;
-
-        /// Get the current value of the wireframe checkbox.
-        /// @returns The current value of the checkbox.
-        bool show_wireframe() const;
-
-        /// <summary>
-        /// Get the current value of the bounding boxes checkbox.
-        /// </summary>
-        /// <returns>The current value of the checkbox.</returns>
-        bool show_bounding_boxes() const;
+        virtual ~ViewOptions() = default;
+        virtual void set_alternate_group(uint32_t value, bool enabled) override;
+        virtual void set_alternate_groups(const std::set<uint32_t>& groups) override;
+        virtual void set_depth(int32_t value) override;
+        virtual void set_depth_enabled(bool value) override;
+        virtual void set_flip(bool flip) override;
+        virtual void set_flip_enabled(bool enabled) override;
+        virtual void set_highlight(bool highlight) override;
+        virtual void set_show_hidden_geometry(bool show) override;
+        virtual void set_show_triggers(bool show) override;
+        virtual void set_show_water(bool show) override;
+        virtual void set_show_wireframe(bool show) override;
+        virtual void set_use_alternate_groups(bool value) override;
+        virtual void set_show_bounding_boxes(bool value) override;
+        virtual bool show_hidden_geometry() const override;
+        virtual bool show_triggers() const override;
+        virtual bool show_water() const override;
+        virtual bool show_wireframe() const override;
+        virtual bool show_bounding_boxes() const override;
     private:
         TokenStore _token_store;
         ui::Checkbox* _highlight;

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -260,6 +260,7 @@ namespace trview
         _view_options->on_flip += on_flip;
         _view_options->on_alternate_group += on_alternate_group;
         _view_options->on_show_wireframe += on_show_wireframe;
+        _view_options->on_show_bounding_boxes += on_show_bounding_boxes;
 
         _room_navigator = std::make_unique<RoomNavigator>(*tool_window, texture_storage);
         _room_navigator->on_room_selected += on_select_room;
@@ -469,6 +470,11 @@ namespace trview
         _view_options->set_show_wireframe(value);
     }
 
+    void ViewerUI::set_show_bounding_boxes(bool value)
+    {
+        _view_options->set_show_bounding_boxes(value);
+    }
+
     void ViewerUI::set_use_alternate_groups(bool value)
     {
         _view_options->set_use_alternate_groups(value);
@@ -497,6 +503,11 @@ namespace trview
     bool ViewerUI::show_wireframe() const
     {
         return _view_options->show_wireframe();
+    }
+
+    bool ViewerUI::show_bounding_boxes() const
+    {
+        return _view_options->show_bounding_boxes();
     }
 
     bool ViewerUI::show_context_menu() const

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -16,7 +16,8 @@ namespace trview
         const ui::IInput::Source& input_source,
         const ui::render::IRenderer::Source& ui_renderer_source,
         const ui::render::IMapRenderer::Source& map_renderer_source,
-        const ISettingsWindow::Source& settings_window_source)
+        const ISettingsWindow::Source& settings_window_source,
+        const IViewOptions::Source& view_options_source)
         : _mouse(window, std::make_unique<input::WindowTester>(window)), _window(window), _input_source(input_source)
     {
         _control = std::make_unique<ui::Window>(window.size(), Colour::Transparent);
@@ -60,7 +61,7 @@ namespace trview
             }
         };
 
-        generate_tool_window(*texture_storage);
+        generate_tool_window(view_options_source, *texture_storage);
 
         _go_to = std::make_unique<GoTo>(*_control.get());
         _token_store += _go_to->on_selected += [&](uint32_t index)
@@ -244,13 +245,13 @@ namespace trview
             || (_map_renderer->loaded() && _map_renderer->cursor_is_over_control());
     }
 
-    void ViewerUI::generate_tool_window(const ITextureStorage& texture_storage)
+    void ViewerUI::generate_tool_window(const IViewOptions::Source& view_options_source, const ITextureStorage& texture_storage)
     {
         // This is the main tool window on the side of the screen.
         auto tool_window = _control->add_child(std::make_unique<StackPanel>(Size(150.0f, 348.0f), Colour(0.5f, 0.0f, 0.0f, 0.0f), Size(5, 5)));
         tool_window->set_margin(Size(5, 5));
 
-        _view_options = std::make_unique<ViewOptions>(*tool_window, texture_storage);
+        _view_options = view_options_source(*tool_window, texture_storage);
         _view_options->on_highlight += on_highlight;
         _view_options->on_show_triggers += on_show_triggers;
         _view_options->on_show_hidden_geometry += on_show_hidden_geometry;

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -28,7 +28,8 @@ namespace trview
             const ui::IInput::Source& input_source,
             const ui::render::IRenderer::Source& ui_renderer_source,
             const ui::render::IMapRenderer::Source& map_renderer_source,
-            const ISettingsWindow::Source& settings_window_source);
+            const ISettingsWindow::Source& settings_window_source,
+            const IViewOptions::Source& view_options_source);
 
         virtual ~ViewerUI() = default;
         virtual void clear_minimap_highlight() override;
@@ -81,7 +82,7 @@ namespace trview
         virtual void print_console(const std::wstring& text) override;
         virtual void initialise_input() override;
     private:
-        void generate_tool_window(const ITextureStorage& texture_storage);
+        void generate_tool_window(const IViewOptions::Source& view_options_source, const ITextureStorage& texture_storage);
         void initialise_camera_controls(ui::Control& parent);
         void register_change_detection(ui::Control* control);
 
@@ -96,7 +97,7 @@ namespace trview
         std::unique_ptr<ContextMenu> _context_menu;
         std::unique_ptr<GoTo> _go_to;
         std::unique_ptr<RoomNavigator> _room_navigator;
-        std::unique_ptr<ViewOptions> _view_options;
+        std::unique_ptr<IViewOptions> _view_options;
         std::unique_ptr<Toolbar> _toolbar;
         std::unique_ptr<LevelInfo> _level_info;
         std::unique_ptr<ISettingsWindow> _settings_window;

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -31,175 +31,54 @@ namespace trview
             const ISettingsWindow::Source& settings_window_source);
 
         virtual ~ViewerUI() = default;
-
-        /// Clear the highlighted minimap sector.
         virtual void clear_minimap_highlight() override;
-
-        /// Get the currently hovered minimap sector, if any.
         virtual std::shared_ptr<ISector> current_minimap_sector() const override;
-
-        /// Get whether there is any text input currently active.
         virtual bool is_input_active() const override;
-
-        /// Determiens if the cursor is over any ui element.
-        /// @returns Whether the cursor is over an element.
         virtual bool is_cursor_over() const override;
-
-        /// Render the UI.
         virtual void render() override;
-
-        /// Set whether an alternate group is enabled.
-        /// @param value The group to change.
-        /// @param enabled Whether the group is enabled.
         virtual void set_alternate_group(uint32_t value, bool enabled) override;
-
-        /// Set the alternate groups for the level.
-        /// @param groups The alternate groups for the level.
         virtual void set_alternate_groups(const std::set<uint32_t>& groups) override;
-
-        /// Set the current camera position.
-        /// @param position The camera position.
         virtual void set_camera_position(const DirectX::SimpleMath::Vector3& position) override;
         virtual void set_camera_rotation(float yaw, float pitch) override;
-
-        /// Set the camera mode.
-        /// @param mode The current camera mode.
         virtual void set_camera_mode(CameraMode mode) override;
-
-        /// Set the camera projection mode.
-        /// @param mode The current camera projection mode.
         virtual void set_camera_projection_mode(ProjectionMode mode) override;
-
-        /// Set whether depth is enabled.
-        /// @param value Whether depth is enabled.
         virtual void set_depth_enabled(bool value) override;
-
-        /// Set the level of depth.
-        /// @param value The depth level.
         virtual void set_depth_level(int32_t value) override;
-
-        /// Set the current flip state.
-        /// @param value The flip state.
         virtual void set_flip(bool value) override;
-
-        /// Set whether there are any flipmaps in the level.
-        /// @param value Whether there are any flipmaps.
         virtual void set_flip_enabled(bool value) override;
-
-        /// Set whether the hide button on the context menu is enabled.
-        /// @param value Whether the hide button is enabled.
         virtual void set_hide_enabled(bool value) override;
-
-        /// Set whether highlight is enabled.
-        /// @param value Whether highlight is enabled.
         virtual void set_highlight(bool value) override;
 
         /// Set the size of the host window.
         void set_host_size(const Size& size) override;
-
-        /// Set the level name and version.
-        /// @param name The file.
-        /// @param version The version of the level.
         virtual void set_level(const std::string& name, trlevel::LevelVersion version) override;
-
-        /// Set the maximum number of rooms in the level.
-        /// @param rooms The number of rooms that are in the level.
         virtual void set_max_rooms(uint32_t rooms) override;
-
-        /// Set the current measure distance to display on the label.
-        /// @param distance The distance to measure.
         virtual void set_measure_distance(float distance) override;
-
-        /// Set the position of the measure label.
-        /// @param position The position of the label.
         virtual void set_measure_position(const Point& position) override;
-
-        /// Set which square is highlighted on the minimap.
-        /// @param x The x coordinate.
-        /// @param z The z coordinate.
         virtual void set_minimap_highlight(uint16_t x, uint16_t z) override;
-
-        /// Set the current pick result.
-        /// @param info The parameters for the pick.
-        /// @param pick_result The pick result.
         virtual void set_pick(const PickInfo& info, const PickResult& pick_result) override;
-
-        /// Set whether the user can click the remove waypoint button.
-        /// "param value Whether the button is enabled.
         virtual void set_remove_waypoint_enabled(bool value) override;
-
-        /// Set the selected room.
-        /// @param room The selected room.
         virtual void set_selected_room(const std::shared_ptr<IRoom>& room) override;
-
-        /// Set the user settings.
-        /// @param settings The user settings.
         virtual void set_settings(const UserSettings& settings) override;
-
-        /// Set whether the context menu is visible.
-        /// "param value Whether the context menu is visible.
         virtual void set_show_context_menu(bool value) override;
-
-        /// Set whether hidden geometry is visible.
-        /// @param value Whether hidden geometry is visible.
         virtual void set_show_hidden_geometry(bool value) override;
-
-        /// Set whether to show the measure label.
-        /// @param value Whether to show the measure label.
         virtual void set_show_measure(bool value) override;
-
-        /// Set whether to show the minimap.
-        /// @param value Whether to show the minimap.
         virtual void set_show_minimap(bool value) override;
-
-        /// Set whether to show the tooltip.
-        /// @param value Whether to show the tooltip.
         virtual void set_show_tooltip(bool value) override;
-
-        /// Set whether triggers are visible.
-        /// @param value Whether triggers are visible.
         virtual void set_show_triggers(bool value) override;
-
-        /// Set whether water is visible.
-        /// @param value Whether water is visible.
         virtual void set_show_water(bool value) override;
-
-        /// Set whether wireframe is visible.
-        /// @param value Whether wireframe is visible.
         virtual void set_show_wireframe(bool value) override;
-
-        /// Set whether the level uses alternate groups.
-        /// @param value Whether alternate groups are used.
+        virtual void set_show_bounding_boxes(bool value) override;
         virtual void set_use_alternate_groups(bool value) override;
-
-        /// Set whether the UI is visible.
-        /// @param value Whether the UI is visible.
         virtual void set_visible(bool value) override;
-
-        /// Get whether hidden geometry is visible.
         virtual bool show_hidden_geometry() const override;
-
-        /// Get whether triggers are visible.
         virtual bool show_triggers() const override;
-
-        /// Get whether water is visible.
         virtual bool show_water() const override;
-
-        /// Get whether wireframe is visible.
         virtual bool show_wireframe() const override;
-
-        /// Get whether the context menu is visible.
+        virtual bool show_bounding_boxes() const override;
         virtual bool show_context_menu() const override;
-
-        /// Toggle the visibility of the settings window.
         virtual void toggle_settings_visibility() override;
-
-        /// <summary>
-        /// Write the text to the console.
-        /// </summary>
-        /// <param name="text">The text to write.</param>
         virtual void print_console(const std::wstring& text) override;
-
         virtual void initialise_input() override;
     private:
         void generate_tool_window(const ITextureStorage& texture_storage);

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -11,7 +11,7 @@
 #include <trview.app/UI/RoomNavigator.h>
 #include <trview.app/UI/ISettingsWindow.h>
 #include <trview.app/UI/Tooltip.h>
-#include <trview.app/UI/ViewOptions.h>
+#include <trview.app/UI/IViewOptions.h>
 #include <trview.input/Mouse.h>
 #include <trview.ui/Input.h>
 #include <trview.ui.render/Renderer.h>

--- a/trview.app/UI/di.hpp
+++ b/trview.app/UI/di.hpp
@@ -3,6 +3,7 @@
 #include <external/boost/di.hpp>
 #include "ViewerUI.h"
 #include "SettingsWindow.h"
+#include "ViewOptions.h"
 #include "Bubble.h"
 
 namespace trview
@@ -17,6 +18,14 @@ namespace trview
                     return [&](ui::Control& parent)
                     {
                         return std::make_unique<SettingsWindow>(parent);
+                    };
+                }),
+            di::bind<IViewOptions::Source>.to(
+                [](const auto&) -> IViewOptions::Source
+                {
+                    return [&](auto&& parent, auto&& texture_storage)
+                    {
+                        return std::make_unique<ViewOptions>(parent, texture_storage);
                     };
                 }),
             di::bind<IBubble::Source>.to(

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -67,6 +67,7 @@ namespace trview
         _token_store += _ui->on_show_water += [&](bool value) { set_show_water(value); };
         _token_store += _ui->on_show_wireframe += [&](bool value) { set_show_wireframe(value); };
         _token_store += _ui->on_show_triggers += [&](bool value) { set_show_triggers(value); };
+        _token_store += _ui->on_show_bounding_boxes += [&](bool value) { set_show_bounding_boxes(value); };
         _token_store += _ui->on_flip += [&](bool value) { set_alternate_mode(value); };
         _token_store += _ui->on_alternate_group += [&](uint32_t group, bool value) { set_alternate_group(group, value); };
         _token_store += _ui->on_depth += [&](bool value) { if (_level) { _level->set_highlight_mode(ILevel::RoomHighlightMode::Neighbours, value); } };
@@ -445,7 +446,8 @@ namespace trview
         _level->set_show_triggers(_ui->show_triggers());
         _level->set_show_hidden_geometry(_ui->show_hidden_geometry());
         _level->set_show_water(_ui->show_water());
-        _level->set_show_wireframe(_ui->show_wireframe());
+        _level->set_show_wireframe(_ui->show_wireframe()); 
+        _level->set_show_bounding_boxes(_ui->show_bounding_boxes());
 
         // Set up the views.
         auto rooms = _level->room_info();
@@ -939,6 +941,15 @@ namespace trview
         {
             _level->set_show_wireframe(show);
             _ui->set_show_wireframe(show);
+        }
+    }
+
+    void Viewer::set_show_bounding_boxes(bool show)
+    {
+        if (_level)
+        {
+            _level->set_show_bounding_boxes(show);
+            _ui->set_show_bounding_boxes(show);
         }
     }
 

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -107,6 +107,7 @@ namespace trview
         void toggle_show_hidden_geometry();
         void set_show_water(bool show);
         void set_show_wireframe(bool show);
+        void set_show_bounding_boxes(bool show);
         uint32_t room_from_pick(const PickResult& pick) const;
         void add_recent_orbit(const PickResult& pick);
         void select_previous_orbit();

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -121,6 +121,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="UI\IBubble.cpp" />
     <ClCompile Include="UI\ISettingsWindow.cpp" />
     <ClCompile Include="UI\IViewerUI.cpp" />
+    <ClCompile Include="UI\IViewOptions.cpp" />
     <ClCompile Include="UI\LevelInfo.cpp" />
     <ClCompile Include="UI\RoomNavigator.cpp" />
     <ClCompile Include="UI\SettingsWindow.cpp" />
@@ -249,6 +250,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\UI\IBubble.h" />
     <ClInclude Include="Mocks\UI\ISettingsWindow.h" />
     <ClInclude Include="Mocks\UI\IViewerUI.h" />
+    <ClInclude Include="Mocks\UI\IViewOptions.h" />
     <ClInclude Include="Mocks\Windows\IItemsWindow.h" />
     <ClInclude Include="Mocks\Windows\IItemsWindowManager.h" />
     <ClInclude Include="Mocks\Windows\IRoomsWindow.h" />
@@ -299,6 +301,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="UI\IBubble.h" />
     <ClInclude Include="UI\ISettingsWindow.h" />
     <ClInclude Include="UI\IViewerUI.h" />
+    <ClInclude Include="UI\IViewOptions.h" />
     <ClInclude Include="UI\LevelInfo.h" />
     <ClInclude Include="UI\RoomNavigator.h" />
     <ClInclude Include="UI\SettingsWindow.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -340,6 +340,9 @@
     <ClCompile Include="Routing\IWaypoint.cpp">
       <Filter>Routing</Filter>
     </ClCompile>
+    <ClCompile Include="UI\IViewOptions.cpp">
+      <Filter>UI</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -872,6 +875,12 @@
     <ClInclude Include="Mocks\Routing\IWaypoint.h">
       <Filter>Mocks\Routing</Filter>
     </ClInclude>
+    <ClInclude Include="UI\IViewOptions.h">
+      <Filter>UI</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\UI\IViewOptions.h">
+      <Filter>Mocks\UI</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">
@@ -931,9 +940,6 @@
     <Filter Include="Mocks\Menus">
       <UniqueIdentifier>{46297bfe-0f61-4ad3-9380-7bb4c429fe95}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Mocks\Settings">
-      <UniqueIdentifier>{dd4f8f55-fa38-46f7-8a03-a4f1ed7b68b2}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Mocks\Graphics">
       <UniqueIdentifier>{fc010d02-678c-4f36-977f-06c6b9379694}</UniqueIdentifier>
     </Filter>
@@ -948,6 +954,9 @@
     </Filter>
     <Filter Include="Mocks\Camera">
       <UniqueIdentifier>{77a62a69-05bf-4350-ba5d-849404977f4b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Mocks\Settings">
+      <UniqueIdentifier>{dd4f8f55-fa38-46f7-8a03-a4f1ed7b68b2}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/trview.graphics/mocks/D3D/ID3D11DeviceContext.h
+++ b/trview.graphics/mocks/D3D/ID3D11DeviceContext.h
@@ -13,16 +13,16 @@ namespace trview
                 virtual ~MockD3D11DeviceContext() = default;
 
                 // IUnknown
-                MOCK_METHOD(HRESULT, QueryInterface, (REFIID riid, void** ppvObject), (override));
+                MOCK_METHOD(HRESULT, QueryInterface, (REFIID riid, void** ppvObject), (Calltype(STDMETHODCALLTYPE), override));
                 unsigned int ref_count{ 1 };
 
-                virtual ULONG AddRef() override
+                virtual ULONG STDMETHODCALLTYPE AddRef() override
                 {
                     InterlockedIncrement(&ref_count);
                     return ref_count;
                 }
 
-                virtual ULONG Release() override
+                virtual ULONG STDMETHODCALLTYPE Release() override
                 {
                     ULONG ulRefCount = InterlockedDecrement(&ref_count);
                     if (0 == ref_count)
@@ -33,125 +33,125 @@ namespace trview
                 }
 
                 template<class Q>
-                HRESULT QueryInterface(_COM_Outptr_ Q** pp)
+                HRESULT STDMETHODCALLTYPE QueryInterface(_COM_Outptr_ Q** pp)
                 {
                     return QueryInterface(__uuidof(Q), (void**)pp);
                 }
 
                 // ID3D11DeviceChild
-                MOCK_METHOD(void, GetDevice, (ID3D11Device** ppDevice), (override));
-                MOCK_METHOD(HRESULT, GetPrivateData, (REFGUID guid, UINT* pDataSize, void* pData), (override));
-                MOCK_METHOD(HRESULT, SetPrivateData, (REFGUID guid, UINT DataSize, const void* pData), (override));
-                MOCK_METHOD(HRESULT, SetPrivateDataInterface, (REFGUID guid, const IUnknown* pData), (override));
+                MOCK_METHOD(void, GetDevice, (ID3D11Device** ppDevice), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(HRESULT, GetPrivateData, (REFGUID guid, UINT* pDataSize, void* pData), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(HRESULT, SetPrivateData, (REFGUID guid, UINT DataSize, const void* pData), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(HRESULT, SetPrivateDataInterface, (REFGUID guid, const IUnknown* pData), (Calltype(STDMETHODCALLTYPE), override));
                 // ID3D11DeviceContext
-                MOCK_METHOD(void, VSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (override));
-                MOCK_METHOD(void, PSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (override));
-                MOCK_METHOD(void, PSSetShader, (ID3D11PixelShader* pPixelShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (override));
-                MOCK_METHOD(void, PSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (override));
-                MOCK_METHOD(void, VSSetShader, (ID3D11VertexShader* pVertexShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (override));
-                MOCK_METHOD(void, DrawIndexed, (UINT IndexCount, UINT StartIndexLocation, INT BaseVertexLocation), (override));
-                MOCK_METHOD(void, Draw, (UINT VertexCount, UINT StartVertexLocation), (override));
-                MOCK_METHOD(HRESULT, Map, (ID3D11Resource* pResource, UINT Subresource, D3D11_MAP MapType, UINT MapFlags, D3D11_MAPPED_SUBRESOURCE* pMappedResource), (override));
-                MOCK_METHOD(void, Unmap, (ID3D11Resource* pResource, UINT Subresource), (override));
-                MOCK_METHOD(void, PSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (override));
-                MOCK_METHOD(void, IASetInputLayout, (ID3D11InputLayout* pInputLayout), (override));
-                MOCK_METHOD(void, IASetVertexBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppVertexBuffers, const UINT* pStrides, const UINT* pOffsets), (override));
-                MOCK_METHOD(void, IASetIndexBuffer, (ID3D11Buffer* pIndexBuffer, DXGI_FORMAT Format, UINT Offset), (override));
-                MOCK_METHOD(void, DrawIndexedInstanced, (UINT IndexCountPerInstance, UINT InstanceCount, UINT StartIndexLocation, INT BaseVertexLocation, UINT StartInstanceLocation), (override));
-                MOCK_METHOD(void, DrawInstanced, (UINT VertexCountPerInstance, UINT InstanceCount, UINT StartVertexLocation, UINT StartInstanceLocation), (override));
-                MOCK_METHOD(void, GSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (override));
-                MOCK_METHOD(void, GSSetShader, (ID3D11GeometryShader* pShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (override));
-                MOCK_METHOD(void, IASetPrimitiveTopology, (D3D11_PRIMITIVE_TOPOLOGY Topology), (override));
-                MOCK_METHOD(void, VSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (override));
-                MOCK_METHOD(void, VSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (override));
-                MOCK_METHOD(void, Begin, (ID3D11Asynchronous* pAsync), (override));
-                MOCK_METHOD(void, End, (ID3D11Asynchronous* pAsync), (override));
-                MOCK_METHOD(HRESULT, GetData, (ID3D11Asynchronous* pAsync, void* pData, UINT DataSize, UINT GetDataFlags), (override));
-                MOCK_METHOD(void, SetPredication, (ID3D11Predicate* pPredicate, BOOL PredicateValue), (override));
-                MOCK_METHOD(void, GSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (override));
-                MOCK_METHOD(void, GSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (override));
-                MOCK_METHOD(void, OMSetRenderTargets, (UINT NumViews, ID3D11RenderTargetView* const* ppRenderTargetViews, ID3D11DepthStencilView* pDepthStencilView), (override));
-                MOCK_METHOD(void, OMSetRenderTargetsAndUnorderedAccessViews, (UINT NumRTVs, ID3D11RenderTargetView* const* ppRenderTargetViews, ID3D11DepthStencilView* pDepthStencilView, UINT UAVStartSlot, UINT NumUAVs, ID3D11UnorderedAccessView* const* ppUnorderedAccessViews, const UINT* pUAVInitialCounts), (override));
-                MOCK_METHOD(void, OMSetBlendState, (ID3D11BlendState* pBlendState, const FLOAT BlendFactor[4], UINT SampleMask), (override));
-                MOCK_METHOD(void, OMSetDepthStencilState, (ID3D11DepthStencilState* pDepthStencilState, UINT StencilRef), (override));
-                MOCK_METHOD(void, SOSetTargets, (UINT NumBuffers, ID3D11Buffer* const* ppSOTargets, const UINT* pOffsets), (override));
-                MOCK_METHOD(void, DrawAuto, (), (override));
-                MOCK_METHOD(void, DrawIndexedInstancedIndirect, (ID3D11Buffer* pBufferForArgs, UINT AlignedByteOffsetForArgs), (override));
-                MOCK_METHOD(void, DrawInstancedIndirect, (ID3D11Buffer* pBufferForArgs, UINT AlignedByteOffsetForArgs), (override));
-                MOCK_METHOD(void, Dispatch, (UINT ThreadGroupCountX, UINT ThreadGroupCountY, UINT ThreadGroupCountZ), (override));
-                MOCK_METHOD(void, DispatchIndirect, (ID3D11Buffer* pBufferForArgs, UINT AlignedByteOffsetForArgs), (override));
-                MOCK_METHOD(void, RSSetState, (ID3D11RasterizerState* pRasterizerState), (override));
-                MOCK_METHOD(void, RSSetViewports, (UINT NumViewports, const D3D11_VIEWPORT* pViewports), (override));
-                MOCK_METHOD(void, RSSetScissorRects, (UINT NumRects, const D3D11_RECT* pRects), (override));
-                MOCK_METHOD(void, CopySubresourceRegion, (ID3D11Resource* pDstResource, UINT DstSubresource, UINT DstX, UINT DstY, UINT DstZ, ID3D11Resource* pSrcResource, UINT SrcSubresource, const D3D11_BOX* pSrcBox), (override));
-                MOCK_METHOD(void, CopyResource, (ID3D11Resource* pDstResource, ID3D11Resource* pSrcResource), (override));
-                MOCK_METHOD(void, UpdateSubresource, (ID3D11Resource* pDstResource, UINT DstSubresource, const D3D11_BOX* pDstBox, const void* pSrcData, UINT SrcRowPitch, UINT SrcDepthPitch), (override));
-                MOCK_METHOD(void, CopyStructureCount, (ID3D11Buffer* pDstBuffer, UINT DstAlignedByteOffset, ID3D11UnorderedAccessView* pSrcView), (override));
-                MOCK_METHOD(void, ClearRenderTargetView, (ID3D11RenderTargetView* pRenderTargetView, const FLOAT ColorRGBA[4]), (override));
-                MOCK_METHOD(void, ClearUnorderedAccessViewUint, (ID3D11UnorderedAccessView* pUnorderedAccessView, const UINT Values[4]), (override));
-                MOCK_METHOD(void, ClearUnorderedAccessViewFloat, (ID3D11UnorderedAccessView* pUnorderedAccessView, const FLOAT Values[4]), (override));
-                MOCK_METHOD(void, ClearDepthStencilView, (ID3D11DepthStencilView* pDepthStencilView, UINT ClearFlags, FLOAT Depth, UINT8 Stencil), (override));
-                MOCK_METHOD(void, GenerateMips, (ID3D11ShaderResourceView* pShaderResourceView), (override));
-                MOCK_METHOD(void, SetResourceMinLOD, (ID3D11Resource* pResource, FLOAT MinLOD), (override));
-                MOCK_METHOD(FLOAT, GetResourceMinLOD, (ID3D11Resource* pResource), (override));
-                MOCK_METHOD(void, ResolveSubresource, (ID3D11Resource* pDstResource, UINT DstSubresource, ID3D11Resource* pSrcResource, UINT SrcSubresource, DXGI_FORMAT Format), (override));
-                MOCK_METHOD(void, ExecuteCommandList, (ID3D11CommandList* pCommandList, BOOL RestoreContextState), (override));
-                MOCK_METHOD(void, HSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (override));
-                MOCK_METHOD(void, HSSetShader, (ID3D11HullShader* pHullShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (override));
-                MOCK_METHOD(void, HSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (override));
-                MOCK_METHOD(void, HSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (override));
-                MOCK_METHOD(void, DSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (override));
-                MOCK_METHOD(void, DSSetShader, (ID3D11DomainShader* pDomainShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (override));
-                MOCK_METHOD(void, DSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (override));
-                MOCK_METHOD(void, DSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (override));
-                MOCK_METHOD(void, CSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (override));
-                MOCK_METHOD(void, CSSetUnorderedAccessViews, (UINT StartSlot, UINT NumUAVs, ID3D11UnorderedAccessView* const* ppUnorderedAccessViews, const UINT* pUAVInitialCounts), (override));
-                MOCK_METHOD(void, CSSetShader, (ID3D11ComputeShader* pComputeShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (override));
-                MOCK_METHOD(void, CSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (override));
-                MOCK_METHOD(void, CSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (override));
-                MOCK_METHOD(void, VSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (override));
-                MOCK_METHOD(void, PSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (override));
-                MOCK_METHOD(void, PSGetShader, (ID3D11PixelShader** ppPixelShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (override));
-                MOCK_METHOD(void, PSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (override));
-                MOCK_METHOD(void, VSGetShader, (ID3D11VertexShader** ppVertexShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (override));
-                MOCK_METHOD(void, PSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (override));
-                MOCK_METHOD(void, IAGetInputLayout, (ID3D11InputLayout** ppInputLayout), (override));
-                MOCK_METHOD(void, IAGetVertexBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppVertexBuffers, UINT* pStrides, UINT* pOffsets), (override));
-                MOCK_METHOD(void, IAGetIndexBuffer, (ID3D11Buffer** pIndexBuffer, DXGI_FORMAT* Format, UINT* Offset), (override));
-                MOCK_METHOD(void, GSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (override));
-                MOCK_METHOD(void, GSGetShader, (ID3D11GeometryShader** ppGeometryShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (override));
-                MOCK_METHOD(void, IAGetPrimitiveTopology, (D3D11_PRIMITIVE_TOPOLOGY* pTopology), (override));
-                MOCK_METHOD(void, VSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (override));
-                MOCK_METHOD(void, VSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (override));
-                MOCK_METHOD(void, GetPredication, (ID3D11Predicate** ppPredicate, BOOL* pPredicateValue), (override));
-                MOCK_METHOD(void, GSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (override));
-                MOCK_METHOD(void, GSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (override));
-                MOCK_METHOD(void, OMGetRenderTargets, (UINT NumViews, ID3D11RenderTargetView** ppRenderTargetViews, ID3D11DepthStencilView** ppDepthStencilView), (override));
-                MOCK_METHOD(void, OMGetRenderTargetsAndUnorderedAccessViews, (UINT NumRTVs, ID3D11RenderTargetView** ppRenderTargetViews, ID3D11DepthStencilView** ppDepthStencilView, UINT UAVStartSlot, UINT NumUAVs, ID3D11UnorderedAccessView** ppUnorderedAccessViews), (override));
-                MOCK_METHOD(void, OMGetBlendState, (ID3D11BlendState** ppBlendState, FLOAT BlendFactor[4], UINT* pSampleMask), (override));
-                MOCK_METHOD(void, OMGetDepthStencilState, (ID3D11DepthStencilState** ppDepthStencilState, UINT* pStencilRef), (override));
-                MOCK_METHOD(void, SOGetTargets, (UINT NumBuffers, ID3D11Buffer** ppSOTargets), (override));
-                MOCK_METHOD(void, RSGetState, (ID3D11RasterizerState** ppRasterizerState), (override));
-                MOCK_METHOD(void, RSGetViewports, (UINT* pNumViewports, D3D11_VIEWPORT* pViewports), (override));
-                MOCK_METHOD(void, RSGetScissorRects, (UINT* pNumRects, D3D11_RECT* pRects), (override));
-                MOCK_METHOD(void, HSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (override));
-                MOCK_METHOD(void, HSGetShader, (ID3D11HullShader** ppHullShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (override));
-                MOCK_METHOD(void, HSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (override));
-                MOCK_METHOD(void, HSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (override));
-                MOCK_METHOD(void, DSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (override));
-                MOCK_METHOD(void, DSGetShader, (ID3D11DomainShader** ppDomainShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (override));
-                MOCK_METHOD(void, DSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (override));
-                MOCK_METHOD(void, DSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (override));
-                MOCK_METHOD(void, CSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (override));
-                MOCK_METHOD(void, CSGetUnorderedAccessViews, (UINT StartSlot, UINT NumUAVs, ID3D11UnorderedAccessView** ppUnorderedAccessViews), (override));
-                MOCK_METHOD(void, CSGetShader, (ID3D11ComputeShader** ppComputeShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (override));
-                MOCK_METHOD(void, CSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (override));
-                MOCK_METHOD(void, CSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (override));
-                MOCK_METHOD(void, ClearState, (), (override));
-                MOCK_METHOD(void, Flush, (), (override));
-                MOCK_METHOD(D3D11_DEVICE_CONTEXT_TYPE, GetType, (), (override));
-                MOCK_METHOD(UINT, GetContextFlags, (), (override));
-                MOCK_METHOD(HRESULT, FinishCommandList, (BOOL RestoreDeferredContextState, ID3D11CommandList** ppCommandList), (override));
+                MOCK_METHOD(void, VSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, PSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, PSSetShader, (ID3D11PixelShader* pPixelShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, PSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, VSSetShader, (ID3D11VertexShader* pVertexShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DrawIndexed, (UINT IndexCount, UINT StartIndexLocation, INT BaseVertexLocation), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, Draw, (UINT VertexCount, UINT StartVertexLocation), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(HRESULT, Map, (ID3D11Resource* pResource, UINT Subresource, D3D11_MAP MapType, UINT MapFlags, D3D11_MAPPED_SUBRESOURCE* pMappedResource), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, Unmap, (ID3D11Resource* pResource, UINT Subresource), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, PSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, IASetInputLayout, (ID3D11InputLayout* pInputLayout), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, IASetVertexBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppVertexBuffers, const UINT* pStrides, const UINT* pOffsets), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, IASetIndexBuffer, (ID3D11Buffer* pIndexBuffer, DXGI_FORMAT Format, UINT Offset), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DrawIndexedInstanced, (UINT IndexCountPerInstance, UINT InstanceCount, UINT StartIndexLocation, INT BaseVertexLocation, UINT StartInstanceLocation), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DrawInstanced, (UINT VertexCountPerInstance, UINT InstanceCount, UINT StartVertexLocation, UINT StartInstanceLocation), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, GSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, GSSetShader, (ID3D11GeometryShader* pShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, IASetPrimitiveTopology, (D3D11_PRIMITIVE_TOPOLOGY Topology), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, VSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, VSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, Begin, (ID3D11Asynchronous* pAsync), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, End, (ID3D11Asynchronous* pAsync), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(HRESULT, GetData, (ID3D11Asynchronous* pAsync, void* pData, UINT DataSize, UINT GetDataFlags), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, SetPredication, (ID3D11Predicate* pPredicate, BOOL PredicateValue), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, GSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, GSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, OMSetRenderTargets, (UINT NumViews, ID3D11RenderTargetView* const* ppRenderTargetViews, ID3D11DepthStencilView* pDepthStencilView), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, OMSetRenderTargetsAndUnorderedAccessViews, (UINT NumRTVs, ID3D11RenderTargetView* const* ppRenderTargetViews, ID3D11DepthStencilView* pDepthStencilView, UINT UAVStartSlot, UINT NumUAVs, ID3D11UnorderedAccessView* const* ppUnorderedAccessViews, const UINT* pUAVInitialCounts), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, OMSetBlendState, (ID3D11BlendState* pBlendState, const FLOAT BlendFactor[4], UINT SampleMask), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, OMSetDepthStencilState, (ID3D11DepthStencilState* pDepthStencilState, UINT StencilRef), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, SOSetTargets, (UINT NumBuffers, ID3D11Buffer* const* ppSOTargets, const UINT* pOffsets), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DrawAuto, (), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DrawIndexedInstancedIndirect, (ID3D11Buffer* pBufferForArgs, UINT AlignedByteOffsetForArgs), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DrawInstancedIndirect, (ID3D11Buffer* pBufferForArgs, UINT AlignedByteOffsetForArgs), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, Dispatch, (UINT ThreadGroupCountX, UINT ThreadGroupCountY, UINT ThreadGroupCountZ), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DispatchIndirect, (ID3D11Buffer* pBufferForArgs, UINT AlignedByteOffsetForArgs), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, RSSetState, (ID3D11RasterizerState* pRasterizerState), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, RSSetViewports, (UINT NumViewports, const D3D11_VIEWPORT* pViewports), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, RSSetScissorRects, (UINT NumRects, const D3D11_RECT* pRects), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, CopySubresourceRegion, (ID3D11Resource* pDstResource, UINT DstSubresource, UINT DstX, UINT DstY, UINT DstZ, ID3D11Resource* pSrcResource, UINT SrcSubresource, const D3D11_BOX* pSrcBox), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, CopyResource, (ID3D11Resource* pDstResource, ID3D11Resource* pSrcResource), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, UpdateSubresource, (ID3D11Resource* pDstResource, UINT DstSubresource, const D3D11_BOX* pDstBox, const void* pSrcData, UINT SrcRowPitch, UINT SrcDepthPitch), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, CopyStructureCount, (ID3D11Buffer* pDstBuffer, UINT DstAlignedByteOffset, ID3D11UnorderedAccessView* pSrcView), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, ClearRenderTargetView, (ID3D11RenderTargetView* pRenderTargetView, const FLOAT ColorRGBA[4]), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, ClearUnorderedAccessViewUint, (ID3D11UnorderedAccessView* pUnorderedAccessView, const UINT Values[4]), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, ClearUnorderedAccessViewFloat, (ID3D11UnorderedAccessView* pUnorderedAccessView, const FLOAT Values[4]), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, ClearDepthStencilView, (ID3D11DepthStencilView* pDepthStencilView, UINT ClearFlags, FLOAT Depth, UINT8 Stencil), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, GenerateMips, (ID3D11ShaderResourceView* pShaderResourceView), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, SetResourceMinLOD, (ID3D11Resource* pResource, FLOAT MinLOD), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(FLOAT, GetResourceMinLOD, (ID3D11Resource* pResource), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, ResolveSubresource, (ID3D11Resource* pDstResource, UINT DstSubresource, ID3D11Resource* pSrcResource, UINT SrcSubresource, DXGI_FORMAT Format), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, ExecuteCommandList, (ID3D11CommandList* pCommandList, BOOL RestoreContextState), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, HSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, HSSetShader, (ID3D11HullShader* pHullShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, HSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, HSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DSSetShader, (ID3D11DomainShader* pDomainShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, CSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, CSSetUnorderedAccessViews, (UINT StartSlot, UINT NumUAVs, ID3D11UnorderedAccessView* const* ppUnorderedAccessViews, const UINT* pUAVInitialCounts), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, CSSetShader, (ID3D11ComputeShader* pComputeShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, CSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, CSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, VSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, PSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, PSGetShader, (ID3D11PixelShader** ppPixelShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, PSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, VSGetShader, (ID3D11VertexShader** ppVertexShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, PSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, IAGetInputLayout, (ID3D11InputLayout** ppInputLayout), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, IAGetVertexBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppVertexBuffers, UINT* pStrides, UINT* pOffsets), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, IAGetIndexBuffer, (ID3D11Buffer** pIndexBuffer, DXGI_FORMAT* Format, UINT* Offset), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, GSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, GSGetShader, (ID3D11GeometryShader** ppGeometryShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, IAGetPrimitiveTopology, (D3D11_PRIMITIVE_TOPOLOGY* pTopology), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, VSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, VSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, GetPredication, (ID3D11Predicate** ppPredicate, BOOL* pPredicateValue), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, GSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, GSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, OMGetRenderTargets, (UINT NumViews, ID3D11RenderTargetView** ppRenderTargetViews, ID3D11DepthStencilView** ppDepthStencilView), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, OMGetRenderTargetsAndUnorderedAccessViews, (UINT NumRTVs, ID3D11RenderTargetView** ppRenderTargetViews, ID3D11DepthStencilView** ppDepthStencilView, UINT UAVStartSlot, UINT NumUAVs, ID3D11UnorderedAccessView** ppUnorderedAccessViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, OMGetBlendState, (ID3D11BlendState** ppBlendState, FLOAT BlendFactor[4], UINT* pSampleMask), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, OMGetDepthStencilState, (ID3D11DepthStencilState** ppDepthStencilState, UINT* pStencilRef), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, SOGetTargets, (UINT NumBuffers, ID3D11Buffer** ppSOTargets), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, RSGetState, (ID3D11RasterizerState** ppRasterizerState), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, RSGetViewports, (UINT* pNumViewports, D3D11_VIEWPORT* pViewports), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, RSGetScissorRects, (UINT* pNumRects, D3D11_RECT* pRects), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, HSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, HSGetShader, (ID3D11HullShader** ppHullShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, HSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, HSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DSGetShader, (ID3D11DomainShader** ppDomainShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, DSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, CSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, CSGetUnorderedAccessViews, (UINT StartSlot, UINT NumUAVs, ID3D11UnorderedAccessView** ppUnorderedAccessViews), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, CSGetShader, (ID3D11ComputeShader** ppComputeShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, CSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, CSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, ClearState, (), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(void, Flush, (), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(D3D11_DEVICE_CONTEXT_TYPE, GetType, (), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(UINT, GetContextFlags, (), (Calltype(STDMETHODCALLTYPE), override));
+                MOCK_METHOD(HRESULT, FinishCommandList, (BOOL RestoreDeferredContextState, ID3D11CommandList** ppCommandList), (Calltype(STDMETHODCALLTYPE), override));
             };
         }
     }

--- a/trview.graphics/mocks/D3D/ID3D11DeviceContext.h
+++ b/trview.graphics/mocks/D3D/ID3D11DeviceContext.h
@@ -1,0 +1,158 @@
+#pragma once
+
+#include <d3d11.h>
+
+namespace trview
+{
+    namespace graphics
+    {
+        namespace mocks
+        {
+            struct MockD3D11DeviceContext final : public ID3D11DeviceContext
+            {
+                virtual ~MockD3D11DeviceContext() = default;
+
+                // IUnknown
+                MOCK_METHOD(HRESULT, QueryInterface, (REFIID riid, void** ppvObject), (override));
+                unsigned int ref_count{ 1 };
+
+                virtual ULONG AddRef() override
+                {
+                    InterlockedIncrement(&ref_count);
+                    return ref_count;
+                }
+
+                virtual ULONG Release() override
+                {
+                    ULONG ulRefCount = InterlockedDecrement(&ref_count);
+                    if (0 == ref_count)
+                    {
+                        delete this;
+                    }
+                    return ulRefCount;
+                }
+
+                template<class Q>
+                HRESULT QueryInterface(_COM_Outptr_ Q** pp)
+                {
+                    return QueryInterface(__uuidof(Q), (void**)pp);
+                }
+
+                // ID3D11DeviceChild
+                MOCK_METHOD(void, GetDevice, (ID3D11Device** ppDevice), (override));
+                MOCK_METHOD(HRESULT, GetPrivateData, (REFGUID guid, UINT* pDataSize, void* pData), (override));
+                MOCK_METHOD(HRESULT, SetPrivateData, (REFGUID guid, UINT DataSize, const void* pData), (override));
+                MOCK_METHOD(HRESULT, SetPrivateDataInterface, (REFGUID guid, const IUnknown* pData), (override));
+                // ID3D11DeviceContext
+                MOCK_METHOD(void, VSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (override));
+                MOCK_METHOD(void, PSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (override));
+                MOCK_METHOD(void, PSSetShader, (ID3D11PixelShader* pPixelShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (override));
+                MOCK_METHOD(void, PSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (override));
+                MOCK_METHOD(void, VSSetShader, (ID3D11VertexShader* pVertexShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (override));
+                MOCK_METHOD(void, DrawIndexed, (UINT IndexCount, UINT StartIndexLocation, INT BaseVertexLocation), (override));
+                MOCK_METHOD(void, Draw, (UINT VertexCount, UINT StartVertexLocation), (override));
+                MOCK_METHOD(HRESULT, Map, (ID3D11Resource* pResource, UINT Subresource, D3D11_MAP MapType, UINT MapFlags, D3D11_MAPPED_SUBRESOURCE* pMappedResource), (override));
+                MOCK_METHOD(void, Unmap, (ID3D11Resource* pResource, UINT Subresource), (override));
+                MOCK_METHOD(void, PSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (override));
+                MOCK_METHOD(void, IASetInputLayout, (ID3D11InputLayout* pInputLayout), (override));
+                MOCK_METHOD(void, IASetVertexBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppVertexBuffers, const UINT* pStrides, const UINT* pOffsets), (override));
+                MOCK_METHOD(void, IASetIndexBuffer, (ID3D11Buffer* pIndexBuffer, DXGI_FORMAT Format, UINT Offset), (override));
+                MOCK_METHOD(void, DrawIndexedInstanced, (UINT IndexCountPerInstance, UINT InstanceCount, UINT StartIndexLocation, INT BaseVertexLocation, UINT StartInstanceLocation), (override));
+                MOCK_METHOD(void, DrawInstanced, (UINT VertexCountPerInstance, UINT InstanceCount, UINT StartVertexLocation, UINT StartInstanceLocation), (override));
+                MOCK_METHOD(void, GSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (override));
+                MOCK_METHOD(void, GSSetShader, (ID3D11GeometryShader* pShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (override));
+                MOCK_METHOD(void, IASetPrimitiveTopology, (D3D11_PRIMITIVE_TOPOLOGY Topology), (override));
+                MOCK_METHOD(void, VSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (override));
+                MOCK_METHOD(void, VSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (override));
+                MOCK_METHOD(void, Begin, (ID3D11Asynchronous* pAsync), (override));
+                MOCK_METHOD(void, End, (ID3D11Asynchronous* pAsync), (override));
+                MOCK_METHOD(HRESULT, GetData, (ID3D11Asynchronous* pAsync, void* pData, UINT DataSize, UINT GetDataFlags), (override));
+                MOCK_METHOD(void, SetPredication, (ID3D11Predicate* pPredicate, BOOL PredicateValue), (override));
+                MOCK_METHOD(void, GSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (override));
+                MOCK_METHOD(void, GSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (override));
+                MOCK_METHOD(void, OMSetRenderTargets, (UINT NumViews, ID3D11RenderTargetView* const* ppRenderTargetViews, ID3D11DepthStencilView* pDepthStencilView), (override));
+                MOCK_METHOD(void, OMSetRenderTargetsAndUnorderedAccessViews, (UINT NumRTVs, ID3D11RenderTargetView* const* ppRenderTargetViews, ID3D11DepthStencilView* pDepthStencilView, UINT UAVStartSlot, UINT NumUAVs, ID3D11UnorderedAccessView* const* ppUnorderedAccessViews, const UINT* pUAVInitialCounts), (override));
+                MOCK_METHOD(void, OMSetBlendState, (ID3D11BlendState* pBlendState, const FLOAT BlendFactor[4], UINT SampleMask), (override));
+                MOCK_METHOD(void, OMSetDepthStencilState, (ID3D11DepthStencilState* pDepthStencilState, UINT StencilRef), (override));
+                MOCK_METHOD(void, SOSetTargets, (UINT NumBuffers, ID3D11Buffer* const* ppSOTargets, const UINT* pOffsets), (override));
+                MOCK_METHOD(void, DrawAuto, (), (override));
+                MOCK_METHOD(void, DrawIndexedInstancedIndirect, (ID3D11Buffer* pBufferForArgs, UINT AlignedByteOffsetForArgs), (override));
+                MOCK_METHOD(void, DrawInstancedIndirect, (ID3D11Buffer* pBufferForArgs, UINT AlignedByteOffsetForArgs), (override));
+                MOCK_METHOD(void, Dispatch, (UINT ThreadGroupCountX, UINT ThreadGroupCountY, UINT ThreadGroupCountZ), (override));
+                MOCK_METHOD(void, DispatchIndirect, (ID3D11Buffer* pBufferForArgs, UINT AlignedByteOffsetForArgs), (override));
+                MOCK_METHOD(void, RSSetState, (ID3D11RasterizerState* pRasterizerState), (override));
+                MOCK_METHOD(void, RSSetViewports, (UINT NumViewports, const D3D11_VIEWPORT* pViewports), (override));
+                MOCK_METHOD(void, RSSetScissorRects, (UINT NumRects, const D3D11_RECT* pRects), (override));
+                MOCK_METHOD(void, CopySubresourceRegion, (ID3D11Resource* pDstResource, UINT DstSubresource, UINT DstX, UINT DstY, UINT DstZ, ID3D11Resource* pSrcResource, UINT SrcSubresource, const D3D11_BOX* pSrcBox), (override));
+                MOCK_METHOD(void, CopyResource, (ID3D11Resource* pDstResource, ID3D11Resource* pSrcResource), (override));
+                MOCK_METHOD(void, UpdateSubresource, (ID3D11Resource* pDstResource, UINT DstSubresource, const D3D11_BOX* pDstBox, const void* pSrcData, UINT SrcRowPitch, UINT SrcDepthPitch), (override));
+                MOCK_METHOD(void, CopyStructureCount, (ID3D11Buffer* pDstBuffer, UINT DstAlignedByteOffset, ID3D11UnorderedAccessView* pSrcView), (override));
+                MOCK_METHOD(void, ClearRenderTargetView, (ID3D11RenderTargetView* pRenderTargetView, const FLOAT ColorRGBA[4]), (override));
+                MOCK_METHOD(void, ClearUnorderedAccessViewUint, (ID3D11UnorderedAccessView* pUnorderedAccessView, const UINT Values[4]), (override));
+                MOCK_METHOD(void, ClearUnorderedAccessViewFloat, (ID3D11UnorderedAccessView* pUnorderedAccessView, const FLOAT Values[4]), (override));
+                MOCK_METHOD(void, ClearDepthStencilView, (ID3D11DepthStencilView* pDepthStencilView, UINT ClearFlags, FLOAT Depth, UINT8 Stencil), (override));
+                MOCK_METHOD(void, GenerateMips, (ID3D11ShaderResourceView* pShaderResourceView), (override));
+                MOCK_METHOD(void, SetResourceMinLOD, (ID3D11Resource* pResource, FLOAT MinLOD), (override));
+                MOCK_METHOD(FLOAT, GetResourceMinLOD, (ID3D11Resource* pResource), (override));
+                MOCK_METHOD(void, ResolveSubresource, (ID3D11Resource* pDstResource, UINT DstSubresource, ID3D11Resource* pSrcResource, UINT SrcSubresource, DXGI_FORMAT Format), (override));
+                MOCK_METHOD(void, ExecuteCommandList, (ID3D11CommandList* pCommandList, BOOL RestoreContextState), (override));
+                MOCK_METHOD(void, HSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (override));
+                MOCK_METHOD(void, HSSetShader, (ID3D11HullShader* pHullShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (override));
+                MOCK_METHOD(void, HSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (override));
+                MOCK_METHOD(void, HSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (override));
+                MOCK_METHOD(void, DSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (override));
+                MOCK_METHOD(void, DSSetShader, (ID3D11DomainShader* pDomainShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (override));
+                MOCK_METHOD(void, DSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (override));
+                MOCK_METHOD(void, DSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (override));
+                MOCK_METHOD(void, CSSetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView* const* ppShaderResourceViews), (override));
+                MOCK_METHOD(void, CSSetUnorderedAccessViews, (UINT StartSlot, UINT NumUAVs, ID3D11UnorderedAccessView* const* ppUnorderedAccessViews, const UINT* pUAVInitialCounts), (override));
+                MOCK_METHOD(void, CSSetShader, (ID3D11ComputeShader* pComputeShader, ID3D11ClassInstance* const* ppClassInstances, UINT NumClassInstances), (override));
+                MOCK_METHOD(void, CSSetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState* const* ppSamplers), (override));
+                MOCK_METHOD(void, CSSetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer* const* ppConstantBuffers), (override));
+                MOCK_METHOD(void, VSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (override));
+                MOCK_METHOD(void, PSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (override));
+                MOCK_METHOD(void, PSGetShader, (ID3D11PixelShader** ppPixelShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (override));
+                MOCK_METHOD(void, PSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (override));
+                MOCK_METHOD(void, VSGetShader, (ID3D11VertexShader** ppVertexShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (override));
+                MOCK_METHOD(void, PSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (override));
+                MOCK_METHOD(void, IAGetInputLayout, (ID3D11InputLayout** ppInputLayout), (override));
+                MOCK_METHOD(void, IAGetVertexBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppVertexBuffers, UINT* pStrides, UINT* pOffsets), (override));
+                MOCK_METHOD(void, IAGetIndexBuffer, (ID3D11Buffer** pIndexBuffer, DXGI_FORMAT* Format, UINT* Offset), (override));
+                MOCK_METHOD(void, GSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (override));
+                MOCK_METHOD(void, GSGetShader, (ID3D11GeometryShader** ppGeometryShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (override));
+                MOCK_METHOD(void, IAGetPrimitiveTopology, (D3D11_PRIMITIVE_TOPOLOGY* pTopology), (override));
+                MOCK_METHOD(void, VSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (override));
+                MOCK_METHOD(void, VSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (override));
+                MOCK_METHOD(void, GetPredication, (ID3D11Predicate** ppPredicate, BOOL* pPredicateValue), (override));
+                MOCK_METHOD(void, GSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (override));
+                MOCK_METHOD(void, GSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (override));
+                MOCK_METHOD(void, OMGetRenderTargets, (UINT NumViews, ID3D11RenderTargetView** ppRenderTargetViews, ID3D11DepthStencilView** ppDepthStencilView), (override));
+                MOCK_METHOD(void, OMGetRenderTargetsAndUnorderedAccessViews, (UINT NumRTVs, ID3D11RenderTargetView** ppRenderTargetViews, ID3D11DepthStencilView** ppDepthStencilView, UINT UAVStartSlot, UINT NumUAVs, ID3D11UnorderedAccessView** ppUnorderedAccessViews), (override));
+                MOCK_METHOD(void, OMGetBlendState, (ID3D11BlendState** ppBlendState, FLOAT BlendFactor[4], UINT* pSampleMask), (override));
+                MOCK_METHOD(void, OMGetDepthStencilState, (ID3D11DepthStencilState** ppDepthStencilState, UINT* pStencilRef), (override));
+                MOCK_METHOD(void, SOGetTargets, (UINT NumBuffers, ID3D11Buffer** ppSOTargets), (override));
+                MOCK_METHOD(void, RSGetState, (ID3D11RasterizerState** ppRasterizerState), (override));
+                MOCK_METHOD(void, RSGetViewports, (UINT* pNumViewports, D3D11_VIEWPORT* pViewports), (override));
+                MOCK_METHOD(void, RSGetScissorRects, (UINT* pNumRects, D3D11_RECT* pRects), (override));
+                MOCK_METHOD(void, HSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (override));
+                MOCK_METHOD(void, HSGetShader, (ID3D11HullShader** ppHullShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (override));
+                MOCK_METHOD(void, HSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (override));
+                MOCK_METHOD(void, HSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (override));
+                MOCK_METHOD(void, DSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (override));
+                MOCK_METHOD(void, DSGetShader, (ID3D11DomainShader** ppDomainShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (override));
+                MOCK_METHOD(void, DSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (override));
+                MOCK_METHOD(void, DSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (override));
+                MOCK_METHOD(void, CSGetShaderResources, (UINT StartSlot, UINT NumViews, ID3D11ShaderResourceView** ppShaderResourceViews), (override));
+                MOCK_METHOD(void, CSGetUnorderedAccessViews, (UINT StartSlot, UINT NumUAVs, ID3D11UnorderedAccessView** ppUnorderedAccessViews), (override));
+                MOCK_METHOD(void, CSGetShader, (ID3D11ComputeShader** ppComputeShader, ID3D11ClassInstance** ppClassInstances, UINT* pNumClassInstances), (override));
+                MOCK_METHOD(void, CSGetSamplers, (UINT StartSlot, UINT NumSamplers, ID3D11SamplerState** ppSamplers), (override));
+                MOCK_METHOD(void, CSGetConstantBuffers, (UINT StartSlot, UINT NumBuffers, ID3D11Buffer** ppConstantBuffers), (override));
+                MOCK_METHOD(void, ClearState, (), (override));
+                MOCK_METHOD(void, Flush, (), (override));
+                MOCK_METHOD(D3D11_DEVICE_CONTEXT_TYPE, GetType, (), (override));
+                MOCK_METHOD(UINT, GetContextFlags, (), (override));
+                MOCK_METHOD(HRESULT, FinishCommandList, (BOOL RestoreDeferredContextState, ID3D11CommandList** ppCommandList), (override));
+            };
+        }
+    }
+}

--- a/trview.graphics/mocks/IShader.h
+++ b/trview.graphics/mocks/IShader.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace trview
+{
+    namespace graphics
+    {
+        namespace mocks
+        {
+            struct MockShader final : public IShader
+            {
+                virtual ~MockShader() = default;
+                MOCK_METHOD(void, apply, (const Microsoft::WRL::ComPtr<ID3D11DeviceContext>&), (override));
+            };
+        }
+    }
+}
+

--- a/trview.graphics/trview.graphics.vcxproj
+++ b/trview.graphics/trview.graphics.vcxproj
@@ -34,11 +34,13 @@
     <ClInclude Include="IShader.h" />
     <ClInclude Include="IShaderStorage.h" />
     <ClInclude Include="ISprite.h" />
+    <ClInclude Include="Mocks\D3D\ID3D11DeviceContext.h" />
     <ClInclude Include="Mocks\IDevice.h" />
     <ClInclude Include="mocks\IDeviceWindow.h" />
     <ClInclude Include="mocks\IFont.h" />
     <ClInclude Include="mocks\IFontFactory.h" />
     <ClInclude Include="mocks\IRenderTarget.h" />
+    <ClInclude Include="Mocks\IShader.h" />
     <ClInclude Include="Mocks\IShaderStorage.h" />
     <ClInclude Include="Mocks\ISprite.h" />
     <ClInclude Include="ParagraphAlignment.h" />

--- a/trview.graphics/trview.graphics.vcxproj.filters
+++ b/trview.graphics/trview.graphics.vcxproj.filters
@@ -106,6 +106,12 @@
     </ClInclude>
     <ClInclude Include="di.h" />
     <ClInclude Include="di.hpp" />
+    <ClInclude Include="Mocks\D3D\ID3D11DeviceContext.h">
+      <Filter>Mocks\D3D</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\IShader.h">
+      <Filter>Mocks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="IShaderStorage.cpp">
@@ -212,6 +218,9 @@
     </Filter>
     <Filter Include="Rasterizer">
       <UniqueIdentifier>{4bfba0e9-fb4c-4f56-b8a2-64a51daa20ba}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Mocks\D3D">
+      <UniqueIdentifier>{5a5fdaf9-9583-4d9a-8809-e38269df4bfd}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Renders white wireframe collision boxes around static meshes in a pass after rendering all rooms - this can be expanded in the future if bounding boxes for other entities need to be added.
A 'Bounds' checkbox is added to `ViewOptions` to toggle visibility. This defaults to off and isn't persisted across instances of the application.
Converts `ViewOptions` to DI so that `ViewerUI` can be properly tested. Mock added.
Adds a shared bounding mesh for all `StaticMesh` instances in the DI registration.
In order to test the rendering of the bounds in `Level` I had to mock `ID3D11DeviceContext` which was quite large - it will be useful for future graphics mocking though.
Closes #763 