### PR TITLE
Update steam emitter names for TR4 and TR5

### DIFF
--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -3750,10 +3750,10 @@
 				"name": "Compass"
 			}, {
 				"id": 364,
-				"name": "Steam"
+				"name": "Smoke emitter"
 			}, {
 				"id": 365,
-				"name": "Steam"
+				"name": "Steam emitter"
 			}, {
 				"id": 366,
 				"name": "Earthquake"

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -2983,8 +2983,11 @@
 				"id": 375,
 				"name": "Compass"
 			}, {
+				"id": 380,
+				"name": "White smoke emitter"
+			}, {
 				"id": 381,
-				"name": "Smoke emitter"
+				"name": "Black smoke emitter"
 			}, {
 				"id": 382,
 				"name": "Steam emitter"
@@ -3749,8 +3752,11 @@
 				"id": 356,
 				"name": "Compass"
 			}, {
+				"id": 363,
+				"name": "White smoke emitter"
+			}, {
 				"id": 364,
-				"name": "Smoke emitter"
+				"name": "Black smoke emitter"
 			}, {
 				"id": 365,
 				"name": "Steam emitter"


### PR DESCRIPTION
TR4:
Add `380: White smoke emitter`
Change `381: Smoke emitter` to `381: Black smoke emitter`

TR5:
Add `363: White smoke emitter`
Change `364: Steam` to `364: Black smoke emitter`.
Change `365: Steam` to `365: Steam emitter`

Closes #871