### PR TITLE
Add import and improve export of Rando locations

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -379,7 +379,7 @@ TEST(Application, FileOpenOpensFile)
     auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
     EXPECT_CALL(level_loader, load_level).Times(1);
     auto dialogs = std::make_shared<MockDialogs>();
-    EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return("filename"));
+    EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename" }));
 
     auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_dialogs(dialogs).build();
     application->process_message(WM_COMMAND, MAKEWPARAM(ID_FILE_OPEN, 0), 0);
@@ -401,7 +401,7 @@ TEST(Application, FileOpenAcceleratorOpensFile)
     auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
     EXPECT_CALL(level_loader, load_level).Times(1);
     auto dialogs = std::make_shared<MockDialogs>();
-    EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return("filename"));
+    EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename" }));
 
     auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_dialogs(dialogs).build();
     application->process_message(WM_COMMAND, MAKEWPARAM(ID_ACCEL_FILE_OPEN, 0), 0);
@@ -451,7 +451,7 @@ TEST(Application, ImportRouteLoadsFile)
         .with_viewer(std::move(viewer_ptr))
         .with_files(files).build();
 
-    route_window_manager.on_route_import("filename");
+    route_window_manager.on_route_import("filename", false);
 }
 
 TEST(Application, WindowManagersUpdated)

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -223,7 +223,7 @@ TEST(RouteWindow, ClearSaveMarksRouteUnsaved)
 TEST(RouteWindow, ExportRouteButtonRaisesEvent)
 {
     auto dialogs = std::make_shared<MockDialogs>();
-    EXPECT_CALL(*dialogs, save_file).Times(1).WillRepeatedly(Return(IDialogs::SaveFileResult{ "filename", 0 }));
+    EXPECT_CALL(*dialogs, save_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename", 0 }));
 
     std::optional<std::string> file_raised;
     auto window = register_test_module().with_dialogs(dialogs).build();
@@ -262,11 +262,11 @@ TEST(RouteWindow, ExportRouteButtonDoesNotRaiseEventWhenCancelled)
 TEST(RouteWindow, ImportRouteButtonRaisesEvent)
 {
     auto dialogs = std::make_shared<MockDialogs>();
-    EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return("filename"));
+    EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename" }));
 
     std::optional<std::string> file_raised;
     auto window = register_test_module().with_dialogs(dialogs).build();
-    auto token = window->on_route_import += [&](const auto& filename)
+    auto token = window->on_route_import += [&](const auto& filename, bool is_rando)
     {
         file_raised = filename;
     };
@@ -287,7 +287,7 @@ TEST(RouteWindow, ImportRouteButtonDoesNotRaiseEventWhenCancelled)
 
     bool file_raised = false;
     auto window = register_test_module().with_dialogs(dialogs).build();
-    auto token = window->on_route_import += [&](const auto& filename)
+    auto token = window->on_route_import += [&](const auto& filename, bool is_rando)
     {
         file_raised = true;
     };
@@ -301,7 +301,7 @@ TEST(RouteWindow, ImportRouteButtonDoesNotRaiseEventWhenCancelled)
 TEST(RouteWindow, ExportSaveButtonSavesFile)
 {
     auto dialogs = std::make_shared<MockDialogs>();
-    EXPECT_CALL(*dialogs, save_file).Times(1).WillRepeatedly(Return(IDialogs::SaveFileResult{ "filename", 0 }));
+    EXPECT_CALL(*dialogs, save_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename", 0 }));
 
     auto files = std::make_shared<MockFiles>();
     EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::vector<uint8_t>&>())).Times(1);
@@ -326,7 +326,7 @@ TEST(RouteWindow, ExportSaveButtonSavesFile)
 TEST(RouteWindow, ExportSaveButtonShowsErrorOnFailure)
 {
     auto dialogs = std::make_shared<MockDialogs>();
-    EXPECT_CALL(*dialogs, save_file).Times(1).WillRepeatedly(Return(IDialogs::SaveFileResult{ "filename", 0 }));
+    EXPECT_CALL(*dialogs, save_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename", 0 }));
     EXPECT_CALL(*dialogs, message_box).Times(1);
 
     auto files = std::make_shared<MockFiles>();
@@ -375,7 +375,7 @@ TEST(RouteWindow, ExportSaveButtonDoesNotSaveFileWhenCancelled)
 TEST(RouteWindow, AttachSaveButtonLoadsSave)
 {
     auto dialogs = std::make_shared<MockDialogs>();
-    EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return("filename"));
+    EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename" }));
 
     auto files = std::make_shared<MockFiles>();
     EXPECT_CALL(*files, load_file).Times(1).WillRepeatedly(Return(std::vector<uint8_t>{ 0x1, 0x2 }));
@@ -400,7 +400,7 @@ TEST(RouteWindow, AttachSaveButtonLoadsSave)
 TEST(RouteWindow, AttachSaveButtonShowsMessageOnError)
 {
     auto dialogs = std::make_shared<MockDialogs>();
-    EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return("filename"));
+    EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename" }));
     EXPECT_CALL(*dialogs, message_box).Times(1);
 
     auto files = std::make_shared<MockFiles>();

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -494,28 +494,6 @@ TEST(RouteWindow, RequiresGlitchSetRouteUnsaved)
     requires_glitch->clicked(Point());
 }
 
-TEST(RouteWindow, IsInRoomSpaceSetsRouteUnsaved)
-{
-    MockWaypoint waypoint;
-    EXPECT_CALL(waypoint, is_in_room_space).Times(AtLeast(1)).WillRepeatedly(Return(false));
-    EXPECT_CALL(waypoint, type).WillRepeatedly(Return(IWaypoint::Type::RandoLocation));
-    EXPECT_CALL(waypoint, set_is_in_room_space(true)).Times(1);
-
-    MockRoute route;
-    EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
-    EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
-    EXPECT_CALL(route, set_unsaved(true)).Times(1);
-
-    auto window = register_test_module().build();
-    window->set_route(&route);
-
-    auto is_in_room_space = window->root_control()->find<ui::Checkbox>(RouteWindow::Names::is_in_room_space);
-    ASSERT_NE(is_in_room_space, nullptr);
-    ASSERT_TRUE(is_in_room_space->visible(true));
-
-    is_in_room_space->clicked(Point());
-}
-
 TEST(RouteWindow, VehicleRequiredSetsRouteUnsaved)
 {
     MockWaypoint waypoint;

--- a/trview.app.tests/Routing/WaypointTests.cpp
+++ b/trview.app.tests/Routing/WaypointTests.cpp
@@ -31,14 +31,6 @@ TEST(Waypoint, EmptySave)
     ASSERT_FALSE(waypoint.has_save());
 }
 
-TEST(Waypoint, IsInRoomSpace)
-{
-    Waypoint waypoint(std::make_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::RandoLocation, 0, Colour::Red);
-    ASSERT_TRUE(waypoint.is_in_room_space());
-    waypoint.set_is_in_room_space(false);
-    ASSERT_FALSE(waypoint.is_in_room_space());
-}
-
 TEST(Waypoint, IsItem)
 {
     Waypoint waypoint(std::make_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::RandoLocation, 0, Colour::Red);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -218,7 +218,7 @@ namespace trview
                         const auto filename = _dialogs->open_file(L"Open level", { { L"All Tomb Raider Files", { L"*.tr*", L"*.phd" } } }, OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST);
                         if (filename.has_value())
                         {
-                            open(filename.value());
+                            open(filename.value().filename);
                         }
                         break;
                     }
@@ -327,6 +327,7 @@ namespace trview
         {
             _settings = settings;
             _viewer->set_settings(_settings);
+            _route_window->set_randomizer_enabled(settings.randomizer_tools);
         };
         _viewer->set_settings(_settings);
 
@@ -388,9 +389,9 @@ namespace trview
         _token_store += _route_window->on_waypoint_selected += [&](auto index) { select_waypoint(index); };
         _token_store += _route_window->on_item_selected += [&](const auto& item) { select_item(item); };
         _token_store += _route_window->on_trigger_selected += [&](const auto& trigger) { select_trigger(trigger); };
-        _token_store += _route_window->on_route_import += [&](const std::string& path)
+        _token_store += _route_window->on_route_import += [&](const std::string& path, bool is_rando)
         {
-            auto route = import_route(_route_source, _files, path);
+            auto route = import_route(_route_source, _files, path, _level.get(), is_rando);
             if (route)
             {
                 _route = route;
@@ -409,6 +410,7 @@ namespace trview
             _route->set_colour(colour);
             _viewer->set_route(_route);
         };
+        _route_window->set_randomizer_enabled(_settings.randomizer_tools);
     }
 
     void Application::setup_shortcuts()

--- a/trview.app/Mocks/Routing/IWaypoint.h
+++ b/trview.app/Mocks/Routing/IWaypoint.h
@@ -15,14 +15,12 @@ namespace trview
             MOCK_METHOD(Type, type, (), (const, override));
             MOCK_METHOD(bool, has_save, (), (const, override));
             MOCK_METHOD(uint32_t, index, (), (const, override));
-            MOCK_METHOD(bool, is_in_room_space, (), (const, override));
             MOCK_METHOD(bool, is_item, (), (const, override));
             MOCK_METHOD(std::wstring, notes, (), (const, override));
             MOCK_METHOD(bool, requires_glitch, (), (const, override));
             MOCK_METHOD(uint32_t, room, (), (const, override));
             MOCK_METHOD(std::vector<uint8_t>, save_file, (), (const, override));
             MOCK_METHOD(void, set_difficulty, (const std::string&), (override));
-            MOCK_METHOD(void, set_is_in_room_space, (bool), (override));
             MOCK_METHOD(void, set_is_item, (bool), (override));
             MOCK_METHOD(void, set_notes, (const std::wstring&), (override));
             MOCK_METHOD(void, set_requires_glitch, (bool), (override));

--- a/trview.app/Mocks/Windows/IRouteWindow.h
+++ b/trview.app/Mocks/Windows/IRouteWindow.h
@@ -17,6 +17,7 @@ namespace trview
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(void, focus, (), (override));
             MOCK_METHOD(void, update, (float), (override));
+            MOCK_METHOD(void, set_randomizer_enabled, (bool), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRouteWindowManager.h
+++ b/trview.app/Mocks/Windows/IRouteWindowManager.h
@@ -17,6 +17,7 @@ namespace trview
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
             MOCK_METHOD(void, update, (float), (override));
+            MOCK_METHOD(void, set_randomizer_enabled, (bool), (override));
         };
     }
 }

--- a/trview.app/Routing/IWaypoint.h
+++ b/trview.app/Routing/IWaypoint.h
@@ -70,10 +70,6 @@ namespace trview
         /// </summary>
         virtual uint32_t index() const = 0;
         /// <summary>
-        /// Whether the Randomizer 'is in room space' flag is set.
-        /// </summary>
-        virtual bool is_in_room_space() const = 0;
-        /// <summary>
         /// Whether the Randomizer 'is item' flag is set.
         /// </summary>
         virtual bool is_item() const = 0;
@@ -106,11 +102,6 @@ namespace trview
         /// </summary>
         /// <param name="value">The new difficulty value.</param>
         virtual void set_difficulty(const std::string& value) = 0;
-        /// <summary>
-        /// Set the Randomizer 'is in room space' flag.
-        /// </summary>
-        /// <param name="value">The new flag value.</param>
-        virtual void set_is_in_room_space(bool value) = 0;
         /// <summary>
         /// Set the Randomizer 'is item' flag.
         /// </summary>

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -284,7 +284,6 @@ namespace trview
                 {
                     new_waypoint.set_requires_glitch(waypoint["RequiresGlitch"].get<bool>());
                     new_waypoint.set_difficulty(waypoint["Difficulty"].get<std::string>());
-                    new_waypoint.set_is_in_room_space(waypoint["IsInRoomSpace"].get<bool>());
                     new_waypoint.set_is_item(waypoint["IsItem"].get<bool>());
                     new_waypoint.set_vehicle_required(waypoint["VehicleRequired"].get<bool>());
                 }
@@ -339,10 +338,6 @@ namespace trview
                         {
                             waypoint_json["Difficulty"] = waypoint.difficulty();
                         }
-                        if (!waypoint.is_in_room_space())
-                        {
-                            waypoint_json["IsInRoomSpace"] = waypoint.is_in_room_space();
-                        }
                         if (waypoint.is_item())
                         {
                             waypoint_json["IsItem"] = waypoint.is_item();
@@ -394,7 +389,6 @@ namespace trview
                     {
                         waypoint_json["RequiresGlitch"] = waypoint.requires_glitch();
                         waypoint_json["Difficulty"] = waypoint.difficulty();
-                        waypoint_json["IsInRoomSpace"] = waypoint.is_in_room_space();
                         waypoint_json["IsItem"] = waypoint.is_item();
                         waypoint_json["VehicleRequired"] = waypoint.vehicle_required();
                     }

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -285,7 +285,20 @@ namespace trview
             route->add(Vector3(x, y, z) / 1024.0f, Vector3::Down, room_number, IWaypoint::Type::RandoLocation, 0);
             auto& new_waypoint = route->waypoint(route->waypoints() - 1);
             new_waypoint.set_requires_glitch(read_attribute<bool>(location, "RequiresGlitch", false));
-            new_waypoint.set_difficulty(read_attribute<std::string>(location, "Difficulty", "Easy"));
+            
+            if (location.count("Difficulty") > 0)
+            {
+                if (location["Difficulty"].is_number())
+                {
+                    int difficulty = read_attribute<int>(location, "Difficulty");
+                    new_waypoint.set_difficulty(difficulty == 0 ? "Easy" : difficulty == 1 ? "Medium" : "Hard");
+                }
+                else
+                {
+                    new_waypoint.set_difficulty(read_attribute<std::string>(location, "Difficulty", "Easy"));
+                }
+            }
+
             new_waypoint.set_is_item(read_attribute<bool>(location, "IsItem", false));
             new_waypoint.set_vehicle_required(read_attribute<bool>(location, "VehicleRequired", false));
         }
@@ -351,8 +364,9 @@ namespace trview
             
             return import_trview_route(route_source, data.value());
         }
-        catch (std::exception&)
+        catch (std::exception& e)
         {
+            MessageBoxA(0, e.what(), "Error", MB_OK);
             return nullptr;
         }
     }

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -266,8 +266,8 @@ namespace trview
             int z = location["Z"];
             int room_number = location["Room"];
 
-            // If the room space attribute is missing or it is true then the coordinate must be transformed.
-            if (location.count("IsInRoomSpace") == 0 || read_attribute<bool>(location, "IsInRoomSpace"))
+            // If the room space attribute is true then the coordinate must be transformed.
+            if (read_attribute<bool>(location, "IsInRoomSpace", false))
             {
                 if (room_number >= level->number_of_rooms())
                 {
@@ -406,8 +406,8 @@ namespace trview
             {
                 auto pos = waypoint.position();
                 waypoint_json["X"] = static_cast<int>(pos.x * 1024);
-                waypoint_json["Y"] = static_cast<int>(pos.y * 1024);
                 waypoint_json["Z"] = static_cast<int>(pos.z * 1024);
+                waypoint_json["Y"] = static_cast<int>(pos.y * 1024);
                 waypoint_json["Room"] = waypoint.room();
                 if (waypoint.requires_glitch())
                 {
@@ -425,7 +425,6 @@ namespace trview
                 {
                     waypoint_json["VehicleRequired"] = waypoint.vehicle_required();
                 }
-                waypoint_json["IsInRoomSpace"] = false;
 
                 waypoints.push_back(waypoint_json);
             }

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -285,7 +285,7 @@ namespace trview
             route->add(Vector3(x, y, z) / 1024.0f, Vector3::Down, room_number, IWaypoint::Type::RandoLocation, 0);
             auto& new_waypoint = route->waypoint(route->waypoints() - 1);
             new_waypoint.set_requires_glitch(read_attribute<bool>(location, "RequiresGlitch", false));
-            
+
             if (location.count("Difficulty") > 0)
             {
                 if (location["Difficulty"].is_number())

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -408,8 +408,8 @@ namespace trview
             {
                 auto pos = waypoint.position();
                 waypoint_json["X"] = static_cast<int>(pos.x * 1024);
-                waypoint_json["Z"] = static_cast<int>(pos.z * 1024);
                 waypoint_json["Y"] = static_cast<int>(pos.y * 1024);
+                waypoint_json["Z"] = static_cast<int>(pos.z * 1024);
                 waypoint_json["Room"] = waypoint.room();
                 if (waypoint.requires_glitch())
                 {
@@ -434,7 +434,7 @@ namespace trview
 
         auto trimmed = level_filename.substr(level_filename.find_last_of("/\\") + 1);
         json[trimmed] = waypoints;
-        files->save_file(route_filename, json.dump(1, '\t'));
+        files->save_file(route_filename, json.dump(2, ' '));
     }
 
     void export_trview_route(const IRoute& route, std::shared_ptr<IFiles>& files, const std::string& route_filename)

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -181,7 +181,9 @@ namespace trview
             auto& waypoint = _waypoints[i];
             waypoint->render(camera, texture_storage, Color(1.0f, 1.0f, 1.0f));
 
-            if (i < _waypoints.size() - 1)
+            if (waypoint->type() != IWaypoint::Type::RandoLocation &&
+                i < _waypoints.size() - 1 &&
+                _waypoints[i + 1]->type() != IWaypoint::Type::RandoLocation)
             {
                 waypoint->render_join(*_waypoints[i + 1], camera, texture_storage, _colour);
             }

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -357,9 +357,31 @@ namespace trview
         }
     }
 
+    nlohmann::ordered_json try_load_route(std::shared_ptr<IFiles>& files, const std::string& route_filename)
+    {
+        try
+        {
+            auto data = files->load_file(route_filename);
+            if (!data.has_value())
+            {
+                return nlohmann::ordered_json();
+            }
+
+            const auto data_bytes = data.value();
+            return nlohmann::ordered_json::parse(data_bytes.begin(), data_bytes.end());
+        }
+        catch(...)
+        {
+        }
+        
+        return nlohmann::ordered_json();
+    }
+
     void export_randomizer_route(const IRoute& route, std::shared_ptr<IFiles>& files, const std::string& route_filename, const std::string& level_filename)
     {
-        nlohmann::ordered_json json;
+        // Try to load the existing route
+        nlohmann::ordered_json json = try_load_route(files, route_filename);
+
         std::vector<nlohmann::ordered_json> waypoints;
         for (uint32_t i = 0; i < route.waypoints(); ++i)
         {

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -8,6 +8,8 @@
 
 namespace trview
 {
+    struct ILevel;
+
     /// A series of waypoints.
     class Route final : public IRoute
     {
@@ -45,6 +47,6 @@ namespace trview
         bool _is_unsaved{ false };
     };
 
-    std::shared_ptr<IRoute> import_route(const IRoute::Source& route_source, const std::shared_ptr<IFiles>& files, const std::string& filename);
+    std::shared_ptr<IRoute> import_route(const IRoute::Source& route_source, const std::shared_ptr<IFiles>& files, const std::string& route_filename, const ILevel* const level, bool rando_import);
     void export_route(const IRoute& route, std::shared_ptr<IFiles>& files, const std::string& route_filename, const std::string& level_filename, bool rando_export);
 }

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -152,11 +152,6 @@ namespace trview
         return _difficulty;
     }
 
-    bool Waypoint::is_in_room_space() const
-    {
-        return _is_in_room_space;
-    }
-
     bool Waypoint::is_item() const
     {
         return _is_item;
@@ -175,11 +170,6 @@ namespace trview
     void Waypoint::set_difficulty(const std::string& value)
     {
         _difficulty = value;
-    }
-
-    void Waypoint::set_is_in_room_space(bool value)
-    {
-        _is_in_room_space = value;
     }
 
     void Waypoint::set_is_item(bool value)

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -32,14 +32,12 @@ namespace trview
         virtual Type type() const override;
         virtual bool has_save() const override;
         virtual uint32_t index() const override;
-        virtual bool is_in_room_space() const override;
         virtual bool is_item() const override;
         virtual std::wstring notes() const override;
         virtual uint32_t room() const override;
         virtual bool requires_glitch() const override;
         virtual std::vector<uint8_t> save_file() const override;
         virtual void set_difficulty(const std::string& value) override;
-        virtual void set_is_in_room_space(bool value) override;
         virtual void set_is_item(bool value) override;
         virtual void set_notes(const std::wstring& notes) override;
         virtual void set_requires_glitch(bool value) override;
@@ -66,7 +64,6 @@ namespace trview
         bool _visible{ true };
         bool _requires_glitch{ false };
         bool _vehicle_required{ false };
-        bool _is_in_room_space{ true };
         bool _is_item{ false };
         std::string _difficulty{ "Easy" };
     };    

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -27,7 +27,7 @@ namespace trview
         Event<Colour> on_colour_changed;
 
         /// Event raised when a route file is opened.
-        Event<std::string> on_route_import;
+        Event<std::string, bool> on_route_import;
 
         /// Event raised when a route is exported.
         Event<std::string, bool> on_route_export;
@@ -66,6 +66,11 @@ namespace trview
         /// </summary>
         /// <param name="delta">Elapsed time since previous update.</param>
         virtual void update(float delta) = 0;
+        /// <summary>
+        /// Set whether randomizer integration is enabled.
+        /// </summary>
+        /// <param name="value">Whether randomizer integration is enabled.</param>
+        virtual void set_randomizer_enabled(bool value) = 0;
     };
 }
 

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -13,7 +13,7 @@ namespace trview
         Event<Colour> on_colour_changed;
 
         /// Event raised when a route is imported.
-        Event<std::string> on_route_import;
+        Event<std::string, bool> on_route_import;
 
         /// Event raised when a route is exported.
         Event<std::string, bool> on_route_export;
@@ -57,5 +57,10 @@ namespace trview
         /// </summary>
         /// <param name="delta">Elapsed time since previous update.</param>
         virtual void update(float delta) = 0;
+        /// <summary>
+        /// Set whether randomizer integration is enabled.
+        /// </summary>
+        /// <param name="value">Whether randomizer integration is enabled.</param>
+        virtual void set_randomizer_enabled(bool value) = 0;
     };
 }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -35,7 +35,6 @@ namespace trview
     const std::string RouteWindow::Names::select_save_button = "select_save_button";
     const std::string RouteWindow::Names::waypoint_stats = "waypoint_stats";
     const std::string RouteWindow::Names::requires_glitch = "requires_glitch";
-    const std::string RouteWindow::Names::is_in_room_space = "is_in_room_space";
     const std::string RouteWindow::Names::vehicle_required = "vehicle_required";
     const std::string RouteWindow::Names::is_item = "is_item";
     const std::string RouteWindow::Names::difficulty = "difficulty";
@@ -343,16 +342,6 @@ namespace trview
                 _route->set_unsaved(true);
             }
         };
-        _is_in_room_space = grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Is In Room Space"));
-        _is_in_room_space->set_name(Names::is_in_room_space);
-        _token_store += _is_in_room_space->on_state_changed += [&](bool state)
-        {
-            if (_route && _selected_index < _route->waypoints())
-            {
-                _route->waypoint(_selected_index).set_is_in_room_space(state);
-                _route->set_unsaved(true);
-            }
-        };
         _vehicle_required = grid->add_child(std::make_unique<Checkbox>(Colour::Transparent, L"Vehicle Required"));
         _vehicle_required->set_name(Names::vehicle_required);
         _token_store += _vehicle_required->on_state_changed += [&](bool state)
@@ -502,7 +491,6 @@ namespace trview
 
             _requires_glitch->set_state(waypoint.requires_glitch());
             _difficulty->set_selected_value(to_utf16(waypoint.difficulty()));
-            _is_in_room_space->set_state(waypoint.is_in_room_space());
             _vehicle_required->set_state(waypoint.vehicle_required());
             _is_item->set_state(waypoint.is_item());
         }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -26,6 +26,18 @@ namespace trview
         {
             return Listbox::Item{ { { L"Name", name }, { L"Value", value } } };
         };
+
+        bool has_randomizer_elements(const IRoute& route)
+        {
+            for (uint32_t i = 0u; i < route.waypoints(); ++i)
+            {
+                if (route.waypoint(i).type() == IWaypoint::Type::RandoLocation)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     const std::string RouteWindow::Names::export_button = "export_button";
@@ -139,12 +151,17 @@ namespace trview
         _token_store += export_button->on_click += [&]()
         {
             std::vector<IDialogs::FileFilter> filters { { L"trview route", { L"*.tvr" } } };
+            uint32_t filter_index = 1;
             if (_randomizer_enabled)
             {
                 filters.push_back({ L"Randomizer Locations", { L"*.json" } });
+                if (has_randomizer_elements(*_route))
+                {
+                    filter_index = 2;
+                }
             }
 
-            const auto filename = _dialogs->save_file(L"Export route", filters);
+            const auto filename = _dialogs->save_file(L"Export route", filters, filter_index);
             if (filename.has_value())
             {
                 on_route_export(filename.value().filename, filename.value().filter_index == 2);
@@ -260,7 +277,7 @@ namespace trview
             }
             else
             {
-                const auto filename = _dialogs->save_file(L"Export Save", { { L"Savegame File", { L"*.*" } } });
+                const auto filename = _dialogs->save_file(L"Export Save", { { L"Savegame File", { L"*.*" } } }, 1);
                 if (filename.has_value())
                 {
                     try

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -54,12 +54,12 @@ namespace trview
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void focus() override;
         virtual void update(float delta) override;
+        virtual void set_randomizer_enabled(bool value) override;
     private:
         void load_waypoint_details(uint32_t index);
         std::unique_ptr<ui::Control> create_left_panel();
         std::unique_ptr<ui::Control> create_right_panel();
         ui::Listbox::Item create_listbox_item(uint32_t index, const IWaypoint& waypoint);
-        bool has_randomizer_elements() const;
 
         ui::Dropdown* _colour;
         ui::Listbox* _waypoints;
@@ -86,5 +86,6 @@ namespace trview
         ui::Checkbox* _vehicle_required;
         ui::Checkbox* _is_item;
         ui::Dropdown* _difficulty;
+        bool _randomizer_enabled{ false };
     };
 }

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -33,7 +33,6 @@ namespace trview
             static const std::string select_save_button;
             static const std::string waypoint_stats;
             static const std::string requires_glitch;
-            static const std::string is_in_room_space;
             static const std::string vehicle_required;
             static const std::string is_item;
             static const std::string difficulty;
@@ -84,7 +83,6 @@ namespace trview
         // Randomizer settings:
         ui::Window* _rando_area;
         ui::Checkbox* _requires_glitch;
-        ui::Checkbox* _is_in_room_space;
         ui::Checkbox* _vehicle_required;
         ui::Checkbox* _is_item;
         ui::Dropdown* _difficulty;

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -46,6 +46,7 @@ namespace trview
             _route_window->set_route(_route);
         }
         _route_window->select_waypoint(_selected_waypoint);
+        _route_window->set_randomizer_enabled(_randomizer_enabled);
     }
 
     void RouteWindowManager::render(bool vsync)
@@ -114,6 +115,15 @@ namespace trview
         if (_route_window)
         {
             _route_window->update(delta);
+        }
+    }
+
+    void RouteWindowManager::set_randomizer_enabled(bool value)
+    {
+        _randomizer_enabled = value;
+        if (_route_window)
+        {
+            _route_window->set_randomizer_enabled(value);
         }
     }
 }

--- a/trview.app/Windows/RouteWindowManager.h
+++ b/trview.app/Windows/RouteWindowManager.h
@@ -22,6 +22,7 @@ namespace trview
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void select_waypoint(uint32_t index) override;
         virtual void update(float delta) override;
+        virtual void set_randomizer_enabled(bool value) override;
     private:
         TokenStore _token_store;
         std::shared_ptr<IRouteWindow> _route_window;
@@ -32,5 +33,6 @@ namespace trview
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;
         uint32_t _selected_waypoint{ 0u };
         IRouteWindow::Source _route_window_source;
+        bool _randomizer_enabled{ false };
     };
 }

--- a/trview.common/Json.h
+++ b/trview.common/Json.h
@@ -11,6 +11,9 @@ namespace trview
     T read_attribute(const nlohmann::json& json, const std::string& attribute_name);
 
     template <typename T>
+    T read_attribute(const nlohmann::json& json, const std::string& attribute_name, const T& default_value);
+
+    template <typename T>
     void read_attribute(const nlohmann::json& json, T& destination, const std::string& attribute_name);
 }
 

--- a/trview.common/Json.hpp
+++ b/trview.common/Json.hpp
@@ -13,6 +13,16 @@ namespace trview
     }
 
     template <typename T>
+    T read_attribute(const nlohmann::json& json, const std::string& attribute_name, const T& default_value)
+    {
+        if (json.count(attribute_name) != 0)
+        {
+            return json[attribute_name].get<T>();
+        }
+        return default_value;
+    }
+
+    template <typename T>
     void read_attribute(const nlohmann::json& json, T& destination, const std::string& attribute_name)
     {
         if (json.count(attribute_name) != 0)

--- a/trview.common/Mocks/Windows/IDialogs.h
+++ b/trview.common/Mocks/Windows/IDialogs.h
@@ -11,7 +11,7 @@ namespace trview
             virtual ~MockDialogs() = default;
             MOCK_METHOD(bool, message_box, (const Window&, const std::wstring&, const std::wstring&, Buttons), (const, override));
             MOCK_METHOD(std::optional<FileResult>, open_file, (const std::wstring&, const std::vector<FileFilter>&, uint32_t), (const, override));
-            MOCK_METHOD(std::optional<FileResult>, save_file, (const std::wstring&, const std::vector<FileFilter>&), (const, override));
+            MOCK_METHOD(std::optional<FileResult>, save_file, (const std::wstring&, const std::vector<FileFilter>&, uint32_t), (const, override));
         };
     }
 }

--- a/trview.common/Mocks/Windows/IDialogs.h
+++ b/trview.common/Mocks/Windows/IDialogs.h
@@ -10,8 +10,8 @@ namespace trview
         {
             virtual ~MockDialogs() = default;
             MOCK_METHOD(bool, message_box, (const Window&, const std::wstring&, const std::wstring&, Buttons), (const, override));
-            MOCK_METHOD(std::optional<std::string>, open_file, (const std::wstring&, const std::vector<FileFilter>&, uint32_t), (const, override));
-            MOCK_METHOD(std::optional<SaveFileResult>, save_file, (const std::wstring&, const std::vector<FileFilter>&), (const, override));
+            MOCK_METHOD(std::optional<FileResult>, open_file, (const std::wstring&, const std::vector<FileFilter>&, uint32_t), (const, override));
+            MOCK_METHOD(std::optional<FileResult>, save_file, (const std::wstring&, const std::vector<FileFilter>&), (const, override));
         };
     }
 }

--- a/trview.common/Windows/Dialogs.cpp
+++ b/trview.common/Windows/Dialogs.cpp
@@ -90,7 +90,7 @@ namespace trview
         return {};
     }
 
-    std::optional<IDialogs::FileResult> Dialogs::save_file(const std::wstring& title, const std::vector<FileFilter>& filters) const
+    std::optional<IDialogs::FileResult> Dialogs::save_file(const std::wstring& title, const std::vector<FileFilter>& filters, uint32_t filter_index) const
     {
         OPENFILENAME ofn;
         memset(&ofn, 0, sizeof(ofn));
@@ -106,6 +106,7 @@ namespace trview
         ofn.lpstrTitle = title.c_str();
         ofn.lpstrFile = path;
         ofn.lpstrDefExt = L"0";
+        ofn.nFilterIndex = filter_index;
 
         if (GetSaveFileName(&ofn))
         {

--- a/trview.common/Windows/Dialogs.cpp
+++ b/trview.common/Windows/Dialogs.cpp
@@ -66,7 +66,7 @@ namespace trview
         return convert_response(MessageBox(window, message.c_str(), title.c_str(), convert_button(buttons)));
     }
 
-    std::optional<std::string> Dialogs::open_file(const std::wstring& title, const std::vector<FileFilter>& filters, uint32_t flags) const
+    std::optional<IDialogs::FileResult> Dialogs::open_file(const std::wstring& title, const std::vector<FileFilter>& filters, uint32_t flags) const
     {
         OPENFILENAME ofn;
         memset(&ofn, 0, sizeof(ofn));
@@ -85,12 +85,12 @@ namespace trview
 
         if (GetOpenFileName(&ofn))
         {
-            return to_utf8(ofn.lpstrFile);
+            return IDialogs::FileResult{ trview::to_utf8(ofn.lpstrFile), static_cast<int>(ofn.nFilterIndex) };
         }
         return {};
     }
 
-    std::optional<IDialogs::SaveFileResult> Dialogs::save_file(const std::wstring& title, const std::vector<FileFilter>& filters) const
+    std::optional<IDialogs::FileResult> Dialogs::save_file(const std::wstring& title, const std::vector<FileFilter>& filters) const
     {
         OPENFILENAME ofn;
         memset(&ofn, 0, sizeof(ofn));
@@ -109,7 +109,7 @@ namespace trview
 
         if (GetSaveFileName(&ofn))
         {
-            return IDialogs::SaveFileResult { trview::to_utf8(ofn.lpstrFile), static_cast<int>(ofn.nFilterIndex) };
+            return IDialogs::FileResult{ trview::to_utf8(ofn.lpstrFile), static_cast<int>(ofn.nFilterIndex) };
         }
         return {};
     }

--- a/trview.common/Windows/Dialogs.h
+++ b/trview.common/Windows/Dialogs.h
@@ -10,6 +10,6 @@ namespace trview
         virtual ~Dialogs() = default;
         virtual bool message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons) const override;
         virtual std::optional<FileResult> open_file(const std::wstring& title, const std::vector<FileFilter>& filters, uint32_t flags) const override;
-        virtual std::optional<FileResult> save_file(const std::wstring& title, const std::vector<FileFilter>& filters) const override;
+        virtual std::optional<FileResult> save_file(const std::wstring& title, const std::vector<FileFilter>& filters, uint32_t filter_index) const override;
     };
 }

--- a/trview.common/Windows/Dialogs.h
+++ b/trview.common/Windows/Dialogs.h
@@ -9,7 +9,7 @@ namespace trview
     public:
         virtual ~Dialogs() = default;
         virtual bool message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons) const override;
-        virtual std::optional<std::string> open_file(const std::wstring& title, const std::vector<FileFilter>& filters, uint32_t flags) const override;
-        virtual std::optional<SaveFileResult> save_file(const std::wstring& title, const std::vector<FileFilter>& filters) const override;
+        virtual std::optional<FileResult> open_file(const std::wstring& title, const std::vector<FileFilter>& filters, uint32_t flags) const override;
+        virtual std::optional<FileResult> save_file(const std::wstring& title, const std::vector<FileFilter>& filters) const override;
     };
 }

--- a/trview.common/Windows/IDialogs.h
+++ b/trview.common/Windows/IDialogs.h
@@ -51,7 +51,8 @@ namespace trview
         /// </summary>
         /// <param name="title">The title of the dialog box.</param>
         /// <param name="filters">The file filters to apply.</param>
+        /// <param name="filter_index">The file filter to select by default.</param>
         /// <returns>The save file result if one was selected or an empty optional.</returns>
-        virtual std::optional<FileResult> save_file(const std::wstring& title, const std::vector<FileFilter>& filters) const = 0;
+        virtual std::optional<FileResult> save_file(const std::wstring& title, const std::vector<FileFilter>& filters, uint32_t filter_index) const = 0;
     };
 }

--- a/trview.common/Windows/IDialogs.h
+++ b/trview.common/Windows/IDialogs.h
@@ -16,7 +16,7 @@ namespace trview
             Yes_No
         };
 
-        struct SaveFileResult
+        struct FileResult
         {
             std::string filename;
             int filter_index;
@@ -44,14 +44,14 @@ namespace trview
         /// <param name="title">The title of the dialog box.</param>
         /// <param name="filters">The filters to use.</param>
         /// <param name="flags">The flags for the dialog.</param>
-        /// <returns>The filename if one was selected or an empty optional.</returns>
-        virtual std::optional<std::string> open_file(const std::wstring& title, const std::vector<FileFilter>& filters, uint32_t flags) const = 0;
+        /// <returns>The open file result if one was selected or an empty optional.</returns>
+        virtual std::optional<FileResult> open_file(const std::wstring& title, const std::vector<FileFilter>& filters, uint32_t flags) const = 0;
         /// <summary>
         /// Prompt the user to select a file to save.
         /// </summary>
         /// <param name="title">The title of the dialog box.</param>
         /// <param name="filters">The file filters to apply.</param>
         /// <returns>The save file result if one was selected or an empty optional.</returns>
-        virtual std::optional<SaveFileResult> save_file(const std::wstring& title, const std::vector<FileFilter>& filters) const = 0;
+        virtual std::optional<FileResult> save_file(const std::wstring& title, const std::vector<FileFilter>& filters) const = 0;
     };
 }


### PR DESCRIPTION
Allow importing of Randomizer locations from the locations files that Randomizer uses. It will look for the element that matches the filename of the current level and then load those waypoints.
On export trview will either update the element matching the current level filename in an existing locations file or create a new one and write it there.
Removed the 'Is in Room Space' option the route window for Rando locations as it is only used for support with another tool and the default has now be changed to be false. TRView will always export coordinates in world space.
Closes #843