### PR TITLE
Change ViewOptions to be easier to update

### DIFF
--- a/trview.app.tests/UI/ViewOptionsTests.cpp
+++ b/trview.app.tests/UI/ViewOptionsTests.cpp
@@ -14,17 +14,18 @@ TEST(ViewOptions, HighlightCheckboxToggle)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    std::optional<bool> clicked;
-    auto token = view_options.on_highlight += [&](bool value)
+    std::optional<std::tuple<std::string, bool>> clicked;
+    auto token = view_options.on_toggle_changed += [&](const std::string& name, bool value)
     {
-        clicked = value;
+        clicked = { name, value };
     };
 
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::highlight);
     ASSERT_FALSE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_TRUE(clicked.value());
+    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::highlight);
+    ASSERT_TRUE(std::get<1>(clicked.value()));
 }
 
 TEST(ViewOptions, HighlightCheckboxUpdated)
@@ -35,7 +36,7 @@ TEST(ViewOptions, HighlightCheckboxUpdated)
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::highlight);
     ASSERT_FALSE(checkbox->state());
 
-    view_options.set_highlight(true);
+    view_options.set_toggle(ViewOptions::Names::highlight, true);
     ASSERT_TRUE(checkbox->state());
 };
 
@@ -44,17 +45,18 @@ TEST(ViewOptions, TriggersCheckboxToggle)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    std::optional<bool> clicked;
-    auto token = view_options.on_show_triggers += [&](bool value)
+    std::optional<std::tuple<std::string, bool>> clicked;
+    auto token = view_options.on_toggle_changed += [&](const std::string& name, bool value)
     {
-        clicked = value;
+        clicked = { name, value };
     };
 
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::triggers);
     ASSERT_TRUE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_FALSE(clicked.value());
+    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::triggers);
+    ASSERT_FALSE(std::get<1>(clicked.value()));
 }
 
 TEST(ViewOptions, TriggersCheckboxUpdated)
@@ -65,7 +67,7 @@ TEST(ViewOptions, TriggersCheckboxUpdated)
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::triggers);
     ASSERT_TRUE(checkbox->state());
 
-    view_options.set_show_triggers(false);
+    view_options.set_toggle(ViewOptions::Names::triggers, false);
     ASSERT_FALSE(checkbox->state());
 }
 
@@ -74,17 +76,18 @@ TEST(ViewOptions, HiddenGeometryCheckboxToggle)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    std::optional<bool> clicked;
-    auto token = view_options.on_show_hidden_geometry += [&](bool value)
+    std::optional<std::tuple<std::string, bool>> clicked;
+    auto token = view_options.on_toggle_changed += [&](const std::string& name, bool value)
     {
-        clicked = value;
+        clicked = { name, value };
     };
 
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::hidden_geometry);
     ASSERT_FALSE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_TRUE(clicked.value());
+    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::hidden_geometry);
+    ASSERT_TRUE(std::get<1>(clicked.value()));
 }
 
 TEST(ViewOptions, HiddenGeometryCheckboxUpdated)
@@ -95,7 +98,7 @@ TEST(ViewOptions, HiddenGeometryCheckboxUpdated)
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::hidden_geometry);
     ASSERT_FALSE(checkbox->state());
 
-    view_options.set_show_hidden_geometry(true);
+    view_options.set_toggle(ViewOptions::Names::hidden_geometry, true);
     ASSERT_TRUE(checkbox->state());
 }
 
@@ -104,17 +107,18 @@ TEST(ViewOptions, WaterCheckboxToggle)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    std::optional<bool> clicked;
-    auto token = view_options.on_show_water += [&](bool value)
+    std::optional<std::tuple<std::string, bool>> clicked;
+    auto token = view_options.on_toggle_changed += [&](const std::string& name, bool value)
     {
-        clicked = value;
+        clicked = { name, value };
     };
 
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::water);
     ASSERT_TRUE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_FALSE(clicked.value());
+    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::water);
+    ASSERT_FALSE(std::get<1>(clicked.value()));
 }
 
 TEST(ViewOptions, WaterCheckboxUpdated)
@@ -125,7 +129,7 @@ TEST(ViewOptions, WaterCheckboxUpdated)
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::water);
     ASSERT_TRUE(checkbox->state());
 
-    view_options.set_show_water(false);
+    view_options.set_toggle(ViewOptions::Names::water, false);
     ASSERT_FALSE(checkbox->state());
 }
 
@@ -134,17 +138,18 @@ TEST(ViewOptions, DepthCheckboxToggle)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    std::optional<bool> clicked;
-    auto token = view_options.on_depth_enabled += [&](bool value)
+    std::optional<std::tuple<std::string, bool>> clicked;
+    auto token = view_options.on_toggle_changed += [&](const std::string& name, bool value)
     {
-        clicked = value;
+        clicked = { name, value };
     };
 
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::depth_enabled);
     ASSERT_FALSE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_TRUE(clicked.value());
+    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::depth_enabled);
+    ASSERT_TRUE(std::get<1>(clicked.value()));
 }
 
 TEST(ViewOptions, DepthCheckboxUpdated)
@@ -155,7 +160,7 @@ TEST(ViewOptions, DepthCheckboxUpdated)
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::depth_enabled);
     ASSERT_FALSE(checkbox->state());
 
-    view_options.set_depth_enabled(true);
+    view_options.set_toggle(ViewOptions::Names::depth_enabled, true);
     ASSERT_TRUE(checkbox->state());
 }
 
@@ -164,17 +169,18 @@ TEST(ViewOptions, WireframeCheckboxToggle)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    std::optional<bool> clicked;
-    auto token = view_options.on_show_wireframe += [&](bool value)
+    std::optional<std::tuple<std::string, bool>> clicked;
+    auto token = view_options.on_toggle_changed += [&](const std::string& name, bool value)
     {
-        clicked = value;
+        clicked = { name, value };
     };
 
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::wireframe);
     ASSERT_FALSE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_TRUE(clicked.value());
+    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::wireframe);
+    ASSERT_TRUE(std::get<1>(clicked.value()));
 }
 
 TEST(ViewOptions, WireframeCheckboxUpdated)
@@ -185,7 +191,7 @@ TEST(ViewOptions, WireframeCheckboxUpdated)
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::wireframe);
     ASSERT_FALSE(checkbox->state());
 
-    view_options.set_show_wireframe(true);
+    view_options.set_toggle(ViewOptions::Names::wireframe, true);
     ASSERT_TRUE(checkbox->state());
 }
 
@@ -194,17 +200,18 @@ TEST(ViewOptions, BoundsCheckboxToggle)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    std::optional<bool> clicked;
-    auto token = view_options.on_show_bounding_boxes += [&](bool value)
+    std::optional<std::tuple<std::string, bool>> clicked;
+    auto token = view_options.on_toggle_changed += [&](const std::string& name, bool value)
     {
-        clicked = value;
+        clicked = { name, value };
     };
 
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::show_bounding_boxes);
     ASSERT_FALSE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_TRUE(clicked.value());
+    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::show_bounding_boxes);
+    ASSERT_TRUE(std::get<1>(clicked.value()));
 }
 
 TEST(ViewOptions, BoundsCheckboxUpdated)
@@ -215,7 +222,7 @@ TEST(ViewOptions, BoundsCheckboxUpdated)
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::show_bounding_boxes);
     ASSERT_FALSE(checkbox->state());
     
-    view_options.set_show_bounding_boxes(true);
+    view_options.set_toggle(ViewOptions::Names::show_bounding_boxes, true);
     ASSERT_TRUE(checkbox->state());
 }
 
@@ -224,17 +231,18 @@ TEST(ViewOptions, FlipCheckboxToggle)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    std::optional<bool> clicked;
-    auto token = view_options.on_flip += [&](bool value)
+    std::optional<std::tuple<std::string, bool>> clicked;
+    auto token = view_options.on_toggle_changed += [&](const std::string& name, bool value)
     {
-        clicked = value;
+        clicked = { name, value };
     };
 
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::flip);
     ASSERT_FALSE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_TRUE(clicked.value());
+    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::flip);
+    ASSERT_TRUE(std::get<1>(clicked.value()));
 }
 
 TEST(ViewOptions, FlipCheckboxUpdated)
@@ -245,7 +253,7 @@ TEST(ViewOptions, FlipCheckboxUpdated)
     auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::flip);
     ASSERT_FALSE(checkbox->state());
 
-    view_options.set_flip(true);
+    view_options.set_toggle(ViewOptions::Names::flip, true);
     ASSERT_TRUE(checkbox->state());
 }
 

--- a/trview.app.tests/UI/ViewOptionsTests.cpp
+++ b/trview.app.tests/UI/ViewOptionsTests.cpp
@@ -1,4 +1,5 @@
 #include <trview.app/UI/ViewOptions.h>
+#include <trview.app/Windows/IViewer.h>
 #include <trview.ui/Window.h>
 #include <trview.ui/Checkbox.h>
 #include <trview.ui/Button.h>
@@ -20,11 +21,11 @@ TEST(ViewOptions, HighlightCheckboxToggle)
         clicked = { name, value };
     };
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::highlight);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::highlight);
     ASSERT_FALSE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::highlight);
+    ASSERT_EQ(std::get<0>(clicked.value()), IViewer::Options::highlight);
     ASSERT_TRUE(std::get<1>(clicked.value()));
 }
 
@@ -33,10 +34,10 @@ TEST(ViewOptions, HighlightCheckboxUpdated)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::highlight);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::highlight);
     ASSERT_FALSE(checkbox->state());
 
-    view_options.set_toggle(ViewOptions::Names::highlight, true);
+    view_options.set_toggle(IViewer::Options::highlight, true);
     ASSERT_TRUE(checkbox->state());
 };
 
@@ -51,11 +52,11 @@ TEST(ViewOptions, TriggersCheckboxToggle)
         clicked = { name, value };
     };
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::triggers);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::triggers);
     ASSERT_TRUE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::triggers);
+    ASSERT_EQ(std::get<0>(clicked.value()), IViewer::Options::triggers);
     ASSERT_FALSE(std::get<1>(clicked.value()));
 }
 
@@ -64,10 +65,10 @@ TEST(ViewOptions, TriggersCheckboxUpdated)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::triggers);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::triggers);
     ASSERT_TRUE(checkbox->state());
 
-    view_options.set_toggle(ViewOptions::Names::triggers, false);
+    view_options.set_toggle(IViewer::Options::triggers, false);
     ASSERT_FALSE(checkbox->state());
 }
 
@@ -82,11 +83,11 @@ TEST(ViewOptions, HiddenGeometryCheckboxToggle)
         clicked = { name, value };
     };
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::hidden_geometry);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::hidden_geometry);
     ASSERT_FALSE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::hidden_geometry);
+    ASSERT_EQ(std::get<0>(clicked.value()), IViewer::Options::hidden_geometry);
     ASSERT_TRUE(std::get<1>(clicked.value()));
 }
 
@@ -95,10 +96,10 @@ TEST(ViewOptions, HiddenGeometryCheckboxUpdated)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::hidden_geometry);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::hidden_geometry);
     ASSERT_FALSE(checkbox->state());
 
-    view_options.set_toggle(ViewOptions::Names::hidden_geometry, true);
+    view_options.set_toggle(IViewer::Options::hidden_geometry, true);
     ASSERT_TRUE(checkbox->state());
 }
 
@@ -113,11 +114,11 @@ TEST(ViewOptions, WaterCheckboxToggle)
         clicked = { name, value };
     };
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::water);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::water);
     ASSERT_TRUE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::water);
+    ASSERT_EQ(std::get<0>(clicked.value()), IViewer::Options::water);
     ASSERT_FALSE(std::get<1>(clicked.value()));
 }
 
@@ -126,10 +127,10 @@ TEST(ViewOptions, WaterCheckboxUpdated)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::water);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::water);
     ASSERT_TRUE(checkbox->state());
 
-    view_options.set_toggle(ViewOptions::Names::water, false);
+    view_options.set_toggle(IViewer::Options::water, false);
     ASSERT_FALSE(checkbox->state());
 }
 
@@ -144,11 +145,11 @@ TEST(ViewOptions, DepthCheckboxToggle)
         clicked = { name, value };
     };
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::depth_enabled);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::depth_enabled);
     ASSERT_FALSE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::depth_enabled);
+    ASSERT_EQ(std::get<0>(clicked.value()), IViewer::Options::depth_enabled);
     ASSERT_TRUE(std::get<1>(clicked.value()));
 }
 
@@ -157,10 +158,10 @@ TEST(ViewOptions, DepthCheckboxUpdated)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::depth_enabled);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::depth_enabled);
     ASSERT_FALSE(checkbox->state());
 
-    view_options.set_toggle(ViewOptions::Names::depth_enabled, true);
+    view_options.set_toggle(IViewer::Options::depth_enabled, true);
     ASSERT_TRUE(checkbox->state());
 }
 
@@ -175,11 +176,11 @@ TEST(ViewOptions, WireframeCheckboxToggle)
         clicked = { name, value };
     };
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::wireframe);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::wireframe);
     ASSERT_FALSE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::wireframe);
+    ASSERT_EQ(std::get<0>(clicked.value()), IViewer::Options::wireframe);
     ASSERT_TRUE(std::get<1>(clicked.value()));
 }
 
@@ -188,10 +189,10 @@ TEST(ViewOptions, WireframeCheckboxUpdated)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::wireframe);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::wireframe);
     ASSERT_FALSE(checkbox->state());
 
-    view_options.set_toggle(ViewOptions::Names::wireframe, true);
+    view_options.set_toggle(IViewer::Options::wireframe, true);
     ASSERT_TRUE(checkbox->state());
 }
 
@@ -206,11 +207,11 @@ TEST(ViewOptions, BoundsCheckboxToggle)
         clicked = { name, value };
     };
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::show_bounding_boxes);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::show_bounding_boxes);
     ASSERT_FALSE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::show_bounding_boxes);
+    ASSERT_EQ(std::get<0>(clicked.value()), IViewer::Options::show_bounding_boxes);
     ASSERT_TRUE(std::get<1>(clicked.value()));
 }
 
@@ -219,10 +220,10 @@ TEST(ViewOptions, BoundsCheckboxUpdated)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::show_bounding_boxes);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::show_bounding_boxes);
     ASSERT_FALSE(checkbox->state());
     
-    view_options.set_toggle(ViewOptions::Names::show_bounding_boxes, true);
+    view_options.set_toggle(IViewer::Options::show_bounding_boxes, true);
     ASSERT_TRUE(checkbox->state());
 }
 
@@ -237,11 +238,11 @@ TEST(ViewOptions, FlipCheckboxToggle)
         clicked = { name, value };
     };
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::flip);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::flip);
     ASSERT_FALSE(checkbox->state());
     checkbox->clicked({});
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_EQ(std::get<0>(clicked.value()), ViewOptions::Names::flip);
+    ASSERT_EQ(std::get<0>(clicked.value()), IViewer::Options::flip);
     ASSERT_TRUE(std::get<1>(clicked.value()));
 }
 
@@ -250,10 +251,10 @@ TEST(ViewOptions, FlipCheckboxUpdated)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::flip);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::flip);
     ASSERT_FALSE(checkbox->state());
 
-    view_options.set_toggle(ViewOptions::Names::flip, true);
+    view_options.set_toggle(IViewer::Options::flip, true);
     ASSERT_TRUE(checkbox->state());
 }
 
@@ -262,7 +263,7 @@ TEST(ViewOptions, FlipCheckboxEnabled)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::flip);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::flip);
     ASSERT_TRUE(checkbox->enabled());
 
     view_options.set_flip_enabled(false);
@@ -315,7 +316,7 @@ TEST(ViewOptions, FlipCheckboxHiddenWithAlternateGroups)
     ui::Window window(Size(1, 1), Colour::White);
     auto view_options = ViewOptions(window, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
 
-    auto checkbox = window.find<ui::Checkbox>(ViewOptions::Names::flip);
+    auto checkbox = window.find<ui::Checkbox>(IViewer::Options::flip);
     ASSERT_TRUE(checkbox->visible());
 
     view_options.set_use_alternate_groups(true);

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -103,9 +103,9 @@ TEST(ViewerUI, BoundingBoxUpdatesViewOptions)
     auto view_options_ptr_actual = std::move(view_options_ptr);
     auto ui = register_test_module().with_view_options_source([&](auto&&...) { return std::move(view_options_ptr_actual); }).build();
 
-    EXPECT_CALL(view_options, set_show_bounding_boxes(true)).Times(1);
+    EXPECT_CALL(view_options, set_toggle("show_bounding_boxes", true)).Times(1);
 
-    ui->set_show_bounding_boxes(true);
+    ui->set_toggle("show_bounding_boxes", true);
 }
 
 TEST(ViewerUI, ShowBoundingBoxesEventRaised)
@@ -114,15 +114,16 @@ TEST(ViewerUI, ShowBoundingBoxesEventRaised)
     auto view_options_ptr_actual = std::move(view_options_ptr);
     auto ui = register_test_module().with_view_options_source([&](auto&&...) { return std::move(view_options_ptr_actual); }).build();
 
-    std::optional<bool> show;
-    auto token = ui->on_show_bounding_boxes += [&](const auto& value)
+    std::optional<std::tuple<std::string, bool>> show;
+    auto token = ui->on_toggle_changed += [&](const auto& name, const auto& value)
     {
-        show = value;
+        show = { name, value };
     };
 
-    view_options.on_show_bounding_boxes(true);
+    view_options.on_toggle_changed("show_bounding_boxes", true);
     ASSERT_TRUE(show.has_value());
-    ASSERT_TRUE(show.value());
+    ASSERT_EQ(std::get<0>(show.value()), "show_bounding_boxes");
+    ASSERT_TRUE(std::get<1>(show.value()));
 }
 
 TEST(ViewerUI, SetMidWaypointEnabled)

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -1,4 +1,5 @@
 #include <trview.app/UI/ViewerUI.h>
+#include <trview.app/Windows/IViewer.h>
 #include <trview.app/Mocks/Graphics/ITextureStorage.h>
 #include <trview.common/Mocks/Windows/IShortcuts.h>
 #include <trview.ui.render/Mocks/IRenderer.h>
@@ -103,9 +104,9 @@ TEST(ViewerUI, BoundingBoxUpdatesViewOptions)
     auto view_options_ptr_actual = std::move(view_options_ptr);
     auto ui = register_test_module().with_view_options_source([&](auto&&...) { return std::move(view_options_ptr_actual); }).build();
 
-    EXPECT_CALL(view_options, set_toggle("show_bounding_boxes", true)).Times(1);
+    EXPECT_CALL(view_options, set_toggle(IViewer::Options::show_bounding_boxes, true)).Times(1);
 
-    ui->set_toggle("show_bounding_boxes", true);
+    ui->set_toggle(IViewer::Options::show_bounding_boxes, true);
 }
 
 TEST(ViewerUI, ShowBoundingBoxesEventRaised)
@@ -120,9 +121,9 @@ TEST(ViewerUI, ShowBoundingBoxesEventRaised)
         show = { name, value };
     };
 
-    view_options.on_toggle_changed("show_bounding_boxes", true);
+    view_options.on_toggle_changed(IViewer::Options::show_bounding_boxes, true);
     ASSERT_TRUE(show.has_value());
-    ASSERT_EQ(std::get<0>(show.value()), "show_bounding_boxes");
+    ASSERT_EQ(std::get<0>(show.value()), IViewer::Options::show_bounding_boxes);
     ASSERT_TRUE(std::get<1>(show.value()));
 }
 

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -563,11 +563,12 @@ TEST(Viewer, SetShowBoundingBox)
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
 
     EXPECT_CALL(level, set_show_bounding_boxes(false)).Times(1);
-    EXPECT_CALL(ui, set_show_bounding_boxes(true)).Times(1);
+    EXPECT_CALL(ui, set_toggle(testing::A<const std::string&>(), testing::A<bool>())).Times(testing::AtLeast(0));
+    EXPECT_CALL(ui, set_toggle("show_bounding_boxes", true)).Times(1);
     EXPECT_CALL(level, set_show_bounding_boxes(true)).Times(1);
 
     viewer->open(&level);
-    ui.on_show_bounding_boxes(true);
+    ui.on_toggle_changed("show_bounding_boxes", true);
 }
 
 TEST(Viewer, OnAddWaypointRaisedForWaypoint)

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -564,11 +564,11 @@ TEST(Viewer, SetShowBoundingBox)
 
     EXPECT_CALL(level, set_show_bounding_boxes(false)).Times(1);
     EXPECT_CALL(ui, set_toggle(testing::A<const std::string&>(), testing::A<bool>())).Times(testing::AtLeast(0));
-    EXPECT_CALL(ui, set_toggle("show_bounding_boxes", true)).Times(1);
+    EXPECT_CALL(ui, set_toggle(IViewer::Options::show_bounding_boxes, true)).Times(1);
     EXPECT_CALL(level, set_show_bounding_boxes(true)).Times(1);
 
     viewer->open(&level);
-    ui.on_toggle_changed("show_bounding_boxes", true);
+    ui.on_toggle_changed(IViewer::Options::show_bounding_boxes, true);
 }
 
 TEST(Viewer, OnAddWaypointRaisedForWaypoint)

--- a/trview.app/Mocks/UI/IViewOptions.h
+++ b/trview.app/Mocks/UI/IViewOptions.h
@@ -12,21 +12,10 @@ namespace trview
             MOCK_METHOD(void, set_alternate_group, (uint32_t, bool), (override));
             MOCK_METHOD(void, set_alternate_groups, (const std::set<uint32_t>&), (override));
             MOCK_METHOD(void, set_depth, (int32_t), (override));
-            MOCK_METHOD(void, set_depth_enabled, (bool), (override));
-            MOCK_METHOD(void, set_flip, (bool), (override));
             MOCK_METHOD(void, set_flip_enabled, (bool), (override));
-            MOCK_METHOD(void, set_highlight, (bool), (override));
-            MOCK_METHOD(void, set_show_hidden_geometry, (bool), (override));
-            MOCK_METHOD(void, set_show_triggers, (bool), (override));
-            MOCK_METHOD(void, set_show_water, (bool), (override));
-            MOCK_METHOD(void, set_show_wireframe, (bool), (override));
             MOCK_METHOD(void, set_use_alternate_groups, (bool), (override));
-            MOCK_METHOD(void, set_show_bounding_boxes, (bool), (override));
-            MOCK_METHOD(bool, show_hidden_geometry, (), (const, override));
-            MOCK_METHOD(bool, show_triggers, (), (const, override));
-            MOCK_METHOD(bool, show_water, (), (const, override));
-            MOCK_METHOD(bool, show_wireframe, (), (const, override));
-            MOCK_METHOD(bool, show_bounding_boxes, (), (const, override));
+            MOCK_METHOD(void, set_toggle, (const std::string&, bool), (override));
+            MOCK_METHOD(bool, toggle, (const std::string&), (const, override));
         };
     }
 }

--- a/trview.app/Mocks/UI/IViewOptions.h
+++ b/trview.app/Mocks/UI/IViewOptions.h
@@ -11,7 +11,7 @@ namespace trview
             virtual ~MockViewOptions() = default;
             MOCK_METHOD(void, set_alternate_group, (uint32_t, bool), (override));
             MOCK_METHOD(void, set_alternate_groups, (const std::set<uint32_t>&), (override));
-            MOCK_METHOD(void, set_depth, (int32_t), (override));
+            MOCK_METHOD(void, set_scalar, (const std::string&, int32_t), (override));
             MOCK_METHOD(void, set_flip_enabled, (bool), (override));
             MOCK_METHOD(void, set_use_alternate_groups, (bool), (override));
             MOCK_METHOD(void, set_toggle, (const std::string&, bool), (override));

--- a/trview.app/Mocks/UI/IViewerUI.h
+++ b/trview.app/Mocks/UI/IViewerUI.h
@@ -21,7 +21,6 @@ namespace trview
             MOCK_METHOD(void, set_camera_rotation, (float, float), (override));
             MOCK_METHOD(void, set_camera_mode, (CameraMode), (override));
             MOCK_METHOD(void, set_camera_projection_mode, (ProjectionMode), (override));
-            MOCK_METHOD(void, set_depth_level, (int32_t), (override));
             MOCK_METHOD(void, set_flip_enabled, (bool), (override));
             MOCK_METHOD(void, set_hide_enabled, (bool), (override));
             MOCK_METHOD(void, set_host_size, (const Size&), (override));
@@ -47,6 +46,7 @@ namespace trview
             MOCK_METHOD(void, set_mid_waypoint_enabled, (bool), (override));
             MOCK_METHOD(void, set_toggle, (const std::string&, bool), (override));
             MOCK_METHOD(bool, toggle, (const std::string&), (const, override));
+            MOCK_METHOD(void, set_scalar, (const std::string&, int32_t), (override));
         };
     }
 }

--- a/trview.app/Mocks/UI/IViewerUI.h
+++ b/trview.app/Mocks/UI/IViewerUI.h
@@ -21,12 +21,9 @@ namespace trview
             MOCK_METHOD(void, set_camera_rotation, (float, float), (override));
             MOCK_METHOD(void, set_camera_mode, (CameraMode), (override));
             MOCK_METHOD(void, set_camera_projection_mode, (ProjectionMode), (override));
-            MOCK_METHOD(void, set_depth_enabled, (bool), (override));
             MOCK_METHOD(void, set_depth_level, (int32_t), (override));
-            MOCK_METHOD(void, set_flip, (bool), (override));
             MOCK_METHOD(void, set_flip_enabled, (bool), (override));
             MOCK_METHOD(void, set_hide_enabled, (bool), (override));
-            MOCK_METHOD(void, set_highlight, (bool), (override));
             MOCK_METHOD(void, set_host_size, (const Size&), (override));
             MOCK_METHOD(void, set_level, (const std::string&, trlevel::LevelVersion), (override));
             MOCK_METHOD(void, set_max_rooms, (uint32_t), (override));
@@ -38,26 +35,18 @@ namespace trview
             MOCK_METHOD(void, set_selected_room, (const std::shared_ptr<IRoom>&), (override));
             MOCK_METHOD(void, set_settings, (const UserSettings&), (override));
             MOCK_METHOD(void, set_show_context_menu, (bool), (override));
-            MOCK_METHOD(void, set_show_hidden_geometry, (bool), (override));
             MOCK_METHOD(void, set_show_measure, (bool), (override));
             MOCK_METHOD(void, set_show_minimap, (bool), (override));
             MOCK_METHOD(void, set_show_tooltip, (bool), (override));
-            MOCK_METHOD(void, set_show_triggers, (bool), (override));
-            MOCK_METHOD(void, set_show_water, (bool), (override));
-            MOCK_METHOD(void, set_show_wireframe, (bool), (override));
-            MOCK_METHOD(void, set_show_bounding_boxes, (bool), (override));
             MOCK_METHOD(void, set_use_alternate_groups, (bool), (override));
             MOCK_METHOD(void, set_visible, (bool), (override));
-            MOCK_METHOD(bool, show_hidden_geometry, (), (const, override));
-            MOCK_METHOD(bool, show_triggers, (), (const, override));
-            MOCK_METHOD(bool, show_water, (), (const, override));
-            MOCK_METHOD(bool, show_wireframe, (), (const, override));
-            MOCK_METHOD(bool, show_bounding_boxes, (), (const, override));
             MOCK_METHOD(bool, show_context_menu, (), (const, override));
             MOCK_METHOD(void, toggle_settings_visibility, (), (override));
             MOCK_METHOD(void, print_console, (const std::wstring&), (override));
             MOCK_METHOD(void, initialise_input, (), (override));
             MOCK_METHOD(void, set_mid_waypoint_enabled, (bool), (override));
+            MOCK_METHOD(void, set_toggle, (const std::string&, bool), (override));
+            MOCK_METHOD(bool, toggle, (const std::string&), (const, override));
         };
     }
 }

--- a/trview.app/UI/IViewOptions.h
+++ b/trview.app/UI/IViewOptions.h
@@ -21,44 +21,9 @@ namespace trview
         /// </summary>
         Event<int32_t> on_depth_changed;
         /// <summary>
-        /// Event raised when the user has enabled or disabled neighbour mode. The boolean passed to when the event is raised indicates whether neighbours mode is enabled.
+        /// Event raised when the user changes a toggle.
         /// </summary>
-        /// <remarks>This event is not raised when the set_enabled function is called.</remarks>
-        Event<bool> on_depth_enabled;
-        /// <summary>
-        /// Event raised when the user toggles the alternate mode. The boolean passed as a parameter when this event is raised indicates whether flip mode is enabled.
-        /// </summary>
-        /// <remarks>This event is not raised by the set_flip function.</remarks>
-        Event<bool> on_flip;
-        /// Event raised when the user toggles the highlight mode. The boolean passed as a parameter when this
-        /// event is raised indicates whether highlight mode is enabled.
-        /// @remarks This event is not raised by the set_highlight function.
-        Event<bool> on_highlight;
-        /// <summary>
-        /// Event raised when the user toggles the hidden geometry visibility. The boolean passed as a parameter when this event is raised indicates whether hidden geomety is visible.
-        /// </summary>
-        /// <remarks>This event is not raised by the set_show_hidden_geometry function.</remarks>
-        Event<bool> on_show_hidden_geometry;
-        /// <summary>
-        /// Event raised when the user toggles the trigger visibility. The boolean passed as a parameter when this event is raised indicates whether triggers are visible.
-        /// </summary>
-        /// <remarks>This event is not raised by the set_show_triggers function.</remarks>
-        Event<bool> on_show_triggers;
-        /// <summary>
-        /// Event raised when the user toggles showing water. The boolean passed as a paramter when this event is raised indicates whether water colouring is visible.
-        /// </summary>
-        /// <remarks>This event is not raised by the set_show_water function.</remarks>
-        Event<bool> on_show_water;
-        /// <summary>
-        /// Event raised when the user toggles wireframe mode. The boolean passed as a parameter when this event is raised indicates whether wireframe mode is used.
-        /// </summary>
-        /// <remarks>This event is not raised by the set_wireframe function.</remarks>
-        Event<bool> on_show_wireframe;
-        /// <summary>
-        /// Event raised when the user toggles bounding boxes. The boolean passed as a parameter when this event is raised.
-        /// </summary>
-        /// <remarks>This event is not raised by the set_show_bounding_boxes function.</remarks>
-        Event<bool> on_show_bounding_boxes;
+        Event<std::string, bool> on_toggle_changed;
         /// <summary>
         /// Set whether an alternate group is enabled. This will not raise the on_alternate_group event.
         /// </summary>
@@ -76,79 +41,26 @@ namespace trview
         /// <param name="value">The neighbour depth to use.</param>
         virtual void set_depth(int32_t value) = 0;
         /// <summary>
-        /// Set whether neighbours are enabled. This will not raise the on_enabled_changed event.
-        /// </summary>
-        /// <param name="value">Whether neighbours are enabled.</param>
-        virtual void set_depth_enabled(bool value) = 0;
-        /// <summary>
-        /// Set the current flip mode. This will not raise the on_flip event but will update the user interface appropriately.
-        /// </summary>
-        /// <param name="flip">The new flip mode.</param>
-        virtual void set_flip(bool flip) = 0;
-        /// <summary>
-        /// Set whether the flip control is enabled or disabled.
-        /// </summary>
-        /// <param name="enabled">Whether the control is enabled.</param>
-        virtual void set_flip_enabled(bool enabled) = 0;
-        /// <summary>
-        /// Set the current highlight mode. This will not raise the on_highlight event but will update the user interface appropriately.
-        /// </summary>
-        /// <param name="highlight">Whether the highlight mode is enabled or disabled.</param>
-        virtual void set_highlight(bool highlight) = 0;
-        /// <summary>
-        /// Set whether hidden geometry is visible or not.
-        /// </summary>
-        /// <param name="show">Whether the hidden geometry is visible.</param>
-        virtual void set_show_hidden_geometry(bool show) = 0;
-        /// <summary>
-        /// Set whether triggers are visible or not.
-        /// </summary>
-        /// <param name="show">Whether the triggers are visible.</param>
-        virtual void set_show_triggers(bool show) = 0;
-        /// <summary>
-        /// Set whether water is visible or not.
-        /// </summary>
-        /// <param name="show">Whether water is visible.</param>
-        virtual void set_show_water(bool show) = 0;
-        /// <summary>
-        /// Set whether wireframe mode is enabled.
-        /// </summary>
-        /// <param name="show">Whether to use wireframe.</param>
-        virtual void set_show_wireframe(bool show) = 0;
-        /// <summary>
         /// Set whether to use alternate groups method of flipmaps.
         /// </summary>
         /// <param name="value">Whether to use alternate groups or a single toggle.</param>
         virtual void set_use_alternate_groups(bool value) = 0;
         /// <summary>
-        /// Set whether to show bounding boxes.
+        /// Set the value of a toggle variable.
         /// </summary>
-        /// <param name="value">Whether to show bouding boxes.</param>
-        virtual void set_show_bounding_boxes(bool value) = 0;
+        /// <param name="name">The name of the variable.</param>
+        /// <param name="value">The new state.</param>
+        virtual void set_toggle(const std::string& name, bool value) = 0;
         /// <summary>
-        /// Get the current value of the show hidden geometry checkbox.
+        /// Get the value of a toggle variable.
         /// </summary>
-        /// <returns>The current value of the checkbox.</returns>
-        virtual bool show_hidden_geometry() const = 0;
+        /// <param name="name">The name of the variable.</param>
+        /// <returns>The state of the variable.</returns>
+        virtual bool toggle(const std::string& name) const = 0;
         /// <summary>
-        /// Get the current value of the show triggers checkbox.
+        /// Set whether the flip control is enabled or disabled.
         /// </summary>
-        /// <returns>The current value of the checkbox.</returns>
-        virtual bool show_triggers() const = 0;
-        /// <summary>
-        /// Get the current value of the show water checkbox.
-        /// </summary>
-        /// <returns>The current value of the checkbox.</returns>
-        virtual bool show_water() const = 0;
-        /// <summary>
-        /// Get the current value of the wireframe checkbox.
-        /// </summary>
-        /// <returns>The current value of the checkbox.</returns>
-        virtual bool show_wireframe() const = 0;
-        /// <summary>
-        /// Get the current value of the bounding boxes checkbox.
-        /// </summary>
-        /// <returns>The current value of the checkbox.</returns>
-        virtual bool show_bounding_boxes() const = 0;
+        /// <param name="enabled">Whether the control is enabled.</param>
+        virtual void set_flip_enabled(bool enabled) = 0;
     };
 }

--- a/trview.app/UI/IViewOptions.h
+++ b/trview.app/UI/IViewOptions.h
@@ -17,9 +17,9 @@ namespace trview
         /// </summary>
         Event<uint32_t, bool> on_alternate_group;
         /// <summary>
-        /// Event raised when the user has changed the depth of neighbour to display. The newly selected depth is passed when the event is raised.
+        /// Event raised when the user changes a scalar setting.
         /// </summary>
-        Event<int32_t> on_depth_changed;
+        Event<std::string, int32_t> on_scalar_changed;
         /// <summary>
         /// Event raised when the user changes a toggle.
         /// </summary>
@@ -36,15 +36,16 @@ namespace trview
         /// <param name="groups">The groups in the level.</param>
         virtual void set_alternate_groups(const std::set<uint32_t>& groups) = 0;
         /// <summary>
-        /// Set the value of the depth control. This will not raise the on_depth_changed event.
-        /// </summary>
-        /// <param name="value">The neighbour depth to use.</param>
-        virtual void set_depth(int32_t value) = 0;
-        /// <summary>
         /// Set whether to use alternate groups method of flipmaps.
         /// </summary>
         /// <param name="value">Whether to use alternate groups or a single toggle.</param>
         virtual void set_use_alternate_groups(bool value) = 0;
+        /// <summary>
+        /// Set the value of a scalar setting.
+        /// </summary>
+        /// <param name="name">The name of the setting.</param>
+        /// <param name="value">The value to set.</param>
+        virtual void set_scalar(const std::string& name, int32_t value) = 0;
         /// <summary>
         /// Set the value of a toggle variable.
         /// </summary>

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -59,8 +59,10 @@ namespace trview
         /// Event raised when the camera is reset.
         Event<> on_camera_reset;
 
-        /// Event raised when the depth level changes.
-        Event<int32_t> on_depth_level_changed;
+        /// <summary>
+        /// Event raised when a scalar value has changed.
+        /// </summary>
+        Event<std::string, int32_t> on_scalar_changed;
 
         /// Event raised when the hide button is clicked.
         Event<> on_hide;
@@ -129,10 +131,6 @@ namespace trview
         /// Set the camera projection mode.
         /// @param mode The current camera projection mode.
         virtual void set_camera_projection_mode(ProjectionMode mode) = 0;
-
-        /// Set the level of depth.
-        /// @param value The depth level.
-        virtual void set_depth_level(int32_t value) = 0;
 
         /// Set whether there are any flipmaps in the level.
         /// @param value Whether there are any flipmaps.
@@ -226,6 +224,12 @@ namespace trview
         /// </summary>
         /// <param name="value">Whether the button is enabled.</param>
         virtual void set_mid_waypoint_enabled(bool value) = 0;
+        /// <summary>
+        /// Set the value of a scalar setting.
+        /// </summary>
+        /// <param name="name">The name of the setting.</param>
+        /// <param name="value">The value to set.</param>
+        virtual void set_scalar(const std::string& name, int32_t value) = 0;
         /// <summary>
         /// Set the value of a toggle variable.
         /// </summary>

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -62,17 +62,8 @@ namespace trview
         /// Event raised when the depth level changes.
         Event<int32_t> on_depth_level_changed;
 
-        /// Event raised when the depth setting is changed.
-        Event<bool> on_depth;
-
-        /// Event raised when the flip settings is changed.
-        Event<bool> on_flip;
-
         /// Event raised when the hide button is clicked.
         Event<> on_hide;
-
-        /// Event raised when the higlight setting is changed.
-        Event<bool> on_highlight;
 
         /// Event raised when a minimap sector is hovered over.
         Event<std::shared_ptr<ISector>> on_sector_hover;
@@ -85,23 +76,6 @@ namespace trview
 
         /// Event raised when the user settings are changed.
         Event<UserSettings> on_settings;
-
-        /// Event raised when the hidden geometry setting is changed.
-        Event<bool> on_show_hidden_geometry;
-
-        /// Event raised when the show triggers setting is changed.
-        Event<bool> on_show_triggers;
-
-        /// Event raised when the show water setting is changed.
-        Event<bool> on_show_water;
-
-        /// Event raised when the show wireframe setting is changed.
-        Event<bool> on_show_wireframe;
-
-        /// <summary>
-        /// Event raised when the show bouding boxes setting is changed.
-        /// </summary>
-        Event<bool> on_show_bounding_boxes;
 
         /// Event raised when a tool is selected.
         Event<Tool> on_tool_selected;
@@ -119,6 +93,11 @@ namespace trview
 
         /// Event raised when user enters a command.
         Event<std::wstring> on_command;
+
+        /// <summary>
+        /// Event raised when the user changes a toggle.
+        /// </summary>
+        Event<std::string, bool> on_toggle_changed;
 
         /// Render the UI.
         virtual void render() = 0;
@@ -151,17 +130,9 @@ namespace trview
         /// @param mode The current camera projection mode.
         virtual void set_camera_projection_mode(ProjectionMode mode) = 0;
 
-        /// Set whether depth is enabled.
-        /// @param value Whether depth is enabled.
-        virtual void set_depth_enabled(bool value) = 0;
-
         /// Set the level of depth.
         /// @param value The depth level.
         virtual void set_depth_level(int32_t value) = 0;
-
-        /// Set the current flip state.
-        /// @param value The flip state.
-        virtual void set_flip(bool value) = 0;
 
         /// Set whether there are any flipmaps in the level.
         /// @param value Whether there are any flipmaps.
@@ -170,10 +141,6 @@ namespace trview
         /// Set whether the hide button on the context menu is enabled.
         /// @param value Whether the hide button is enabled.
         virtual void set_hide_enabled(bool value) = 0;
-
-        /// Set whether highlight is enabled.
-        /// @param value Whether highlight is enabled.
-        virtual void set_highlight(bool value) = 0;
 
         /// Set the size of the host window.
         virtual void set_host_size(const Size& size) = 0;
@@ -221,10 +188,6 @@ namespace trview
         /// "param value Whether the context menu is visible.
         virtual void set_show_context_menu(bool value) = 0;
 
-        /// Set whether hidden geometry is visible.
-        /// @param value Whether hidden geometry is visible.
-        virtual void set_show_hidden_geometry(bool value) = 0;
-
         /// Set whether to show the measure label.
         /// @param value Whether to show the measure label.
         virtual void set_show_measure(bool value) = 0;
@@ -237,24 +200,6 @@ namespace trview
         /// @param value Whether to show the tooltip.
         virtual void set_show_tooltip(bool value) = 0;
 
-        /// Set whether triggers are visible.
-        /// @param value Whether triggers are visible.
-        virtual void set_show_triggers(bool value) = 0;
-
-        /// Set whether water is visible.
-        /// @param value Whether water is visible.
-        virtual void set_show_water(bool value) = 0;
-
-        /// Set whether wireframe is visible.
-        /// @param value Whether wireframe is visible.
-        virtual void set_show_wireframe(bool value) = 0;
-
-        /// <summary>
-        /// Set whether to show bounding boxes.
-        /// </summary>
-        /// <param name="value">Whether bounding boxes are visible.</param>
-        virtual void set_show_bounding_boxes(bool value) = 0;
-
         /// Set whether the level uses alternate groups.
         /// @param value Whether alternate groups are used.
         virtual void set_use_alternate_groups(bool value) = 0;
@@ -262,23 +207,6 @@ namespace trview
         /// Set whether the UI is visible.
         /// @param value Whether the UI is visible.
         virtual void set_visible(bool value) = 0;
-
-        /// Get whether hidden geometry is visible.
-        virtual bool show_hidden_geometry() const = 0;
-
-        /// Get whether triggers are visible.
-        virtual bool show_triggers() const = 0;
-
-        /// Get whether water is visible.
-        virtual bool show_water() const = 0;
-
-        /// Get whether wireframe is visible.
-        virtual bool show_wireframe() const = 0;
-
-        /// <summary>
-        /// Get whether bounding boxes are visible.
-        /// </summary>
-        virtual bool show_bounding_boxes() const = 0;
 
         /// Get whether the context menu is visible.
         virtual bool show_context_menu() const = 0;
@@ -298,5 +226,17 @@ namespace trview
         /// </summary>
         /// <param name="value">Whether the button is enabled.</param>
         virtual void set_mid_waypoint_enabled(bool value) = 0;
+        /// <summary>
+        /// Set the value of a toggle variable.
+        /// </summary>
+        /// <param name="name">The name of the variable.</param>
+        /// <param name="value">The new state.</param>
+        virtual void set_toggle(const std::string& name, bool value) = 0;
+        /// <summary>
+        /// Get the value of a toggle variable.
+        /// </summary>
+        /// <param name="name">The name of the variable.</param>
+        /// <returns>The state of the variable.</returns>
+        virtual bool toggle(const std::string& name) const = 0;
     };
 }

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -10,12 +10,6 @@ namespace trview
 {
     using namespace ui;
 
-    const std::string ViewOptions::Names::depth{ "depth" };
-    const std::string ViewOptions::Names::group{ "group" };
-    const std::string ViewOptions::Names::tr_1_3_panel{ "tr1-3-panel" };
-    const std::string ViewOptions::Names::tr_4_5_panel{ "tr4-5-panel" };
-    const std::string ViewOptions::Names::alternate_groups{ "alternate_groups" };
-
     const Colour ViewOptions::Colours::FlipOff{ 0.2f, 0.2f, 0.2f };
     const Colour ViewOptions::Colours::FlipOn{ 0.6f, 0.6f, 0.6f };
 

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -10,15 +10,7 @@ namespace trview
 {
     using namespace ui;
 
-    const std::string ViewOptions::Names::hidden_geometry{ "hidden_geometry" };
-    const std::string ViewOptions::Names::highlight{ "highlight" };
-    const std::string ViewOptions::Names::depth_enabled{ "depth_enabled" };
     const std::string ViewOptions::Names::depth{ "depth" };
-    const std::string ViewOptions::Names::triggers{ "triggers" };
-    const std::string ViewOptions::Names::show_bounding_boxes { "show_bounding_boxes" };
-    const std::string ViewOptions::Names::water{ "water" };
-    const std::string ViewOptions::Names::wireframe{ "wireframe" };
-    const std::string ViewOptions::Names::flip{ "flip" };
     const std::string ViewOptions::Names::group{ "group" };
     const std::string ViewOptions::Names::tr_1_3_panel{ "tr1-3-panel" };
     const std::string ViewOptions::Names::tr_4_5_panel{ "tr4-5-panel" };

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -73,7 +73,7 @@ namespace trview
 
     void ViewOptions::find_scalars(ui::Control& options)
     {
-        for (auto scalar : options.find_all<NumericUpDown>())
+        for (auto scalar : options.find<NumericUpDown>())
         {
             _scalars[scalar->name()] = scalar;
             _token_store += scalar->on_value_changed += [this, scalar](int32_t value)
@@ -85,7 +85,7 @@ namespace trview
 
     void ViewOptions::find_toggles(Control& options)
     {
-        for (auto toggle : options.find_all<Checkbox>())
+        for (auto toggle : options.find<Checkbox>())
         {
             _toggles[toggle->name()] = toggle;
             _token_store += toggle->on_state_changed += [this, toggle](bool value)

--- a/trview.app/UI/ViewOptions.h
+++ b/trview.app/UI/ViewOptions.h
@@ -24,11 +24,11 @@ namespace trview
     public:
         struct Names
         {
-            static const std::string depth;
-            static const std::string group;
-            static const std::string tr_1_3_panel;
-            static const std::string tr_4_5_panel;
-            static const std::string alternate_groups;
+            inline static const std::string depth = "depth";
+            inline static const std::string group = "group";
+            inline static const std::string tr_1_3_panel = "tr1-3-panel";
+            inline static const std::string tr_4_5_panel = "tr4-5-panel";
+            inline static const std::string alternate_groups = "alternate_groups";
         };
 
         struct Colours

--- a/trview.app/UI/ViewOptions.h
+++ b/trview.app/UI/ViewOptions.h
@@ -24,7 +24,6 @@ namespace trview
     public:
         struct Names
         {
-            inline static const std::string depth = "depth";
             inline static const std::string group = "group";
             inline static const std::string tr_1_3_panel = "tr1-3-panel";
             inline static const std::string tr_4_5_panel = "tr4-5-panel";
@@ -41,21 +40,22 @@ namespace trview
         virtual ~ViewOptions() = default;
         virtual void set_alternate_group(uint32_t value, bool enabled) override;
         virtual void set_alternate_groups(const std::set<uint32_t>& groups) override;
-        virtual void set_depth(int32_t value) override;
         virtual void set_flip_enabled(bool enabled) override;
+        virtual void set_scalar(const std::string& name, int32_t value) override;
         virtual void set_toggle(const std::string& name, bool value) override;
         virtual void set_use_alternate_groups(bool value) override;
         virtual bool toggle(const std::string& name) const override;
     private:
+        void find_scalars(ui::Control& options);
         void find_toggles(ui::Control& options);
 
         TokenStore _token_store;
-        ui::NumericUpDown* _depth;
         ui::Window* _tr1_3_panel;
         ui::Window* _tr4_5_panel;
         ui::Window* _alternate_groups;
         std::unordered_map<uint32_t, bool> _alternate_group_values;
         std::unordered_map<uint32_t, ui::Button*> _alternate_group_buttons;
         std::unordered_map<std::string, ui::Checkbox*> _toggles;
+        std::unordered_map<std::string, ui::NumericUpDown*> _scalars;
     };
 }

--- a/trview.app/UI/ViewOptions.h
+++ b/trview.app/UI/ViewOptions.h
@@ -24,15 +24,7 @@ namespace trview
     public:
         struct Names
         {
-            static const std::string depth_enabled;
             static const std::string depth;
-            static const std::string flip;
-            static const std::string hidden_geometry;
-            static const std::string highlight;
-            static const std::string triggers;
-            static const std::string show_bounding_boxes;
-            static const std::string water;
-            static const std::string wireframe;
             static const std::string group;
             static const std::string tr_1_3_panel;
             static const std::string tr_4_5_panel;

--- a/trview.app/UI/ViewOptions.h
+++ b/trview.app/UI/ViewOptions.h
@@ -50,36 +50,20 @@ namespace trview
         virtual void set_alternate_group(uint32_t value, bool enabled) override;
         virtual void set_alternate_groups(const std::set<uint32_t>& groups) override;
         virtual void set_depth(int32_t value) override;
-        virtual void set_depth_enabled(bool value) override;
-        virtual void set_flip(bool flip) override;
-        virtual void set_flip_enabled(bool enabled) override;
-        virtual void set_highlight(bool highlight) override;
-        virtual void set_show_hidden_geometry(bool show) override;
-        virtual void set_show_triggers(bool show) override;
-        virtual void set_show_water(bool show) override;
-        virtual void set_show_wireframe(bool show) override;
+        virtual void set_toggle(const std::string& name, bool value) override;
+        virtual bool toggle(const std::string& name) const override;
         virtual void set_use_alternate_groups(bool value) override;
-        virtual void set_show_bounding_boxes(bool value) override;
-        virtual bool show_hidden_geometry() const override;
-        virtual bool show_triggers() const override;
-        virtual bool show_water() const override;
-        virtual bool show_wireframe() const override;
-        virtual bool show_bounding_boxes() const override;
+        virtual void set_flip_enabled(bool enabled) override;
     private:
+        void find_toggles(ui::Control& options);
+
         TokenStore _token_store;
-        ui::Checkbox* _highlight;
-        ui::Checkbox* _flip;
-        ui::Checkbox* _triggers;
-        ui::Checkbox* _hidden_geometry;
-        ui::Checkbox* _water;
-        ui::Checkbox* _depth_enabled;
-        ui::Checkbox* _wireframe;
-        ui::Checkbox* _bounding_boxes;
         ui::NumericUpDown* _depth;
         ui::Window* _tr1_3_panel;
         ui::Window* _tr4_5_panel;
         ui::Window* _alternate_groups;
         std::unordered_map<uint32_t, bool> _alternate_group_values;
         std::unordered_map<uint32_t, ui::Button*> _alternate_group_buttons;
+        std::unordered_map<std::string, ui::Checkbox*> _toggles;
     };
 }

--- a/trview.app/UI/ViewOptions.h
+++ b/trview.app/UI/ViewOptions.h
@@ -50,10 +50,10 @@ namespace trview
         virtual void set_alternate_group(uint32_t value, bool enabled) override;
         virtual void set_alternate_groups(const std::set<uint32_t>& groups) override;
         virtual void set_depth(int32_t value) override;
-        virtual void set_toggle(const std::string& name, bool value) override;
-        virtual bool toggle(const std::string& name) const override;
-        virtual void set_use_alternate_groups(bool value) override;
         virtual void set_flip_enabled(bool enabled) override;
+        virtual void set_toggle(const std::string& name, bool value) override;
+        virtual void set_use_alternate_groups(bool value) override;
+        virtual bool toggle(const std::string& name) const override;
     private:
         void find_toggles(ui::Control& options);
 

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -267,7 +267,7 @@ namespace trview
 
         _view_options = view_options_source(*tool_window);
         _view_options->on_toggle_changed += on_toggle_changed;
-        _view_options->on_depth_changed += on_depth_level_changed;
+        _view_options->on_scalar_changed += on_scalar_changed;
         _view_options->on_alternate_group += on_alternate_group;
 
         _room_navigator = std::make_unique<RoomNavigator>(*tool_window, ui_source);
@@ -313,11 +313,6 @@ namespace trview
     void ViewerUI::set_camera_projection_mode(ProjectionMode mode)
     {
         _camera_controls->set_projection_mode(mode);
-    }
-
-    void ViewerUI::set_depth_level(int32_t value)
-    {
-        _view_options->set_depth(value);
     }
 
     void ViewerUI::set_flip_enabled(bool value)
@@ -473,6 +468,11 @@ namespace trview
     void ViewerUI::set_mid_waypoint_enabled(bool value)
     {
         _context_menu->set_mid_waypoint_enabled(value);
+    }
+
+    void ViewerUI::set_scalar(const std::string& name, int32_t value)
+    {
+        _view_options->set_scalar(name, value);
     }
 
     void ViewerUI::set_toggle(const std::string& name, bool value)

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -266,16 +266,9 @@ namespace trview
         auto tool_window = _control->add_child(ui_source.load_from_resource(IDR_UI_TOOL_WINDOW));
 
         _view_options = view_options_source(*tool_window);
-        _view_options->on_highlight += on_highlight;
-        _view_options->on_show_triggers += on_show_triggers;
-        _view_options->on_show_hidden_geometry += on_show_hidden_geometry;
-        _view_options->on_show_water += on_show_water;
+        _view_options->on_toggle_changed += on_toggle_changed;
         _view_options->on_depth_changed += on_depth_level_changed;
-        _view_options->on_depth_enabled += on_depth;
-        _view_options->on_flip += on_flip;
         _view_options->on_alternate_group += on_alternate_group;
-        _view_options->on_show_wireframe += on_show_wireframe;
-        _view_options->on_show_bounding_boxes += on_show_bounding_boxes;
 
         _room_navigator = std::make_unique<RoomNavigator>(*tool_window, ui_source);
         _room_navigator->on_room_selected += on_select_room;
@@ -322,19 +315,9 @@ namespace trview
         _camera_controls->set_projection_mode(mode);
     }
 
-    void ViewerUI::set_depth_enabled(bool value)
-    {
-        _view_options->set_depth_enabled(value);
-    }
-
     void ViewerUI::set_depth_level(int32_t value)
     {
         _view_options->set_depth(value);
-    }
-
-    void ViewerUI::set_flip(bool value)
-    {
-        _view_options->set_flip(value);
     }
 
     void ViewerUI::set_flip_enabled(bool value)
@@ -345,11 +328,6 @@ namespace trview
     void ViewerUI::set_hide_enabled(bool value)
     {
         _context_menu->set_hide_enabled(value);
-    }
-
-    void ViewerUI::set_highlight(bool value)
-    {
-        _view_options->set_highlight(value);
     }
 
     void ViewerUI::set_host_size(const Size& size)
@@ -445,11 +423,6 @@ namespace trview
         }
     }
 
-    void ViewerUI::set_show_hidden_geometry(bool value)
-    {
-        _view_options->set_show_hidden_geometry(value);
-    }
-
     void ViewerUI::set_show_measure(bool value)
     {
         _measure->set_visible(value);
@@ -467,26 +440,6 @@ namespace trview
         _map_tooltip->set_visible(_map_tooltip->visible() && _show_tooltip);
     }
 
-    void ViewerUI::set_show_triggers(bool value)
-    {
-        _view_options->set_show_triggers(value);
-    }
-
-    void ViewerUI::set_show_water(bool value)
-    {
-        _view_options->set_show_water(value);
-    }
-
-    void ViewerUI::set_show_wireframe(bool value)
-    {
-        _view_options->set_show_wireframe(value);
-    }
-
-    void ViewerUI::set_show_bounding_boxes(bool value)
-    {
-        _view_options->set_show_bounding_boxes(value);
-    }
-
     void ViewerUI::set_use_alternate_groups(bool value)
     {
         _view_options->set_use_alternate_groups(value);
@@ -495,31 +448,6 @@ namespace trview
     void ViewerUI::set_visible(bool value)
     {
         _control->set_visible(value);
-    }
-
-    bool ViewerUI::show_hidden_geometry() const
-    {
-        return _view_options->show_hidden_geometry();
-    }
-
-    bool ViewerUI::show_triggers() const
-    {
-        return _view_options->show_triggers();
-    }
-
-    bool ViewerUI::show_water() const
-    {
-        return _view_options->show_water();
-    }
-
-    bool ViewerUI::show_wireframe() const
-    {
-        return _view_options->show_wireframe();
-    }
-
-    bool ViewerUI::show_bounding_boxes() const
-    {
-        return _view_options->show_bounding_boxes();
     }
 
     bool ViewerUI::show_context_menu() const
@@ -545,5 +473,15 @@ namespace trview
     void ViewerUI::set_mid_waypoint_enabled(bool value)
     {
         _context_menu->set_mid_waypoint_enabled(value);
+    }
+
+    void ViewerUI::set_toggle(const std::string& name, bool value)
+    {
+        _view_options->set_toggle(name, value);
+    }
+
+    bool ViewerUI::toggle(const std::string& name) const
+    {
+        return _view_options->toggle(name);
     }
 }

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -46,7 +46,6 @@ namespace trview
         virtual void set_camera_rotation(float yaw, float pitch) override;
         virtual void set_camera_mode(CameraMode mode) override;
         virtual void set_camera_projection_mode(ProjectionMode mode) override;
-        virtual void set_depth_level(int32_t value) override;
         virtual void set_flip_enabled(bool value) override;
         virtual void set_hide_enabled(bool value) override;
 
@@ -72,6 +71,7 @@ namespace trview
         virtual void print_console(const std::wstring& text) override;
         virtual void initialise_input() override;
         virtual void set_mid_waypoint_enabled(bool value) override;
+        virtual void set_scalar(const std::string& name, int32_t value) override;
         virtual void set_toggle(const std::string& name, bool value) override;
         virtual bool toggle(const std::string& name) const override;
     private:

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -46,12 +46,9 @@ namespace trview
         virtual void set_camera_rotation(float yaw, float pitch) override;
         virtual void set_camera_mode(CameraMode mode) override;
         virtual void set_camera_projection_mode(ProjectionMode mode) override;
-        virtual void set_depth_enabled(bool value) override;
         virtual void set_depth_level(int32_t value) override;
-        virtual void set_flip(bool value) override;
         virtual void set_flip_enabled(bool value) override;
         virtual void set_hide_enabled(bool value) override;
-        virtual void set_highlight(bool value) override;
 
         /// Set the size of the host window.
         void set_host_size(const Size& size) override;
@@ -65,26 +62,18 @@ namespace trview
         virtual void set_selected_room(const std::shared_ptr<IRoom>& room) override;
         virtual void set_settings(const UserSettings& settings) override;
         virtual void set_show_context_menu(bool value) override;
-        virtual void set_show_hidden_geometry(bool value) override;
         virtual void set_show_measure(bool value) override;
         virtual void set_show_minimap(bool value) override;
         virtual void set_show_tooltip(bool value) override;
-        virtual void set_show_triggers(bool value) override;
-        virtual void set_show_water(bool value) override;
-        virtual void set_show_wireframe(bool value) override;
-        virtual void set_show_bounding_boxes(bool value) override;
         virtual void set_use_alternate_groups(bool value) override;
         virtual void set_visible(bool value) override;
-        virtual bool show_hidden_geometry() const override;
-        virtual bool show_triggers() const override;
-        virtual bool show_water() const override;
-        virtual bool show_wireframe() const override;
-        virtual bool show_bounding_boxes() const override;
         virtual bool show_context_menu() const override;
         virtual void toggle_settings_visibility() override;
         virtual void print_console(const std::wstring& text) override;
         virtual void initialise_input() override;
         virtual void set_mid_waypoint_enabled(bool value) override;
+        virtual void set_toggle(const std::string& name, bool value) override;
+        virtual bool toggle(const std::string& name) const override;
     private:
         void generate_tool_window(const IViewOptions::Source& view_options_source, const ICameraControls::Source& camera_controls_source, const ui::ILoader& ui_source);
         void register_change_detection(ui::Control* control);

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -17,6 +17,7 @@ namespace trview
     {
         struct Options
         {
+            inline static const std::string depth = "depth";
             inline static const std::string depth_enabled = "depth_enabled";
             inline static const std::string flip = "flip";
             inline static const std::string hidden_geometry = "hidden_geometry";

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -15,6 +15,18 @@ namespace trview
 {
     struct IViewer
     {
+        struct Options
+        {
+            inline static const std::string depth_enabled = "depth_enabled";
+            inline static const std::string flip = "flip";
+            inline static const std::string hidden_geometry = "hidden_geometry";
+            inline static const std::string highlight = "highlight";
+            inline static const std::string show_bounding_boxes = "show_bounding_boxes";
+            inline static const std::string triggers = "triggers";
+            inline static const std::string water = "water";
+            inline static const std::string wireframe = "wireframe";
+        };
+
         virtual ~IViewer() = 0;
 
         /// Event raised when the user settings have changed.

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -52,14 +52,14 @@ namespace trview
 
 
         std::unordered_map<std::string, std::function<void(bool)>> toggles;
-        toggles["highlight"] = [this](bool) { toggle_highlight(); };
-        toggles["hidden_geometry"] = [this](bool value) { set_show_hidden_geometry(value); };
-        toggles["water"] = [this](bool value) { set_show_water(value); };
-        toggles["wireframe"] = [this](bool value) { set_show_wireframe(value); };
-        toggles["triggers"] = [this](bool value) { set_show_triggers(value); };
-        toggles["show_bounding_boxes"] = [this](bool value) { set_show_bounding_boxes(value); };
-        toggles["flip"] = [this](bool value) { set_alternate_mode(value); };
-        toggles["depth_enabled"] = [this](bool value) { if (_level) { _level->set_highlight_mode(ILevel::RoomHighlightMode::Neighbours, value); } };
+        toggles[Options::highlight] = [this](bool) { toggle_highlight(); };
+        toggles[Options::hidden_geometry] = [this](bool value) { set_show_hidden_geometry(value); };
+        toggles[Options::water] = [this](bool value) { set_show_water(value); };
+        toggles[Options::wireframe] = [this](bool value) { set_show_wireframe(value); };
+        toggles[Options::triggers] = [this](bool value) { set_show_triggers(value); };
+        toggles[Options::show_bounding_boxes] = [this](bool value) { set_show_bounding_boxes(value); };
+        toggles[Options::flip] = [this](bool value) { set_alternate_mode(value); };
+        toggles[Options::depth_enabled] = [this](bool value) { if (_level) { _level->set_highlight_mode(ILevel::RoomHighlightMode::Neighbours, value); } };
 
         _ui->initialise_input();
         _token_store += _ui->on_ui_changed += [&]() {_ui_changed = true; };
@@ -496,11 +496,11 @@ namespace trview
         _token_store += _level->on_alternate_group_selected += [&](uint16_t group, bool enabled) { set_alternate_group(group, enabled); };
         _token_store += _level->on_level_changed += [&]() { _scene_changed = true; };
 
-        _level->set_show_triggers(_ui->toggle("triggers"));
-        _level->set_show_hidden_geometry(_ui->toggle("hidden_geometry"));
-        _level->set_show_water(_ui->toggle("water"));
-        _level->set_show_wireframe(_ui->toggle("wireframe")); 
-        _level->set_show_bounding_boxes(_ui->toggle("show_bounding_boxes"));
+        _level->set_show_triggers(_ui->toggle(Options::triggers));
+        _level->set_show_hidden_geometry(_ui->toggle(Options::hidden_geometry));
+        _level->set_show_water(_ui->toggle(Options::water));
+        _level->set_show_wireframe(_ui->toggle(Options::wireframe)); 
+        _level->set_show_bounding_boxes(_ui->toggle(Options::show_bounding_boxes));
 
         // Set up the views.
         auto rooms = _level->room_info();
@@ -508,10 +508,10 @@ namespace trview
 
         // Reset UI buttons
         _ui->set_max_rooms(static_cast<uint32_t>(rooms.size()));
-        _ui->set_toggle("highlight", false);
+        _ui->set_toggle(Options::highlight, false);
         _ui->set_use_alternate_groups(_level->version() >= trlevel::LevelVersion::Tomb4);
         _ui->set_alternate_groups(_level->alternate_groups());
-        _ui->set_toggle("flip", false);
+        _ui->set_toggle(Options::flip, false);
         _ui->set_flip_enabled(_level->any_alternates());
 
         Item lara;
@@ -524,7 +524,7 @@ namespace trview
             on_room_selected(0);
         }
 
-        _ui->set_toggle("depth", false);
+        _ui->set_toggle(Options::depth_enabled, false);
         _ui->set_depth_level(1);
 
         // Strip the last part of the path away.
@@ -670,7 +670,7 @@ namespace trview
         {
             bool new_value = !_level->highlight_mode_enabled(Level::RoomHighlightMode::Highlight);
             _level->set_highlight_mode(Level::RoomHighlightMode::Highlight, new_value);
-            _ui->set_toggle("highlight", new_value);
+            _ui->set_toggle(Options::highlight, new_value);
         }
     }
 
@@ -787,7 +787,7 @@ namespace trview
         {
             _was_alternate_select = true;
             _level->set_alternate_mode(enabled);
-            _ui->set_toggle("flip", enabled);
+            _ui->set_toggle(Options::flip, enabled);
         }
     }
 
@@ -951,7 +951,7 @@ namespace trview
         if (_level)
         {
             _level->set_show_triggers(show);
-            _ui->set_toggle("triggers", show);
+            _ui->set_toggle(Options::triggers, show);
         }
     }
 
@@ -968,7 +968,7 @@ namespace trview
         if (_level)
         {
             _level->set_show_hidden_geometry(show);
-            _ui->set_toggle("hidden_geometry", show);
+            _ui->set_toggle(Options::hidden_geometry, show);
         }
     }
 
@@ -993,7 +993,7 @@ namespace trview
         if (_level)
         {
             _level->set_show_wireframe(show);
-            _ui->set_toggle("wireframe", show);
+            _ui->set_toggle(Options::wireframe, show);
         }
     }
 
@@ -1002,7 +1002,7 @@ namespace trview
         if (_level)
         {
             _level->set_show_bounding_boxes(show);
-            _ui->set_toggle("show_bounding_boxes", show);
+            _ui->set_toggle(Options::show_bounding_boxes, show);
         }
     }
 

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -508,11 +508,9 @@ namespace trview
 
         // Reset UI buttons
         _ui->set_max_rooms(static_cast<uint32_t>(rooms.size()));
-        // _ui->set_highlight(false);
         _ui->set_toggle("highlight", false);
         _ui->set_use_alternate_groups(_level->version() >= trlevel::LevelVersion::Tomb4);
         _ui->set_alternate_groups(_level->alternate_groups());
-        // _ui->set_flip(false);
         _ui->set_toggle("flip", false);
         _ui->set_flip_enabled(_level->any_alternates());
 
@@ -526,8 +524,7 @@ namespace trview
             on_room_selected(0);
         }
 
-        // TODO: Fix depth enabled.
-        // _ui->set_depth_enabled(false);
+        _ui->set_toggle("depth", false);
         _ui->set_depth_level(1);
 
         // Strip the last part of the path away.
@@ -673,7 +670,7 @@ namespace trview
         {
             bool new_value = !_level->highlight_mode_enabled(Level::RoomHighlightMode::Highlight);
             _level->set_highlight_mode(Level::RoomHighlightMode::Highlight, new_value);
-            // _ui->set_highlight(new_value);
+            _ui->set_toggle("highlight", new_value);
         }
     }
 
@@ -790,8 +787,7 @@ namespace trview
         {
             _was_alternate_select = true;
             _level->set_alternate_mode(enabled);
-            // _ui->set_flip(enabled);
-            // TODO: Fix
+            _ui->set_toggle("flip", enabled);
         }
     }
 
@@ -955,7 +951,7 @@ namespace trview
         if (_level)
         {
             _level->set_show_triggers(show);
-            // _ui->set_show_triggers(show);
+            _ui->set_toggle("triggers", show);
         }
     }
 
@@ -972,7 +968,7 @@ namespace trview
         if (_level)
         {
             _level->set_show_hidden_geometry(show);
-            // _ui->set_show_hidden_geometry(show);
+            _ui->set_toggle("hidden_geometry", show);
         }
     }
 
@@ -997,7 +993,7 @@ namespace trview
         if (_level)
         {
             _level->set_show_wireframe(show);
-            // _ui->set_show_wireframe(show);
+            _ui->set_toggle("wireframe", show);
         }
     }
 
@@ -1006,7 +1002,7 @@ namespace trview
         if (_level)
         {
             _level->set_show_bounding_boxes(show);
-            // _ui->set_show_bounding_boxes(show);
+            _ui->set_toggle("show_bounding_boxes", show);
         }
     }
 

--- a/trview.ui.tests/ControlTests.cpp
+++ b/trview.ui.tests/ControlTests.cpp
@@ -78,6 +78,22 @@ TEST(Control, Find)
     ASSERT_EQ(found, child_ptr);
 }
 
+TEST(Control, FindType)
+{
+    TestControl control;
+
+    auto child = std::make_unique<TestControl>();
+    child->set_name("Child");
+    auto child_ptr = child.get();
+    auto added = control.add_child(std::move(child));
+
+    auto found = control.find<TestControl>();
+
+    const std::vector<TestControl*> expected{ &control, child_ptr };
+    ASSERT_EQ(added, child_ptr);
+    ASSERT_THAT(found, testing::ContainerEq(expected));
+}
+
 TEST(Control, RemoveChild)
 {
     TestControl control;

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -144,6 +144,22 @@ namespace trview
             template <typename T>
             T* find(const std::string& name);
 
+            /// <summary>
+            /// Find all controls with the specified type.
+            /// </summary>
+            /// <typeparam name="T">The control type to find.</typeparam>
+            /// <returns>The controls with the given types. If there are no control found, this returns an empty vector.</returns>
+            template <typename T>
+            std::vector<const T*> find_all() const;
+
+            /// <summary>
+            /// Find all controls with the specified type.
+            /// </summary>
+            /// <typeparam name="T">The control type to find.</typeparam>
+            /// <returns>The controls with the given types. If there are no control found, this returns an empty vector.</returns>
+            template <typename T>
+            std::vector<T*> find_all();
+
             /// Get the z order of the control.
             /// @returns The z order.
             int z() const;

--- a/trview.ui/Control.h
+++ b/trview.ui/Control.h
@@ -150,7 +150,7 @@ namespace trview
             /// <typeparam name="T">The control type to find.</typeparam>
             /// <returns>The controls with the given types. If there are no control found, this returns an empty vector.</returns>
             template <typename T>
-            std::vector<const T*> find_all() const;
+            std::vector<const T*> find() const;
 
             /// <summary>
             /// Find all controls with the specified type.
@@ -158,7 +158,7 @@ namespace trview
             /// <typeparam name="T">The control type to find.</typeparam>
             /// <returns>The controls with the given types. If there are no control found, this returns an empty vector.</returns>
             template <typename T>
-            std::vector<T*> find_all();
+            std::vector<T*> find();
 
             /// Get the z order of the control.
             /// @returns The z order.

--- a/trview.ui/Control.inl
+++ b/trview.ui/Control.inl
@@ -45,7 +45,7 @@ namespace trview
         }
 
         template <typename T>
-        std::vector<const T*> Control::find_all() const
+        std::vector<const T*> Control::find() const
         {
             std::vector<const T*> results;
             T* as_t = dynamic_cast<const T*>(this);
@@ -56,14 +56,14 @@ namespace trview
 
             for (const auto& child : _child_elements)
             {
-                auto child_results = child->find_all<T>();
+                auto child_results = child->find<T>();
                 results.insert(results.end(), child_results.begin(), child_results.end());
             }
             return results;
         }
 
         template <typename T>
-        std::vector<T*> Control::find_all()
+        std::vector<T*> Control::find()
         {
             std::vector<T*> results;
             T* as_t = dynamic_cast<T*>(this);
@@ -74,7 +74,7 @@ namespace trview
 
             for (auto& child : _child_elements)
             {
-                auto child_results = child->find_all<T>();
+                auto child_results = child->find<T>();
                 results.insert(results.end(), child_results.begin(), child_results.end());
             }
             return results;

--- a/trview.ui/Control.inl
+++ b/trview.ui/Control.inl
@@ -45,6 +45,42 @@ namespace trview
         }
 
         template <typename T>
+        std::vector<const T*> Control::find_all() const
+        {
+            std::vector<const T*> results;
+            T* as_t = dynamic_cast<const T*>(this);
+            if (as_t)
+            {
+                results.push_back(as_t);
+            }
+
+            for (const auto& child : _child_elements)
+            {
+                auto child_results = child->find_all<T>();
+                results.insert(results.end(), child_results.begin(), child_results.end());
+            }
+            return results;
+        }
+
+        template <typename T>
+        std::vector<T*> Control::find_all()
+        {
+            std::vector<T*> results;
+            T* as_t = dynamic_cast<T*>(this);
+            if (as_t)
+            {
+                results.push_back(as_t);
+            }
+
+            for (auto& child : _child_elements)
+            {
+                auto child_results = child->find_all<T>();
+                results.insert(results.end(), child_results.begin(), child_results.end());
+            }
+            return results;
+        }
+
+        template <typename T>
         T* Control::add_child(std::unique_ptr<T>&& child_element)
         {
             static_assert(std::is_base_of<Control, T>::value, "Element must be derived from Control");


### PR DESCRIPTION
Change the `ViewOptions` class to scan the UI tree to find `Checkbox` and `NumericUpDown` controls and use them as the settings values. Instead of the individual events for each setting there is now one for toggles and one for scalars.

`Viewer` now checks the name of the setting changed and takes action based on that.

This means that to add a new setting only the JSON and the handling in `Viewer` needs to be updated instead of adding control instances and events to `IViewOptions` and `IViewerUI`.

This code might be taken for other 'settings' areas at some point.

Alternate group handling is left as it is for now, as well as disabling the `Flip` checkbox when there are no flipmaps present.

Closes #866 