### PR TITLE
Fix scrolling for text areas

### DIFF
--- a/trview.ui/Scrollbar.cpp
+++ b/trview.ui/Scrollbar.cpp
@@ -12,7 +12,7 @@ namespace trview
         Scrollbar::Scrollbar(const Point& position, const Size& size, const Colour& background_colour)
             : Window(position, size, background_colour)
         {
-            _blob = add_child(std::make_unique<Window>(Size(size.width, 10), Colour(1.0f, 0.15f, 0.15f, 0.15f)));
+            _blob = add_child(std::make_unique<Window>(Point(1, 1), Size(size.width - 2, 10), Colour(0.2f, 0.2f, 0.2f)));
         }
 
         void Scrollbar::set_range(float range_start, float range_end, float maximum)
@@ -28,10 +28,9 @@ namespace trview
             const float range = range_end_percentage - range_start_percentage;
             const auto current_size = size();
 
-            _blob->set_size(Size(current_size.width, range * current_size.height));
-
             const auto blob_height = range * current_size.height;
-            _blob->set_position(Point(0, range_start_percentage * current_size.height));
+            _blob->set_size(Size(current_size.width - 2, std::max(1.0f, blob_height - 2)));
+            _blob->set_position(Point(1, range_start_percentage * current_size.height + 1));
             _blob->set_visible(blob_height != current_size.height);
         }
 

--- a/trview.ui/TextArea.h
+++ b/trview.ui/TextArea.h
@@ -185,6 +185,7 @@ namespace trview
             bool _dragging{ false };
             bool _read_only{ false };
             int32_t _scroll_offset{ 0 };
+            bool _scroll_visible{ false };
         };
     }
 }


### PR DESCRIPTION
Don't allow the user to scroll if they can see all of the text in the current view.
Add a margin to the scrollbar blob so you can actually see which part is the blob and which part is the background.
Make scrollbar invisible when scrolling is not possible - it will come back when enough text is added.
Closes #818