### PR TITLE
Interpret object textures differently in customs

### DIFF
--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -290,10 +290,10 @@ namespace trlevel
 
     struct tr_object_texture_vert // 4 bytes
     {
-        int8_t Xcoordinate; // 1 if Xpixel is the low value, 255 if Xpixel is the high value in the object texture
-        uint8_t Xpixel;
-        int8_t Ycoordinate; // 1 if Ypixel is the low value, 255 if Ypixel is the high value in the object texture
-        uint8_t Ypixel;
+        uint8_t x_frac;
+        uint8_t x_whole;
+        uint8_t y_frac;
+        uint8_t y_whole;
     };
 
     // Version of box used in TR1/UB.

--- a/trview.app/Graphics/LevelTextureStorage.cpp
+++ b/trview.app/Graphics/LevelTextureStorage.cpp
@@ -28,20 +28,20 @@ namespace trview
             }
         }
 
+        determine_texture_mode();
+    }
+
+    void LevelTextureStorage::determine_texture_mode()
+    {
         for (const auto& object_texture : _object_textures)
         {
-            if (_texture_mode == TextureMode::Custom)
-            {
-                break;
-            }
-
             for (const auto& vert : object_texture.Vertices)
             {
                 if ((vert.x_frac > 1 && vert.x_frac < 255) ||
                     (vert.y_frac > 1 && vert.y_frac < 255))
                 {
                     _texture_mode = TextureMode::Custom;
-                    break;
+                    return;
                 }
             }
         }

--- a/trview.app/Graphics/LevelTextureStorage.cpp
+++ b/trview.app/Graphics/LevelTextureStorage.cpp
@@ -27,6 +27,24 @@ namespace trview
                 _palette[i] = Color(entry.Red / 255.f, entry.Green / 255.f, entry.Blue / 255.f, 1.0f);
             }
         }
+
+        for (const auto& object_texture : _object_textures)
+        {
+            if (_texture_mode == TextureMode::Custom)
+            {
+                break;
+            }
+
+            for (const auto& vert : object_texture.Vertices)
+            {
+                if ((vert.x_frac > 1 && vert.x_frac < 255) ||
+                    (vert.y_frac > 1 && vert.y_frac < 255))
+                {
+                    _texture_mode = TextureMode::Custom;
+                    break;
+                }
+            }
+        }
     }
 
     graphics::Texture LevelTextureStorage::texture(uint32_t tile_index) const
@@ -52,7 +70,15 @@ namespace trview
     {
         using namespace DirectX::SimpleMath;
         const auto& vert = _object_textures[texture_index].Vertices[uv_index];
-        return Vector2(static_cast<float>(vert.Xpixel + vert.Xcoordinate), static_cast<float>(vert.Ypixel + vert.Ycoordinate)) / 255.0f;
+
+        if (_texture_mode == TextureMode::Official)
+        {
+            return Vector2(static_cast<float>(vert.x_whole + static_cast<int8_t>(vert.x_frac)), static_cast<float>(vert.y_whole + static_cast<int8_t>(vert.y_frac))) / 255.0f;
+        }
+        
+        float x = static_cast<float>(vert.x_whole) + (vert.x_frac / 256.0f);
+        float y = static_cast<float>(vert.y_whole) + (vert.y_frac / 256.0f);
+        return Vector2(x, y) / 256.0f;
     }
 
     uint32_t LevelTextureStorage::tile(uint32_t texture_index) const

--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -27,6 +27,8 @@ namespace trview
         virtual uint16_t attribute(uint32_t texture_index) const override;
         virtual DirectX::SimpleMath::Color palette_from_texture(uint32_t texture) const override;
     private:
+        void determine_texture_mode();
+
         std::vector<graphics::Texture> _tiles;
         std::vector<trlevel::tr_object_texture> _object_textures;
         std::unique_ptr<ITextureStorage> _texture_storage;

--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -33,5 +33,12 @@ namespace trview
         mutable graphics::Texture _untextured_texture;
         std::array<DirectX::SimpleMath::Color, 256> _palette;
         trlevel::LevelVersion _version;
+
+        enum class TextureMode
+        {
+            Official,
+            Custom
+        };
+        TextureMode _texture_mode{ TextureMode::Official };
     };
 }


### PR DESCRIPTION
Tomb Editor can output the fractional part of object texture coordinates correctly, so handle this.
Handling this seems to make official levels have seams, so detect official levels and handle them in the old fashioned, broken way.
Closes #620
Closes #661 