### PR TITLE
Fix definition of on_scalar_changed handler to take integers

### DIFF
--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -640,3 +640,13 @@ TEST(Viewer, MidWaypointUsesCentroid)
     ASSERT_TRUE(raised_position.has_value());
     ASSERT_EQ(raised_position.value(), Vector3(3, 4, 5));
 }
+
+TEST(Viewer, DepthViewOptionUpdatesLevel)
+{
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    MockLevel level;
+    EXPECT_CALL(level, set_neighbour_depth(6)).Times(1);
+    auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
+    viewer->open(&level);
+    ui.on_scalar_changed(IViewer::Options::depth, 6);
+}

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -82,7 +82,7 @@ namespace trview
             toggle->second(value);
         };
         _token_store += _ui->on_alternate_group += [&](uint32_t group, bool value) { set_alternate_group(group, value); };
-        _token_store += _ui->on_scalar_changed += [this, scalars](const std::string& name, bool value)
+        _token_store += _ui->on_scalar_changed += [this, scalars](const std::string& name, int32_t value)
         {
             auto scalar = scalars.find(name);
             if (scalar == scalars.end())


### PR DESCRIPTION
The handler attached to `on_scalar_changed` was unfortunately defined with `bool` instead of `int32_t`, so the values were being converted to `bool` and so were always `0` or `1`. This broke the depth setting from the view options.

Added a test to stop this happening again which should have been there in the first place really.

Closes #876