### PR TITLE
Add tests for the ViewOptions class

### DIFF
--- a/trview.app.tests/UI/ViewOptionsTests.cpp
+++ b/trview.app.tests/UI/ViewOptionsTests.cpp
@@ -2,6 +2,7 @@
 #include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
 #include <trview.ui/Window.h>
 #include <trview.ui/Checkbox.h>
+#include <trview.ui/Button.h>
 
 using namespace trview;
 using namespace trview::mocks;
@@ -249,15 +250,65 @@ TEST(ViewOptions, FlipCheckboxUpdated)
 
 TEST(ViewOptions, FlipCheckboxEnabled)
 {
-    FAIL();
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::flip);
+    ASSERT_TRUE(checkbox->enabled());
+
+    view_options.set_flip_enabled(false);
+    ASSERT_FALSE(checkbox->enabled());
 }
 
 TEST(ViewOptions, FlipFlagsToggle)
 {
-    FAIL();
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    std::unordered_map<uint32_t, bool> raised;
+    auto token = view_options.on_alternate_group += [&](uint32_t group, bool state)
+    {
+        raised[group] = state;
+    };
+
+    view_options.set_use_alternate_groups(true);
+    view_options.set_alternate_groups({ 1, 3, 5 });
+
+    auto group3 = window.find<ui::Button>(ViewOptions::Names::group + "3");
+    ASSERT_NE(group3, nullptr);
+    ASSERT_EQ(group3->text_background_colour(), ViewOptions::Colours::FlipOff);
+
+    group3->clicked({});
+
+    ASSERT_EQ(group3->text_background_colour(), ViewOptions::Colours::FlipOn);
+    ASSERT_EQ(raised.size(), 1);
+    ASSERT_EQ(raised[3], true);
 }
 
 TEST(ViewOptions, FlipFlagsUpdated)
 {
-    FAIL();
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    view_options.set_use_alternate_groups(true);
+    view_options.set_alternate_groups({ 1, 3, 5 });
+
+    auto group3 = window.find<ui::Button>(ViewOptions::Names::group + "3");
+    ASSERT_NE(group3, nullptr);
+    ASSERT_EQ(group3->text_background_colour(), ViewOptions::Colours::FlipOff);
+
+    view_options.set_alternate_group(3, true);
+    ASSERT_EQ(group3->text_background_colour(), ViewOptions::Colours::FlipOn);
+}
+
+TEST(ViewOptions, FlipCheckboxHiddenWithAlternateGroups)
+{
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::flip);
+    ASSERT_TRUE(checkbox->visible());
+
+    view_options.set_use_alternate_groups(true);
+    ASSERT_FALSE(checkbox->visible(true));
 }

--- a/trview.app.tests/UI/ViewOptionsTests.cpp
+++ b/trview.app.tests/UI/ViewOptionsTests.cpp
@@ -219,12 +219,32 @@ TEST(ViewOptions, BoundsCheckboxUpdated)
 
 TEST(ViewOptions, FlipCheckboxToggle)
 {
-    FAIL();
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    std::optional<bool> clicked;
+    auto token = view_options.on_flip += [&](bool value)
+    {
+        clicked = value;
+    };
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::flip);
+    ASSERT_FALSE(checkbox->state());
+    checkbox->clicked({});
+    ASSERT_TRUE(clicked.has_value());
+    ASSERT_TRUE(clicked.value());
 }
 
 TEST(ViewOptions, FlipCheckboxUpdated)
 {
-    FAIL();
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::flip);
+    ASSERT_FALSE(checkbox->state());
+
+    view_options.set_flip(true);
+    ASSERT_TRUE(checkbox->state());
 }
 
 TEST(ViewOptions, FlipCheckboxEnabled)

--- a/trview.app.tests/UI/ViewOptionsTests.cpp
+++ b/trview.app.tests/UI/ViewOptionsTests.cpp
@@ -159,12 +159,32 @@ TEST(ViewOptions, DepthCheckboxUpdated)
 
 TEST(ViewOptions, WireframeCheckboxToggle)
 {
-    FAIL();
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    std::optional<bool> clicked;
+    auto token = view_options.on_show_wireframe += [&](bool value)
+    {
+        clicked = value;
+    };
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::wireframe);
+    ASSERT_FALSE(checkbox->state());
+    checkbox->clicked({});
+    ASSERT_TRUE(clicked.has_value());
+    ASSERT_TRUE(clicked.value());
 }
 
 TEST(ViewOptions, WireframeCheckboxUpdated)
 {
-    FAIL();
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::wireframe);
+    ASSERT_FALSE(checkbox->state());
+
+    view_options.set_show_wireframe(true);
+    ASSERT_TRUE(checkbox->state());
 }
 
 TEST(ViewOptions, BoundsCheckboxToggle)

--- a/trview.app.tests/UI/ViewOptionsTests.cpp
+++ b/trview.app.tests/UI/ViewOptionsTests.cpp
@@ -7,6 +7,166 @@ using namespace trview;
 using namespace trview::mocks;
 using namespace trview::ui;
 
+TEST(ViewOptions, HighlightCheckboxToggle)
+{
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    std::optional<bool> clicked;
+    auto token = view_options.on_highlight += [&](bool value)
+    {
+        clicked = value;
+    };
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::highlight);
+    ASSERT_FALSE(checkbox->state());
+    checkbox->clicked({});
+    ASSERT_TRUE(clicked.has_value());
+    ASSERT_TRUE(clicked.value());
+}
+
+TEST(ViewOptions, HighlightCheckboxUpdated)
+{
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::highlight);
+    ASSERT_FALSE(checkbox->state());
+
+    view_options.set_highlight(true);
+    ASSERT_TRUE(checkbox->state());
+};
+
+TEST(ViewOptions, TriggersCheckboxToggle)
+{
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    std::optional<bool> clicked;
+    auto token = view_options.on_show_triggers += [&](bool value)
+    {
+        clicked = value;
+    };
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::triggers);
+    ASSERT_TRUE(checkbox->state());
+    checkbox->clicked({});
+    ASSERT_TRUE(clicked.has_value());
+    ASSERT_FALSE(clicked.value());
+}
+
+TEST(ViewOptions, TriggersCheckboxUpdated)
+{
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::triggers);
+    ASSERT_TRUE(checkbox->state());
+
+    view_options.set_show_triggers(false);
+    ASSERT_FALSE(checkbox->state());
+}
+
+TEST(ViewOptions, HiddenGeometryCheckboxToggle)
+{
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    std::optional<bool> clicked;
+    auto token = view_options.on_show_hidden_geometry += [&](bool value)
+    {
+        clicked = value;
+    };
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::hidden_geometry);
+    ASSERT_FALSE(checkbox->state());
+    checkbox->clicked({});
+    ASSERT_TRUE(clicked.has_value());
+    ASSERT_TRUE(clicked.value());
+}
+
+TEST(ViewOptions, HiddenGeometryCheckboxUpdated)
+{
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::hidden_geometry);
+    ASSERT_FALSE(checkbox->state());
+
+    view_options.set_show_hidden_geometry(true);
+    ASSERT_TRUE(checkbox->state());
+}
+
+TEST(ViewOptions, WaterCheckboxToggle)
+{
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    std::optional<bool> clicked;
+    auto token = view_options.on_show_water += [&](bool value)
+    {
+        clicked = value;
+    };
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::water);
+    ASSERT_TRUE(checkbox->state());
+    checkbox->clicked({});
+    ASSERT_TRUE(clicked.has_value());
+    ASSERT_FALSE(clicked.value());
+}
+
+TEST(ViewOptions, WaterCheckboxUpdated)
+{
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::water);
+    ASSERT_TRUE(checkbox->state());
+
+    view_options.set_show_water(false);
+    ASSERT_FALSE(checkbox->state());
+}
+
+TEST(ViewOptions, DepthCheckboxToggle)
+{
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    std::optional<bool> clicked;
+    auto token = view_options.on_depth_enabled += [&](bool value)
+    {
+        clicked = value;
+    };
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::depth_enabled);
+    ASSERT_FALSE(checkbox->state());
+    checkbox->clicked({});
+    ASSERT_TRUE(clicked.has_value());
+    ASSERT_TRUE(clicked.value());
+}
+
+TEST(ViewOptions, DepthCheckboxUpdated)
+{
+    ui::Window window(Size(1, 1), Colour::White);
+    auto view_options = ViewOptions(window, MockLevelTextureStorage{});
+
+    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::depth_enabled);
+    ASSERT_FALSE(checkbox->state());
+
+    view_options.set_depth_enabled(true);
+    ASSERT_TRUE(checkbox->state());
+}
+
+TEST(ViewOptions, WireframeCheckboxToggle)
+{
+    FAIL();
+}
+
+TEST(ViewOptions, WireframeCheckboxUpdated)
+{
+    FAIL();
+}
+
 TEST(ViewOptions, BoundsCheckboxToggle)
 {
     ui::Window window(Size(1, 1), Colour::White);
@@ -35,4 +195,29 @@ TEST(ViewOptions, BoundsCheckboxUpdated)
     
     view_options.set_show_bounding_boxes(true);
     ASSERT_TRUE(checkbox->state());
+}
+
+TEST(ViewOptions, FlipCheckboxToggle)
+{
+    FAIL();
+}
+
+TEST(ViewOptions, FlipCheckboxUpdated)
+{
+    FAIL();
+}
+
+TEST(ViewOptions, FlipCheckboxEnabled)
+{
+    FAIL();
+}
+
+TEST(ViewOptions, FlipFlagsToggle)
+{
+    FAIL();
+}
+
+TEST(ViewOptions, FlipFlagsUpdated)
+{
+    FAIL();
 }

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -17,6 +17,7 @@ namespace trview
     const std::string ViewOptions::Names::show_bounding_boxes { "show_bounding_boxes" };
     const std::string ViewOptions::Names::water{ "water" };
     const std::string ViewOptions::Names::wireframe{ "wireframe" };
+    const std::string ViewOptions::Names::flip{ "flip" };
 
     namespace Colours
     {
@@ -70,6 +71,7 @@ namespace trview
         auto flip_panel = rooms_area->add_child(std::make_unique<ui::Window>(panel_size, Colour::Transparent));
         _tr1_3_panel = flip_panel->add_child(std::make_unique<ui::Window>(panel_size, Colour::Transparent));
         _flip = _tr1_3_panel->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Flip"));
+        _flip->set_name(Names::flip);
         _flip->on_state_changed += on_flip;
 
         _tr4_5_panel = flip_panel->add_child(std::make_unique<ui::Window>(panel_size, Colour::Transparent));

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -18,12 +18,10 @@ namespace trview
     const std::string ViewOptions::Names::water{ "water" };
     const std::string ViewOptions::Names::wireframe{ "wireframe" };
     const std::string ViewOptions::Names::flip{ "flip" };
+    const std::string ViewOptions::Names::group{ "group" };
 
-    namespace Colours
-    {
-        const Colour FlipOff{ 0.2f, 0.2f, 0.2f };
-        const Colour FlipOn{ 0.6f, 0.6f, 0.6f };
-    }
+    const Colour ViewOptions::Colours::FlipOff{ 0.2f, 0.2f, 0.2f };
+    const Colour ViewOptions::Colours::FlipOn{ 0.6f, 0.6f, 0.6f };
 
     ViewOptions::ViewOptions(ui::Control& parent, const ITextureStorage& texture_storage)
     {
@@ -102,6 +100,7 @@ namespace trview
             _alternate_group_values.insert({ group, false });
 
             auto button = std::make_unique<ui::Button>(Size(16, 16), std::to_wstring(group));
+            button->set_name(Names::group + std::to_string(group));
             button->set_text_background_colour(Colours::FlipOff);
             auto group_button = _alternate_groups->add_child(std::move(button));
 

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -16,6 +16,7 @@ namespace trview
     const std::string ViewOptions::Names::triggers{ "triggers" };
     const std::string ViewOptions::Names::show_bounding_boxes { "show_bounding_boxes" };
     const std::string ViewOptions::Names::water{ "water" };
+    const std::string ViewOptions::Names::wireframe{ "wireframe" };
 
     namespace Colours
     {
@@ -58,6 +59,7 @@ namespace trview
         _depth->on_value_changed += on_depth_changed;
 
         _wireframe = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Wireframe"));
+        _wireframe->set_name(Names::wireframe);
         _wireframe->on_state_changed += on_show_wireframe;
 
         _bounding_boxes = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Bounds"));

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -10,7 +10,12 @@
 
 namespace trview
 {
+    const std::string ViewOptions::Names::hidden_geometry{ "hidden_geometry" };
+    const std::string ViewOptions::Names::highlight{ "highlight" };
+    const std::string ViewOptions::Names::depth_enabled{ "depth_enabled" };
+    const std::string ViewOptions::Names::triggers{ "triggers" };
     const std::string ViewOptions::Names::show_bounding_boxes { "show_bounding_boxes" };
+    const std::string ViewOptions::Names::water{ "water" };
 
     namespace Colours
     {
@@ -27,21 +32,26 @@ namespace trview
         auto rooms_grid = rooms_area->add_child(std::make_unique<Grid>(Size(150, 95), Colour::Transparent, 2, 4));
 
         _highlight = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Highlight"));
+        _highlight->set_name(Names::highlight);
         _highlight->on_state_changed += on_highlight;
 
         _triggers = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Triggers"));
+        _triggers->set_name(Names::triggers);
         _triggers->set_state(true);
         _triggers->on_state_changed += on_show_triggers;
 
         _hidden_geometry = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Geometry"));
+        _hidden_geometry->set_name(Names::hidden_geometry);
         _hidden_geometry->on_state_changed += on_show_hidden_geometry;
 
         _water = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Water"));
+        _water->set_name(Names::water);
         _water->set_state(true);
         _water->on_state_changed += on_show_water;
 
-        _enabled = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Depth"));
-        _enabled->on_state_changed += on_depth_enabled;
+        _depth_enabled = rooms_grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Depth"));
+        _depth_enabled->set_name(Names::depth_enabled);
+        _depth_enabled->on_state_changed += on_depth_enabled;
 
         _depth = rooms_grid->add_child(std::make_unique<NumericUpDown>(Size(50, 20), Colour::Transparent, texture_storage.lookup("numeric_up"), texture_storage.lookup("numeric_down"), 0, 20));
         _depth->set_value(1);
@@ -110,7 +120,7 @@ namespace trview
     
     void ViewOptions::set_depth_enabled(bool value)
     {
-        _enabled->set_state(value);
+        _depth_enabled->set_state(value);
     }
 
     void ViewOptions::set_flip(bool flip)

--- a/trview.app/UI/ViewOptions.h
+++ b/trview.app/UI/ViewOptions.h
@@ -25,7 +25,12 @@ namespace trview
     public:
         struct Names
         {
+            static const std::string depth_enabled;
+            static const std::string hidden_geometry;
+            static const std::string highlight;
+            static const std::string triggers;
             static const std::string show_bounding_boxes;
+            static const std::string water;
         };
 
         explicit ViewOptions(ui::Control& parent, const ITextureStorage& texture_storage);
@@ -55,7 +60,7 @@ namespace trview
         ui::Checkbox* _triggers;
         ui::Checkbox* _hidden_geometry;
         ui::Checkbox* _water;
-        ui::Checkbox* _enabled;
+        ui::Checkbox* _depth_enabled;
         ui::Checkbox* _wireframe;
         ui::Checkbox* _bounding_boxes;
         ui::NumericUpDown* _depth;

--- a/trview.app/UI/ViewOptions.h
+++ b/trview.app/UI/ViewOptions.h
@@ -31,6 +31,7 @@ namespace trview
             static const std::string triggers;
             static const std::string show_bounding_boxes;
             static const std::string water;
+            static const std::string wireframe;
         };
 
         explicit ViewOptions(ui::Control& parent, const ITextureStorage& texture_storage);

--- a/trview.app/UI/ViewOptions.h
+++ b/trview.app/UI/ViewOptions.h
@@ -26,6 +26,7 @@ namespace trview
         struct Names
         {
             static const std::string depth_enabled;
+            static const std::string flip;
             static const std::string hidden_geometry;
             static const std::string highlight;
             static const std::string triggers;

--- a/trview.app/UI/ViewOptions.h
+++ b/trview.app/UI/ViewOptions.h
@@ -33,6 +33,13 @@ namespace trview
             static const std::string show_bounding_boxes;
             static const std::string water;
             static const std::string wireframe;
+            static const std::string group;
+        };
+
+        struct Colours
+        {
+            static const Colour FlipOff;
+            static const Colour FlipOn;
         };
 
         explicit ViewOptions(ui::Control& parent, const ITextureStorage& texture_storage);

--- a/trview.ui/Button.cpp
+++ b/trview.ui/Button.cpp
@@ -137,5 +137,14 @@ namespace trview
             }
             return std::optional<Colour>();
         }
+
+        std::optional<Colour> Button::text_background_colour() const
+        {
+            if (_text)
+            {
+                return _text->background_colour();
+            }
+            return std::optional<Colour>();
+        }
     }
 }

--- a/trview.ui/Button.h
+++ b/trview.ui/Button.h
@@ -90,6 +90,11 @@ namespace trview
             /// @returns The text colour.
             std::optional<Colour> text_colour() const;
 
+            /// <summary>
+            /// Get the text background colour, if set.
+            /// </summary>
+            std::optional<Colour> text_background_colour() const;
+
             virtual bool mouse_down(const Point& position) override;
             virtual bool mouse_up(const Point& position) override;
             virtual void mouse_enter() override;

--- a/trview.ui/Checkbox.cpp
+++ b/trview.ui/Checkbox.cpp
@@ -66,10 +66,21 @@ namespace trview
 
         bool Checkbox::clicked(Point)
         {
+            if (!_enabled)
+            {
+                on_focus_clear_requested();
+                return true;
+            }
+
             set_state(!_state);
             on_state_changed(_state);
             on_focus_clear_requested();
             return true;
+        }
+
+        bool Checkbox::enabled() const
+        {
+            return _enabled;
         }
 
         // Gets whether the checkbox is currently checked.

--- a/trview.ui/Checkbox.h
+++ b/trview.ui/Checkbox.h
@@ -45,6 +45,11 @@ namespace trview
             /// The new state of the checkbox is passed as a paramter to the listener.
             Event<bool> on_state_changed;
 
+            /// <summary>
+            /// Gets whether this checkbox is enabled.
+            /// </summary>
+            bool enabled() const;
+
             /// Gets whether the checkbox is currently checked.
             /// @returns Whether the checkbox is currently checked.
             bool state() const;


### PR DESCRIPTION
Add missing tests for the `ViewOptions` class. Tests that all the checkboxes and buttons raise the correct events and are updated when the update functions are callled.
A couple of new functions are added to `Button` and `Checkbox` to help with testing.
Closes #819 