### PR TITLE
Fix ImGui windows being stretched on window move

### DIFF
--- a/external/imgui/imgui.cpp
+++ b/external/imgui/imgui.cpp
@@ -4035,6 +4035,7 @@ static void TranslateWindow(ImGuiWindow* window, const ImVec2& delta)
     window->DC.CursorPos += delta;
     window->DC.CursorStartPos += delta;
     window->DC.CursorMaxPos += delta;
+    window->DC.IdealMaxPos += delta;
 }
 
 static void ScaleWindow(ImGuiWindow* window, float scale)


### PR DESCRIPTION
Fix taken from commit related to https://github.com/ocornut/imgui/issues/5057
Will come in properly in when I update ImGui.
Closes #890