### PR TITLE
Convert all mocks to NiceMock

### DIFF
--- a/trlevel/Mocks/ILevelLoader.h
+++ b/trlevel/Mocks/ILevelLoader.h
@@ -6,11 +6,10 @@ namespace trlevel
 {
     namespace mocks
     {
-        class MockLevelLoader final : public ILevelLoader
+        struct MockLevelLoader : public ILevelLoader
         {
-        public:
             virtual ~MockLevelLoader() = default;
-            MOCK_METHOD(std::unique_ptr<ILevel>, load_level, (const std::string&), (const));
+            MOCK_METHOD(std::unique_ptr<ILevel>, load_level, (const std::string&), (const, override));
         };
     }
 }

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -36,23 +36,23 @@ namespace
         struct test_module
         {
             Window window{ create_test_window(L"ApplicationTests") };
-            std::unique_ptr<IUpdateChecker> update_checker{ std::make_unique<MockUpdateChecker>() };
-            std::unique_ptr<ISettingsLoader> settings_loader{ std::make_unique<MockSettingsLoader>() };
-            std::unique_ptr<IFileDropper> file_dropper{ std::make_unique<MockFileDropper>() };
-            std::unique_ptr<trlevel::ILevelLoader> level_loader{ std::make_unique<MockLevelLoader>() };
-            std::unique_ptr<ILevelSwitcher> level_switcher{ std::make_unique<MockLevelSwitcher>() };
-            std::unique_ptr<IRecentFiles> recent_files{ std::make_unique<MockRecentFiles>() };
-            std::unique_ptr<IViewer> viewer{ std::make_unique<MockViewer>() };
-            IRoute::Source route_source{ [](auto&&...) { return std::make_shared<MockRoute>(); } };
-            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<MockShortcuts>() };
-            std::unique_ptr<IItemsWindowManager> items_window_manager{ std::make_unique<MockItemsWindowManager>() };
-            std::unique_ptr<ITriggersWindowManager> triggers_window_manager{ std::make_unique<MockTriggersWindowManager>() };
-            std::unique_ptr<IRouteWindowManager> route_window_manager{ std::make_unique<MockRouteWindowManager>() };
-            std::unique_ptr<IRoomsWindowManager> rooms_window_manager{ std::make_unique<MockRoomsWindowManager>() };
-            ILevel::Source level_source{ [](auto&&...) { return std::make_unique<trview::mocks::MockLevel>(); } };
-            std::shared_ptr<IStartupOptions> startup_options{ std::make_shared<MockStartupOptions>() };
-            std::shared_ptr<IDialogs> dialogs{ std::make_shared<MockDialogs>() };
-            std::shared_ptr<IFiles> files{ std::make_shared<MockFiles>() };
+            std::unique_ptr<IUpdateChecker> update_checker{ std::make_unique<NiceMock<MockUpdateChecker>>() };
+            std::unique_ptr<ISettingsLoader> settings_loader{ std::make_unique<NiceMock<MockSettingsLoader>>() };
+            std::unique_ptr<IFileDropper> file_dropper{ std::make_unique<NiceMock<MockFileDropper>>() };
+            std::unique_ptr<trlevel::ILevelLoader> level_loader{ std::make_unique<NiceMock<MockLevelLoader>>() };
+            std::unique_ptr<ILevelSwitcher> level_switcher{ std::make_unique<NiceMock<MockLevelSwitcher>>() };
+            std::unique_ptr<IRecentFiles> recent_files{ std::make_unique<NiceMock<MockRecentFiles>>() };
+            std::unique_ptr<IViewer> viewer{ std::make_unique<NiceMock<MockViewer>>() };
+            IRoute::Source route_source{ [](auto&&...) { return std::make_shared<NiceMock<MockRoute>>(); } };
+            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<NiceMock<MockShortcuts>>() };
+            std::unique_ptr<IItemsWindowManager> items_window_manager{ std::make_unique<NiceMock<MockItemsWindowManager>>() };
+            std::unique_ptr<ITriggersWindowManager> triggers_window_manager{ std::make_unique<NiceMock<MockTriggersWindowManager>>() };
+            std::unique_ptr<IRouteWindowManager> route_window_manager{ std::make_unique<NiceMock<MockRouteWindowManager>>() };
+            std::unique_ptr<IRoomsWindowManager> rooms_window_manager{ std::make_unique<NiceMock<MockRoomsWindowManager>>() };
+            ILevel::Source level_source{ [](auto&&...) { return std::make_unique<NiceMock<trview::mocks::MockLevel>>(); } };
+            std::shared_ptr<IStartupOptions> startup_options{ std::make_shared<NiceMock<MockStartupOptions>>() };
+            std::shared_ptr<IDialogs> dialogs{ std::make_shared<NiceMock<MockDialogs>>() };
+            std::shared_ptr<IFiles> files{ std::make_shared<NiceMock<MockFiles>>() };
             std::unique_ptr<IImGuiBackend> imgui_backend{ std::make_unique<NullImGuiBackend>() };
 
             std::unique_ptr<Application> build()

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -231,7 +231,7 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
     auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
     auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
     auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    auto route = std::make_shared<MockRoute>();
+    auto route = mock_shared<MockRoute>();
 
     std::vector<std::string> events;
 
@@ -286,7 +286,7 @@ TEST(Application, SavesSettingsOnShutdown)
 
 TEST(Application, FileOpenedFromCommandLine)
 {
-    auto startup_options = std::make_shared<MockStartupOptions>();
+    auto startup_options = mock_shared<MockStartupOptions>();
     ON_CALL(*startup_options, filename).WillByDefault(testing::Return("test.tr2"));
     auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
@@ -307,7 +307,7 @@ TEST(Application, FileNotOpenedWhenNotSpecified)
 TEST(Application, DialogShownOnCloseWithUnsavedRouteBlocksClose)
 {
     auto [route_ptr, route] = create_mock<MockRoute>();
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     auto route_ptr_actual = std::move(route_ptr);
 
     EXPECT_CALL(route, is_unsaved).WillRepeatedly(Return(true));
@@ -321,7 +321,7 @@ TEST(Application, DialogShownOnCloseWithUnsavedRouteBlocksClose)
 TEST(Application, DialogShownOnCloseWithUnsavedRouteAllowsClose)
 {
     auto [route_ptr, route] = create_mock<MockRoute>();
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     auto route_ptr_actual = std::move(route_ptr);
 
     EXPECT_CALL(route, is_unsaved).WillRepeatedly(Return(true));
@@ -336,7 +336,7 @@ TEST(Application, DialogShownOnCloseWithUnsavedRouteAllowsClose)
 TEST(Application, DialogShownOnOpenWithUnsavedRouteBlocksOpen)
 {
     auto [route_ptr, route] = create_mock<MockRoute>();
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     auto route_ptr_actual = std::move(route_ptr);
     auto [level_loader_ptr, level_loader] = create_mock<trlevel::mocks::MockLevelLoader>();
 
@@ -353,7 +353,7 @@ TEST(Application, DialogShownOnOpenWithUnsavedRouteBlocksOpen)
 TEST(Application, DialogShownOnOpenWithUnsavedRouteAllowsOpen)
 {
     auto [route_ptr, route] = create_mock<MockRoute>();
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     auto route_ptr_actual = std::move(route_ptr);
     auto [level_loader_ptr, level_loader] = create_mock<trlevel::mocks::MockLevelLoader>();
 
@@ -381,7 +381,7 @@ TEST(Application, FileOpenOpensFile)
 {
     auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
     EXPECT_CALL(level_loader, load_level).Times(1);
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename" }));
 
     auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_dialogs(dialogs).build();
@@ -392,7 +392,7 @@ TEST(Application, FileOpenDoesNotOpenFileWhenCancelled)
 {
     auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
     EXPECT_CALL(level_loader, load_level).Times(0);
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, open_file).Times(1);
 
     auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_dialogs(dialogs).build();
@@ -403,7 +403,7 @@ TEST(Application, FileOpenAcceleratorOpensFile)
 {
     auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
     EXPECT_CALL(level_loader, load_level).Times(1);
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename" }));
 
     auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_dialogs(dialogs).build();
@@ -414,7 +414,7 @@ TEST(Application, FileOpenAcceleratorDoesNotOpenFileWhenCancelled)
 {
     auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
     EXPECT_CALL(level_loader, load_level).Times(0);
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, open_file).Times(1);
 
     auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_dialogs(dialogs).build();
@@ -424,9 +424,9 @@ TEST(Application, FileOpenAcceleratorDoesNotOpenFileWhenCancelled)
 TEST(Application, ExportRouteSavesFile)
 {
     auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    auto files = std::make_shared<MockFiles>();
+    auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::string&>())).Times(1);
-    auto route = std::make_shared<MockRoute>();
+    auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, set_unsaved(false)).Times(1);
 
     auto application = register_test_module()
@@ -443,9 +443,9 @@ TEST(Application, ImportRouteLoadsFile)
     EXPECT_CALL(viewer, set_route).Times(1);
     auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
     EXPECT_CALL(route_window_manager, set_route).Times(1);
-    auto files = std::make_shared<MockFiles>();
+    auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, load_file).Times(1).WillRepeatedly(Return<std::vector<uint8_t>>({ 0x7b, 0x7d }));;
-    auto route = std::make_shared<MockRoute>();
+    auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, set_unsaved(false)).Times(1);
 
     auto application = register_test_module()

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -36,23 +36,23 @@ namespace
         struct test_module
         {
             Window window{ create_test_window(L"ApplicationTests") };
-            std::unique_ptr<IUpdateChecker> update_checker{ std::make_unique<NiceMock<MockUpdateChecker>>() };
-            std::unique_ptr<ISettingsLoader> settings_loader{ std::make_unique<NiceMock<MockSettingsLoader>>() };
-            std::unique_ptr<IFileDropper> file_dropper{ std::make_unique<NiceMock<MockFileDropper>>() };
-            std::unique_ptr<trlevel::ILevelLoader> level_loader{ std::make_unique<NiceMock<MockLevelLoader>>() };
-            std::unique_ptr<ILevelSwitcher> level_switcher{ std::make_unique<NiceMock<MockLevelSwitcher>>() };
-            std::unique_ptr<IRecentFiles> recent_files{ std::make_unique<NiceMock<MockRecentFiles>>() };
-            std::unique_ptr<IViewer> viewer{ std::make_unique<NiceMock<MockViewer>>() };
-            IRoute::Source route_source{ [](auto&&...) { return std::make_shared<NiceMock<MockRoute>>(); } };
-            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<NiceMock<MockShortcuts>>() };
-            std::unique_ptr<IItemsWindowManager> items_window_manager{ std::make_unique<NiceMock<MockItemsWindowManager>>() };
-            std::unique_ptr<ITriggersWindowManager> triggers_window_manager{ std::make_unique<NiceMock<MockTriggersWindowManager>>() };
-            std::unique_ptr<IRouteWindowManager> route_window_manager{ std::make_unique<NiceMock<MockRouteWindowManager>>() };
-            std::unique_ptr<IRoomsWindowManager> rooms_window_manager{ std::make_unique<NiceMock<MockRoomsWindowManager>>() };
-            ILevel::Source level_source{ [](auto&&...) { return std::make_unique<NiceMock<trview::mocks::MockLevel>>(); } };
-            std::shared_ptr<IStartupOptions> startup_options{ std::make_shared<NiceMock<MockStartupOptions>>() };
-            std::shared_ptr<IDialogs> dialogs{ std::make_shared<NiceMock<MockDialogs>>() };
-            std::shared_ptr<IFiles> files{ std::make_shared<NiceMock<MockFiles>>() };
+            std::unique_ptr<IUpdateChecker> update_checker{ mock_unique<MockUpdateChecker>() };
+            std::unique_ptr<ISettingsLoader> settings_loader{ mock_unique<MockSettingsLoader>() };
+            std::unique_ptr<IFileDropper> file_dropper{ mock_unique<MockFileDropper>() };
+            std::unique_ptr<trlevel::ILevelLoader> level_loader{ mock_unique<MockLevelLoader>() };
+            std::unique_ptr<ILevelSwitcher> level_switcher{ mock_unique<MockLevelSwitcher>() };
+            std::unique_ptr<IRecentFiles> recent_files{ mock_unique<MockRecentFiles>() };
+            std::unique_ptr<IViewer> viewer{ mock_unique<MockViewer>() };
+            IRoute::Source route_source{ [](auto&&...) { return mock_shared<MockRoute>(); } };
+            std::shared_ptr<MockShortcuts> shortcuts{ mock_shared<MockShortcuts>() };
+            std::unique_ptr<IItemsWindowManager> items_window_manager{ mock_unique<MockItemsWindowManager>() };
+            std::unique_ptr<ITriggersWindowManager> triggers_window_manager{ mock_unique<MockTriggersWindowManager>() };
+            std::unique_ptr<IRouteWindowManager> route_window_manager{ mock_unique<MockRouteWindowManager>() };
+            std::unique_ptr<IRoomsWindowManager> rooms_window_manager{ mock_unique<MockRoomsWindowManager>() };
+            ILevel::Source level_source{ [](auto&&...) { return mock_unique<trview::mocks::MockLevel>(); } };
+            std::shared_ptr<IStartupOptions> startup_options{ mock_shared<MockStartupOptions>() };
+            std::shared_ptr<IDialogs> dialogs{ mock_shared<MockDialogs>() };
+            std::shared_ptr<IFiles> files{ mock_shared<MockFiles>() };
             std::unique_ptr<IImGuiBackend> imgui_backend{ std::make_unique<NullImGuiBackend>() };
 
             std::unique_ptr<Application> build()

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -206,7 +206,7 @@ TEST(Application, RecentFilesUpdatedOnFileOpen)
     auto [level_loader_ptr, level_loader] = create_mock<MockLevelLoader>();
     EXPECT_CALL(recent_files, set_recent_files(std::list<std::string>{})).Times(1);
     EXPECT_CALL(recent_files, set_recent_files(std::list<std::string>{"test_path.tr2"})).Times(1);
-    EXPECT_CALL(level_loader, load_level("test_path.tr2")).WillOnce(Return(ByMove(std::make_unique<trlevel::mocks::MockLevel>())));
+    EXPECT_CALL(level_loader, load_level("test_path.tr2")).WillOnce(Return(ByMove(mock_unique<trlevel::mocks::MockLevel>())));
     auto application = register_test_module().with_level_loader(std::move(level_loader_ptr)).with_recent_files(std::move(recent_files_ptr)).build();
     application->open("test_path.tr2");
 }

--- a/trview.app.tests/Elements/EntityTests.cpp
+++ b/trview.app.tests/Elements/EntityTests.cpp
@@ -6,8 +6,8 @@
 using namespace trlevel::mocks;
 using namespace trview;
 using namespace trview::mocks;
+using namespace trview::tests;
 using testing::Return;
-using testing::NiceMock;
 
 namespace
 {
@@ -15,9 +15,9 @@ namespace
     {
         struct test_module
         {
-            std::shared_ptr<trlevel::ILevel> level{ std::make_shared<NiceMock<trlevel::mocks::MockLevel>>() };
-            IMesh::Source mesh_source = [](auto&&...) { return std::make_shared<NiceMock<MockMesh>>(); };
-            std::shared_ptr<IMeshStorage> mesh_storage = std::make_shared<NiceMock<MockMeshStorage>>();
+            std::shared_ptr<trlevel::ILevel> level{ mock_shared<trlevel::mocks::MockLevel>() };
+            IMesh::Source mesh_source = [](auto&&...) { return mock_shared<MockMesh>(); };
+            std::shared_ptr<IMeshStorage> mesh_storage = mock_shared<MockMeshStorage>();
             trlevel::tr2_entity entity{};
             uint32_t index{ 0u };
             bool is_pickup{ false };
@@ -51,7 +51,7 @@ namespace
 
 TEST(Entity, OcbAdjustmentTrueForPickup)
 {
-    auto level = std::make_shared<NiceMock<trlevel::mocks::MockLevel>>();
+    auto level = mock_shared<trlevel::mocks::MockLevel>();
     EXPECT_CALL(*level, get_version).WillRepeatedly(Return(trlevel::LevelVersion::Tomb4));
     auto entity = register_test_module().with_level(level).with_pickup(true).build();
     ASSERT_TRUE(entity->needs_ocb_adjustment());
@@ -59,7 +59,7 @@ TEST(Entity, OcbAdjustmentTrueForPickup)
 
 TEST(Entity, OcbAdjustmentFalseForNonPickup)
 {
-    auto level = std::make_shared<NiceMock<trlevel::mocks::MockLevel>>();
+    auto level = mock_shared<trlevel::mocks::MockLevel>();
     EXPECT_CALL(*level, get_version).WillRepeatedly(Return(trlevel::LevelVersion::Tomb4));
     auto entity = register_test_module().with_level(level).with_pickup(false).build();
     ASSERT_FALSE(entity->needs_ocb_adjustment());
@@ -67,7 +67,7 @@ TEST(Entity, OcbAdjustmentFalseForNonPickup)
 
 TEST(Entity, OcbAdjustmentFalseForPickupWithNonMatchingOCB)
 {
-    auto level = std::make_shared<NiceMock<trlevel::mocks::MockLevel>>();
+    auto level = mock_shared<trlevel::mocks::MockLevel>();
     EXPECT_CALL(*level, get_version).WillRepeatedly(Return(trlevel::LevelVersion::Tomb4));
     trlevel::tr2_entity tr2_entity{};
     tr2_entity.Intensity2 = 1;
@@ -77,7 +77,7 @@ TEST(Entity, OcbAdjustmentFalseForPickupWithNonMatchingOCB)
 
 TEST(Entity, OcbAdjustmentNotDonePreTR4)
 {
-    auto level = std::make_shared<NiceMock<trlevel::mocks::MockLevel>>();
+    auto level = mock_shared<trlevel::mocks::MockLevel>();
     EXPECT_CALL(*level, get_version).WillRepeatedly(Return(trlevel::LevelVersion::Tomb3));
     auto entity = register_test_module().with_level(level).with_pickup(true).build();
     ASSERT_FALSE(entity->needs_ocb_adjustment());

--- a/trview.app.tests/Elements/EntityTests.cpp
+++ b/trview.app.tests/Elements/EntityTests.cpp
@@ -7,6 +7,7 @@ using namespace trlevel::mocks;
 using namespace trview;
 using namespace trview::mocks;
 using testing::Return;
+using testing::NiceMock;
 
 namespace
 {
@@ -14,9 +15,9 @@ namespace
     {
         struct test_module
         {
-            std::shared_ptr<trlevel::ILevel> level{ std::make_shared<trlevel::mocks::MockLevel>() };
-            IMesh::Source mesh_source = [](auto&&...) { return std::make_shared<MockMesh>(); };
-            std::shared_ptr<IMeshStorage> mesh_storage = std::make_shared<MockMeshStorage>();
+            std::shared_ptr<trlevel::ILevel> level{ std::make_shared<NiceMock<trlevel::mocks::MockLevel>>() };
+            IMesh::Source mesh_source = [](auto&&...) { return std::make_shared<NiceMock<MockMesh>>(); };
+            std::shared_ptr<IMeshStorage> mesh_storage = std::make_shared<NiceMock<MockMeshStorage>>();
             trlevel::tr2_entity entity{};
             uint32_t index{ 0u };
             bool is_pickup{ false };
@@ -50,7 +51,7 @@ namespace
 
 TEST(Entity, OcbAdjustmentTrueForPickup)
 {
-    auto level = std::make_shared<trlevel::mocks::MockLevel>();
+    auto level = std::make_shared<NiceMock<trlevel::mocks::MockLevel>>();
     EXPECT_CALL(*level, get_version).WillRepeatedly(Return(trlevel::LevelVersion::Tomb4));
     auto entity = register_test_module().with_level(level).with_pickup(true).build();
     ASSERT_TRUE(entity->needs_ocb_adjustment());
@@ -58,7 +59,7 @@ TEST(Entity, OcbAdjustmentTrueForPickup)
 
 TEST(Entity, OcbAdjustmentFalseForNonPickup)
 {
-    auto level = std::make_shared<trlevel::mocks::MockLevel>();
+    auto level = std::make_shared<NiceMock<trlevel::mocks::MockLevel>>();
     EXPECT_CALL(*level, get_version).WillRepeatedly(Return(trlevel::LevelVersion::Tomb4));
     auto entity = register_test_module().with_level(level).with_pickup(false).build();
     ASSERT_FALSE(entity->needs_ocb_adjustment());
@@ -66,7 +67,7 @@ TEST(Entity, OcbAdjustmentFalseForNonPickup)
 
 TEST(Entity, OcbAdjustmentFalseForPickupWithNonMatchingOCB)
 {
-    auto level = std::make_shared<trlevel::mocks::MockLevel>();
+    auto level = std::make_shared<NiceMock<trlevel::mocks::MockLevel>>();
     EXPECT_CALL(*level, get_version).WillRepeatedly(Return(trlevel::LevelVersion::Tomb4));
     trlevel::tr2_entity tr2_entity{};
     tr2_entity.Intensity2 = 1;
@@ -76,7 +77,7 @@ TEST(Entity, OcbAdjustmentFalseForPickupWithNonMatchingOCB)
 
 TEST(Entity, OcbAdjustmentNotDonePreTR4)
 {
-    auto level = std::make_shared<trlevel::mocks::MockLevel>();
+    auto level = std::make_shared<NiceMock<trlevel::mocks::MockLevel>>();
     EXPECT_CALL(*level, get_version).WillRepeatedly(Return(trlevel::LevelVersion::Tomb3));
     auto entity = register_test_module().with_level(level).with_pickup(true).build();
     ASSERT_FALSE(entity->needs_ocb_adjustment());

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -23,7 +23,6 @@ using namespace trlevel::mocks;
 using namespace trview::tests;
 using testing::Return;
 using testing::A;
-using testing::NiceMock;
 using namespace DirectX::SimpleMath;
 
 namespace
@@ -32,18 +31,18 @@ namespace
     {
         struct test_module
         {
-            std::shared_ptr<IDevice> device{ std::make_shared<NiceMock<MockDevice>>() };
-            std::shared_ptr<graphics::IShaderStorage> shader_storage{ std::make_shared<NiceMock<MockShaderStorage>>() };
-            std::unique_ptr<trlevel::ILevel> level{ std::make_unique<NiceMock<trlevel::mocks::MockLevel>>() };
-            std::shared_ptr<ILevelTextureStorage> level_texture_storage{ std::make_shared<NiceMock<MockLevelTextureStorage>>() };
-            std::unique_ptr<IMeshStorage> mesh_storage { std::make_unique<NiceMock<MockMeshStorage>>() };
-            std::unique_ptr<ITransparencyBuffer> transparency_buffer{ std::make_unique<NiceMock<MockTransparencyBuffer>>() };
-            std::unique_ptr<ISelectionRenderer> selection_renderer{ std::make_unique<NiceMock<MockSelectionRenderer>>() };
-            std::shared_ptr<ITypeNameLookup> type_name_lookup{ std::make_shared<NiceMock<MockTypeNameLookup>>() };
-            IEntity::EntitySource entity_source{ [](auto&&...) { return std::make_shared<NiceMock<MockEntity>>(); } };
-            IEntity::AiSource ai_source{ [](auto&&...) { return std::make_shared<NiceMock<MockEntity>>(); } };
-            IRoom::Source room_source{ [](auto&&...) { return std::make_shared<NiceMock<MockRoom>>(); } };
-            ITrigger::Source trigger_source{ [](auto&&...) {return std::make_shared<NiceMock<MockTrigger>>(); } };
+            std::shared_ptr<IDevice> device{ mock_shared<MockDevice>() };
+            std::shared_ptr<graphics::IShaderStorage> shader_storage{ mock_shared<MockShaderStorage>() };
+            std::unique_ptr<trlevel::ILevel> level{ mock_unique<trlevel::mocks::MockLevel>() };
+            std::shared_ptr<ILevelTextureStorage> level_texture_storage{ mock_shared<MockLevelTextureStorage>() };
+            std::unique_ptr<IMeshStorage> mesh_storage { mock_unique<MockMeshStorage>() };
+            std::unique_ptr<ITransparencyBuffer> transparency_buffer{ mock_unique<MockTransparencyBuffer>() };
+            std::unique_ptr<ISelectionRenderer> selection_renderer{ mock_unique<MockSelectionRenderer>() };
+            std::shared_ptr<ITypeNameLookup> type_name_lookup{ mock_shared<MockTypeNameLookup>() };
+            IEntity::EntitySource entity_source{ [](auto&&...) { return mock_shared<MockEntity>(); } };
+            IEntity::AiSource ai_source{ [](auto&&...) { return mock_shared<MockEntity>(); } };
+            IRoom::Source room_source{ [](auto&&...) { return mock_shared<MockRoom>(); } };
+            ITrigger::Source trigger_source{ [](auto&&...) {return mock_shared<MockTrigger>(); } };
 
             std::unique_ptr<Level> build()
             {

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -292,7 +292,7 @@ TEST(Level, BoundingBoxesNotRenderedWhenDisabled)
     auto room = mock_shared<MockRoom>();
 
     auto device = mock_shared<MockDevice>();
-    Microsoft::WRL::ComPtr<ID3D11DeviceContext> context{ new MockD3D11DeviceContext() };
+    Microsoft::WRL::ComPtr<ID3D11DeviceContext> context{ new NiceMock<MockD3D11DeviceContext>() };
     EXPECT_CALL(*device, context).WillRepeatedly(Return(context));
 
     NiceMock<MockShader> shader;
@@ -320,7 +320,7 @@ TEST(Level, BoundingBoxesRenderedWhenEnabled)
     auto room = mock_shared<MockRoom>();
 
     auto device = mock_shared<MockDevice>();
-    Microsoft::WRL::ComPtr<ID3D11DeviceContext> context{ new MockD3D11DeviceContext() };
+    Microsoft::WRL::ComPtr<ID3D11DeviceContext> context{ new NiceMock<MockD3D11DeviceContext>() };
     EXPECT_CALL(*device, context).WillRepeatedly(Return(context));
 
     MockShader shader;

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -323,7 +323,7 @@ TEST(Level, BoundingBoxesRenderedWhenEnabled)
     Microsoft::WRL::ComPtr<ID3D11DeviceContext> context{ new NiceMock<MockD3D11DeviceContext>() };
     EXPECT_CALL(*device, context).WillRepeatedly(Return(context));
 
-    MockShader shader;
+    NiceMock<MockShader> shader;
     auto shader_storage = mock_shared<MockShaderStorage>();
     EXPECT_CALL(*shader_storage, get).WillRepeatedly(Return(&shader));
 

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -23,6 +23,7 @@ using namespace trlevel::mocks;
 using namespace trview::tests;
 using testing::Return;
 using testing::A;
+using testing::NiceMock;
 using namespace DirectX::SimpleMath;
 
 namespace
@@ -31,18 +32,18 @@ namespace
     {
         struct test_module
         {
-            std::shared_ptr<IDevice> device{ std::make_shared<MockDevice>() };
-            std::shared_ptr<graphics::IShaderStorage> shader_storage{ std::make_shared<MockShaderStorage>() };
-            std::unique_ptr<trlevel::ILevel> level{ std::make_unique<trlevel::mocks::MockLevel>() };
-            std::shared_ptr<ILevelTextureStorage> level_texture_storage{ std::make_shared<MockLevelTextureStorage>() };
-            std::unique_ptr<IMeshStorage> mesh_storage { std::make_unique<MockMeshStorage>() };
-            std::unique_ptr<ITransparencyBuffer> transparency_buffer{ std::make_unique<MockTransparencyBuffer>() };
-            std::unique_ptr<ISelectionRenderer> selection_renderer{ std::make_unique<MockSelectionRenderer>() };
-            std::shared_ptr<ITypeNameLookup> type_name_lookup{ std::make_shared<MockTypeNameLookup>() };
-            IEntity::EntitySource entity_source{ [](auto&&...) { return std::make_shared<MockEntity>(); } };
-            IEntity::AiSource ai_source{ [](auto&&...) { return std::make_shared<MockEntity>(); } };
-            IRoom::Source room_source{ [](auto&&...) { return std::make_shared<MockRoom>(); } };
-            ITrigger::Source trigger_source{ [](auto&&...) {return std::make_shared<MockTrigger>(); } };
+            std::shared_ptr<IDevice> device{ std::make_shared<NiceMock<MockDevice>>() };
+            std::shared_ptr<graphics::IShaderStorage> shader_storage{ std::make_shared<NiceMock<MockShaderStorage>>() };
+            std::unique_ptr<trlevel::ILevel> level{ std::make_unique<NiceMock<trlevel::mocks::MockLevel>>() };
+            std::shared_ptr<ILevelTextureStorage> level_texture_storage{ std::make_shared<NiceMock<MockLevelTextureStorage>>() };
+            std::unique_ptr<IMeshStorage> mesh_storage { std::make_unique<NiceMock<MockMeshStorage>>() };
+            std::unique_ptr<ITransparencyBuffer> transparency_buffer{ std::make_unique<NiceMock<MockTransparencyBuffer>>() };
+            std::unique_ptr<ISelectionRenderer> selection_renderer{ std::make_unique<NiceMock<MockSelectionRenderer>>() };
+            std::shared_ptr<ITypeNameLookup> type_name_lookup{ std::make_shared<NiceMock<MockTypeNameLookup>>() };
+            IEntity::EntitySource entity_source{ [](auto&&...) { return std::make_shared<NiceMock<MockEntity>>(); } };
+            IEntity::AiSource ai_source{ [](auto&&...) { return std::make_shared<NiceMock<MockEntity>>(); } };
+            IRoom::Source room_source{ [](auto&&...) { return std::make_shared<NiceMock<MockRoom>>(); } };
+            ITrigger::Source trigger_source{ [](auto&&...) {return std::make_shared<NiceMock<MockTrigger>>(); } };
 
             std::unique_ptr<Level> build()
             {

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -23,6 +23,7 @@ using namespace trlevel::mocks;
 using namespace trview::tests;
 using testing::Return;
 using testing::A;
+using testing::NiceMock;
 using namespace DirectX::SimpleMath;
 
 namespace
@@ -242,7 +243,7 @@ TEST(Level, PickUsesCorrectDefaultFilters)
         .with_room_source([&](auto&&...) { return room; })
         .build();
 
-    MockCamera camera;
+    NiceMock<MockCamera> camera;
     level->pick(camera, Vector3::Zero, Vector3::Forward);
 }
 
@@ -261,7 +262,7 @@ TEST(Level, PickUsesCorrectOptionalFilters)
     level->set_show_triggers(true);
     level->set_show_hidden_geometry(true);
 
-    MockCamera camera;
+    NiceMock<MockCamera> camera;
     level->pick(camera, Vector3::Zero, Vector3::Forward);
 }
 
@@ -280,7 +281,7 @@ TEST(Level, PickUsesCorrectMinimalFilters)
     level->set_show_triggers(false);
     level->set_show_hidden_geometry(false);
 
-    MockCamera camera;
+    NiceMock<MockCamera> camera;
     level->pick(camera, Vector3::Zero, Vector3::Forward);
 }
 
@@ -294,7 +295,7 @@ TEST(Level, BoundingBoxesNotRenderedWhenDisabled)
     Microsoft::WRL::ComPtr<ID3D11DeviceContext> context{ new MockD3D11DeviceContext() };
     EXPECT_CALL(*device, context).WillRepeatedly(Return(context));
 
-    MockShader shader;
+    NiceMock<MockShader> shader;
     auto shader_storage = mock_shared<MockShaderStorage>();
     EXPECT_CALL(*shader_storage, get).WillRepeatedly(Return(&shader));
 
@@ -308,7 +309,7 @@ TEST(Level, BoundingBoxesNotRenderedWhenDisabled)
         .with_room_source([&](auto&&...) { return room; })
         .build();
 
-    MockCamera camera;
+    NiceMock<MockCamera> camera;
     level->render(camera, false);
 }
 
@@ -338,7 +339,7 @@ TEST(Level, BoundingBoxesRenderedWhenEnabled)
 
     level->set_show_bounding_boxes(true);
 
-    MockCamera camera;
+    NiceMock<MockCamera> camera;
     level->render(camera, false);
 }
 

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -111,7 +111,7 @@ TEST(Level, LoadTypeNames)
     EXPECT_CALL(mock_level, num_entities()).WillRepeatedly(Return(1));
     EXPECT_CALL(mock_level, get_entity(0)).WillRepeatedly(Return(entity));
 
-    auto mock_type_name_lookup = std::make_shared<MockTypeNameLookup>();
+    auto mock_type_name_lookup = mock_shared<MockTypeNameLookup>();
     EXPECT_CALL(*mock_type_name_lookup, lookup_type_name(LevelVersion::Tomb2, 123));
     auto level = register_test_module().with_level(std::move(mock_level_ptr)).with_type_name_lookup(mock_type_name_lookup).build();
 }
@@ -140,13 +140,13 @@ TEST(Level, LoadFromEntitySources)
             [&](auto&&...)
             {
                 ++entity_source_called;
-                return std::make_shared<MockEntity>();
+                return mock_shared<MockEntity>();
             })
         .with_ai_source(
             [&](auto&&...)
             {
                 ++ai_source_called;
-                return std::make_shared<MockEntity>();
+                return mock_shared<MockEntity>();
             }).build();
 
     ASSERT_EQ(entity_source_called, 1);
@@ -166,7 +166,7 @@ TEST(Level, LoadRooms)
             [&](auto&&...)
             {
                 ++room_called;
-                return std::make_shared<MockRoom>();
+                return mock_shared<MockRoom>();
             }).build();
 
     ASSERT_EQ(room_called, 3);
@@ -182,7 +182,7 @@ TEST(Level, OcbAdjustmentsPerformedWhenNeeded)
         .with_room_source(
             [&](auto&&...)
             {
-                auto room = std::make_shared<MockRoom>();
+                auto room = mock_shared<MockRoom>();
                 PickResult result{};
                 result.hit = true;
                 EXPECT_CALL(*room, pick).WillRepeatedly(Return(result));
@@ -192,7 +192,7 @@ TEST(Level, OcbAdjustmentsPerformedWhenNeeded)
             [&](auto&&...)
             {
                 ++entity_source_called;
-                auto entity = std::make_shared<MockEntity>();
+                auto entity = mock_shared<MockEntity>();
                 EXPECT_CALL(*entity, needs_ocb_adjustment).WillRepeatedly(Return(true));
                 EXPECT_CALL(*entity, adjust_y).Times(1);
                 return entity;
@@ -211,7 +211,7 @@ TEST(Level, OcbAdjustmentsNotPerformedWhenNotNeeded)
         .with_room_source(
             [&](auto&&...)
             {
-                auto room = std::make_shared<MockRoom>();
+                auto room = mock_shared<MockRoom>();
                 PickResult result{};
                 result.hit = true;
                 EXPECT_CALL(*room, pick).WillRepeatedly(Return(result));
@@ -221,7 +221,7 @@ TEST(Level, OcbAdjustmentsNotPerformedWhenNotNeeded)
             [&](auto&&...)
             {
                 ++entity_source_called;
-                auto entity = std::make_shared<MockEntity>();
+                auto entity = mock_shared<MockEntity>();
                 EXPECT_CALL(*entity, needs_ocb_adjustment).WillRepeatedly(Return(false));
                 EXPECT_CALL(*entity, adjust_y).Times(0);
                 return entity;
@@ -235,7 +235,7 @@ TEST(Level, PickUsesCorrectDefaultFilters)
     auto [mock_level_ptr, mock_level] = create_mock<trlevel::mocks::MockLevel>();
     EXPECT_CALL(mock_level, num_rooms()).WillRepeatedly(Return(1));
 
-    auto room = std::make_shared<MockRoom>();
+    auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, pick(A<const Vector3&>(), A<const Vector3&>(), PickFilter::Geometry | PickFilter::Entities | PickFilter::StaticMeshes | PickFilter::Triggers)).Times(1);
 
     auto level = register_test_module()
@@ -252,7 +252,7 @@ TEST(Level, PickUsesCorrectOptionalFilters)
     auto [mock_level_ptr, mock_level] = create_mock<trlevel::mocks::MockLevel>();
     EXPECT_CALL(mock_level, num_rooms()).WillRepeatedly(Return(1));
 
-    auto room = std::make_shared<MockRoom>();
+    auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, pick(A<const Vector3&>(), A<const Vector3&>(), PickFilter::Geometry | PickFilter::Entities | PickFilter::StaticMeshes | PickFilter::Triggers | PickFilter::HiddenGeometry)).Times(1);
 
     auto level = register_test_module()
@@ -271,7 +271,7 @@ TEST(Level, PickUsesCorrectMinimalFilters)
     auto [mock_level_ptr, mock_level] = create_mock<trlevel::mocks::MockLevel>();
     EXPECT_CALL(mock_level, num_rooms()).WillRepeatedly(Return(1));
 
-    auto room = std::make_shared<MockRoom>();
+    auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, pick(A<const Vector3&>(), A<const Vector3&>(), PickFilter::Geometry | PickFilter::Entities | PickFilter::StaticMeshes)).Times(1);
 
     auto level = register_test_module()
@@ -289,14 +289,14 @@ TEST(Level, BoundingBoxesNotRenderedWhenDisabled)
 {
     auto [mock_level_ptr, mock_level] = create_mock<trlevel::mocks::MockLevel>();
     EXPECT_CALL(mock_level, num_rooms()).WillRepeatedly(Return(1));
-    auto room = std::make_shared<MockRoom>();
+    auto room = mock_shared<MockRoom>();
 
-    auto device = std::make_shared<MockDevice>();
+    auto device = mock_shared<MockDevice>();
     Microsoft::WRL::ComPtr<ID3D11DeviceContext> context{ new MockD3D11DeviceContext() };
     EXPECT_CALL(*device, context).WillRepeatedly(Return(context));
 
     MockShader shader;
-    auto shader_storage = std::make_shared<MockShaderStorage>();
+    auto shader_storage = mock_shared<MockShaderStorage>();
     EXPECT_CALL(*shader_storage, get).WillRepeatedly(Return(&shader));
 
     EXPECT_CALL(*room, render).Times(1);
@@ -317,14 +317,14 @@ TEST(Level, BoundingBoxesRenderedWhenEnabled)
 {
     auto [mock_level_ptr, mock_level] = create_mock<trlevel::mocks::MockLevel>();
     EXPECT_CALL(mock_level, num_rooms()).WillRepeatedly(Return(1));
-    auto room = std::make_shared<MockRoom>();
+    auto room = mock_shared<MockRoom>();
 
-    auto device = std::make_shared<MockDevice>();
+    auto device = mock_shared<MockDevice>();
     Microsoft::WRL::ComPtr<ID3D11DeviceContext> context{ new MockD3D11DeviceContext() };
     EXPECT_CALL(*device, context).WillRepeatedly(Return(context));
 
     MockShader shader;
-    auto shader_storage = std::make_shared<MockShaderStorage>();
+    auto shader_storage = mock_shared<MockShaderStorage>();
     EXPECT_CALL(*shader_storage, get).WillRepeatedly(Return(&shader));
 
     EXPECT_CALL(*room, render).Times(1);

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -15,7 +15,6 @@ using namespace trview;
 using namespace trview::mocks;
 using namespace trview::tests;
 using testing::Return;
-using testing::NiceMock;
 
 namespace
 {
@@ -23,16 +22,16 @@ namespace
     {
         struct test_module
         {
-            std::shared_ptr<ILevelTextureStorage> level_texture_storage{ std::make_shared<NiceMock<MockLevelTextureStorage>>() };
-            std::shared_ptr<IMeshStorage> mesh_storage{ std::make_shared<NiceMock<MockMeshStorage>>() };
-            IMesh::Source mesh_source{ [](auto&&...) { return std::make_shared<NiceMock<MockMesh>>(); } };
-            std::shared_ptr<trlevel::ILevel> tr_level{ std::make_shared<NiceMock<trlevel::mocks::MockLevel>>() };
+            std::shared_ptr<ILevelTextureStorage> level_texture_storage{ mock_shared<MockLevelTextureStorage>() };
+            std::shared_ptr<IMeshStorage> mesh_storage{ mock_shared<MockMeshStorage>() };
+            IMesh::Source mesh_source{ [](auto&&...) { return mock_shared<MockMesh>(); } };
+            std::shared_ptr<trlevel::ILevel> tr_level{ mock_shared<trlevel::mocks::MockLevel>() };
             trlevel::tr3_room room;
             uint32_t index{ 0u };
-            std::shared_ptr<ILevel> level{ std::make_shared<NiceMock<MockLevel>>() };
-            IStaticMesh::MeshSource static_mesh_source{ [](auto&&...) { return std::make_shared<NiceMock<MockStaticMesh>>(); } };
-            IStaticMesh::PositionSource static_mesh_position_source{ [](auto&&...) { return std::make_shared<NiceMock<MockStaticMesh>>(); } };
-            ISector::Source sector_source{ [](auto&&...) { return std::make_shared<NiceMock<MockSector>>(); } };
+            std::shared_ptr<ILevel> level{ mock_shared<MockLevel>() };
+            IStaticMesh::MeshSource static_mesh_source{ [](auto&&...) { return mock_shared<MockStaticMesh>(); } };
+            IStaticMesh::PositionSource static_mesh_position_source{ [](auto&&...) { return mock_shared<MockStaticMesh>(); } };
+            ISector::Source sector_source{ [](auto&&...) { return mock_shared<MockSector>(); } };
 
             std::unique_ptr<Room> build()
             {

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -15,6 +15,7 @@ using namespace trview;
 using namespace trview::mocks;
 using namespace trview::tests;
 using testing::Return;
+using testing::NiceMock;
 
 namespace
 {
@@ -174,7 +175,7 @@ TEST(Room, GetTransparentTriangles)
     EXPECT_CALL(*trigger, get_transparent_triangles).Times(1);
     room->add_entity(entity);
     room->add_trigger(trigger);
-    room->get_transparent_triangles(MockTransparencyBuffer{}, MockCamera{}, IRoom::SelectionMode::NotSelected, true, true);
+    room->get_transparent_triangles(NiceMock<MockTransparencyBuffer>{}, NiceMock<MockCamera>{}, IRoom::SelectionMode::NotSelected, true, true);
 }
 
 /// <summary>
@@ -189,7 +190,7 @@ TEST(Room, GetTransparentTrianglesWithoutTriggers)
     EXPECT_CALL(*trigger, get_transparent_triangles).Times(0);
     room->add_entity(entity);
     room->add_trigger(trigger);
-    room->get_transparent_triangles(MockTransparencyBuffer{}, MockCamera{}, IRoom::SelectionMode::NotSelected, false, true);
+    room->get_transparent_triangles(NiceMock<MockTransparencyBuffer>{}, NiceMock<MockCamera>{}, IRoom::SelectionMode::NotSelected, false, true);
 }
 
 /// <summary>
@@ -204,7 +205,7 @@ TEST(Room, GetTransparentTrianglesFromContents)
     EXPECT_CALL(*trigger, get_transparent_triangles).Times(0);
     room->add_entity(entity);
     room->add_trigger(trigger);
-    room->get_contained_transparent_triangles(MockTransparencyBuffer{}, MockCamera{}, IRoom::SelectionMode::NotSelected, true);
+    room->get_contained_transparent_triangles(NiceMock<MockTransparencyBuffer>{}, NiceMock<MockCamera>{}, IRoom::SelectionMode::NotSelected, true);
 }
 
 /// <summary>
@@ -416,7 +417,7 @@ TEST(Room, RendersContainedEntities)
     auto entity = mock_shared<MockEntity>();
     EXPECT_CALL(*entity, render).Times(1);
     room->add_entity(entity);
-    room->render(MockCamera{}, IRoom::SelectionMode::NotSelected, true, true);
+    room->render(NiceMock<MockCamera>{}, IRoom::SelectionMode::NotSelected, true, true);
 }
 
 /// <summary>
@@ -562,5 +563,5 @@ TEST(Room, BoundingBoxesRendered)
         .with_room(level_room)
         .with_static_mesh_source([&](auto&&...) { return mesh; })
         .build();
-    room->render_bounding_boxes(MockCamera{});
+    room->render_bounding_boxes(NiceMock<MockCamera>{});
 }

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -15,6 +15,7 @@ using namespace trview;
 using namespace trview::mocks;
 using namespace trview::tests;
 using testing::Return;
+using testing::NiceMock;
 
 namespace
 {
@@ -22,16 +23,16 @@ namespace
     {
         struct test_module
         {
-            std::shared_ptr<ILevelTextureStorage> level_texture_storage{ std::make_shared<MockLevelTextureStorage>() };
-            std::shared_ptr<IMeshStorage> mesh_storage{ std::make_shared<MockMeshStorage>() };
-            IMesh::Source mesh_source{ [](auto&&...) { return std::make_shared<MockMesh>(); } };
-            std::shared_ptr<trlevel::ILevel> tr_level{ std::make_shared<trlevel::mocks::MockLevel>() };
+            std::shared_ptr<ILevelTextureStorage> level_texture_storage{ std::make_shared<NiceMock<MockLevelTextureStorage>>() };
+            std::shared_ptr<IMeshStorage> mesh_storage{ std::make_shared<NiceMock<MockMeshStorage>>() };
+            IMesh::Source mesh_source{ [](auto&&...) { return std::make_shared<NiceMock<MockMesh>>(); } };
+            std::shared_ptr<trlevel::ILevel> tr_level{ std::make_shared<NiceMock<trlevel::mocks::MockLevel>>() };
             trlevel::tr3_room room;
             uint32_t index{ 0u };
-            std::shared_ptr<ILevel> level{ std::make_shared<MockLevel>() };
-            IStaticMesh::MeshSource static_mesh_source{ [](auto&&...) { return std::make_shared<MockStaticMesh>(); } };
-            IStaticMesh::PositionSource static_mesh_position_source{ [](auto&&...) { return std::make_shared<MockStaticMesh>(); } };
-            ISector::Source sector_source{ [](auto&&...) { return std::make_shared<MockSector>(); } };
+            std::shared_ptr<ILevel> level{ std::make_shared<NiceMock<MockLevel>>() };
+            IStaticMesh::MeshSource static_mesh_source{ [](auto&&...) { return std::make_shared<NiceMock<MockStaticMesh>>(); } };
+            IStaticMesh::PositionSource static_mesh_position_source{ [](auto&&...) { return std::make_shared<NiceMock<MockStaticMesh>>(); } };
+            ISector::Source sector_source{ [](auto&&...) { return std::make_shared<NiceMock<MockSector>>(); } };
 
             std::unique_ptr<Room> build()
             {

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -135,7 +135,7 @@ TEST(Room, BoundingBoxIncorporatesContents)
     level_room.info.yTop = -1024;
     auto room = register_test_module().with_room(level_room).build();
 
-    auto entity = std::make_shared<MockEntity>();
+    auto entity = mock_shared<MockEntity>();
     EXPECT_CALL(*entity, bounding_box).WillOnce(Return(BoundingBox(Vector3(1.0f, -1.0f, 1.0f), Vector3(0.5f, 0.5f, 0.5f))));
     room->add_entity(entity);
     room->update_bounding_box();
@@ -169,9 +169,9 @@ TEST(Room, CentreCalculated)
 TEST(Room, GetTransparentTriangles)
 {
     auto room = register_test_module().build();
-    auto entity = std::make_shared<MockEntity>();
+    auto entity = mock_shared<MockEntity>();
     EXPECT_CALL(*entity, get_transparent_triangles).Times(1);
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, get_transparent_triangles).Times(1);
     room->add_entity(entity);
     room->add_trigger(trigger);
@@ -184,9 +184,9 @@ TEST(Room, GetTransparentTriangles)
 TEST(Room, GetTransparentTrianglesWithoutTriggers)
 {
     auto room = register_test_module().build();
-    auto entity = std::make_shared<MockEntity>();
+    auto entity = mock_shared<MockEntity>();
     EXPECT_CALL(*entity, get_transparent_triangles).Times(1);
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, get_transparent_triangles).Times(0);
     room->add_entity(entity);
     room->add_trigger(trigger);
@@ -199,9 +199,9 @@ TEST(Room, GetTransparentTrianglesWithoutTriggers)
 TEST(Room, GetTransparentTrianglesFromContents)
 {
     auto room = register_test_module().build();
-    auto entity = std::make_shared<MockEntity>();
+    auto entity = mock_shared<MockEntity>();
     EXPECT_CALL(*entity, get_transparent_triangles).Times(1);
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, get_transparent_triangles).Times(0);
     room->add_entity(entity);
     room->add_trigger(trigger);
@@ -250,9 +250,9 @@ TEST(Room, NeighboursLoaded)
     level_room.sector_list.resize(2);
 
     std::set<uint16_t> expected{ 0, 10, 20, 30 };
-    auto sector1 = std::make_shared<MockSector>();
+    auto sector1 = mock_shared<MockSector>();
     ON_CALL(*sector1, neighbours).WillByDefault(Return(std::set<uint16_t>{ 0, 20 }));
-    auto sector2 = std::make_shared<MockSector>();
+    auto sector2 = mock_shared<MockSector>();
     ON_CALL(*sector2, neighbours).WillByDefault(Return(std::set<uint16_t>{ 0, 10, 30 }));
     uint32_t times_called = 0;
 
@@ -300,7 +300,7 @@ TEST(Room, PickTestsEntities)
     using namespace DirectX::SimpleMath;
 
     auto room = register_test_module().build();
-    auto entity = std::make_shared<MockEntity>();
+    auto entity = mock_shared<MockEntity>();
     ON_CALL(*entity, visible).WillByDefault(Return(true));
     EXPECT_CALL(*entity, pick).Times(1).WillOnce(Return(PickResult{ true, 0, {}, {}, PickResult::Type::Entity, 10 }));
     room->add_entity(entity);
@@ -320,7 +320,7 @@ TEST(Room, PickTestsTriggers)
     using namespace DirectX::SimpleMath;
 
     auto room = register_test_module().build();
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     ON_CALL(*trigger, visible).WillByDefault(Return(true));
     EXPECT_CALL(*trigger, pick).Times(1).WillOnce(Return(PickResult{ true, 0, {}, {}, PickResult::Type::Trigger, 10 }));
     room->add_trigger(trigger);
@@ -340,12 +340,12 @@ TEST(Room, PickChoosesClosest)
     using namespace DirectX::SimpleMath;
 
     auto room = register_test_module().build();
-    auto entity = std::make_shared<MockEntity>();
+    auto entity = mock_shared<MockEntity>();
     ON_CALL(*entity, visible).WillByDefault(Return(true));
     EXPECT_CALL(*entity, pick).Times(1).WillOnce(Return(PickResult{ true, 0.5f, {}, {}, PickResult::Type::Entity, 5 }));
     room->add_entity(entity);
 
-    auto entity2 = std::make_shared<MockEntity>();
+    auto entity2 = mock_shared<MockEntity>();
     ON_CALL(*entity2, visible).WillByDefault(Return(true));
     EXPECT_CALL(*entity2, pick).Times(1).WillOnce(Return(PickResult{ true, 1.0f, {}, {}, PickResult::Type::Entity, 10 }));
     room->add_entity(entity2);
@@ -366,12 +366,12 @@ TEST(Room, PickChoosesEntityOverTrigger)
     using namespace DirectX::SimpleMath;
 
     auto room = register_test_module().build();
-    auto entity = std::make_shared<MockEntity>();
+    auto entity = mock_shared<MockEntity>();
     ON_CALL(*entity, visible).WillByDefault(Return(true));
     EXPECT_CALL(*entity, pick).Times(1).WillOnce(Return(PickResult{ true, 1.0f, {}, {}, PickResult::Type::Entity, 5 }));
     room->add_entity(entity);
 
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, pick).Times(0);
     room->add_trigger(trigger);
 
@@ -389,7 +389,7 @@ TEST(Room, QuicksandDetectedAfterTR3)
 {
     trlevel::tr3_room level_room;
     level_room.flags |= 0x80;
-    auto level = std::make_shared<MockLevel>();
+    auto level = mock_shared<MockLevel>();
     ON_CALL(*level, version).WillByDefault(Return(trlevel::LevelVersion::Tomb3));
     auto room = register_test_module().with_room(level_room).with_level(level).build();
     ASSERT_EQ(room->quicksand(), true);
@@ -402,7 +402,7 @@ TEST(Room, QuicksandNotDetectedBeforeTR3)
 {
     trlevel::tr3_room level_room;
     level_room.flags |= 0x80;
-    auto level = std::make_shared<MockLevel>();
+    auto level = mock_shared<MockLevel>();
     ON_CALL(*level, version).WillByDefault(Return(trlevel::LevelVersion::Tomb1));
     auto room = register_test_module().with_room(level_room).with_level(level).build();
     ASSERT_EQ(room->quicksand(), false);
@@ -414,7 +414,7 @@ TEST(Room, QuicksandNotDetectedBeforeTR3)
 TEST(Room, RendersContainedEntities)
 {
     auto room = register_test_module().build();
-    auto entity = std::make_shared<MockEntity>();
+    auto entity = mock_shared<MockEntity>();
     EXPECT_CALL(*entity, render).Times(1);
     room->add_entity(entity);
     room->render(MockCamera{}, IRoom::SelectionMode::NotSelected, true, true);
@@ -444,7 +444,7 @@ TEST(Room, SectorsCreated)
     auto source = [&](auto&&...)
     {
         ++times_called;
-        return std::make_shared<MockSector>();
+        return mock_shared<MockSector>();
     };
     auto room = register_test_module().with_room(level_room).with_sector_source(source).build();
     ASSERT_EQ(times_called, 4);
@@ -463,7 +463,7 @@ TEST(Room, StaticMeshesLoaded)
     auto static_mesh_source = [&](auto&&...)
     {
         ++times_called;
-        return std::make_shared<MockStaticMesh>();
+        return mock_shared<MockStaticMesh>();
     };
 
     register_test_module().with_room(level_room).with_static_mesh_source(static_mesh_source).build();
@@ -483,7 +483,7 @@ TEST(Room, SpritesLoaded)
     auto static_mesh_position_source = [&](auto&&...)
     {
         ++times_called;
-        return std::make_shared<MockStaticMesh>();
+        return mock_shared<MockStaticMesh>();
     };
 
     register_test_module().with_room(level_room).with_static_mesh_position_source(static_mesh_position_source).build();
@@ -500,9 +500,9 @@ TEST(Room, TriggerAtSectorId)
     level_room.num_z_sectors = 3;
     auto room = register_test_module().with_room(level_room).build();
 
-    auto trigger1 = std::make_shared<MockTrigger>();
+    auto trigger1 = mock_shared<MockTrigger>();
     ON_CALL(*trigger1, sector_id).WillByDefault(Return(0));
-    auto trigger2 = std::make_shared<MockTrigger>();
+    auto trigger2 = mock_shared<MockTrigger>();
     ON_CALL(*trigger2, sector_id).WillByDefault(Return(4));
 
     room->add_trigger(trigger1);
@@ -530,7 +530,7 @@ TEST(Room, TriggerAtNotFound)
 /// </summary>
 TEST(Room, TriggerGeometryGenerated)
 {
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, set_triangles).Times(1);
     EXPECT_CALL(*trigger, set_position).Times(1);
 
@@ -555,7 +555,7 @@ TEST(Room, WaterDetected)
 
 TEST(Room, BoundingBoxesRendered)
 {
-    auto mesh = std::make_shared<MockStaticMesh>();
+    auto mesh = mock_shared<MockStaticMesh>();
     EXPECT_CALL(*mesh, render_bounding_box).Times(1);
     trlevel::tr3_room level_room;
     level_room.static_meshes.push_back({});

--- a/trview.app.tests/Elements/StaticMeshTests.cpp
+++ b/trview.app.tests/Elements/StaticMeshTests.cpp
@@ -5,12 +5,13 @@
 
 using namespace trview;
 using namespace trview::mocks;
+using namespace trview::tests;
 using namespace DirectX::SimpleMath;
 
 TEST(StaticMesh, BoundingBoxRendered)
 {
-    auto actual_mesh = std::make_shared<MockMesh>();
-    auto bounding_mesh = std::make_shared<MockMesh>();
+    auto actual_mesh = mock_shared<MockMesh>();
+    auto bounding_mesh = mock_shared<MockMesh>();
     EXPECT_CALL(*bounding_mesh, render).Times(1);
 
     StaticMesh mesh({}, {}, actual_mesh, bounding_mesh);

--- a/trview.app.tests/Elements/StaticMeshTests.cpp
+++ b/trview.app.tests/Elements/StaticMeshTests.cpp
@@ -7,6 +7,7 @@ using namespace trview;
 using namespace trview::mocks;
 using namespace trview::tests;
 using namespace DirectX::SimpleMath;
+using testing::NiceMock;
 
 TEST(StaticMesh, BoundingBoxRendered)
 {
@@ -15,5 +16,5 @@ TEST(StaticMesh, BoundingBoxRendered)
     EXPECT_CALL(*bounding_mesh, render).Times(1);
 
     StaticMesh mesh({}, {}, actual_mesh, bounding_mesh);
-    mesh.render_bounding_box(MockCamera{}, MockLevelTextureStorage{}, Colour::White);
+    mesh.render_bounding_box(NiceMock<MockCamera>{}, NiceMock<MockLevelTextureStorage>{}, Colour::White);
 }

--- a/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
+++ b/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
@@ -12,11 +12,12 @@ using testing::Return;
 using testing::_;
 using testing::AtLeast;
 using testing::Exactly;
+using testing::NiceMock;
 using namespace trview::graphics::mocks;
 
 TEST(LevelTextureStorage, PaletteLoadedTomb1)
 {
-    trlevel::mocks::MockLevel level;
+    NiceMock<trlevel::mocks::MockLevel> level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb1));
     EXPECT_CALL(level, get_palette_entry(_)).Times(AtLeast(1));
     LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
@@ -24,7 +25,7 @@ TEST(LevelTextureStorage, PaletteLoadedTomb1)
 
 TEST(LevelTextureStorage, PaletteLoadedTomb2)
 {
-    trlevel::mocks::MockLevel level;
+    NiceMock<trlevel::mocks::MockLevel> level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb2));
     EXPECT_CALL(level, get_palette_entry(_)).Times(AtLeast(1));
     LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
@@ -32,7 +33,7 @@ TEST(LevelTextureStorage, PaletteLoadedTomb2)
 
 TEST(LevelTextureStorage, PaletteLoadedTomb3)
 {
-    trlevel::mocks::MockLevel level;
+    NiceMock<trlevel::mocks::MockLevel> level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb3));
     EXPECT_CALL(level, get_palette_entry(_)).Times(AtLeast(1));
     LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
@@ -40,7 +41,7 @@ TEST(LevelTextureStorage, PaletteLoadedTomb3)
 
 TEST(LevelTextureStorage, PaletteNotLoadedTomb4)
 {
-    trlevel::mocks::MockLevel level;
+    NiceMock<trlevel::mocks::MockLevel> level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb4));
     EXPECT_CALL(level, get_palette_entry(_)).Times(Exactly(0));
     LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
@@ -48,7 +49,7 @@ TEST(LevelTextureStorage, PaletteNotLoadedTomb4)
 
 TEST(LevelTextureStorage, PaletteNotLoadedTomb5)
 {
-    trlevel::mocks::MockLevel level;
+    NiceMock<trlevel::mocks::MockLevel> level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb5));
     EXPECT_CALL(level, get_palette_entry(_)).Times(Exactly(0));
     LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);

--- a/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
+++ b/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
@@ -19,7 +19,7 @@ TEST(LevelTextureStorage, PaletteLoadedTomb1)
     trlevel::mocks::MockLevel level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb1));
     EXPECT_CALL(level, get_palette_entry(_)).Times(AtLeast(1));
-    LevelTextureStorage subject(mock_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
 }
 
 TEST(LevelTextureStorage, PaletteLoadedTomb2)
@@ -27,7 +27,7 @@ TEST(LevelTextureStorage, PaletteLoadedTomb2)
     trlevel::mocks::MockLevel level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb2));
     EXPECT_CALL(level, get_palette_entry(_)).Times(AtLeast(1));
-    LevelTextureStorage subject(mock_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
 }
 
 TEST(LevelTextureStorage, PaletteLoadedTomb3)
@@ -35,7 +35,7 @@ TEST(LevelTextureStorage, PaletteLoadedTomb3)
     trlevel::mocks::MockLevel level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb3));
     EXPECT_CALL(level, get_palette_entry(_)).Times(AtLeast(1));
-    LevelTextureStorage subject(mock_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
 }
 
 TEST(LevelTextureStorage, PaletteNotLoadedTomb4)
@@ -43,7 +43,7 @@ TEST(LevelTextureStorage, PaletteNotLoadedTomb4)
     trlevel::mocks::MockLevel level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb4));
     EXPECT_CALL(level, get_palette_entry(_)).Times(Exactly(0));
-    LevelTextureStorage subject(mock_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
 }
 
 TEST(LevelTextureStorage, PaletteNotLoadedTomb5)
@@ -51,5 +51,5 @@ TEST(LevelTextureStorage, PaletteNotLoadedTomb5)
     trlevel::mocks::MockLevel level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb5));
     EXPECT_CALL(level, get_palette_entry(_)).Times(Exactly(0));
-    LevelTextureStorage subject(mock_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
 }

--- a/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
+++ b/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
@@ -7,6 +7,7 @@ using namespace trview;
 using namespace trlevel;
 using namespace trlevel::mocks;
 using namespace trview::mocks;
+using namespace trview::tests;
 using testing::Return;
 using testing::_;
 using testing::AtLeast;
@@ -18,7 +19,7 @@ TEST(LevelTextureStorage, PaletteLoadedTomb1)
     trlevel::mocks::MockLevel level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb1));
     EXPECT_CALL(level, get_palette_entry(_)).Times(AtLeast(1));
-    LevelTextureStorage subject(std::make_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
 }
 
 TEST(LevelTextureStorage, PaletteLoadedTomb2)
@@ -26,7 +27,7 @@ TEST(LevelTextureStorage, PaletteLoadedTomb2)
     trlevel::mocks::MockLevel level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb2));
     EXPECT_CALL(level, get_palette_entry(_)).Times(AtLeast(1));
-    LevelTextureStorage subject(std::make_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
 }
 
 TEST(LevelTextureStorage, PaletteLoadedTomb3)
@@ -34,7 +35,7 @@ TEST(LevelTextureStorage, PaletteLoadedTomb3)
     trlevel::mocks::MockLevel level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb3));
     EXPECT_CALL(level, get_palette_entry(_)).Times(AtLeast(1));
-    LevelTextureStorage subject(std::make_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
 }
 
 TEST(LevelTextureStorage, PaletteNotLoadedTomb4)
@@ -42,7 +43,7 @@ TEST(LevelTextureStorage, PaletteNotLoadedTomb4)
     trlevel::mocks::MockLevel level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb4));
     EXPECT_CALL(level, get_palette_entry(_)).Times(Exactly(0));
-    LevelTextureStorage subject(std::make_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
 }
 
 TEST(LevelTextureStorage, PaletteNotLoadedTomb5)
@@ -50,5 +51,5 @@ TEST(LevelTextureStorage, PaletteNotLoadedTomb5)
     trlevel::mocks::MockLevel level;
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb5));
     EXPECT_CALL(level, get_palette_entry(_)).Times(Exactly(0));
-    LevelTextureStorage subject(std::make_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), std::make_unique<MockTextureStorage>(), level);
 }

--- a/trview.app.tests/Graphics/MeshStorageTests.cpp
+++ b/trview.app.tests/Graphics/MeshStorageTests.cpp
@@ -16,7 +16,7 @@ namespace
         struct test_module
         {
             IMesh::Source mesh_source{ [](auto&&...) { return mock_shared<MockMesh>(); } };
-            std::shared_ptr<trlevel::ILevel> level{ std::make_shared<trlevel::mocks::MockLevel>() };
+            std::shared_ptr<trlevel::ILevel> level{ mock_shared<trlevel::mocks::MockLevel>() };
             std::shared_ptr<ILevelTextureStorage> texture_storage{ mock_shared<MockLevelTextureStorage>() };
 
             std::unique_ptr<MeshStorage> build()
@@ -36,7 +36,7 @@ namespace
 
 TEST(MeshStorage, MeshesLoadedFromLevel)
 {
-    auto level = std::make_shared<trlevel::mocks::MockLevel>();
+    auto level = mock_shared<trlevel::mocks::MockLevel>();
     ON_CALL(*level, num_mesh_pointers).WillByDefault(testing::Return(2));
     EXPECT_CALL(*level, get_mesh_by_pointer(0)).Times(1);
     EXPECT_CALL(*level, get_mesh_by_pointer(1)).Times(1);
@@ -45,7 +45,7 @@ TEST(MeshStorage, MeshesLoadedFromLevel)
 
 TEST(MeshStorage, MeshCanBeRetrieved)
 {
-    auto level = std::make_shared<trlevel::mocks::MockLevel>();
+    auto level = mock_shared<trlevel::mocks::MockLevel>();
     ON_CALL(*level, num_mesh_pointers).WillByDefault(testing::Return(1));
     EXPECT_CALL(*level, get_mesh_by_pointer(0)).Times(1);
     auto storage = register_test_module().with_level(level).build();
@@ -55,7 +55,7 @@ TEST(MeshStorage, MeshCanBeRetrieved)
 
 TEST(MeshStorage, MissingMeshNotFound)
 {
-    auto level = std::make_shared<trlevel::mocks::MockLevel>();
+    auto level = mock_shared<trlevel::mocks::MockLevel>();
     ON_CALL(*level, num_mesh_pointers).WillByDefault(testing::Return(1));
     EXPECT_CALL(*level, get_mesh_by_pointer(0)).Times(1);
     auto storage = register_test_module().with_level(level).build();

--- a/trview.app.tests/Graphics/MeshStorageTests.cpp
+++ b/trview.app.tests/Graphics/MeshStorageTests.cpp
@@ -5,6 +5,7 @@
 
 using namespace trview;
 using namespace trview::mocks;
+using namespace trview::tests;
 using namespace trlevel;
 using namespace trlevel::mocks;
 
@@ -14,9 +15,9 @@ namespace
     {
         struct test_module
         {
-            IMesh::Source mesh_source{ [](auto&&...) { return std::make_shared<MockMesh>(); } };
+            IMesh::Source mesh_source{ [](auto&&...) { return mock_shared<MockMesh>(); } };
             std::shared_ptr<trlevel::ILevel> level{ std::make_shared<trlevel::mocks::MockLevel>() };
-            std::shared_ptr<ILevelTextureStorage> texture_storage{ std::make_shared<MockLevelTextureStorage>() };
+            std::shared_ptr<ILevelTextureStorage> texture_storage{ mock_shared<MockLevelTextureStorage>() };
 
             std::unique_ptr<MeshStorage> build()
             {

--- a/trview.app.tests/Graphics/TextureStorage.cpp
+++ b/trview.app.tests/Graphics/TextureStorage.cpp
@@ -3,10 +3,11 @@
 using namespace trview;
 using namespace trview::graphics;
 using namespace trview::graphics::mocks;
+using namespace trview::tests;
 
 TEST(TextureStorage, KeysAreCaseInsensitive)
 {
-    TextureStorage storage(std::make_shared<MockDevice>());
+    TextureStorage storage(mock_shared<MockDevice>());
     auto existing_texture = storage.lookup("test_key");
     ASSERT_EQ(existing_texture.name(), std::string());
 

--- a/trview.app.tests/ItemsWindowManagerTests.cpp
+++ b/trview.app.tests/ItemsWindowManagerTests.cpp
@@ -17,8 +17,8 @@ namespace
         struct test_module
         {
             Window window{ create_test_window(L"ItemsWindowManagerTests") };
-            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<MockShortcuts>() };
-            ItemsWindow::Source window_source{ [](auto&&...) { return std::make_shared<MockItemsWindow>(); } };
+            std::shared_ptr<MockShortcuts> shortcuts{ mock_shared<MockShortcuts>() };
+            ItemsWindow::Source window_source{ [](auto&&...) { return mock_shared<MockItemsWindow>(); } };
 
             test_module& with_window_source(const ItemsWindow::Source& source)
             {
@@ -109,7 +109,7 @@ TEST(ItemsWindowManager, TriggerSelectedEventRaised)
     auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
-    auto test_trigger = std::make_shared<MockTrigger>();
+    auto test_trigger = mock_shared<MockTrigger>();
     created_window->on_trigger_selected(test_trigger);
 
     ASSERT_TRUE(raised_trigger.has_value());
@@ -118,7 +118,7 @@ TEST(ItemsWindowManager, TriggerSelectedEventRaised)
 
 TEST(ItemsWindowManager, SetItemsSetsItemsOnWindows)
 {
-    auto mock_window = std::make_shared<MockItemsWindow>();
+    auto mock_window = mock_shared<MockItemsWindow>();
     EXPECT_CALL(*mock_window, set_items).Times(2);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
@@ -136,7 +136,7 @@ TEST(ItemsWindowManager, SetItemsSetsItemsOnWindows)
 
 TEST(ItemsWindowManager, SetItemVisibilityUpdatesWindows)
 {
-    auto mock_window = std::make_shared<MockItemsWindow>();
+    auto mock_window = mock_shared<MockItemsWindow>();
     EXPECT_CALL(*mock_window, update_items).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
@@ -154,11 +154,11 @@ TEST(ItemsWindowManager, SetItemVisibilityUpdatesWindows)
 
 TEST(ItemsWindowManager, SetTriggersSetsTriggersOnWindows)
 {
-    auto mock_window = std::make_shared<MockItemsWindow>();
+    auto mock_window = mock_shared<MockItemsWindow>();
     EXPECT_CALL(*mock_window, set_triggers).Times(2);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     manager->set_triggers({ trigger });
 
     auto created_window = manager->create_window().lock();
@@ -169,7 +169,7 @@ TEST(ItemsWindowManager, SetTriggersSetsTriggersOnWindows)
 
 TEST(ItemsWindowManager, SetRoomSetsRoomOnWindows)
 {
-    auto mock_window = std::make_shared<MockItemsWindow>();
+    auto mock_window = mock_shared<MockItemsWindow>();
     EXPECT_CALL(*mock_window, set_current_room).Times(2);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
@@ -181,7 +181,7 @@ TEST(ItemsWindowManager, SetRoomSetsRoomOnWindows)
 
 TEST(ItemsWindowManager, SetSelectedItemSetsSelectedItemOnWindows)
 {
-    auto mock_window = std::make_shared<MockItemsWindow>();
+    auto mock_window = mock_shared<MockItemsWindow>();
     EXPECT_CALL(*mock_window, set_selected_item).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
@@ -200,7 +200,7 @@ TEST(ItemsWindowManager, SetSelectedItemSetsSelectedItemOnWindows)
 
 TEST(ItemsWindowManager, CreateWindowCreatesNewWindowWithSavedValues)
 {
-    auto mock_window = std::make_shared<MockItemsWindow>();
+    auto mock_window = mock_shared<MockItemsWindow>();
     EXPECT_CALL(*mock_window, set_items).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
@@ -219,14 +219,14 @@ TEST(ItemsWindowManager, CreateWindowCreatesNewWindowWithSavedValues)
 
 TEST(ItemsWindowManager, CreateItemsWindowKeyboardShortcut)
 {
-    auto shortcuts = std::make_shared<MockShortcuts>();
+    auto shortcuts = mock_shared<MockShortcuts>();
     EXPECT_CALL(*shortcuts, add_shortcut).Times(1).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto manager = register_test_module().with_shortcuts(shortcuts).build();
 }
 
 TEST(ItemsWindowManager, WindowsUpdated)
 {
-    auto mock_window = std::make_shared<MockItemsWindow>();
+    auto mock_window = mock_shared<MockItemsWindow>();
     EXPECT_CALL(*mock_window, update(1.0f)).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
     manager->create_window();

--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -8,7 +8,6 @@ using namespace trview;
 using namespace trview::tests;
 using namespace trview::mocks;
 using namespace DirectX::SimpleMath;
-using testing::NiceMock;
 
 namespace
 {
@@ -16,7 +15,7 @@ namespace
     {
         struct test_module
         {
-            std::shared_ptr<IClipboard> clipboard{ std::make_shared<NiceMock<MockClipboard>>() };
+            std::shared_ptr<IClipboard> clipboard{ mock_shared<MockClipboard>() };
 
             std::unique_ptr<ItemsWindow> build()
             {
@@ -271,8 +270,8 @@ TEST(ItemsWindow, TriggersLoadedForItem)
 {
     auto window = register_test_module().build();
 
-    auto trigger1 = std::make_shared<NiceMock<MockTrigger>>()->with_number(0);
-    auto trigger2 = std::make_shared<NiceMock<MockTrigger>>()->with_number(1);
+    auto trigger1 = mock_shared<MockTrigger>()->with_number(0);
+    auto trigger2 = mock_shared<MockTrigger>()->with_number(1);
     std::vector<Item> items
     {
         Item(0, 0, 0, L"Type", 0, 0, {}, Vector3::Zero),
@@ -301,7 +300,7 @@ TEST(ItemsWindow, TriggerSelectedEventRaised)
     std::optional<std::weak_ptr<ITrigger>> raised_trigger;
     auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
-    auto trigger = std::make_shared<NiceMock<MockTrigger>>();
+    auto trigger = mock_shared<MockTrigger>();
     std::vector<Item> items
     {
         Item(0, 0, 0, L"Type", 0, 0, {}, Vector3::Zero),
@@ -327,7 +326,7 @@ TEST(ItemsWindow, TriggerSelectedEventRaised)
 
 TEST(ItemsWindow, ClickStatShowsBubbleAndCopies)
 {
-    auto clipboard = std::make_shared<NiceMock<MockClipboard>>();
+    auto clipboard = mock_shared<MockClipboard>();
     EXPECT_CALL(*clipboard, write).Times(1);
 
     auto window = register_test_module().with_clipboard(clipboard).build();

--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -18,8 +18,8 @@ namespace
         struct test_module
         {
             Window window{ create_test_window(L"RoomsWindowManagerTests") };
-            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<MockShortcuts>() };
-            RoomsWindow::Source window_source{ [](auto&&...) { return std::make_shared<MockRoomsWindow>(); } };
+            std::shared_ptr<MockShortcuts> shortcuts{ mock_shared<MockShortcuts>() };
+            RoomsWindow::Source window_source{ [](auto&&...) { return mock_shared<MockRoomsWindow>(); } };
 
             test_module& with_window_source(const RoomsWindow::Source& source)
             {
@@ -50,7 +50,7 @@ namespace
 
 TEST(RoomsWindowManager, SetTriggersClearsSelectedTrigger)
 {
-    auto mock_window = std::make_shared<MockRoomsWindow>();
+    auto mock_window = mock_shared<MockRoomsWindow>();
     EXPECT_CALL(*mock_window, set_triggers).Times(3);
     EXPECT_CALL(*mock_window, clear_selected_trigger).Times(2);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
@@ -59,7 +59,7 @@ TEST(RoomsWindowManager, SetTriggersClearsSelectedTrigger)
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     manager->set_triggers({ trigger });
 
     ASSERT_EQ(manager->selected_trigger().lock(), nullptr);
@@ -71,7 +71,7 @@ TEST(RoomsWindowManager, SetTriggersClearsSelectedTrigger)
 
 TEST(RoomsWindowManager, WindowsUpdated)
 {
-    auto mock_window = std::make_shared<MockRoomsWindow>();
+    auto mock_window = mock_shared<MockRoomsWindow>();
     EXPECT_CALL(*mock_window, update(1.0f)).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
     manager->create_window();
@@ -80,7 +80,7 @@ TEST(RoomsWindowManager, WindowsUpdated)
 
 TEST(RoomsWindowManager, LevelVersionPassedToNewWindows)
 {
-    auto mock_window = std::make_shared<MockRoomsWindow>();
+    auto mock_window = mock_shared<MockRoomsWindow>();
     EXPECT_CALL(*mock_window, set_level_version(trlevel::LevelVersion::Tomb3)).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
     manager->set_level_version(trlevel::LevelVersion::Tomb3);
@@ -89,7 +89,7 @@ TEST(RoomsWindowManager, LevelVersionPassedToNewWindows)
 
 TEST(RoomsWindowManager, LevelVersionPassedToWindows)
 {
-    auto mock_window = std::make_shared<MockRoomsWindow>();
+    auto mock_window = mock_shared<MockRoomsWindow>();
     EXPECT_CALL(*mock_window, set_level_version(trlevel::LevelVersion::Unknown)).Times(1);
     EXPECT_CALL(*mock_window, set_level_version(trlevel::LevelVersion::Tomb3)).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();

--- a/trview.app.tests/RoomsWindowTests.cpp
+++ b/trview.app.tests/RoomsWindowTests.cpp
@@ -17,7 +17,7 @@ namespace
         struct test_module
         {
             IMapRenderer::Source map_renderer_source{ [](auto&&...) { return std::make_unique<MockMapRenderer>(); } };
-            std::shared_ptr<IClipboard> clipboard{ std::make_shared<MockClipboard>() };
+            std::shared_ptr<IClipboard> clipboard{ mock_shared<MockClipboard>() };
 
             std::unique_ptr<RoomsWindow> build()
             {
@@ -36,11 +36,11 @@ namespace
 
 TEST(RoomsWindow, ClickStatShowsBubbleAndCopies)
 {
-    auto clipboard = std::make_shared<MockClipboard>();
+    auto clipboard = mock_shared<MockClipboard>();
     EXPECT_CALL(*clipboard, write).Times(1);
     auto window = register_test_module().with_clipboard(clipboard).build();
 
-    auto room = std::make_shared<MockRoom>();
+    auto room = mock_shared<MockRoom>();
     window->set_rooms({ room });
     window->set_current_room(0);
 
@@ -61,7 +61,7 @@ TEST(RoomsWindow, ClickStatShowsBubbleAndCopies)
 
 TEST(RoomsWindow, LevelVersionChangesFlags)
 {
-    auto room = std::make_shared<MockRoom>();
+    auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, flag).Times(testing::AtLeast(1)).WillRepeatedly(testing::Return(true));
 
     auto window = register_test_module().build();

--- a/trview.app.tests/RoomsWindowTests.cpp
+++ b/trview.app.tests/RoomsWindowTests.cpp
@@ -16,7 +16,7 @@ namespace
     {
         struct test_module
         {
-            IMapRenderer::Source map_renderer_source{ [](auto&&...) { return std::make_unique<MockMapRenderer>(); } };
+            IMapRenderer::Source map_renderer_source{ [](auto&&...) { return mock_unique<MockMapRenderer>(); } };
             std::shared_ptr<IClipboard> clipboard{ mock_shared<MockClipboard>() };
 
             std::unique_ptr<RoomsWindow> build()

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -67,9 +67,9 @@ TEST(RouteWindow, WaypointRoomPositionCalculatedCorrectly)
     auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, info).WillRepeatedly(Return(info));
 
-    MockWaypoint waypoint;
+    NiceMock<MockWaypoint> waypoint;
     EXPECT_CALL(waypoint, position).WillRepeatedly(Return(waypoint_pos));
-    MockRoute route;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
 
@@ -94,10 +94,10 @@ TEST(RouteWindow, PositionValuesCopiedToClipboard)
     auto window = register_test_module().with_clipboard(clipboard).build();
 
     const Vector3 waypoint_pos{ 130, 250, 325 };
-    MockWaypoint waypoint;
+    NiceMock<MockWaypoint> waypoint;
     EXPECT_CALL(waypoint, position).WillRepeatedly(Return(waypoint_pos));
 
-    MockRoute route;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
 
@@ -119,10 +119,10 @@ TEST(RouteWindow, RoomPositionValuesCopiedToClipboard)
     auto window = register_test_module().with_clipboard(clipboard).build();
 
     const Vector3 waypoint_pos{ 130, 250, 325 };
-    MockWaypoint waypoint;
+    NiceMock<MockWaypoint> waypoint;
     EXPECT_CALL(waypoint, position).WillRepeatedly(Return(waypoint_pos));
 
-    MockRoute route;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
 
@@ -139,11 +139,11 @@ TEST(RouteWindow, RoomPositionValuesCopiedToClipboard)
 TEST(RouteWindow, AddingWaypointNotesMarksRouteUnsaved)
 {
     const Vector3 waypoint_pos{ 130, 250, 325 };
-    MockWaypoint waypoint;
+    NiceMock<MockWaypoint> waypoint;
     EXPECT_CALL(waypoint, position).WillRepeatedly(Return(waypoint_pos));
     EXPECT_CALL(waypoint, set_notes(std::wstring(L"Test"))).Times(1);
 
-    MockRoute route;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
     EXPECT_CALL(route, set_unsaved(true)).Times(1);
@@ -161,11 +161,11 @@ TEST(RouteWindow, AddingWaypointNotesMarksRouteUnsaved)
 
 TEST(RouteWindow, ClearSaveMarksRouteUnsaved)
 {
-    MockWaypoint waypoint;
+    NiceMock<MockWaypoint> waypoint;
     EXPECT_CALL(waypoint, has_save).Times(AtLeast(1)).WillRepeatedly(Return(true));
     EXPECT_CALL(waypoint, set_save_file(std::vector<uint8_t>())).Times(1);
 
-    MockRoute route;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
     EXPECT_CALL(route, set_unsaved(true)).Times(1);
@@ -269,11 +269,11 @@ TEST(RouteWindow, ExportSaveButtonSavesFile)
     auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::vector<uint8_t>&>())).Times(1);
 
-    MockWaypoint waypoint;
+    NiceMock<MockWaypoint> waypoint;
     EXPECT_CALL(waypoint, has_save).Times(AtLeast(1)).WillRepeatedly(Return(true));
     EXPECT_CALL(waypoint, save_file).Times(AtLeast(1)).WillRepeatedly(Return(std::vector<uint8_t>{ 0x1 }));
 
-    MockRoute route;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
 
@@ -295,10 +295,10 @@ TEST(RouteWindow, ExportSaveButtonShowsErrorOnFailure)
     auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::vector<uint8_t>&>())).Times(1).WillRepeatedly(Throw(std::exception()));
 
-    MockWaypoint waypoint;
+    NiceMock<MockWaypoint> waypoint;
     EXPECT_CALL(waypoint, has_save).Times(AtLeast(1)).WillRepeatedly(Return(true));
     EXPECT_CALL(waypoint, save_file).Times(AtLeast(1)).WillRepeatedly(Return(std::vector<uint8_t>{ 0x1 }));
-    MockRoute route;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
 
@@ -319,10 +319,10 @@ TEST(RouteWindow, ExportSaveButtonDoesNotSaveFileWhenCancelled)
     auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::vector<uint8_t>&>())).Times(0);
 
-    MockWaypoint waypoint;
+    NiceMock<MockWaypoint> waypoint;
     EXPECT_CALL(waypoint, has_save).Times(AtLeast(1)).WillRepeatedly(Return(true));
     EXPECT_CALL(waypoint, save_file).Times(0);
-    MockRoute route;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
 
@@ -343,10 +343,10 @@ TEST(RouteWindow, AttachSaveButtonLoadsSave)
     auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, load_file).Times(1).WillRepeatedly(Return(std::vector<uint8_t>{ 0x1, 0x2 }));
 
-    MockWaypoint waypoint;
+    NiceMock<MockWaypoint> waypoint;
     EXPECT_CALL(waypoint, set_save_file(std::vector<uint8_t>{ 0x1, 0x2 })).Times(1);
 
-    MockRoute route;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
     EXPECT_CALL(route, set_unsaved(true)).Times(1);
@@ -369,8 +369,8 @@ TEST(RouteWindow, AttachSaveButtonShowsMessageOnError)
     auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, load_file).Times(1).WillRepeatedly(Throw(std::exception()));
 
-    MockWaypoint waypoint;
-    MockRoute route;
+    NiceMock<MockWaypoint> waypoint;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
     EXPECT_CALL(route, set_unsaved(true)).Times(0);
@@ -394,8 +394,8 @@ TEST(RouteWindow, AttachSaveButtonDoesNotLoadFileWhenCancelled)
     auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, load_file).Times(0);
 
-    MockWaypoint waypoint;
-    MockRoute route;
+    NiceMock<MockWaypoint> waypoint;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
     EXPECT_CALL(route, set_unsaved).Times(0);
@@ -414,8 +414,8 @@ TEST(RouteWindow, ClickStatShowsBubble)
 {
     auto window = register_test_module().build();
 
-    MockWaypoint waypoint;
-    MockRoute route;
+    NiceMock<MockWaypoint> waypoint;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
     window->set_route(&route);
@@ -437,8 +437,8 @@ TEST(RouteWindow, RandomizerPanelVisibleBasedOnSetting)
     settings.settings["test"] = { "Test", RandomizerSettings::Setting::Type::Boolean };
     window->set_randomizer_settings(settings);
 
-    MockWaypoint waypoint;
-    MockRoute route;
+    NiceMock<MockWaypoint> waypoint;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
     window->set_route(&route);
@@ -461,8 +461,8 @@ TEST(RouteWindow, RandomizerPanelCreatesUIFromSettings)
 {
     auto window = register_test_module().build();
 
-    MockWaypoint waypoint;
-    MockRoute route;
+    NiceMock<MockWaypoint> waypoint;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
     window->set_route(&route);
@@ -500,8 +500,8 @@ TEST(RouteWindow, ToggleRandomizerBoolUpdatesWaypoint)
 
     IWaypoint::WaypointRandomizerSettings new_settings;
 
-    MockWaypoint waypoint;
-    MockRoute route;
+    NiceMock<MockWaypoint> waypoint;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
     EXPECT_CALL(waypoint, set_randomizer_settings(An<const IWaypoint::WaypointRandomizerSettings&>())).WillRepeatedly(SaveArg<0>(&new_settings));
@@ -529,8 +529,8 @@ TEST(RouteWindow, ChooseRandomizerDropDownUpdatesWaypoint)
 
     IWaypoint::WaypointRandomizerSettings new_settings;
 
-    MockWaypoint waypoint;
-    MockRoute route;
+    NiceMock<MockWaypoint> waypoint;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
     EXPECT_CALL(waypoint, set_randomizer_settings(An<const IWaypoint::WaypointRandomizerSettings&>())).WillRepeatedly(SaveArg<0>(&new_settings));
@@ -558,8 +558,8 @@ TEST(RouteWindow, SetRandomizerTextUpdatesWaypoint)
 
     IWaypoint::WaypointRandomizerSettings new_settings;
 
-    MockWaypoint waypoint;
-    MockRoute route;
+    NiceMock<MockWaypoint> waypoint;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
     EXPECT_CALL(waypoint, set_randomizer_settings(An<const IWaypoint::WaypointRandomizerSettings&>())).WillRepeatedly(SaveArg<0>(&new_settings));
@@ -587,8 +587,8 @@ TEST(RouteWindow, SetRandomizerNumberUpdatesWaypoint)
 
     IWaypoint::WaypointRandomizerSettings new_settings;
 
-    MockWaypoint waypoint;
-    MockRoute route;
+    NiceMock<MockWaypoint> waypoint;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
     EXPECT_CALL(waypoint, set_randomizer_settings(An<const IWaypoint::WaypointRandomizerSettings&>())).WillRepeatedly(SaveArg<0>(&new_settings));
@@ -608,8 +608,8 @@ TEST(RouteWindow, SetRandomizerNumberUpdatesWaypoint)
 TEST(RouteWindow, DeleteWaypointRaisesEvent)
 {
     auto window = register_test_module().build();
-    MockWaypoint waypoint;
-    MockRoute route;
+    NiceMock<MockWaypoint> waypoint;
+    NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
     window->set_route(&route);

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -19,9 +19,9 @@ namespace
     {
         struct test_module
         {
-            std::shared_ptr<IClipboard> clipboard{ std::make_shared<MockClipboard>() };
-            std::shared_ptr<IDialogs> dialogs{ std::make_shared<MockDialogs>() };
-            std::shared_ptr<IFiles> files{ std::make_shared<MockFiles>() };
+            std::shared_ptr<IClipboard> clipboard{ mock_shared<MockClipboard>() };
+            std::shared_ptr<IDialogs> dialogs{ mock_shared<MockDialogs>() };
+            std::shared_ptr<IFiles> files{ mock_shared<MockFiles>() };
             trview::Window parent{ create_test_window(L"RouteWindowTests") };
 
             test_module& with_clipboard(const std::shared_ptr<IClipboard>& clipboard)
@@ -64,7 +64,7 @@ TEST(RouteWindow, WaypointRoomPositionCalculatedCorrectly)
     info.yBottom = room_pos.y;
     info.z = room_pos.z;
 
-    auto room = std::make_shared<MockRoom>();
+    auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, info).WillRepeatedly(Return(info));
 
     MockWaypoint waypoint;
@@ -88,7 +88,7 @@ TEST(RouteWindow, WaypointRoomPositionCalculatedCorrectly)
 
 TEST(RouteWindow, PositionValuesCopiedToClipboard)
 {
-    auto clipboard = std::make_shared<MockClipboard>();
+    auto clipboard = mock_shared<MockClipboard>();
     EXPECT_CALL(*clipboard, write(std::wstring(L"133120, 256000, 332800"))).Times(1);
 
     auto window = register_test_module().with_clipboard(clipboard).build();
@@ -113,7 +113,7 @@ TEST(RouteWindow, PositionValuesCopiedToClipboard)
 
 TEST(RouteWindow, RoomPositionValuesCopiedToClipboard)
 {
-    auto clipboard = std::make_shared<MockClipboard>();
+    auto clipboard = mock_shared<MockClipboard>();
     EXPECT_CALL(*clipboard, write(std::wstring(L"133120, 256000, 332800"))).Times(1);
 
     auto window = register_test_module().with_clipboard(clipboard).build();
@@ -181,7 +181,7 @@ TEST(RouteWindow, ClearSaveMarksRouteUnsaved)
 
 TEST(RouteWindow, ExportRouteButtonRaisesEvent)
 {
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, save_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename", 0 }));
 
     std::optional<std::string> file_raised;
@@ -202,7 +202,7 @@ TEST(RouteWindow, ExportRouteButtonRaisesEvent)
 
 TEST(RouteWindow, ExportRouteButtonDoesNotRaiseEventWhenCancelled)
 {
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, save_file).Times(1);
 
     bool file_raised = false;
@@ -222,7 +222,7 @@ TEST(RouteWindow, ExportRouteButtonDoesNotRaiseEventWhenCancelled)
 
 TEST(RouteWindow, ImportRouteButtonRaisesEvent)
 {
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename" }));
 
     std::optional<std::string> file_raised;
@@ -243,7 +243,7 @@ TEST(RouteWindow, ImportRouteButtonRaisesEvent)
 
 TEST(RouteWindow, ImportRouteButtonDoesNotRaiseEventWhenCancelled)
 {
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, open_file).Times(1);
 
     bool file_raised = false;
@@ -263,10 +263,10 @@ TEST(RouteWindow, ImportRouteButtonDoesNotRaiseEventWhenCancelled)
 
 TEST(RouteWindow, ExportSaveButtonSavesFile)
 {
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, save_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename", 0 }));
 
-    auto files = std::make_shared<MockFiles>();
+    auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::vector<uint8_t>&>())).Times(1);
 
     MockWaypoint waypoint;
@@ -288,11 +288,11 @@ TEST(RouteWindow, ExportSaveButtonSavesFile)
 
 TEST(RouteWindow, ExportSaveButtonShowsErrorOnFailure)
 {
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, save_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename", 0 }));
     EXPECT_CALL(*dialogs, message_box).Times(1);
 
-    auto files = std::make_shared<MockFiles>();
+    auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::vector<uint8_t>&>())).Times(1).WillRepeatedly(Throw(std::exception()));
 
     MockWaypoint waypoint;
@@ -313,10 +313,10 @@ TEST(RouteWindow, ExportSaveButtonShowsErrorOnFailure)
 
 TEST(RouteWindow, ExportSaveButtonDoesNotSaveFileWhenCancelled)
 {
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, save_file).Times(1);
 
-    auto files = std::make_shared<MockFiles>();
+    auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::vector<uint8_t>&>())).Times(0);
 
     MockWaypoint waypoint;
@@ -337,10 +337,10 @@ TEST(RouteWindow, ExportSaveButtonDoesNotSaveFileWhenCancelled)
 
 TEST(RouteWindow, AttachSaveButtonLoadsSave)
 {
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename" }));
 
-    auto files = std::make_shared<MockFiles>();
+    auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, load_file).Times(1).WillRepeatedly(Return(std::vector<uint8_t>{ 0x1, 0x2 }));
 
     MockWaypoint waypoint;
@@ -362,11 +362,11 @@ TEST(RouteWindow, AttachSaveButtonLoadsSave)
 
 TEST(RouteWindow, AttachSaveButtonShowsMessageOnError)
 {
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, open_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename" }));
     EXPECT_CALL(*dialogs, message_box).Times(1);
 
-    auto files = std::make_shared<MockFiles>();
+    auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, load_file).Times(1).WillRepeatedly(Throw(std::exception()));
 
     MockWaypoint waypoint;
@@ -388,10 +388,10 @@ TEST(RouteWindow, AttachSaveButtonShowsMessageOnError)
 
 TEST(RouteWindow, AttachSaveButtonDoesNotLoadFileWhenCancelled)
 {
-    auto dialogs = std::make_shared<MockDialogs>();
+    auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, open_file).Times(1);
 
-    auto files = std::make_shared<MockFiles>();
+    auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, load_file).Times(0);
 
     MockWaypoint waypoint;

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -10,6 +10,7 @@ using namespace trview::mocks;
 using namespace trview::tests;
 using namespace DirectX::SimpleMath;
 using testing::Return;
+using testing::NiceMock;
 
 namespace
 {
@@ -17,8 +18,8 @@ namespace
     {
         struct test_module
         {
-            std::unique_ptr<ISelectionRenderer> selection_renderer = std::make_unique<MockSelectionRenderer>();
-            IWaypoint::Source waypoint_source = [](auto&&...) { return std::make_unique<MockWaypoint>(); };
+            std::unique_ptr<ISelectionRenderer> selection_renderer = mock_unique<MockSelectionRenderer>();
+            IWaypoint::Source waypoint_source = [](auto&&...) { return mock_unique<MockWaypoint>(); };
 
             test_module& with_selection_renderer(std::unique_ptr<ISelectionRenderer> selection_renderer)
             {
@@ -59,7 +60,7 @@ namespace
     {
         return [&](auto&&...)
         {
-            auto waypoint = std::make_unique<MockWaypoint>();
+            auto waypoint = mock_unique<MockWaypoint>();
             waypoint->test_index = test_index++;
             return waypoint;
         };
@@ -87,7 +88,7 @@ TEST(Route, Add)
     auto source = [&](auto&& position, auto&& normal, auto&& room, auto&& type, auto&& index, auto&& colour)
     {
         waypoint_values = { position, normal, room, type, index, colour };
-        return std::make_unique<MockWaypoint>();
+        return mock_unique<MockWaypoint>();
     };
 
     auto route = register_test_module().with_waypoint_source(source).build();
@@ -107,7 +108,7 @@ TEST(Route, AddSpecificType)
     auto source = [&](auto&& position, auto&& normal, auto&& room, auto&& type, auto&& index, auto&& colour)
     {
         waypoint_values = { position, normal, room, type, index, colour };
-        return std::make_unique<MockWaypoint>();
+        return mock_unique<MockWaypoint>();
     };
     auto route = register_test_module().with_waypoint_source(source).build();
     route->add(Vector3(0, 1, 0), Vector3::Down, 10, IWaypoint::Type::Trigger, 100);
@@ -261,8 +262,8 @@ TEST(Route, Render)
     route->add(Vector3::Zero, Vector3::Down, 0);
     route->add(Vector3::Zero, Vector3::Down, 0);
  
-    MockCamera camera;
-    MockLevelTextureStorage texture_storage;
+    NiceMock<MockCamera> camera;
+    NiceMock<MockLevelTextureStorage> texture_storage;
     route->render(camera, texture_storage);
 }
 
@@ -298,7 +299,7 @@ TEST(Route, RenderDoesNotJoinWhenRandoEnabled)
     route->add(Vector3::Zero, Vector3::Down, 0);
     route->add(Vector3::Zero, Vector3::Down, 0);
 
-    MockCamera camera;
-    MockLevelTextureStorage texture_storage;
+    NiceMock<MockCamera> camera;
+    NiceMock<MockLevelTextureStorage> texture_storage;
     route->render(camera, texture_storage);
 }

--- a/trview.app.tests/Routing/WaypointTests.cpp
+++ b/trview.app.tests/Routing/WaypointTests.cpp
@@ -3,11 +3,12 @@
 
 using namespace trview;
 using namespace trview::mocks;
+using namespace trview::tests;
 using namespace DirectX::SimpleMath;
 
 TEST(Waypoint, ConstructorProperties)
 {
-    Waypoint waypoint(std::make_shared<MockMesh>(), Vector3(1, 2, 3), Vector3::Down, 12, IWaypoint::Type::Trigger, 23, Colour::Red);
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3(1, 2, 3), Vector3::Down, 12, IWaypoint::Type::Trigger, 23, Colour::Red);
     ASSERT_EQ(waypoint.position(), Vector3(1, 2, 3));
     ASSERT_EQ(waypoint.normal(), Vector3::Down);
     ASSERT_EQ(waypoint.room(), 12);
@@ -17,7 +18,7 @@ TEST(Waypoint, ConstructorProperties)
 
 TEST(Waypoint, EmptySave)
 {
-    Waypoint waypoint(std::make_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red);
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red);
     ASSERT_FALSE(waypoint.has_save());
     waypoint.set_save_file({});
     ASSERT_FALSE(waypoint.has_save());
@@ -25,14 +26,14 @@ TEST(Waypoint, EmptySave)
 
 TEST(Waypoint, Notes)
 {
-    Waypoint waypoint(std::make_shared<MockMesh>(), Vector3(1, 2, 3), Vector3::Down, 12, IWaypoint::Type::Trigger, 23, Colour::Red);
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3(1, 2, 3), Vector3::Down, 12, IWaypoint::Type::Trigger, 23, Colour::Red);
     waypoint.set_notes(L"Test notes\nNew line");
     ASSERT_EQ(waypoint.notes(), L"Test notes\nNew line");
 }
 
 TEST(Waypoint, SaveFile)
 {
-    Waypoint waypoint(std::make_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red);
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red);
     ASSERT_FALSE(waypoint.has_save());
     waypoint.set_save_file({ 0x1 });
     ASSERT_TRUE(waypoint.has_save());
@@ -41,7 +42,7 @@ TEST(Waypoint, SaveFile)
 
 TEST(Waypoint, Visibility)
 {
-    Waypoint waypoint(std::make_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red);
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red);
     ASSERT_TRUE(waypoint.visible());
     waypoint.set_visible(false);
     ASSERT_FALSE(waypoint.visible());
@@ -51,7 +52,7 @@ TEST(Waypoint, Visibility)
 
 TEST(Waypoint, RandomizerProperties)
 {
-    Waypoint waypoint(std::make_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red);
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red);
     auto existing = waypoint.randomizer_settings();
     ASSERT_TRUE(existing.empty());
     existing["test1"] = std::string("Test");

--- a/trview.app.tests/Settings/SettingsLoaderTests.cpp
+++ b/trview.app.tests/Settings/SettingsLoaderTests.cpp
@@ -2,6 +2,7 @@
 #include <trview.common/Mocks/IFiles.h>
 
 using namespace trview;
+using namespace trview::mocks;
 using testing::Return;
 using testing::A;
 using testing::SaveArg;

--- a/trview.app.tests/Settings/SettingsLoaderTests.cpp
+++ b/trview.app.tests/Settings/SettingsLoaderTests.cpp
@@ -3,6 +3,7 @@
 
 using namespace trview;
 using namespace trview::mocks;
+using namespace trview::tests;
 using testing::Return;
 using testing::A;
 using testing::SaveArg;
@@ -14,7 +15,7 @@ namespace
     {
         struct test_module
         {
-            std::shared_ptr<IFiles> files{ std::make_shared<MockFiles>() };
+            std::shared_ptr<IFiles> files{ mock_shared<MockFiles>() };
 
             std::unique_ptr<SettingsLoader> build()
             {
@@ -39,7 +40,7 @@ namespace
     std::unique_ptr<SettingsLoader> setup_setting(const std::string& setting, std::string randomizer_settings = "")
     {
         const auto contents = to_bytes(setting);
-        auto files = std::make_shared<MockFiles>();
+        auto files = mock_shared<MockFiles>();
         EXPECT_CALL(*files, appdata_directory).Times(2).WillRepeatedly(Return("appdata"));
         EXPECT_CALL(*files, load_file("appdata\\trview\\settings.txt")).Times(1).WillRepeatedly(Return(contents));
         EXPECT_CALL(*files, load_file("appdata\\trview\\randomizer.json")).Times(1).WillRepeatedly(Return(to_bytes(randomizer_settings)));
@@ -48,7 +49,7 @@ namespace
 
     std::unique_ptr<SettingsLoader> setup_save_setting(std::string& setting)
     {
-        auto files = std::make_shared<MockFiles>();
+        auto files = mock_shared<MockFiles>();
         EXPECT_CALL(*files, appdata_directory).Times(testing::AtLeast(1)).WillRepeatedly(Return("appdata"));
         EXPECT_CALL(*files, save_file(A<const std::string&>(), A<const std::string&>())).WillRepeatedly(SaveArg<1>(&setting));
         return register_test_module().with_files(files).build();
@@ -57,7 +58,7 @@ namespace
 
 TEST(SettingsLoader, FileNotFound)
 {
-    auto files = std::make_shared<MockFiles>();
+    auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, appdata_directory).Times(1).WillRepeatedly(Return("appdata"));
     EXPECT_CALL(*files, load_file("appdata\\trview\\settings.txt")).Times(1);
     auto loader = register_test_module().with_files(files).build();
@@ -69,7 +70,7 @@ TEST(SettingsLoader, FileNotFound)
 
 TEST(SettingsLoader, FileSaved)
 {
-    auto files = std::make_shared<MockFiles>();
+    auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, appdata_directory).Times(1).WillRepeatedly(Return("appdata"));
     EXPECT_CALL(*files, save_file("appdata\\trview\\settings.txt", A<const std::string&>())).Times(1);
     auto loader = register_test_module().with_files(files).build();

--- a/trview.app.tests/SettingsWindowTests.cpp
+++ b/trview.app.tests/SettingsWindowTests.cpp
@@ -272,7 +272,7 @@ TEST(SettingsWindow, ClickingInvertVerticalPanRaisesEvent)
 TEST(SettingsWindow, SetMovementSpeedUpdatesSlider)
 {
     ui::Window host(Size(), Colour::Transparent);
-    SettingsWindow window(host, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
+    SettingsWindow window(host, std::make_shared<JsonLoader>(mock_shared<MockShell>()));
 
     auto slider = host.find<Slider>(SettingsWindow::Names::movement_speed);
     ASSERT_NE(slider, nullptr);
@@ -293,7 +293,7 @@ TEST(SettingsWindow, SetMovementSpeedUpdatesSlider)
 TEST(SettingsWindow, ClickingMovementSpeedRaisesEvent)
 {
     ui::Window host(Size(), Colour::Transparent);
-    SettingsWindow window(host, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
+    SettingsWindow window(host, std::make_shared<JsonLoader>(mock_shared<MockShell>()));
 
     auto slider = host.find<Slider>(SettingsWindow::Names::movement_speed);
     ASSERT_NE(slider, nullptr);
@@ -313,7 +313,7 @@ TEST(SettingsWindow, ClickingMovementSpeedRaisesEvent)
 TEST(SettingsWindow, SetSensitivitySlider)
 {
     ui::Window host(Size(), Colour::Transparent);
-    SettingsWindow window(host, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
+    SettingsWindow window(host, std::make_shared<JsonLoader>(mock_shared<MockShell>()));
 
     auto slider = host.find<Slider>(SettingsWindow::Names::sensitivity);
     ASSERT_NE(slider, nullptr);
@@ -334,7 +334,7 @@ TEST(SettingsWindow, SetSensitivitySlider)
 TEST(SettingsWindow, ClickingSensitivityRaisesEvent)
 {
     ui::Window host(Size(), Colour::Transparent);
-    SettingsWindow window(host, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
+    SettingsWindow window(host, std::make_shared<JsonLoader>(mock_shared<MockShell>()));
 
     auto slider = host.find<Slider>(SettingsWindow::Names::sensitivity);
     ASSERT_NE(slider, nullptr);
@@ -390,7 +390,7 @@ TEST(SettingsWindow, ClickingAccelerationRaisesEvent)
 TEST(SettingsWindow, SetAccelerationRateUpdatesSlider)
 {
     ui::Window host(Size(), Colour::Transparent);
-    SettingsWindow window(host, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
+    SettingsWindow window(host, std::make_shared<JsonLoader>(mock_shared<MockShell>()));
 
     auto slider = host.find<Slider>(SettingsWindow::Names::acceleration_rate);
     ASSERT_NE(slider, nullptr);
@@ -411,7 +411,7 @@ TEST(SettingsWindow, SetAccelerationRateUpdatesSlider)
 TEST(SettingsWindow, ClickingAccelerationRateRaisesEvent)
 {
     // ui::Window host(Size(), Colour::Transparent);
-    // SettingsWindow window(host, std::make_shared<JsonLoader>(std::make_shared<MockShell>()));
+    // SettingsWindow window(host, std::make_shared<JsonLoader>(mock_shared<MockShell>()));
     SettingsWindow window;
     window.toggle_visibility();
 

--- a/trview.app.tests/TriggersWindowManagerTests.cpp
+++ b/trview.app.tests/TriggersWindowManagerTests.cpp
@@ -17,8 +17,8 @@ namespace
         struct test_module
         {
             Window window{ create_test_window(L"TriggersWindowManagerTests") };
-            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<MockShortcuts>() };
-            TriggersWindow::Source window_source{ [](auto&&...) { return std::make_shared<MockTriggersWindow>(); } };
+            std::shared_ptr<MockShortcuts> shortcuts{ mock_shared<MockShortcuts>() };
+            TriggersWindow::Source window_source{ [](auto&&...) { return mock_shared<MockTriggersWindow>(); } };
 
             test_module& with_window_source(const TriggersWindow::Source& source)
             {
@@ -49,19 +49,19 @@ namespace
 
 TEST(TriggersWindowManager, CreateTriggersWindowKeyboardShortcut)
 {
-    auto shortcuts = std::make_shared<MockShortcuts>();
+    auto shortcuts = mock_shared<MockShortcuts>();
     EXPECT_CALL(*shortcuts, add_shortcut).Times(1).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto manager = register_test_module().with_shortcuts(shortcuts).build();
 }
 
 TEST(TriggersWindowManager, CreateTriggersWindowCreatesNewWindowWithSavedValues)
 {
-    auto mock_window = std::make_shared<MockTriggersWindow>();
+    auto mock_window = mock_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_triggers).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    auto trigger1 = std::make_shared<MockTrigger>();
-    auto trigger2 = std::make_shared<MockTrigger>();
+    auto trigger1 = mock_shared<MockTrigger>();
+    auto trigger2 = mock_shared<MockTrigger>();
     manager->set_triggers({ trigger1, trigger2 });
 
     auto created_window = manager->create_window().lock();
@@ -71,12 +71,12 @@ TEST(TriggersWindowManager, CreateTriggersWindowCreatesNewWindowWithSavedValues)
 
 TEST(TriggersWindowManager, CreateTriggersWindowSetsSelectedTriggerOnWindows)
 {
-    auto mock_window = std::make_shared<MockTriggersWindow>();
+    auto mock_window = mock_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_selected_trigger).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    auto trigger1 = std::make_shared<MockTrigger>();
-    auto trigger2 = std::make_shared<MockTrigger>();
+    auto trigger1 = mock_shared<MockTrigger>();
+    auto trigger2 = mock_shared<MockTrigger>();
     manager->set_triggers({ trigger1, trigger2 });
     manager->set_selected_trigger(trigger2);
 
@@ -112,7 +112,7 @@ TEST(TriggersWindowManager, TriggerSelectedEventRaised)
     auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     created_window->on_trigger_selected(trigger);
 
     ASSERT_TRUE(raised_trigger.has_value());
@@ -129,7 +129,7 @@ TEST(TriggersWindowManager, TriggerVisibilityEventRaised)
     auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     created_window->on_trigger_visibility(trigger, true);
 
     ASSERT_TRUE(raised_trigger.has_value());
@@ -147,7 +147,7 @@ TEST(TriggersWindowManager, AddToRouteEventRaised)
     auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     created_window->on_add_to_route(trigger);
 
     ASSERT_TRUE(raised_trigger.has_value());
@@ -156,7 +156,7 @@ TEST(TriggersWindowManager, AddToRouteEventRaised)
 
 TEST(TriggersWindowManager, SetItemsSetsItemsOnWindows)
 {
-    auto mock_window = std::make_shared<MockTriggersWindow>();
+    auto mock_window = mock_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_items).Times(2);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
@@ -173,7 +173,7 @@ TEST(TriggersWindowManager, SetItemsSetsItemsOnWindows)
 
 TEST(TriggersWindowManager, SetTriggersSetsTriggersOnWindows)
 {
-    auto mock_window = std::make_shared<MockTriggersWindow>();
+    auto mock_window = mock_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_triggers).Times(2);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
@@ -181,14 +181,14 @@ TEST(TriggersWindowManager, SetTriggersSetsTriggersOnWindows)
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
-    auto trigger1 = std::make_shared<MockTrigger>();
-    auto trigger2 = std::make_shared<MockTrigger>();
+    auto trigger1 = mock_shared<MockTrigger>();
+    auto trigger2 = mock_shared<MockTrigger>();
     manager->set_triggers({ trigger1, trigger2 });
 }
 
 TEST(TriggersWindowManager, SetTriggersClearsSelectedTrigger)
 {
-    auto mock_window = std::make_shared<MockTriggersWindow>();
+    auto mock_window = mock_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_triggers).Times(3);
     EXPECT_CALL(*mock_window, clear_selected_trigger).Times(2);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
@@ -197,7 +197,7 @@ TEST(TriggersWindowManager, SetTriggersClearsSelectedTrigger)
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     manager->set_triggers({ trigger });
 
     ASSERT_EQ(manager->selected_trigger().lock(), nullptr);
@@ -209,7 +209,7 @@ TEST(TriggersWindowManager, SetTriggersClearsSelectedTrigger)
 
 TEST(TriggersWindowManager, SetTriggerVisibilityUpdatesWindows)
 {
-    auto mock_window = std::make_shared<MockTriggersWindow>();
+    auto mock_window = mock_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, update_triggers).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
@@ -217,14 +217,14 @@ TEST(TriggersWindowManager, SetTriggerVisibilityUpdatesWindows)
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     manager->set_triggers({ trigger });
     manager->set_trigger_visible(trigger, false);
 }
 
 TEST(TriggersWindowManager, SetRoomSetsRoomOnWindows)
 {
-    auto mock_window = std::make_shared<MockTriggersWindow>();
+    auto mock_window = mock_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_current_room).Times(2);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
@@ -236,7 +236,7 @@ TEST(TriggersWindowManager, SetRoomSetsRoomOnWindows)
 
 TEST(TriggersWindowManager, SetSelectedTriggerSetsSelectedTriggerOnWindows)
 {
-    auto mock_window = std::make_shared<MockTriggersWindow>();
+    auto mock_window = mock_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, set_selected_trigger).Times(2);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
@@ -244,15 +244,15 @@ TEST(TriggersWindowManager, SetSelectedTriggerSetsSelectedTriggerOnWindows)
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
 
-    auto trigger1 = std::make_shared<MockTrigger>();
-    auto trigger2 = std::make_shared<MockTrigger>();
+    auto trigger1 = mock_shared<MockTrigger>();
+    auto trigger2 = mock_shared<MockTrigger>();
     manager->set_triggers({ trigger1, trigger2 });
     manager->set_selected_trigger(trigger2);
 }
 
 TEST(TriggersWindowManager, WindowsUpdated)
 {
-    auto mock_window = std::make_shared<MockTriggersWindow>();
+    auto mock_window = mock_shared<MockTriggersWindow>();
     EXPECT_CALL(*mock_window, update(1.0f)).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
     manager->create_window();

--- a/trview.app.tests/TriggersWindowTests.cpp
+++ b/trview.app.tests/TriggersWindowTests.cpp
@@ -8,7 +8,6 @@ using namespace trview;
 using namespace trview::tests;
 using namespace trview::mocks;
 using testing::Return;
-using testing::NiceMock;
 
 namespace
 {
@@ -16,7 +15,7 @@ namespace
     {
         struct test_module
         {
-            std::shared_ptr<IClipboard> clipboard{ std::make_shared<NiceMock<MockClipboard>>() };
+            std::shared_ptr<IClipboard> clipboard{ mock_shared<MockClipboard>() };
 
             std::unique_ptr<TriggersWindow> build()
             {
@@ -35,8 +34,8 @@ TEST(TriggersWindow, TriggerSelectedRaisedWhenSyncTriggerEnabled)
     std::optional<std::weak_ptr<ITrigger>> raised_trigger;
     auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
-    auto trigger1 = std::make_shared<NiceMock<MockTrigger>>()->with_number(0);
-    auto trigger2 = std::make_shared<NiceMock<MockTrigger>>()->with_number(1);
+    auto trigger1 = mock_shared<MockTrigger>()->with_number(0);
+    auto trigger2 = mock_shared<MockTrigger>()->with_number(1);
     window->set_triggers({ trigger1, trigger2 });
 
     TestImgui imgui([&]() { window->render(); });
@@ -59,8 +58,8 @@ TEST(TriggersWindow, TriggerSelectedNotRaisedWhenSyncTriggerDisabled)
     std::optional<std::weak_ptr<ITrigger>> raised_trigger;
     auto token = window->on_trigger_selected += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
-    auto trigger1 = std::make_shared<NiceMock<MockTrigger>>()->with_number(0);
-    auto trigger2 = std::make_shared<NiceMock<MockTrigger>>()->with_number(1);
+    auto trigger1 = mock_shared<MockTrigger>()->with_number(0);
+    auto trigger2 = mock_shared<MockTrigger>()->with_number(1);
     window->set_triggers({ trigger1, trigger2 });
 
     TestImgui imgui([&]() { window->render(); });
@@ -80,8 +79,8 @@ TEST(TriggersWindow, TriggersListNotFilteredWhenRoomSetAndTrackRoomDisabled)
 {
     auto window = register_test_module().build();
 
-    auto trigger1 = std::make_shared<NiceMock<MockTrigger>>()->with_number(0);
-    auto trigger2 = std::make_shared<NiceMock<MockTrigger>>()->with_number(1);
+    auto trigger1 = mock_shared<MockTrigger>()->with_number(0);
+    auto trigger2 = mock_shared<MockTrigger>()->with_number(1);
     window->set_triggers({ trigger1, trigger2 });
     window->set_current_room(78);
 
@@ -101,8 +100,8 @@ TEST(TriggersWindow, TriggersListFilteredWhenRoomSetAndTrackRoomEnabled)
 {
     auto window = register_test_module().build();
 
-    auto trigger1 = std::make_shared<NiceMock<MockTrigger>>()->with_number(0)->with_room(55);
-    auto trigger2 = std::make_shared<NiceMock<MockTrigger>>()->with_number(1)->with_room(78);
+    auto trigger1 = mock_shared<MockTrigger>()->with_number(0)->with_room(55);
+    auto trigger2 = mock_shared<MockTrigger>()->with_number(1)->with_room(78);
     window->set_triggers({ trigger1, trigger2 });
     window->set_current_room(78);
 
@@ -134,8 +133,8 @@ TEST(TriggersWindow, TriggersListFilteredWhenRoomSetAndTrackRoomEnabled)
 TEST(TriggersWindow, TriggersListFilteredByCommand)
 {
     auto window = register_test_module().build();
-    auto trigger1 = std::make_shared<NiceMock<MockTrigger>>()->with_commands({ Command(0, TriggerCommandType::Object, 1) });
-    auto trigger2 = std::make_shared<NiceMock<MockTrigger>>()->with_number(1)->with_commands({ Command(0, TriggerCommandType::Camera, 1) });
+    auto trigger1 = mock_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Object, 1) });
+    auto trigger2 = mock_shared<MockTrigger>()->with_number(1)->with_commands({ Command(0, TriggerCommandType::Camera, 1) });
     std::vector<std::weak_ptr<ITrigger>> triggers{ trigger1, trigger2 };
     window->set_triggers(triggers);
 
@@ -196,7 +195,7 @@ TEST(TriggersWindow, TriggerVisibilityRaised)
     std::optional<std::tuple<std::weak_ptr<ITrigger>, bool>> raised_trigger;
     auto token = window->on_trigger_visibility += [&raised_trigger](const auto& trigger, bool state) { raised_trigger = { trigger, state }; };
 
-    auto trigger = std::make_shared<NiceMock<MockTrigger>>()->with_visible(true);
+    auto trigger = mock_shared<MockTrigger>()->with_visible(true);
     std::vector<std::weak_ptr<ITrigger>> triggers{ trigger };
     window->set_triggers(triggers);
 
@@ -243,7 +242,7 @@ TEST(TriggersWindow, SetTriggerVisiblityUpdatesTrigger)
     auto window = register_test_module().build();
 
     bool visible = true;
-    auto trigger = std::make_shared<NiceMock<MockTrigger>>()->with_visible([&]() { return visible; });
+    auto trigger = mock_shared<MockTrigger>()->with_visible([&]() { return visible; });
     window->set_triggers({ trigger });
 
     TestImgui imgui([&]() { window->render(); });
@@ -263,10 +262,10 @@ TEST(TriggersWindow, SetTriggerVisiblityUpdatesTrigger)
 TEST(TriggersWindow, FlipmapsFiltersAllFlipTriggers)
 {
     auto window = register_test_module().build();
-    auto trigger1 = std::make_shared<NiceMock<MockTrigger>>()->with_number(0)->with_commands({ Command(0, TriggerCommandType::FlipOff, 0) });
-    auto trigger2 = std::make_shared<NiceMock<MockTrigger>>()->with_number(1)->with_commands({ Command(0, TriggerCommandType::FlipOn, 0) });
-    auto trigger3 = std::make_shared<NiceMock<MockTrigger>>()->with_number(2)->with_commands({ Command(0, TriggerCommandType::FlipMap, 0) });
-    auto trigger4 = std::make_shared<NiceMock<MockTrigger>>()->with_number(3);
+    auto trigger1 = mock_shared<MockTrigger>()->with_number(0)->with_commands({ Command(0, TriggerCommandType::FlipOff, 0) });
+    auto trigger2 = mock_shared<MockTrigger>()->with_number(1)->with_commands({ Command(0, TriggerCommandType::FlipOn, 0) });
+    auto trigger3 = mock_shared<MockTrigger>()->with_number(2)->with_commands({ Command(0, TriggerCommandType::FlipMap, 0) });
+    auto trigger4 = mock_shared<MockTrigger>()->with_number(3);
     window->set_triggers({ trigger1, trigger2, trigger3, trigger4 });
 
     TestImgui imgui([&]() { window->render(); });
@@ -316,7 +315,7 @@ TEST(TriggersWindow, ClickStatShowsBubble)
 {
     auto window = register_test_module().build();
 
-    auto trigger1 = std::make_shared<NiceMock<MockTrigger>>()->with_number(0)->with_commands({ Command(0, TriggerCommandType::FlipOff, 0) });
+    auto trigger1 = mock_shared<MockTrigger>()->with_number(0)->with_commands({ Command(0, TriggerCommandType::FlipOff, 0) });
     window->set_triggers({ trigger1 });
     window->set_selected_trigger(trigger1);
 

--- a/trview.app.tests/TriggersWindowTests.cpp
+++ b/trview.app.tests/TriggersWindowTests.cpp
@@ -174,7 +174,7 @@ TEST(TriggersWindow, AddToRouteEventRaised)
     std::optional<std::weak_ptr<ITrigger>> raised_trigger;
     auto token = window->on_add_to_route += [&raised_trigger](const auto& trigger) { raised_trigger = trigger; };
 
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     std::vector<std::weak_ptr<ITrigger>> triggers{ trigger };
 
     window->set_triggers(triggers);
@@ -223,7 +223,7 @@ TEST(TriggersWindow, ItemSelectedRaised)
         Item(1, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero)
     };
 
-    auto trigger = std::make_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Object, 1) });
+    auto trigger = mock_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Object, 1) });
     window->set_items(items);
     window->set_triggers({ trigger });
     window->set_selected_trigger(trigger);

--- a/trview.app.tests/UI/LevelInfoTests.cpp
+++ b/trview.app.tests/UI/LevelInfoTests.cpp
@@ -5,10 +5,11 @@ using namespace trview;
 using namespace trview::mocks;
 using namespace trview::tests;
 using testing::Return;
+using testing::NiceMock;
 
 TEST(LevelInfo, NameUpdated)
 {
-    MockTextureStorage texture_storage;
+    NiceMock<MockTextureStorage> texture_storage;
     LevelInfo info(texture_storage);
 
     TestImgui imgui([&]() { info.render(); });
@@ -21,7 +22,7 @@ TEST(LevelInfo, NameUpdated)
 
 TEST(LevelInfo, OnToggleSettingsRaised)
 {
-    MockTextureStorage texture_storage;
+    NiceMock<MockTextureStorage> texture_storage;
     LevelInfo info(texture_storage);
     TestImgui imgui([&]() { info.render(); });
 

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -25,11 +25,11 @@ namespace
             trview::Window window{ create_test_window(L"ViewerUITests") };
             std::shared_ptr<ITextureStorage> texture_storage{ mock_shared<MockTextureStorage>() };
             std::shared_ptr<MockShortcuts> shortcuts{ mock_shared<MockShortcuts>() };
-            IMapRenderer::Source map_renderer_source{ [](auto&&...) { return std::make_unique<MockMapRenderer>(); }};
-            std::unique_ptr<ISettingsWindow> settings_window{ std::make_unique<MockSettingsWindow>() };
-            std::unique_ptr<IViewOptions> view_options{ std::make_unique<MockViewOptions>() };
-            std::unique_ptr<trview::IContextMenu> context_menu{ std::make_unique<MockContextMenu>() };
-            std::unique_ptr<ICameraControls> camera_controls{ std::make_unique<MockCameraControls>() };
+            IMapRenderer::Source map_renderer_source{ [](auto&&...) { return mock_unique<MockMapRenderer>(); }};
+            std::unique_ptr<ISettingsWindow> settings_window{ mock_unique<MockSettingsWindow>() };
+            std::unique_ptr<IViewOptions> view_options{ mock_unique<MockViewOptions>() };
+            std::unique_ptr<trview::IContextMenu> context_menu{ mock_unique<MockContextMenu>() };
+            std::unique_ptr<ICameraControls> camera_controls{ mock_unique<MockCameraControls>() };
 
             std::unique_ptr<ViewerUI> build()
             {

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -23,8 +23,8 @@ namespace
         struct test_module
         {
             trview::Window window{ create_test_window(L"ViewerUITests") };
-            std::shared_ptr<ITextureStorage> texture_storage{ std::make_shared<MockTextureStorage>() };
-            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<MockShortcuts>() };
+            std::shared_ptr<ITextureStorage> texture_storage{ mock_shared<MockTextureStorage>() };
+            std::shared_ptr<MockShortcuts> shortcuts{ mock_shared<MockShortcuts>() };
             IMapRenderer::Source map_renderer_source{ [](auto&&...) { return std::make_unique<MockMapRenderer>(); }};
             std::unique_ptr<ISettingsWindow> settings_window{ std::make_unique<MockSettingsWindow>() };
             std::unique_ptr<IViewOptions> view_options{ std::make_unique<MockViewOptions>() };

--- a/trview.app.tests/Windows/RouteWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/RouteWindowManagerTests.cpp
@@ -18,8 +18,8 @@ namespace
         struct test_module
         {
             Window window{ create_test_window(L"RouteWindowManagerTests") };
-            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<MockShortcuts>() };
-            RouteWindow::Source window_source{ [](auto&&...) { return std::make_shared<MockRouteWindow>(); } };
+            std::shared_ptr<MockShortcuts> shortcuts{ mock_shared<MockShortcuts>() };
+            RouteWindow::Source window_source{ [](auto&&...) { return mock_shared<MockRouteWindow>(); } };
 
             test_module& with_window_source(const RouteWindow::Source& source)
             {
@@ -50,7 +50,7 @@ namespace
 
 TEST(RouteWindowManager, WindowsUpdated)
 {
-    auto mock_window = std::make_shared<MockRouteWindow>();
+    auto mock_window = mock_shared<MockRouteWindow>();
     EXPECT_CALL(*mock_window, update(1.0f)).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
     manager->create_window();
@@ -59,7 +59,7 @@ TEST(RouteWindowManager, WindowsUpdated)
 
 TEST(RouteWindowManager, RandomizerEnabledPassed)
 {
-    auto mock_window = std::make_shared<MockRouteWindow>();
+    auto mock_window = mock_shared<MockRouteWindow>();
     EXPECT_CALL(*mock_window, set_randomizer_enabled(false)).Times(1);
     EXPECT_CALL(*mock_window, set_randomizer_enabled(true)).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
@@ -69,7 +69,7 @@ TEST(RouteWindowManager, RandomizerEnabledPassed)
 
 TEST(RouteWindowManager, RandomizerEnabledPassedToNewWindows)
 {
-    auto mock_window = std::make_shared<MockRouteWindow>();
+    auto mock_window = mock_shared<MockRouteWindow>();
     EXPECT_CALL(*mock_window, set_randomizer_enabled(false)).Times(0);
     EXPECT_CALL(*mock_window, set_randomizer_enabled(true)).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
@@ -79,7 +79,7 @@ TEST(RouteWindowManager, RandomizerEnabledPassedToNewWindows)
 
 TEST(RouteWindowManager, RandomizerSettingsPassed)
 {
-    auto mock_window = std::make_shared<MockRouteWindow>();
+    auto mock_window = mock_shared<MockRouteWindow>();
     EXPECT_CALL(*mock_window, set_randomizer_settings(testing::_)).Times(2);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
     manager->create_window();
@@ -88,7 +88,7 @@ TEST(RouteWindowManager, RandomizerSettingsPassed)
 
 TEST(RouteWindowManager, RandomizerSettingsPassedToNewWindow)
 {
-    auto mock_window = std::make_shared<MockRouteWindow>();
+    auto mock_window = mock_shared<MockRouteWindow>();
     EXPECT_CALL(*mock_window, set_randomizer_settings(testing::_)).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
     manager->create_window();

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -21,6 +21,7 @@
 #include "TestImgui.h"
 
 using testing::Return;
+using testing::NiceMock;
 using namespace trview;
 using namespace trview::mocks;
 using namespace trview::graphics;
@@ -52,18 +53,18 @@ namespace
         struct test_module
         {
             trview::Window window{ create_test_window(L"ViewerTests") };
-            std::shared_ptr<IDevice> device{ std::make_shared<MockDevice>() };
-            std::unique_ptr<IViewerUI> ui{ std::make_unique<MockViewerUI>() };
-            std::unique_ptr<IPicking> picking{ std::make_unique<MockPicking>() };
-            std::unique_ptr<IMouse> mouse{ std::make_unique<MockMouse>() };
-            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<MockShortcuts>() };
-            std::shared_ptr<IRoute> route{ std::make_shared<MockRoute>() };
-            ISprite::Source sprite_source{ [](auto&&...) { return std::make_unique<MockSprite>(); }};
-            std::unique_ptr<ICompass> compass{ std::make_unique<MockCompass>() };
-            std::unique_ptr<IMeasure> measure{ std::make_unique<MockMeasure>() };
-            IRenderTarget::SizeSource render_target_source{ [](auto&&...) { return std::make_unique<MockRenderTarget>(); } };
-            IDeviceWindow::Source device_window_source{ [](auto&&...) { return std::make_unique<MockDeviceWindow>(); } };
-            std::unique_ptr<ISectorHighlight> sector_highlight{ std::make_unique<MockSectorHighlight>() };
+            std::shared_ptr<IDevice> device{ std::make_shared<NiceMock<MockDevice>>() };
+            std::unique_ptr<IViewerUI> ui{ std::make_unique< NiceMock<MockViewerUI>>() };
+            std::unique_ptr<IPicking> picking{ std::make_unique<NiceMock<MockPicking>>() };
+            std::unique_ptr<IMouse> mouse{ std::make_unique<NiceMock<MockMouse>>() };
+            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<NiceMock<MockShortcuts>>() };
+            std::shared_ptr<IRoute> route{ std::make_shared<NiceMock<MockRoute>>() };
+            ISprite::Source sprite_source{ [](auto&&...) { return std::make_unique<NiceMock<MockSprite>>(); }};
+            std::unique_ptr<ICompass> compass{ std::make_unique<NiceMock<MockCompass>>() };
+            std::unique_ptr<IMeasure> measure{ std::make_unique<NiceMock<MockMeasure>>() };
+            IRenderTarget::SizeSource render_target_source{ [](auto&&...) { return std::make_unique<NiceMock<MockRenderTarget>>(); } };
+            IDeviceWindow::Source device_window_source{ [](auto&&...) { return std::make_unique<NiceMock<MockDeviceWindow>>(); } };
+            std::unique_ptr<ISectorHighlight> sector_highlight{ std::make_unique<NiceMock<MockSectorHighlight>>() };
 
             std::unique_ptr<Viewer> build()
             {

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -53,18 +53,18 @@ namespace
         struct test_module
         {
             trview::Window window{ create_test_window(L"ViewerTests") };
-            std::shared_ptr<IDevice> device{ std::make_shared<NiceMock<MockDevice>>() };
-            std::unique_ptr<IViewerUI> ui{ std::make_unique< NiceMock<MockViewerUI>>() };
-            std::unique_ptr<IPicking> picking{ std::make_unique<NiceMock<MockPicking>>() };
-            std::unique_ptr<IMouse> mouse{ std::make_unique<NiceMock<MockMouse>>() };
-            std::shared_ptr<MockShortcuts> shortcuts{ std::make_shared<NiceMock<MockShortcuts>>() };
-            std::shared_ptr<IRoute> route{ std::make_shared<NiceMock<MockRoute>>() };
-            ISprite::Source sprite_source{ [](auto&&...) { return std::make_unique<NiceMock<MockSprite>>(); }};
-            std::unique_ptr<ICompass> compass{ std::make_unique<NiceMock<MockCompass>>() };
-            std::unique_ptr<IMeasure> measure{ std::make_unique<NiceMock<MockMeasure>>() };
-            IRenderTarget::SizeSource render_target_source{ [](auto&&...) { return std::make_unique<NiceMock<MockRenderTarget>>(); } };
-            IDeviceWindow::Source device_window_source{ [](auto&&...) { return std::make_unique<NiceMock<MockDeviceWindow>>(); } };
-            std::unique_ptr<ISectorHighlight> sector_highlight{ std::make_unique<NiceMock<MockSectorHighlight>>() };
+            std::shared_ptr<IDevice> device{ mock_shared<MockDevice>() };
+            std::unique_ptr<IViewerUI> ui{ mock_unique<MockViewerUI>() };
+            std::unique_ptr<IPicking> picking{ mock_unique<MockPicking>() };
+            std::unique_ptr<IMouse> mouse{ mock_unique<MockMouse>() };
+            std::shared_ptr<MockShortcuts> shortcuts{ mock_shared<MockShortcuts>() };
+            std::shared_ptr<IRoute> route{ mock_shared<MockRoute>() };
+            ISprite::Source sprite_source{ [](auto&&...) { return mock_unique<MockSprite>(); }};
+            std::unique_ptr<ICompass> compass{ mock_unique<MockCompass>() };
+            std::unique_ptr<IMeasure> measure{ mock_unique<MockMeasure>() };
+            IRenderTarget::SizeSource render_target_source{ [](auto&&...) { return mock_unique<MockRenderTarget>(); } };
+            IDeviceWindow::Source device_window_source{ [](auto&&...) { return mock_unique<MockDeviceWindow>(); } };
+            std::unique_ptr<ISectorHighlight> sector_highlight{ mock_unique<MockSectorHighlight>() };
 
             std::unique_ptr<Viewer> build()
             {
@@ -101,7 +101,7 @@ TEST(Viewer, SelectItemRaisedForValidItem)
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
 
     Item item(123, 0, 0, L"Test", 0, 0, {}, Vector3::Zero);
-    MockLevel level;
+    NiceMock<MockLevel> level;
 
     std::vector<Item> items_list{ item };
     EXPECT_CALL(level, items).WillRepeatedly([&]() { return items_list; });
@@ -136,7 +136,7 @@ TEST(Viewer, SelectItemNotRaisedForInvalidItem)
 TEST(Viewer, ItemVisibilityRaisedForValidItem)
 {
     Item item(123, 0, 0, L"Test", 0, 0, {}, Vector3::Zero);
-    MockLevel level;
+    NiceMock<MockLevel> level;
 
     std::vector<Item> items_list{ item };
     EXPECT_CALL(level, items).WillRepeatedly([&]() { return items_list; });
@@ -200,7 +200,7 @@ TEST(Viewer, SelectTriggerRaised)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
 
-    MockLevel level;
+    NiceMock<MockLevel> level;
     auto trigger = mock_shared<MockTrigger>();
     std::vector<std::weak_ptr<ITrigger>> triggers_list(101);
     triggers_list[100] = trigger;
@@ -228,7 +228,7 @@ TEST(Viewer, TriggerVisibilityRaised)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
 
-    MockLevel level;
+    NiceMock<MockLevel> level;
     std::vector<std::weak_ptr<ITrigger>> triggers_list(101);
     auto trigger = mock_shared<MockTrigger>();
     triggers_list[100] = trigger;
@@ -295,7 +295,7 @@ TEST(Viewer, AddWaypointRaised)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
 
-    MockLevel level;
+    NiceMock<MockLevel> level;
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
     viewer->open(&level);
 
@@ -648,7 +648,7 @@ TEST(Viewer, MidWaypointUsesCentroid)
 TEST(Viewer, DepthViewOptionUpdatesLevel)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    MockLevel level;
+    NiceMock<MockLevel> level;
     EXPECT_CALL(level, set_neighbour_depth(6)).Times(1);
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
     viewer->open(&level);

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -201,7 +201,7 @@ TEST(Viewer, SelectTriggerRaised)
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
 
     MockLevel level;
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     std::vector<std::weak_ptr<ITrigger>> triggers_list(101);
     triggers_list[100] = trigger;
 
@@ -230,7 +230,7 @@ TEST(Viewer, TriggerVisibilityRaised)
 
     MockLevel level;
     std::vector<std::weak_ptr<ITrigger>> triggers_list(101);
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     triggers_list[100] = trigger;
 
     EXPECT_CALL(level, triggers).WillRepeatedly([&]() { return triggers_list; });
@@ -415,7 +415,7 @@ TEST(Viewer, OrbitEnabledWhenTriggerSelectedAndAutoOrbitEnabled)
     viewer->set_camera_mode(CameraMode::Free);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     viewer->select_trigger(trigger);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Orbit);
 }
@@ -435,7 +435,7 @@ TEST(Viewer, OrbitNotEnabledWhenTriggerSelectedAndAutoOrbitDisabled)
     viewer->set_camera_mode(CameraMode::Free);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 
-    auto trigger = std::make_shared<MockTrigger>();
+    auto trigger = mock_shared<MockTrigger>();
     viewer->select_trigger(trigger);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 }
@@ -455,7 +455,7 @@ TEST(Viewer, OrbitEnabledWhenWaypointSelectedAndAutoOrbitEnabled)
     viewer->set_camera_mode(CameraMode::Free);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 
-    auto mesh = std::make_shared<MockMesh>();
+    auto mesh = mock_shared<MockMesh>();
     viewer->select_waypoint(MockWaypoint{});
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Orbit);
 }
@@ -475,7 +475,7 @@ TEST(Viewer, OrbitNotEnabledWhenWaypointSelectedAndAutoOrbitDisabled)
     viewer->set_camera_mode(CameraMode::Free);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 
-    auto mesh = std::make_shared<MockMesh>();
+    auto mesh = mock_shared<MockMesh>();
     viewer->select_waypoint(MockWaypoint{});
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 }
@@ -494,7 +494,7 @@ TEST(Viewer, OrbitEnabledWhenRoomSelectedAndAutoOrbitEnabled)
     viewer->set_settings(settings);
 
     auto [level_ptr, level] = create_mock<MockLevel>();
-    auto room = std::make_shared<MockRoom>();
+    auto room = mock_shared<MockRoom>();
 
     EXPECT_CALL(level, number_of_rooms).WillRepeatedly(Return(1));
     EXPECT_CALL(level, rooms).WillRepeatedly(Return(std::vector<std::weak_ptr<IRoom>>{ room }));
@@ -521,7 +521,7 @@ TEST(Viewer, OrbitNotEnabledWhenRoomSelectedAndAutoOrbitDisabled)
     viewer->set_settings(settings);
 
     auto [level_ptr, level] = create_mock<MockLevel>();
-    auto room = std::make_shared<MockRoom>();
+    auto room = mock_shared<MockRoom>();
 
     EXPECT_CALL(level, number_of_rooms).WillRepeatedly(Return(1));
     EXPECT_CALL(level, rooms).WillRepeatedly(Return(std::vector<std::weak_ptr<IRoom>>{ room }));

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -322,7 +322,7 @@ TEST(Viewer, AddWaypointRaisedUsesItemPosition)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
 
-    MockLevel level;
+    NiceMock<MockLevel> level;
     std::vector<Item> items_list(51);
     Item item(50, 10, 0, L"Test", 0, 0, {}, Vector3::Zero);
     items_list[50] = item;

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -456,7 +456,7 @@ TEST(Viewer, OrbitEnabledWhenWaypointSelectedAndAutoOrbitEnabled)
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 
     auto mesh = mock_shared<MockMesh>();
-    viewer->select_waypoint(MockWaypoint{});
+    viewer->select_waypoint(NiceMock<MockWaypoint>{});
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Orbit);
 }
 
@@ -476,7 +476,7 @@ TEST(Viewer, OrbitNotEnabledWhenWaypointSelectedAndAutoOrbitDisabled)
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 
     auto mesh = mock_shared<MockMesh>();
-    viewer->select_waypoint(MockWaypoint{});
+    viewer->select_waypoint(NiceMock<MockWaypoint>{});
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
 }
 

--- a/trview.app/Mocks/Camera/ICamera.h
+++ b/trview.app/Mocks/Camera/ICamera.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockCamera final : public ICamera
+        struct MockCamera : public ICamera
         {
             virtual ~MockCamera() = default;
             MOCK_METHOD(DirectX::SimpleMath::Vector3, forward, (), (const, override));

--- a/trview.app/Mocks/Elements/IEntity.h
+++ b/trview.app/Mocks/Elements/IEntity.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockEntity final : public IEntity
+        struct MockEntity : public IEntity
         {
             virtual ~MockEntity() = default;
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -6,9 +6,9 @@ namespace trview
 {
     namespace mocks
     {
-        class MockLevel final : public ILevel
+        struct MockLevel : public ILevel
         {
-        public:
+            virtual ~MockLevel() = default;
             MOCK_METHOD(bool, alternate_group, (uint32_t), (const));
             MOCK_METHOD(std::set<uint32_t>, alternate_groups, (), (const));
             MOCK_METHOD(bool, alternate_mode, (), (const));

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockRoom final : public IRoom
+        struct MockRoom : public IRoom
         {
             virtual ~MockRoom() = default;
             MOCK_METHOD(void, add_entity, (const std::weak_ptr<IEntity>&), (override));

--- a/trview.app/Mocks/Elements/ISector.h
+++ b/trview.app/Mocks/Elements/ISector.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockSector final : public ISector
+        struct MockSector : public ISector
         {
             virtual ~MockSector() = default;
             MOCK_METHOD(std::uint16_t, portal, (), (const, override));

--- a/trview.app/Mocks/Elements/IStaticMesh.h
+++ b/trview.app/Mocks/Elements/IStaticMesh.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockStaticMesh final : public IStaticMesh
+        struct MockStaticMesh : public IStaticMesh
         {
             virtual ~MockStaticMesh() = default;
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));

--- a/trview.app/Mocks/Elements/ITrigger.h
+++ b/trview.app/Mocks/Elements/ITrigger.h
@@ -9,26 +9,25 @@ namespace trview
         struct MockTrigger : public ITrigger, public std::enable_shared_from_this<MockTrigger>
         {
             virtual ~MockTrigger() = default;
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&));
-            MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&));
-            MOCK_METHOD(bool, visible, (), (const));
-            MOCK_METHOD(void, set_visible, (bool));
-            MOCK_METHOD(uint32_t, number, (), (const));
-            MOCK_METHOD(uint32_t, room, (), (const));
-            MOCK_METHOD(uint16_t, x, (), (const));
-            MOCK_METHOD(uint16_t, z, (), (const));
-            MOCK_METHOD(bool, triggers_item, (uint32_t index), (const));
-            MOCK_METHOD(TriggerType, type, (), (const));
-            MOCK_METHOD(bool, only_once, (), (const));
-            MOCK_METHOD(uint16_t, flags, (), (const));
-            MOCK_METHOD(uint8_t, timer, (), (const));
-            MOCK_METHOD(uint16_t, sector_id, (), (const));
-            MOCK_METHOD(const std::vector<Command>, commands, (), (const));
-            MOCK_METHOD(const std::vector<TransparentTriangle>&, triangles, (), (const));
-            MOCK_METHOD(void, set_triangles, (const std::vector<TransparentTriangle>&));
-            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const));
-            MOCK_METHOD(void, set_position, (const DirectX::SimpleMath::Vector3&));
-            MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const));
+            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(bool, visible, (), (const, override));
+            MOCK_METHOD(void, set_visible, (bool), (override));
+            MOCK_METHOD(uint32_t, number, (), (const, override));
+            MOCK_METHOD(uint32_t, room, (), (const, override));
+            MOCK_METHOD(uint16_t, x, (), (const, override));
+            MOCK_METHOD(uint16_t, z, (), (const, override));
+            MOCK_METHOD(bool, triggers_item, (uint32_t index), (const, override));
+            MOCK_METHOD(TriggerType, type, (), (const, override));
+            MOCK_METHOD(bool, only_once, (), (const, override));
+            MOCK_METHOD(uint16_t, flags, (), (const, override));
+            MOCK_METHOD(uint8_t, timer, (), (const, override));
+            MOCK_METHOD(uint16_t, sector_id, (), (const, override));
+            MOCK_METHOD(const std::vector<Command>, commands, (), (const, override));
+            MOCK_METHOD(void, set_triangles, (const std::vector<TransparentTriangle>&), (override));
+            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
+            MOCK_METHOD(void, set_position, (const DirectX::SimpleMath::Vector3&), (override));
+            MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
 
             std::shared_ptr<MockTrigger> with_number(uint32_t number)
             {

--- a/trview.app/Mocks/Elements/ITypeNameLookup.h
+++ b/trview.app/Mocks/Elements/ITypeNameLookup.h
@@ -6,9 +6,8 @@ namespace trview
 {
     namespace mocks
     {
-        class MockTypeNameLookup : public ITypeNameLookup
+        struct MockTypeNameLookup : public ITypeNameLookup
         {
-        public:
             virtual ~MockTypeNameLookup() = default;
             MOCK_METHOD(std::wstring, lookup_type_name, (trlevel::LevelVersion, uint32_t), (const, override));
             MOCK_METHOD(bool, is_pickup, (trlevel::LevelVersion, uint32_t), (const, override));

--- a/trview.app/Mocks/Geometry/IMesh.h
+++ b/trview.app/Mocks/Geometry/IMesh.h
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <trview.app/Geometry/IMesh.h>
+#include "../../Geometry/IMesh.h"
 
 namespace trview
 {
     namespace mocks
     {
-        class MockMesh : public IMesh
+        struct MockMesh : public IMesh
         {
-        public:
             virtual ~MockMesh() = default;
             MOCK_METHOD(void, render, (const DirectX::SimpleMath::Matrix&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&, float, DirectX::SimpleMath::Vector3), (override));
             MOCK_METHOD(std::vector<TransparentTriangle>, transparent_triangles, (), (const, override));

--- a/trview.app/Mocks/Geometry/IPicking.h
+++ b/trview.app/Mocks/Geometry/IPicking.h
@@ -6,10 +6,10 @@ namespace trview
 {
     namespace mocks
     {
-        class MockPicking final : public IPicking
+        struct MockPicking : public IPicking
         {
-        public:
-            MOCK_METHOD(void, pick, (const Window&, const ICamera&));
+            virtual ~MockPicking() = default;
+            MOCK_METHOD(void, pick, (const Window&, const ICamera&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Geometry/ITransparencyBuffer.h
+++ b/trview.app/Mocks/Geometry/ITransparencyBuffer.h
@@ -1,18 +1,18 @@
 #pragma once
 
-#include <trview.app/Geometry/ITransparencyBuffer.h>
+#include "../../Geometry/ITransparencyBuffer.h"
 
 namespace trview
 {
     namespace mocks
     {
-        class MockTransparencyBuffer final : public ITransparencyBuffer
+        struct MockTransparencyBuffer : public ITransparencyBuffer
         {
-        public:
-            MOCK_METHOD(void, add, (const TransparentTriangle&));
-            MOCK_METHOD(void, sort, (const DirectX::SimpleMath::Vector3&));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool));
-            MOCK_METHOD(void, reset, ());
+            virtual ~MockTransparencyBuffer() = default;
+            MOCK_METHOD(void, add, (const TransparentTriangle&), (override));
+            MOCK_METHOD(void, sort, (const DirectX::SimpleMath::Vector3&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));
+            MOCK_METHOD(void, reset, (), (override));
         };
     }
 }

--- a/trview.app/Mocks/Graphics/ILevelTextureStorage.h
+++ b/trview.app/Mocks/Graphics/ILevelTextureStorage.h
@@ -11,7 +11,7 @@ namespace trview
             virtual ~MockLevelTextureStorage() = default;
             MOCK_METHOD(graphics::Texture, coloured, (uint32_t), (const, override));
             MOCK_METHOD(graphics::Texture, lookup, (const std::string&), (const, override));
-            MOCK_METHOD(void, store, (const std::string&, const graphics::Texture&), (const));
+            MOCK_METHOD(void, store, (const std::string&, const graphics::Texture&), (override));
             MOCK_METHOD(graphics::Texture, texture, (uint32_t texture_index), (const, override));
             MOCK_METHOD(graphics::Texture, untextured, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector2, uv, (uint32_t, uint32_t), (const, override));

--- a/trview.app/Mocks/Graphics/ILevelTextureStorage.h
+++ b/trview.app/Mocks/Graphics/ILevelTextureStorage.h
@@ -1,23 +1,24 @@
 #pragma once
 
-#include <trview.app/Graphics/ILevelTextureStorage.h>
+#include "../../Graphics/ILevelTextureStorage.h"
 
 namespace trview
 {
     namespace mocks
     {
-        class MockLevelTextureStorage final : public ILevelTextureStorage
+        struct MockLevelTextureStorage : public ILevelTextureStorage
         {
-            MOCK_METHOD(graphics::Texture, coloured, (uint32_t), (const));
-            MOCK_METHOD(graphics::Texture, lookup, (const std::string&), (const));
-            MOCK_METHOD(void, store, (const std::string&, const graphics::Texture&));
-            MOCK_METHOD(graphics::Texture, texture, (uint32_t texture_index), (const));
-            MOCK_METHOD(graphics::Texture, untextured, (), (const));
-            MOCK_METHOD(DirectX::SimpleMath::Vector2, uv, (uint32_t, uint32_t), (const));
-            MOCK_METHOD(uint32_t, tile, (uint32_t), (const));
-            MOCK_METHOD(uint32_t, num_tiles, (), (const));
-            MOCK_METHOD(uint16_t, attribute, (uint32_t), (const));
-            MOCK_METHOD(DirectX::SimpleMath::Color, palette_from_texture, (uint32_t), (const));
+            virtual ~MockLevelTextureStorage() = default;
+            MOCK_METHOD(graphics::Texture, coloured, (uint32_t), (const, override));
+            MOCK_METHOD(graphics::Texture, lookup, (const std::string&), (const, override));
+            MOCK_METHOD(void, store, (const std::string&, const graphics::Texture&), (const));
+            MOCK_METHOD(graphics::Texture, texture, (uint32_t texture_index), (const, override));
+            MOCK_METHOD(graphics::Texture, untextured, (), (const, override));
+            MOCK_METHOD(DirectX::SimpleMath::Vector2, uv, (uint32_t, uint32_t), (const, override));
+            MOCK_METHOD(uint32_t, tile, (uint32_t), (const, override));
+            MOCK_METHOD(uint32_t, num_tiles, (), (const, override));
+            MOCK_METHOD(uint16_t, attribute, (uint32_t), (const, override));
+            MOCK_METHOD(DirectX::SimpleMath::Color, palette_from_texture, (uint32_t), (const, override));
         };
     }
 }

--- a/trview.app/Mocks/Graphics/IMeshStorage.h
+++ b/trview.app/Mocks/Graphics/IMeshStorage.h
@@ -1,13 +1,14 @@
 #pragma once
 
-#include <trview.app/Graphics/IMeshStorage.h>
+#include "../../Graphics/IMeshStorage.h"
 
 namespace trview
 {
     namespace mocks
     {
-        class MockMeshStorage final : public IMeshStorage
+        struct MockMeshStorage : public IMeshStorage
         {
+            virtual ~MockMeshStorage() = default;
             MOCK_METHOD(std::shared_ptr<IMesh>, mesh, (uint32_t), (const, override));
         };
     }

--- a/trview.app/Mocks/Graphics/ISectorHighlight.h
+++ b/trview.app/Mocks/Graphics/ISectorHighlight.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <trview.app/Graphics/ISectorHighlight.h>
+#include "../../Graphics/ISectorHighlight.h"
 
 namespace trview
 {
     namespace mocks
     {
-        struct MockSectorHighlight final : public ISectorHighlight
+        struct MockSectorHighlight : public ISectorHighlight
         {
             virtual ~MockSectorHighlight() = default;
-            MOCK_METHOD(void, set_sector, (const std::shared_ptr<ISector>&, const DirectX::SimpleMath::Matrix&));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&));
+            MOCK_METHOD(void, set_sector, (const std::shared_ptr<ISector>&, const DirectX::SimpleMath::Matrix&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Graphics/ISelectionRenderer.h
+++ b/trview.app/Mocks/Graphics/ISelectionRenderer.h
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <trview.app/Graphics/ISelectionRenderer.h>
+#include "../../Graphics/ISelectionRenderer.h"
 
 namespace trview
 {
     namespace mocks
     {
-        class MockSelectionRenderer final : public ISelectionRenderer
+        struct MockSelectionRenderer : public ISelectionRenderer
         {
-        public:
             virtual ~MockSelectionRenderer() = default;
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, IRenderable&, const DirectX::SimpleMath::Color&), (override));
         };

--- a/trview.app/Mocks/Graphics/ITextureStorage.h
+++ b/trview.app/Mocks/Graphics/ITextureStorage.h
@@ -1,19 +1,17 @@
 #pragma once
 
-#include <cstdint>
-#include <trview.app/Graphics/ITextureStorage.h>
+#include "../../Graphics/ITextureStorage.h"
 
 namespace trview
 {
     namespace mocks
     {
-        class MockTextureStorage final : public ITextureStorage
+        struct MockTextureStorage : public ITextureStorage
         {
-        public:
             virtual ~MockTextureStorage() = default;
-            MOCK_METHOD(graphics::Texture, coloured, (uint32_t), (const));
-            MOCK_METHOD(graphics::Texture, lookup, (const std::string&), (const));
-            MOCK_METHOD(void, store, (const std::string&, const graphics::Texture&));
+            MOCK_METHOD(graphics::Texture, coloured, (uint32_t), (const, override));
+            MOCK_METHOD(graphics::Texture, lookup, (const std::string&), (const, override));
+            MOCK_METHOD(void, store, (const std::string&, const graphics::Texture&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Menus/IFileDropper.h
+++ b/trview.app/Mocks/Menus/IFileDropper.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        class MockFileDropper final : public IFileDropper
+        struct MockFileDropper : public IFileDropper
         {
         };
     }

--- a/trview.app/Mocks/Menus/ILevelSwitcher.h
+++ b/trview.app/Mocks/Menus/ILevelSwitcher.h
@@ -6,11 +6,10 @@ namespace trview
 {
     namespace mocks
     {
-        class MockLevelSwitcher final : public ILevelSwitcher
+        struct MockLevelSwitcher : public ILevelSwitcher
         {
-        public:
             virtual ~MockLevelSwitcher() = default;
-            MOCK_METHOD(void, open_file, (const std::string&));
+            MOCK_METHOD(void, open_file, (const std::string&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Menus/IRecentFiles.h
+++ b/trview.app/Mocks/Menus/IRecentFiles.h
@@ -6,11 +6,10 @@ namespace trview
 {
     namespace mocks
     {
-        class MockRecentFiles : public IRecentFiles
+        struct MockRecentFiles : public IRecentFiles
         {
-        public:
             virtual ~MockRecentFiles() = default;
-            MOCK_METHOD(void, set_recent_files, (const std::list<std::string>&));
+            MOCK_METHOD(void, set_recent_files, (const std::list<std::string>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Menus/IUpdateChecker.h
+++ b/trview.app/Mocks/Menus/IUpdateChecker.h
@@ -6,11 +6,10 @@ namespace trview
 {
     namespace mocks
     {
-        class MockUpdateChecker final : public IUpdateChecker
+        struct MockUpdateChecker : public IUpdateChecker
         {
-        public:
             virtual ~MockUpdateChecker() = default;
-            MOCK_METHOD(void, check_for_updates, ());
+            MOCK_METHOD(void, check_for_updates, (), (override));
         };
     }
 }

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <trview.app/Routing/IRoute.h>
+#include "../../Routing/IRoute.h"
 
 namespace trview
 {
     namespace mocks
     {
-        class MockRoute : public IRoute
+        struct MockRoute : public IRoute
         {
-        public:
             virtual ~MockRoute() = default;
             MOCK_METHOD(void, add, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t), (override));
             MOCK_METHOD(void, add, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, IWaypoint::Type, uint32_t), (override));

--- a/trview.app/Mocks/Routing/IWaypoint.h
+++ b/trview.app/Mocks/Routing/IWaypoint.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockWaypoint final : public IWaypoint
+        struct MockWaypoint : public IWaypoint
         {
             virtual ~MockWaypoint() = default;
             MOCK_METHOD(DirectX::BoundingBox, bounding_box, (), (const, override));

--- a/trview.app/Mocks/Routing/IWaypoint.h
+++ b/trview.app/Mocks/Routing/IWaypoint.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <trview.app/Routing/IWaypoint.h>
+#include "../../Routing/IWaypoint.h"
 
 namespace trview
 {

--- a/trview.app/Mocks/Settings/ISettingsLoader.h
+++ b/trview.app/Mocks/Settings/ISettingsLoader.h
@@ -6,12 +6,11 @@ namespace trview
 {
     namespace mocks
     {
-        class MockSettingsLoader final : public ISettingsLoader
+        struct MockSettingsLoader : public ISettingsLoader
         {
-        public:
             virtual ~MockSettingsLoader() = default;
-            MOCK_METHOD(UserSettings, load_user_settings, (), (const));
-            MOCK_METHOD(void, save_user_settings, (const UserSettings&));
+            MOCK_METHOD(UserSettings, load_user_settings, (), (const, override));
+            MOCK_METHOD(void, save_user_settings, (const UserSettings&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Settings/IStartupOptions.h
+++ b/trview.app/Mocks/Settings/IStartupOptions.h
@@ -6,9 +6,8 @@ namespace trview
 {
     namespace mocks
     {
-        class MockStartupOptions final : public IStartupOptions
+        struct MockStartupOptions : public IStartupOptions
         {
-        public:
             virtual ~MockStartupOptions() = default;
             MOCK_METHOD(std::string, filename, (), (const, override));
             MOCK_METHOD(bool, feature, (const std::string&), (const, override));

--- a/trview.app/Mocks/Tools/ICompass.h
+++ b/trview.app/Mocks/Tools/ICompass.h
@@ -6,11 +6,12 @@ namespace trview
 {
     namespace mocks
     {
-        class MockCompass final : public ICompass
+        struct MockCompass : public ICompass
         {
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&));
-            MOCK_METHOD(bool, pick, (const Point&, const Size&, Axis&));
-            MOCK_METHOD(void, set_visible, (bool));
+            virtual ~MockCompass() = default;
+            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&), (override));
+            MOCK_METHOD(bool, pick, (const Point&, const Size&, Axis&), (override));
+            MOCK_METHOD(void, set_visible, (bool), (override));
         };
     }
 }

--- a/trview.app/Mocks/Tools/IMeasure.h
+++ b/trview.app/Mocks/Tools/IMeasure.h
@@ -6,17 +6,16 @@ namespace trview
 {
     namespace mocks
     {
-        class MockMeasure final : public IMeasure
+        struct MockMeasure : public IMeasure
         {
-        public:
             virtual ~MockMeasure() = default;
-            MOCK_METHOD(void, reset, ());
-            MOCK_METHOD(bool, add, (const DirectX::SimpleMath::Vector3&));
-            MOCK_METHOD(void, set, (const DirectX::SimpleMath::Vector3&));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&));
-            MOCK_METHOD(std::wstring, distance, (), (const));
-            MOCK_METHOD(bool, measuring, (), (const));
-            MOCK_METHOD(void, set_visible, (bool));
+            MOCK_METHOD(void, reset, (), (override));
+            MOCK_METHOD(bool, add, (const DirectX::SimpleMath::Vector3&), (override));
+            MOCK_METHOD(void, set, (const DirectX::SimpleMath::Vector3&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&), (override));
+            MOCK_METHOD(std::wstring, distance, (), (const, override));
+            MOCK_METHOD(bool, measuring, (), (const, override));
+            MOCK_METHOD(void, set_visible, (bool), (override));
         };
     }
 }

--- a/trview.app/Mocks/UI/ICameraControls.h
+++ b/trview.app/Mocks/UI/ICameraControls.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockCameraControls final : public ICameraControls
+        struct MockCameraControls : public ICameraControls
         {
             virtual ~MockCameraControls() = default;
             MOCK_METHOD(void, render, (), (override));

--- a/trview.app/Mocks/UI/IContextMenu.h
+++ b/trview.app/Mocks/UI/IContextMenu.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <trview.app/UI/IContextMenu.h>
+#include "../../UI/IContextMenu.h"
 
 namespace trview
 {
     namespace mocks
     {
-        struct MockContextMenu final : public IContextMenu
+        struct MockContextMenu : public IContextMenu
         {
             virtual ~MockContextMenu() = default;
             MOCK_METHOD(void, set_visible, (bool), (override));

--- a/trview.app/Mocks/UI/IImGuiBackend.h
+++ b/trview.app/Mocks/UI/IImGuiBackend.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../UI/IImGuiBackend.h"
+#include "../../UI/IImGuiBackend.h"
 
 namespace trview
 {

--- a/trview.app/Mocks/UI/IMapRenderer.h
+++ b/trview.app/Mocks/UI/IMapRenderer.h
@@ -9,20 +9,20 @@ namespace trview
         struct MockMapRenderer : public IMapRenderer
         {
             virtual ~MockMapRenderer() = default;
-            MOCK_METHOD(void, render, ());
-            MOCK_METHOD(void, load, (const std::shared_ptr<trview::IRoom>&));
-            MOCK_METHOD(std::uint16_t, area, (), (const));
-            MOCK_METHOD(std::shared_ptr<ISector>, sector_at, (const Point&), (const));
-            MOCK_METHOD(std::shared_ptr<ISector>, sector_at_cursor, (), (const));
-            MOCK_METHOD(bool, cursor_is_over_control, (), (const));
-            MOCK_METHOD(void, set_cursor_position, (const Point&));
-            MOCK_METHOD(bool, loaded, (), (const));
-            MOCK_METHOD(void, set_window_size, (const Size&));
-            MOCK_METHOD(void, set_visible, (bool));
-            MOCK_METHOD(void, clear_highlight, ());
-            MOCK_METHOD(void, set_highlight, (uint16_t, uint16_t));
-            MOCK_METHOD(graphics::Texture, texture, (), (const));
-            MOCK_METHOD(Point, first, (), (const));
+            MOCK_METHOD(void, render, (), (override));
+            MOCK_METHOD(void, load, (const std::shared_ptr<trview::IRoom>&), (override));
+            MOCK_METHOD(std::uint16_t, area, (), (const, override));
+            MOCK_METHOD(std::shared_ptr<ISector>, sector_at, (const Point&), (const, override));
+            MOCK_METHOD(std::shared_ptr<ISector>, sector_at_cursor, (), (const, override));
+            MOCK_METHOD(bool, cursor_is_over_control, (), (const, override));
+            MOCK_METHOD(void, set_cursor_position, (const Point&), (override));
+            MOCK_METHOD(bool, loaded, (), (const, override));
+            MOCK_METHOD(void, set_window_size, (const Size&), (override));
+            MOCK_METHOD(void, set_visible, (bool), (override));
+            MOCK_METHOD(void, clear_highlight, (), (override));
+            MOCK_METHOD(void, set_highlight, (uint16_t, uint16_t), (override));
+            MOCK_METHOD(graphics::Texture, texture, (), (const, override));
+            MOCK_METHOD(Point, first, (), (const, override));
             MOCK_METHOD(void, set_render_mode, (RenderMode), (override));
         };
     }

--- a/trview.app/Mocks/UI/ISettingsWindow.h
+++ b/trview.app/Mocks/UI/ISettingsWindow.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockSettingsWindow final : public ISettingsWindow
+        struct MockSettingsWindow : public ISettingsWindow
         {
             virtual ~MockSettingsWindow() = default;
             MOCK_METHOD(void, render, (), (override));

--- a/trview.app/Mocks/UI/IViewOptions.h
+++ b/trview.app/Mocks/UI/IViewOptions.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <trview.app/UI/IViewOptions.h>
+#include "../../UI/IViewOptions.h"
 
 namespace trview
 {
     namespace mocks
     {
-        struct MockViewOptions final : public IViewOptions
+        struct MockViewOptions : public IViewOptions
         {
             virtual ~MockViewOptions() = default;
             MOCK_METHOD(void, set_alternate_group, (uint32_t, bool), (override));

--- a/trview.app/Mocks/UI/IViewerUI.h
+++ b/trview.app/Mocks/UI/IViewerUI.h
@@ -6,9 +6,8 @@ namespace trview
 {
     namespace mocks
     {
-        class MockViewerUI final : public IViewerUI
+        struct MockViewerUI : public IViewerUI
         {
-        public:
             virtual ~MockViewerUI() = default;
             MOCK_METHOD(void, clear_minimap_highlight, (), (override));
             MOCK_METHOD(std::shared_ptr<ISector>, current_minimap_sector, (), (const, override));

--- a/trview.app/Mocks/Windows/IItemsWindow.h
+++ b/trview.app/Mocks/Windows/IItemsWindow.h
@@ -6,9 +6,8 @@ namespace trview
 {
     namespace mocks
     {
-        class MockItemsWindow final : public IItemsWindow
+        struct MockItemsWindow : public IItemsWindow
         {
-        public:
             virtual ~MockItemsWindow() = default;
             MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
             MOCK_METHOD(void, update_items, (const std::vector<Item>&), (override));

--- a/trview.app/Mocks/Windows/IItemsWindowManager.h
+++ b/trview.app/Mocks/Windows/IItemsWindowManager.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <trview.app/Windows/IItemsWindowManager.h>
+#include "../../Windows/IItemsWindowManager.h"
 
 namespace trview
 {
     namespace mocks
     {
-        class MockItemsWindowManager final : public IItemsWindowManager
+        struct MockItemsWindowManager : public IItemsWindowManager
         {
         public:
             MOCK_METHOD(void, render, (), (override));

--- a/trview.app/Mocks/Windows/IRoomsWindow.h
+++ b/trview.app/Mocks/Windows/IRoomsWindow.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <trview.app/Windows/IRoomsWindow.h>
+#include "../../Windows/IRoomsWindow.h"
 
 namespace trview
 {

--- a/trview.app/Mocks/Windows/IRoomsWindowManager.h
+++ b/trview.app/Mocks/Windows/IRoomsWindowManager.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <trview.app/Windows/IRoomsWindowManager.h>
+#include "../../Windows/IRoomsWindowManager.h"
 
 namespace trview
 {
     namespace mocks
     {
-        class MockRoomsWindowManager final : public IRoomsWindowManager
+        struct MockRoomsWindowManager : public IRoomsWindowManager
         {
         public:
             MOCK_METHOD(void, render, (), (override));

--- a/trview.app/Mocks/Windows/IRouteWindow.h
+++ b/trview.app/Mocks/Windows/IRouteWindow.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <trview.app/Windows/IRouteWindow.h>
+#include "../../Windows/IRouteWindow.h"
 
 namespace trview
 {

--- a/trview.app/Mocks/Windows/IRouteWindowManager.h
+++ b/trview.app/Mocks/Windows/IRouteWindowManager.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <trview.app/Windows/IRouteWindowManager.h>
+#include "../../Windows/IRouteWindowManager.h"
 
 namespace trview
 {
     namespace mocks
     {
-        class MockRouteWindowManager final : public IRouteWindowManager
+        struct MockRouteWindowManager : public IRouteWindowManager
         {
-        public:
+            virtual ~MockRouteWindowManager() = default;
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_route, (IRoute*), (override));
             MOCK_METHOD(void, create_window, (), (override));

--- a/trview.app/Mocks/Windows/ITriggersWindow.h
+++ b/trview.app/Mocks/Windows/ITriggersWindow.h
@@ -6,9 +6,9 @@ namespace trview
 {
     namespace mocks
     {
-        class MockTriggersWindow final : public ITriggersWindow
+        struct MockTriggersWindow : public ITriggersWindow
         {
-        public:
+            virtual ~MockTriggersWindow() = default;
             MOCK_METHOD(void, clear_selected_trigger, (), (override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(std::weak_ptr<ITrigger>, selected_trigger, (), (const, override));

--- a/trview.app/Mocks/Windows/ITriggersWindowManager.h
+++ b/trview.app/Mocks/Windows/ITriggersWindowManager.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <trview.app/Windows/ITriggersWindowManager.h>
+#include "../../Windows/ITriggersWindowManager.h"
 
 namespace trview
 {
     namespace mocks
     {
-        class MockTriggersWindowManager final : public ITriggersWindowManager
+        struct MockTriggersWindowManager : public ITriggersWindowManager
         {
-        public:
+            virtual ~MockTriggersWindowManager() = default;
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));

--- a/trview.app/Mocks/Windows/IViewer.h
+++ b/trview.app/Mocks/Windows/IViewer.h
@@ -1,32 +1,32 @@
 #pragma once
 
-#include <trview.app/Windows/IViewer.h>
+#include "../../Windows/IViewer.h"
 
 namespace trview
 {
     namespace mocks
     {
-        class MockViewer : public IViewer
+        struct MockViewer : public IViewer
         {
-        public:
+            virtual ~MockViewer() = default;
             MOCK_METHOD(CameraMode, camera_mode, (), (const, override));
-            MOCK_METHOD(void, render, ());
-            MOCK_METHOD(void, open, (ILevel*));
-            MOCK_METHOD(void, set_settings, (const UserSettings&));
-            MOCK_METHOD(void, select_item, (const Item&));
-            MOCK_METHOD(void, select_room, (uint32_t));
-            MOCK_METHOD(void, select_trigger, (const std::weak_ptr<ITrigger>&));
-            MOCK_METHOD(void, select_waypoint, (const IWaypoint&));
+            MOCK_METHOD(void, render, (), (override));
+            MOCK_METHOD(void, open, (ILevel*), (override));
+            MOCK_METHOD(void, set_settings, (const UserSettings&), (override));
+            MOCK_METHOD(void, select_item, (const Item&), (override));
+            MOCK_METHOD(void, select_room, (uint32_t), (override));
+            MOCK_METHOD(void, select_trigger, (const std::weak_ptr<ITrigger>&), (override));
+            MOCK_METHOD(void, select_waypoint, (const IWaypoint&), (override));
             MOCK_METHOD(void, set_camera_mode, (CameraMode), (override));
-            MOCK_METHOD(void, set_route, (const std::shared_ptr<IRoute>&));
-            MOCK_METHOD(void, set_show_compass, (bool));
-            MOCK_METHOD(void, set_show_minimap, (bool));
-            MOCK_METHOD(void, set_show_route, (bool));
-            MOCK_METHOD(void, set_show_selection, (bool));
-            MOCK_METHOD(void, set_show_tools, (bool));
-            MOCK_METHOD(void, set_show_tooltip, (bool));
-            MOCK_METHOD(void, set_show_ui, (bool));
-            MOCK_METHOD(bool, ui_input_active, (), (const));
+            MOCK_METHOD(void, set_route, (const std::shared_ptr<IRoute>&), (override));
+            MOCK_METHOD(void, set_show_compass, (bool), (override));
+            MOCK_METHOD(void, set_show_minimap, (bool), (override));
+            MOCK_METHOD(void, set_show_route, (bool), (override));
+            MOCK_METHOD(void, set_show_selection, (bool), (override));
+            MOCK_METHOD(void, set_show_tools, (bool), (override));
+            MOCK_METHOD(void, set_show_tooltip, (bool), (override));
+            MOCK_METHOD(void, set_show_ui, (bool), (override));
+            MOCK_METHOD(bool, ui_input_active, (), (const, override));
             MOCK_METHOD(void, present, (bool), (override));
             MOCK_METHOD(void, render_ui, (), (override));
         };

--- a/trview.common/Mocks/IFiles.h
+++ b/trview.common/Mocks/IFiles.h
@@ -4,13 +4,16 @@
 
 namespace trview
 {
-    struct MockFiles final : public IFiles
+    namespace mocks
     {
-        virtual ~MockFiles() = default;
-        MOCK_METHOD(std::string, appdata_directory, (), (const, override));
-        MOCK_METHOD(bool, create_directory, (const std::string&), (const, override));
-        MOCK_METHOD(std::optional<std::vector<uint8_t>>, load_file, (const std::string&), (const, override));
-        MOCK_METHOD(void, save_file, (const std::string&, const std::vector<uint8_t>&), (const, override));
-        MOCK_METHOD(void, save_file, (const std::string&, const std::string&), (const, override));
-    };
+        struct MockFiles : public IFiles
+        {
+            virtual ~MockFiles() = default;
+            MOCK_METHOD(std::string, appdata_directory, (), (const, override));
+            MOCK_METHOD(bool, create_directory, (const std::string&), (const, override));
+            MOCK_METHOD(std::optional<std::vector<uint8_t>>, load_file, (const std::string&), (const, override));
+            MOCK_METHOD(void, save_file, (const std::string&, const std::vector<uint8_t>&), (const, override));
+            MOCK_METHOD(void, save_file, (const std::string&, const std::string&), (const, override));
+        };
+    }
 }

--- a/trview.common/Mocks/Windows/IDialogs.h
+++ b/trview.common/Mocks/Windows/IDialogs.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockDialogs final : public IDialogs
+        struct MockDialogs : public IDialogs
         {
             virtual ~MockDialogs() = default;
             MOCK_METHOD(bool, message_box, (const Window&, const std::wstring&, const std::wstring&, Buttons), (const, override));

--- a/trview.common/Mocks/Windows/IShell.h
+++ b/trview.common/Mocks/Windows/IShell.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockShell final : public IShell
+        struct MockShell : public IShell
         {
             virtual ~MockShell() = default;
             MOCK_METHOD(void, open, (const std::wstring&), (override));

--- a/trview.common/Mocks/Windows/IShortcuts.h
+++ b/trview.common/Mocks/Windows/IShortcuts.h
@@ -1,14 +1,13 @@
 #pragma once
 
-#include <trview.common/Windows/IShortcuts.h>
+#include "../../Windows/IShortcuts.h"
 
 namespace trview
 {
     namespace mocks
     {
-        class MockShortcuts : public IShortcuts
+        struct MockShortcuts : public IShortcuts
         {
-        public:
             virtual ~MockShortcuts() = default;
             MOCK_METHOD(Event<>&, add_shortcut, (bool, uint16_t));
             MOCK_METHOD(std::vector<Shortcut>, shortcuts, (), (const));

--- a/trview.graphics/mocks/D3D/ID3D11DeviceContext.h
+++ b/trview.graphics/mocks/D3D/ID3D11DeviceContext.h
@@ -8,7 +8,7 @@ namespace trview
     {
         namespace mocks
         {
-            struct MockD3D11DeviceContext final : public ID3D11DeviceContext
+            struct MockD3D11DeviceContext : public ID3D11DeviceContext
             {
                 virtual ~MockD3D11DeviceContext() = default;
 

--- a/trview.graphics/mocks/IDevice.h
+++ b/trview.graphics/mocks/IDevice.h
@@ -9,22 +9,21 @@ namespace trview
     {
         namespace mocks
         {
-            class MockDevice final : public IDevice
+            struct MockDevice : public IDevice
             {
-            public:
                 virtual ~MockDevice() = default;
-                MOCK_METHOD(void, begin, ());
-                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11Device>, device, (), (const));
-                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11DeviceContext>, context, (), (const));
-                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11BlendState>, create_blend_state, (const D3D11_BLEND_DESC&), (const));
-                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11Buffer>, create_buffer, (const D3D11_BUFFER_DESC&, const std::optional<D3D11_SUBRESOURCE_DATA>&), (const));
-                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11DepthStencilState>, create_depth_stencil_state, (const D3D11_DEPTH_STENCIL_DESC&), (const));
-                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11DepthStencilView>, create_depth_stencil_view, (const Microsoft::WRL::ComPtr<ID3D11Resource>&, const D3D11_DEPTH_STENCIL_VIEW_DESC&), (const));
-                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11RasterizerState>, create_rasterizer_state, (const D3D11_RASTERIZER_DESC&), (const));
-                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11RenderTargetView>, create_render_target_view, (const Microsoft::WRL::ComPtr<ID3D11Resource>&), (const));
-                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11SamplerState>, create_sampler_state, (const D3D11_SAMPLER_DESC&), (const));
-                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11Texture2D>, create_texture_2D, (const D3D11_TEXTURE2D_DESC&, const D3D11_SUBRESOURCE_DATA&), (const));
-                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>, create_shader_resource_view, (const Microsoft::WRL::ComPtr<ID3D11Texture2D>&), (const));
+                MOCK_METHOD(void, begin, (), (override));
+                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11Device>, device, (), (const, override));
+                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11DeviceContext>, context, (), (const, override));
+                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11BlendState>, create_blend_state, (const D3D11_BLEND_DESC&), (const, override));
+                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11Buffer>, create_buffer, (const D3D11_BUFFER_DESC&, const std::optional<D3D11_SUBRESOURCE_DATA>&), (const, override));
+                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11DepthStencilState>, create_depth_stencil_state, (const D3D11_DEPTH_STENCIL_DESC&), (const, override));
+                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11DepthStencilView>, create_depth_stencil_view, (const Microsoft::WRL::ComPtr<ID3D11Resource>&, const D3D11_DEPTH_STENCIL_VIEW_DESC&), (const, override));
+                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11RasterizerState>, create_rasterizer_state, (const D3D11_RASTERIZER_DESC&), (const, override));
+                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11RenderTargetView>, create_render_target_view, (const Microsoft::WRL::ComPtr<ID3D11Resource>&), (const, override));
+                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11SamplerState>, create_sampler_state, (const D3D11_SAMPLER_DESC&), (const, override));
+                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11Texture2D>, create_texture_2D, (const D3D11_TEXTURE2D_DESC&, const D3D11_SUBRESOURCE_DATA&), (const, override));
+                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11ShaderResourceView>, create_shader_resource_view, (const Microsoft::WRL::ComPtr<ID3D11Texture2D>&), (const, override));
             };
         }
     }

--- a/trview.graphics/mocks/IDeviceWindow.h
+++ b/trview.graphics/mocks/IDeviceWindow.h
@@ -8,15 +8,14 @@ namespace trview
     {
         namespace mocks
         {
-            class MockDeviceWindow final : public IDeviceWindow
+            struct MockDeviceWindow : public IDeviceWindow
             {
-            public:
                 virtual ~MockDeviceWindow() = default;
-                MOCK_METHOD(void, begin, ());
-                MOCK_METHOD(void, clear, (const DirectX::SimpleMath::Color&));
-                MOCK_METHOD(void, present, (bool));
-                MOCK_METHOD(void, resize, ());
-                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11DeviceContext>, context, (), (const));
+                MOCK_METHOD(void, begin, (), (override));
+                MOCK_METHOD(void, clear, (const DirectX::SimpleMath::Color&), (override));
+                MOCK_METHOD(void, present, (bool), (override));
+                MOCK_METHOD(void, resize, (), (override));
+                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11DeviceContext>, context, (), (const, override));
             };
         }
     }

--- a/trview.graphics/mocks/IRenderTarget.h
+++ b/trview.graphics/mocks/IRenderTarget.h
@@ -8,15 +8,16 @@ namespace trview
     {
         namespace mocks
         {
-            class MockRenderTarget final : public IRenderTarget
+            struct MockRenderTarget : public IRenderTarget
             {
-                MOCK_METHOD(void, clear, (const DirectX::SimpleMath::Color& colour));
-                MOCK_METHOD(void, apply, ());
-                MOCK_METHOD(const Texture&, texture, (), (const));
-                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11RenderTargetView>, render_target, (), (const));
-                MOCK_METHOD(uint32_t, width, (), (const));
-                MOCK_METHOD(uint32_t, height, (), (const));
-                MOCK_METHOD(Size, size, (), (const));
+                virtual ~MockRenderTarget() = default;
+                MOCK_METHOD(void, clear, (const DirectX::SimpleMath::Color& colour), (override));
+                MOCK_METHOD(void, apply, (), (override));
+                MOCK_METHOD(const Texture&, texture, (), (const, override));
+                MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11RenderTargetView>, render_target, (), (const, override));
+                MOCK_METHOD(uint32_t, width, (), (const, override));
+                MOCK_METHOD(uint32_t, height, (), (const, override));
+                MOCK_METHOD(Size, size, (), (const, override));
             };
         }
     }

--- a/trview.graphics/mocks/IShader.h
+++ b/trview.graphics/mocks/IShader.h
@@ -6,7 +6,7 @@ namespace trview
     {
         namespace mocks
         {
-            struct MockShader final : public IShader
+            struct MockShader : public IShader
             {
                 virtual ~MockShader() = default;
                 MOCK_METHOD(void, apply, (const Microsoft::WRL::ComPtr<ID3D11DeviceContext>&), (override));

--- a/trview.graphics/mocks/ISprite.h
+++ b/trview.graphics/mocks/ISprite.h
@@ -8,11 +8,12 @@ namespace trview
     {
         namespace mocks
         {
-            class MockSprite final : public ISprite
+            struct MockSprite : public ISprite
             {
-                MOCK_METHOD(void, render, (const Texture&, float, float, float, float, DirectX::SimpleMath::Color));
-                MOCK_METHOD(Size, host_size, (), (const));
-                MOCK_METHOD(void, set_host_size, (const Size&));
+                virtual ~MockSprite() = default;
+                MOCK_METHOD(void, render, (const Texture&, float, float, float, float, DirectX::SimpleMath::Color), (override));
+                MOCK_METHOD(Size, host_size, (), (const, override));
+                MOCK_METHOD(void, set_host_size, (const Size&), (override));
             };
         }
     }

--- a/trview.input.tests/MouseTests.cpp
+++ b/trview.input.tests/MouseTests.cpp
@@ -2,6 +2,7 @@
 #include "gtest/gtest.h"
 #include <trview.input/Mouse.h>
 #include <trview.tests.common/Window.h>
+#include <trview.tests.common/Mocks.h>
 
 using namespace trview::tests;
 using namespace trview::input;
@@ -10,12 +11,12 @@ using namespace trview;
 using testing::Return;
 using testing::_;
 
-class MockWindowTester final : public IWindowTester
+struct MockWindowTester : public IWindowTester
 {
-public:
-    MOCK_CONST_METHOD0(is_window_under_cursor, bool());
-    MOCK_CONST_METHOD1(screen_width, int(bool));
-    MOCK_CONST_METHOD1(screen_height, int(bool));
+    virtual ~MockWindowTester() = default;
+    MOCK_METHOD(bool, is_window_under_cursor, (), (const, override));
+    MOCK_METHOD(int, screen_width, (bool), (const, override));
+    MOCK_METHOD(int, screen_height, (bool), (const, override));
 };
 
 /// Tests that the mouse down event is raised when the mouse button message is
@@ -26,7 +27,7 @@ TEST(Mouse, MouseDownEventRaised)
     Mouse::Button button_received = Mouse::Button::Left;
 
     auto window = create_test_window(L"TRViewInputTests");
-    auto mockTester = std::make_unique<MockWindowTester>();
+    auto mockTester = mock_unique<MockWindowTester>();
     EXPECT_CALL(*mockTester, is_window_under_cursor())
         .WillRepeatedly(Return(true));
 
@@ -58,7 +59,7 @@ TEST(Mouse, MouseUpEventRaised)
     Mouse::Button button_received = Mouse::Button::Left;
 
     auto window = create_test_window(L"TRViewInputTests");
-    auto mockTester = std::make_unique<MockWindowTester>();
+    auto mockTester = mock_unique<MockWindowTester>();
     EXPECT_CALL(*mockTester, is_window_under_cursor())
         .WillRepeatedly(Return(true));
     Mouse mouse(window, std::move(mockTester));
@@ -89,7 +90,7 @@ TEST(Mouse, MouseWheelEventRaised)
     int16_t scroll_received = 0;
 
     auto window = create_test_window(L"TRViewInputTests");
-    auto mockTester = std::make_unique<MockWindowTester>();
+    auto mockTester = mock_unique<MockWindowTester>();
     EXPECT_CALL(*mockTester, is_window_under_cursor())
         .WillRepeatedly(Return(true));
     Mouse mouse(window, std::move(mockTester));
@@ -115,7 +116,7 @@ TEST(Mouse, MouseMoveEventRaised)
     long x_received, y_received = 0;
 
     auto window = create_test_window(L"TRViewInputTests");
-    auto mockTester = std::make_unique<MockWindowTester>();
+    auto mockTester = mock_unique<MockWindowTester>();
     EXPECT_CALL(*mockTester, is_window_under_cursor())
         .WillRepeatedly(Return(true));
     Mouse mouse(window, std::move(mockTester));
@@ -151,7 +152,7 @@ TEST(Mouse, MouseMoveEventRaised)
 TEST(Mouse, MousePositionCorrect)
 {
     auto window = create_test_window(L"TRViewInputTests");
-    auto mockTester = std::make_unique<MockWindowTester>();
+    auto mockTester = mock_unique<MockWindowTester>();
     EXPECT_CALL(*mockTester, is_window_under_cursor()).WillRepeatedly(Return(true));
     EXPECT_CALL(*mockTester, screen_width(_)).WillRepeatedly(Return(1000));
     EXPECT_CALL(*mockTester, screen_height(_)).WillRepeatedly(Return(1000));

--- a/trview.input/Mocks/IMouse.h
+++ b/trview.input/Mocks/IMouse.h
@@ -8,12 +8,11 @@ namespace trview
     {
         namespace mocks
         {
-            class MockMouse final : public IMouse
+            struct MockMouse : public IMouse
             {
-            public:
                 virtual ~MockMouse() = default;
-                MOCK_METHOD(long, x, (), (const));
-                MOCK_METHOD(long, y, (), (const));
+                MOCK_METHOD(long, x, (), (const, override));
+                MOCK_METHOD(long, y, (), (const, override));
             };
         }
     }

--- a/trview.tests.common/Mocks.h
+++ b/trview.tests.common/Mocks.h
@@ -16,6 +16,14 @@ namespace trview
         std::tuple<std::unique_ptr<T>, T&> create_mock();
 
         /// <summary>
+        /// Create a mock in a unique_ptr. May add additional wrappers.
+        /// </summary>
+        /// <typeparam name="T">The mock type.</typeparam>
+        /// <returns>Mock pointer</returns>
+        template <typename T>
+        auto mock_unique();
+
+        /// <summary>
         /// Create a mock in a shared_ptr. May add additional wrappers.
         /// </summary>
         /// <typeparam name="T">The mock type.</typeparam>

--- a/trview.tests.common/Mocks.h
+++ b/trview.tests.common/Mocks.h
@@ -7,8 +7,21 @@ namespace trview
 {
     namespace tests
     {
+        /// <summary>
+        /// Create a mock in a unique ptr. May add additional wrappers.
+        /// </summary>
+        /// <typeparam name="T">The mock type.</typeparam>
+        /// <returns>Mock pointer and reference to mock.</returns>
         template <typename T>
         std::tuple<std::unique_ptr<T>, T&> create_mock();
+
+        /// <summary>
+        /// Create a mock in a shared_ptr. May add additional wrappers.
+        /// </summary>
+        /// <typeparam name="T">The mock type.</typeparam>
+        /// <returns>The new mock.</returns>
+        template <typename T>
+        auto mock_shared();
     }
 }
 

--- a/trview.tests.common/Mocks.hpp
+++ b/trview.tests.common/Mocks.hpp
@@ -15,6 +15,12 @@ namespace trview
             return { std::move(ptr), ref };
         }
 
+        template <typename T>
+        auto mock_shared()
+        {
+            return std::make_shared<testing::NiceMock<T>>();
+        }
+
         template <typename Mock, typename T>
         auto choose_mock(std::unique_ptr<T>& ptr)
         {

--- a/trview.tests.common/Mocks.hpp
+++ b/trview.tests.common/Mocks.hpp
@@ -35,7 +35,7 @@ namespace trview
         {
             if (!ptr)
             {
-                ptr = std::make_shared<Mock>();
+                ptr = mock_shared<Mock>();
             }
         }
     }

--- a/trview.tests.common/Mocks.hpp
+++ b/trview.tests.common/Mocks.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
 namespace trview
 {
     namespace tests
@@ -7,7 +10,7 @@ namespace trview
         template <typename T>
         std::tuple<std::unique_ptr<T>, T&> create_mock()
         {
-            auto ptr = std::make_unique<T>();
+            auto ptr = std::make_unique<testing::NiceMock<T>>();
             auto& ref = *ptr;
             return { std::move(ptr), ref };
         }

--- a/trview.tests.common/Mocks.hpp
+++ b/trview.tests.common/Mocks.hpp
@@ -16,6 +16,12 @@ namespace trview
         }
 
         template <typename T>
+        auto mock_unique()
+        {
+            return std::make_unique<testing::NiceMock<T>>();;
+        }
+
+        template <typename T>
         auto mock_shared()
         {
             return std::make_shared<testing::NiceMock<T>>();


### PR DESCRIPTION
Convert all Mocks to be `NiceMock`. This will remove all the tracing in the test logs that were essentially "everything's ok" alarms.
Added two new functions to make mocks - `mock_shared` and `mock_unique`. They just make a `NiceMock<T>` instead of a `T`.
Updated all of the tests to use these functions or `NiceMock` directly if required.
Test log size is down from about 1.5 MiB to 80KiB and can actually be read by humans now.
Closes #887 