### PR TITLE
Allow user to rearrange route using drag and drop

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -499,3 +499,18 @@ TEST(Application, WindowManagersAndViewerRendered)
         .build();
     application->render();
 }
+
+TEST(Application, WaypointReorderedMovesWaypoint)
+{
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, move(1, 2)).Times(1);
+
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    auto application = register_test_module()
+        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_route_source([&](auto&&...) {return route; })
+        .build();
+
+    route_window_manager.on_waypoint_reordered(1, 2);
+}
+

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -196,6 +196,36 @@ TEST(Route, IsUnsaved)
     ASSERT_TRUE(route->is_unsaved());
 }
 
+TEST(Route, MoveBackwards)
+{
+    uint32_t test_index = 0;
+    auto route = register_test_module().with_waypoint_source(indexed_source(test_index)).build();
+    route->add(Vector3::Zero, Vector3::Down, 0);
+    route->add(Vector3::Zero, Vector3::Down, 1);
+    route->add(Vector3::Zero, Vector3::Down, 2);
+    route->set_unsaved(false);
+    route->move(2, 0);
+    const auto order = get_order(*route);
+    const auto expected = std::vector<uint32_t>{ 2u, 0u, 1u };
+    ASSERT_EQ(order, expected);
+    ASSERT_TRUE(route->is_unsaved());
+}
+
+TEST(Route, MoveForward)
+{
+    uint32_t test_index = 0;
+    auto route = register_test_module().with_waypoint_source(indexed_source(test_index)).build();
+    route->add(Vector3::Zero, Vector3::Down, 0);
+    route->add(Vector3::Zero, Vector3::Down, 1);
+    route->add(Vector3::Zero, Vector3::Down, 2);
+    route->set_unsaved(false);
+    route->move(0, 2);
+    const auto order = get_order(*route);
+    const auto expected = std::vector<uint32_t>{ 1u, 2u, 0u };
+    ASSERT_EQ(order, expected);
+    ASSERT_TRUE(route->is_unsaved());
+}
+
 TEST(Route, Remove)
 {
     auto route = register_test_module().build();

--- a/trview.app.tests/Windows/RouteWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/RouteWindowManagerTests.cpp
@@ -93,3 +93,19 @@ TEST(RouteWindowManager, RandomizerSettingsPassedToNewWindow)
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
     manager->create_window();
 }
+
+TEST(RouteWindowManager, WaypointReorderedEventRaised)
+{
+    auto mock_window = mock_shared<MockRouteWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    std::optional<std::tuple<int32_t, int32_t>> raised;
+    auto token = manager->on_waypoint_reordered += [&](int32_t from, int32_t to)
+    {
+        raised = { from, to };
+    };
+    manager->create_window();
+    mock_window->on_waypoint_reordered(1, 2);
+    ASSERT_TRUE(raised.has_value());
+    ASSERT_EQ(std::get<0>(raised.value()), 1);
+    ASSERT_EQ(std::get<1>(raised.value()), 2);
+}

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -404,6 +404,11 @@ namespace trview
             _route->set_colour(colour);
             _viewer->set_route(_route);
         };
+        _token_store += _route_window->on_waypoint_reordered += [&](int32_t from, int32_t to)
+        {
+            _route->move(from, to);
+            _viewer->set_route(_route);
+        };
         _route_window->set_randomizer_enabled(_settings.randomizer_tools);
         _route->set_randomizer_enabled(_settings.randomizer_tools);
         _route_window->set_randomizer_settings(_settings.randomizer);

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -18,6 +18,7 @@ namespace trview
             MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t, IWaypoint::Type, uint32_t), (override));
             MOCK_METHOD(uint32_t, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, IWaypoint::Type, uint32_t), (override));
             MOCK_METHOD(bool, is_unsaved, (), (const, override));
+            MOCK_METHOD(void, move, (int32_t, int32_t), (override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
             MOCK_METHOD(void, remove, (uint32_t), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&), (override));

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -80,6 +80,12 @@ namespace trview
         /// <returns>True if there are unsaved changes.</returns>
         virtual bool is_unsaved() const = 0;
         /// <summary>
+        /// Move a waypoint from one index to another.
+        /// </summary>
+        /// <param name="from">The source index.</param>
+        /// <param name="to">Destination index.</param>
+        virtual void move(int32_t from, int32_t to) = 0;
+        /// <summary>
         /// Pick against the waypoints in the route.
         /// </summary>
         /// <param name="position">The position of the camera.</param>

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -152,6 +152,19 @@ namespace trview
         return _is_unsaved;
     }
 
+    void Route::move(int32_t from, int32_t to)
+    {
+        auto source = _waypoints[from];
+        auto final_to = to;
+        if (to > from)
+        {
+            final_to = to + 1;
+        }
+        _waypoints.insert(_waypoints.begin() + final_to, source);
+        _waypoints.erase(_waypoints.begin() + from + ((from > final_to) ? 1 : 0));
+        set_unsaved(true);
+    }
+
     PickResult Route::pick(const Vector3& position, const Vector3& direction) const
     {
         PickResult result;

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -27,6 +27,7 @@ namespace trview
         virtual void insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index, IWaypoint::Type type, uint32_t type_index) override;
         virtual bool is_unsaved() const override;
         virtual uint32_t insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, IWaypoint::Type type, uint32_t type_index) override;
+        virtual void move(int32_t left, int32_t right) override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
         virtual void remove(uint32_t index) override;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage) override;

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -27,6 +27,11 @@ namespace trview
         /// Event raised when the route colour has been changed.
         Event<Colour> on_colour_changed;
 
+        /// <summary>
+        /// Event raised when a waypoint has moved from one index to another.
+        /// </summary>
+        Event<int32_t, int32_t> on_waypoint_reordered;
+
         /// Event raised when a route file is opened.
         Event<std::string, bool> on_route_import;
 

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -30,6 +30,11 @@ namespace trview
         /// Event raised when a waypoint is deleted.
         Event<uint32_t> on_waypoint_deleted;
 
+        /// <summary>
+        /// Event raised when a waypoint has moved from one index to another.
+        /// </summary>
+        Event<int32_t, int32_t> on_waypoint_reordered;
+
         /// Render all of the route windows.
         virtual void render() = 0;
 

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -36,6 +36,7 @@ namespace trview
         _route_window->on_trigger_selected += on_trigger_selected;
         _route_window->on_waypoint_selected += on_waypoint_selected;
         _route_window->on_waypoint_deleted += on_waypoint_deleted;
+        _route_window->on_waypoint_reordered += on_waypoint_reordered;
         _token_store += _route_window->on_window_closed += [&]() { _closing = true; };
 
         _route_window->set_randomizer_settings(_randomizer_settings);


### PR DESCRIPTION
Use ImGui drag and drop API to let user rearrange the route waypoints.
Testing of UI itself isn't done, not sure how to do drag and drop properly.
Closes #635