### PR TITLE
Add an option to create a Shortcuts instance for a specific window

### DIFF
--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -598,6 +598,15 @@ namespace trview
             di::bind<Window>.to(create_window(instance, command_show)),
             di::bind<IClipboard>.to<Clipboard>(),
             di::bind<IShortcuts>.to<Shortcuts>(),
+            di::bind<IShortcuts::Source>.to(
+                [](const auto& injector) -> IShortcuts::Source
+                {
+                    return [](auto&& window)
+                    {
+                        return std::make_shared<Shortcuts>(window);
+                    };
+                }
+            ),
             di::bind<IApplication>.to<Application>(),
             di::bind<IDialogs>.to<Dialogs>(),
             di::bind<IFiles>.to<Files>(),

--- a/trview.common/Windows/IShortcuts.h
+++ b/trview.common/Windows/IShortcuts.h
@@ -7,6 +7,8 @@ namespace trview
 {
     struct IShortcuts
     {
+        using Source = std::function<std::shared_ptr<IShortcuts>(const Window&)>;
+
         struct Shortcut
         {
             uint8_t flags;

--- a/trview.common/Windows/Shortcuts.cpp
+++ b/trview.common/Windows/Shortcuts.cpp
@@ -2,8 +2,10 @@
 
 namespace trview
 {
+    uint16_t Shortcuts::_command_index{ 41000 };
+
     Shortcuts::Shortcuts(const Window& window)
-        : MessageHandler(window), _command_index(41000), _accelerators(nullptr)
+        : MessageHandler(window), _accelerators(nullptr)
     {
     }
 

--- a/trview.common/Windows/Shortcuts.h
+++ b/trview.common/Windows/Shortcuts.h
@@ -21,6 +21,6 @@ namespace trview
 
         HACCEL _accelerators;
         std::vector<std::pair<Shortcut, Event<>>> _shortcuts;
-        uint16_t _command_index;
+        static uint16_t _command_index;
     };
 }

--- a/trview.ui/di.hpp
+++ b/trview.ui/di.hpp
@@ -16,13 +16,12 @@ namespace trview
                     {
                         return [&](auto&& window, auto&& control)
                         {
-                            auto mouse = injector.create<input::IMouse::Source>()(window);
                             return std::make_unique<Input>(
                                 window,
                                 control,
-                                injector.create<std::shared_ptr<IShortcuts>>(),
+                                injector.create<IShortcuts::Source>()(window),
                                 injector.create<std::shared_ptr<IClipboard>>(),
-                                mouse);
+                                injector.create<input::IMouse::Source>()(window));
                         };
                     })
             );


### PR DESCRIPTION
Most shortcuts can use the application window, but if it is a new window it has to has its own instance. This mainly affects input at the moment so it will create one when it makes a new input.
Make the command index static so that if more than one shortcuts instance happens to be made for the same window (this is the case for the input fields on the camera position) they don't clash with other shortcut commands.
Closes #824