### PR TITLE
Add a tooltip for the items window for OCB and Clear Body

### DIFF
--- a/trview.app/UI/Bubble.cpp
+++ b/trview.app/UI/Bubble.cpp
@@ -5,17 +5,12 @@ using namespace trview::graphics;
 
 namespace trview
 {
-    namespace
-    {
-        const Colour Background{ Colour::Grey };
-    }
-
     const float Bubble::FadeTime{ 0.66666666666666666666666666666667f };
     const std::string Bubble::Names::Bubble{ "Bubble" };
 
     Bubble::Bubble(Control& control)
     {
-        _label = control.add_child(std::make_unique<Label>(Size(40, 20), Background, L"Copied", 8, TextAlignment::Centre, ParagraphAlignment::Centre));
+        _label = control.add_child(std::make_unique<Label>(Size(40, 20), Colour::Grey, L"Copied", 8, TextAlignment::Centre, ParagraphAlignment::Centre));
         _label->set_name(Names::Bubble);
         _label->set_visible(false);
         _label->set_z(-1);
@@ -45,7 +40,7 @@ namespace trview
     void Bubble::show(const Point& position)
     {
         _label->set_position(position - Point(_label->size().width * 0.5f, 0));
-        _label->set_background_colour(Background);
+        _label->set_background_colour(Colour::Grey);
         _label->set_text_colour(Colour::White);
         _label->set_visible(true);
     }

--- a/trview.app/UI/Tooltip.cpp
+++ b/trview.app/UI/Tooltip.cpp
@@ -8,18 +8,17 @@ namespace trview
 {
     Tooltip::Tooltip(ui::Control& control)
     {
-        auto container = std::make_unique<ui::Window>(Size(), Colour(0.5f, 0.0f, 0.0f, 0.0f));
+        _container = control.add_child(std::make_unique<ui::Window>(Size(), Colour(0.5f, 0.0f, 0.0f, 0.0f)));
         auto layout = std::make_unique<StackLayout>();
         layout->set_margin(Size(5, 5));
-        container->set_layout(std::move(layout));
-        container->set_visible(false);
-        container->set_handles_input(false);
 
-        auto label = std::make_unique<ui::Label>(Point(500, 0), Size(38, 30), Colour::Transparent, L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre, SizeMode::Auto);
-        label->set_handles_input(false);
+        _container->set_layout(std::move(layout));
+        _container->set_visible(false);
+        _container->set_handles_input(false);
+        _container->set_z(-1);
 
-        _label = container->add_child(std::move(label));
-        _container = control.add_child(std::move(container));
+        _label = _container->add_child(std::make_unique<ui::Label>(Point(500, 0), Size(38, 30), Colour::Transparent, L"0", 8, graphics::TextAlignment::Centre, graphics::ParagraphAlignment::Centre, SizeMode::Auto));
+        _label->set_handles_input(false);
     }
 
     void Tooltip::set_position(const Point& position)

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -328,11 +328,6 @@ namespace trview
                     _tooltip->set_text(tip);
                 };
 
-                _token_store += cell->on_mouse_move += [this, cell]()
-                {
-                    _tooltip->set_position(client_cursor_position(window()) + Point(0, 20));
-                };
-
                 _token_store += cell->on_mouse_leave += [this, cell]()
                 {
                     _tooltip_timer.reset();

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -34,7 +34,7 @@ namespace trview
     ItemsWindow::ItemsWindow(const IDeviceWindow::Source& device_window_source, const ui::render::IRenderer::Source& renderer_source, const ui::IInput::Source& input_source, const Window& parent,
         const std::shared_ptr<IClipboard>& clipboard, const IBubble::Source& bubble_source, const std::shared_ptr<ui::ILoader>& ui_source)
         : CollapsiblePanel(device_window_source, renderer_source(Size(450, Height)), parent, L"trview.items", L"Items", input_source, Size(450, Height)), _clipboard(clipboard),
-        _bubble(bubble_source(*_ui))
+        _bubble(bubble_source(*_ui)), _tooltip(std::make_unique<Tooltip>(*_ui))
     {
         CollapsiblePanel::on_window_closed += IItemsWindow::on_window_closed;
         set_panels(create_left_panel(*ui_source), create_right_panel(*ui_source));
@@ -207,6 +207,8 @@ namespace trview
         stats.push_back(make_item(L"OCB", std::to_wstring(item.ocb())));
         _stats_list->set_items(stats);
 
+        bind_tooltip();
+
         std::vector<Listbox::Item> triggers;
         for (auto& trigger : item.triggers())
         {
@@ -291,5 +293,26 @@ namespace trview
     void ItemsWindow::update(float delta)
     {
         _ui->update(delta);
+    }
+
+    void ItemsWindow::bind_tooltip()
+    {
+        using namespace ui;
+
+        const auto items = _stats_list->items();
+        for (uint32_t i = 0; i < items.size(); ++i)
+        {
+            auto row = _stats_list->find<Listbox::Row>(Listbox::Names::row_name_format + std::to_string(i));
+            auto cell = row->find<Button>(Listbox::Row::Names::cell_name_format + "Name");
+            if (cell->text() == L"OCB")
+            {
+                _token_store += cell->on_click += [this, cell]()
+                {
+                    _tooltip->set_position(cell->absolute_position());
+                    _tooltip->set_text(L"OCB is a number");
+                    _tooltip->set_visible(true);
+                };
+            }
+        }
     }
 }

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -328,6 +328,11 @@ namespace trview
                     _tooltip->set_text(tip);
                 };
 
+                _token_store += cell->on_mouse_move += [this, cell]()
+                {
+                    _tooltip->set_position(client_cursor_position(window()) + Point(0, 20));
+                };
+
                 _token_store += cell->on_mouse_leave += [this, cell]()
                 {
                     _tooltip_timer.reset();

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -36,6 +36,9 @@ namespace trview
         : CollapsiblePanel(device_window_source, renderer_source(Size(450, Height)), parent, L"trview.items", L"Items", input_source, Size(450, Height)), _clipboard(clipboard),
         _bubble(bubble_source(*_ui)), _tooltip(std::make_unique<Tooltip>(*_ui))
     {
+        _tips[L"OCB"] = L"Changes entity behaviour";
+        _tips[L"Clear Body"] = L"Removed when Bodybag is triggered";
+
         CollapsiblePanel::on_window_closed += IItemsWindow::on_window_closed;
         set_panels(create_left_panel(*ui_source), create_right_panel(*ui_source));
     }
@@ -293,6 +296,16 @@ namespace trview
     void ItemsWindow::update(float delta)
     {
         _ui->update(delta);
+
+        if (_tooltip_timer.has_value())
+        {
+            _tooltip_timer = _tooltip_timer.value() + delta;
+            if (_tooltip_timer.value() > 0.6f)
+            {
+                _tooltip->set_visible(true);
+                _tooltip_timer.reset();
+            }
+        }
     }
 
     void ItemsWindow::bind_tooltip()
@@ -302,15 +315,28 @@ namespace trview
         const auto items = _stats_list->items();
         for (uint32_t i = 0; i < items.size(); ++i)
         {
-            auto row = _stats_list->find<Listbox::Row>(Listbox::Names::row_name_format + std::to_string(i));
-            auto cell = row->find<Button>(Listbox::Row::Names::cell_name_format + "Name");
-            if (cell->text() == L"OCB")
+            const auto row = _stats_list->find<Listbox::Row>(Listbox::Names::row_name_format + std::to_string(i));
+            const auto cell = row->find<Button>(Listbox::Row::Names::cell_name_format + "Name");
+            const auto found = _tips.find(cell->text());
+            if (found != _tips.end())
             {
-                _token_store += cell->on_click += [this, cell]()
+                const auto tip = found->second;
+                _token_store += cell->on_mouse_enter += [this, tip]()
                 {
-                    _tooltip->set_position(cell->absolute_position());
-                    _tooltip->set_text(L"OCB is a number");
-                    _tooltip->set_visible(true);
+                    _tooltip_timer = 0.0f;
+                    _tooltip->set_position(client_cursor_position(window()) + Point(0, 20));
+                    _tooltip->set_text(tip);
+                };
+
+                _token_store += cell->on_mouse_move += [this, cell]()
+                {
+                    _tooltip->set_position(client_cursor_position(window()) + Point(0, 20));
+                };
+
+                _token_store += cell->on_mouse_leave += [this, cell]()
+                {
+                    _tooltip_timer.reset();
+                    _tooltip->set_visible(false);
                 };
             }
         }

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -84,5 +84,8 @@ namespace trview
         std::shared_ptr<IClipboard> _clipboard;
         std::unique_ptr<IBubble> _bubble;
         std::unique_ptr<Tooltip> _tooltip;
+
+        std::unordered_map<std::wstring, std::wstring> _tips;
+        std::optional<float> _tooltip_timer;
     };
 }

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -10,6 +10,7 @@
 #include <trview.common/Windows/IClipboard.h>
 #include <trview.app/UI/IBubble.h>
 #include <trview.ui/ILoader.h>
+#include <trview.app/UI/Tooltip.h>
 
 namespace trview
 {
@@ -64,6 +65,7 @@ namespace trview
         void set_sync_item(bool value);
         std::unique_ptr<ui::Control> create_left_panel(const ui::ILoader& ui_source);
         std::unique_ptr<ui::Control> create_right_panel(const ui::ILoader& ui_source);
+        void bind_tooltip();
 
         ui::Listbox* _items_list;
         ui::Listbox* _stats_list;
@@ -81,5 +83,6 @@ namespace trview
         std::optional<Item> _selected_item;
         std::shared_ptr<IClipboard> _clipboard;
         std::unique_ptr<IBubble> _bubble;
+        std::unique_ptr<Tooltip> _tooltip;
     };
 }

--- a/trview.ui/Button.cpp
+++ b/trview.ui/Button.cpp
@@ -47,6 +47,7 @@ namespace trview
 
         void Button::mouse_enter()
         {
+            Control::mouse_enter();
             if (_text)
             {
                 // Store the old background colour so that if the background has been changed by a call
@@ -58,6 +59,7 @@ namespace trview
 
         void Button::mouse_leave()
         {
+            Control::mouse_leave();
             // Check that the button has the same background colour as when we changed to the highlight colour.
             if (_text && _text->background_colour() == _previous_colour + Colours::Highlight)
             {

--- a/trview.ui/Control.cpp
+++ b/trview.ui/Control.cpp
@@ -147,6 +147,7 @@ namespace trview
 
         bool Control::move(Point)
         {
+            on_mouse_move();
             return false;
         }
 
@@ -234,10 +235,12 @@ namespace trview
 
         void Control::mouse_enter()
         {
+            on_mouse_enter();
         }
 
         void Control::mouse_leave()
         {
+            on_mouse_leave();
         }
 
         bool Control::handles_hover() const

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -195,8 +195,17 @@ namespace trview
             /// </summary>
             Event<float> on_update;
 
+            /// <summary>
+            /// Event raised when the mouse has entered the control bounds.
+            /// </summary>
             Event<> on_mouse_enter;
+            /// <summary>
+            /// Event raised when the mouse has moved when over the control.
+            /// </summary>
             Event<> on_mouse_move;
+            /// <summary>
+            /// Event raised when the mouse has left the control bounds.
+            /// </summary>
             Event<> on_mouse_leave;
 
             /// To be called when the mouse has been pressed down over the element.

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -195,6 +195,10 @@ namespace trview
             /// </summary>
             Event<float> on_update;
 
+            Event<> on_mouse_enter;
+            Event<> on_mouse_move;
+            Event<> on_mouse_leave;
+
             /// To be called when the mouse has been pressed down over the element.
             /// @param position The position of the mouse down relative to the control.
             /// @return True if the event was handled by the element.

--- a/trview.ui/ListboxRow.cpp
+++ b/trview.ui/ListboxRow.cpp
@@ -122,12 +122,14 @@ namespace trview
 
         void Listbox::Row::mouse_enter()
         {
+            Control::mouse_enter();
             _hovered = true;
             update_row_colour();
         }
 
         void Listbox::Row::mouse_leave()
         {
+            Control::mouse_leave();
             _hovered = false;
             update_row_colour();
         }

--- a/trview.ui/Scrollbar.cpp
+++ b/trview.ui/Scrollbar.cpp
@@ -50,6 +50,7 @@ namespace trview
 
         bool Scrollbar::move(Point position)
         {
+            Control::move(position);
             if (_input && _input->focus_control() == this)
             {
                 return clicked(position);

--- a/trview.ui/Slider.cpp
+++ b/trview.ui/Slider.cpp
@@ -65,6 +65,7 @@ namespace trview
 
         bool Slider::move(Point position)
         {
+            Control::move(position);
             if (_input && _input->focus_control() == this)
             {
                 set_blob_position(position, true);

--- a/trview.ui/TextArea.cpp
+++ b/trview.ui/TextArea.cpp
@@ -500,6 +500,8 @@ namespace trview
 
         bool TextArea::move(Point position)
         {
+            Control::move(position);
+
             if (_lines.empty() || _line_structure.empty())
             {
                 return true;


### PR DESCRIPTION
Add a tooltip to explain the meaning of Clear Body and OCB. This can be expanded to other fields later if they need explanation.
`Tooltip` should really be merged with `Bubble` but this can be done separately to avoid exploding the PR.
Closes #319 