### PR TITLE
Correctly set sampler state

### DIFF
--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -182,7 +182,7 @@ namespace trview
 
         {
             graphics::RasterizerStateStore rasterizer_store(context);
-            context->PSSetSamplers(0, 1, &_sampler_state);
+            context->PSSetSamplers(0, 1, _sampler_state.GetAddressOf());
             if (_show_wireframe)
             {
                 context->RSSetState(_wireframe_rasterizer.Get());


### PR DESCRIPTION
The sampler state was being set by using the `&` operator on the sampler state - however `&` in `ComPtr` means take the address and release it - so it wasn't being actually used. Changed this to `GetAddressOf` instead.
Closes #875