### PR TITLE
Improve interaction between camera rotation and context menu

### DIFF
--- a/trview.app/Camera/Camera.cpp
+++ b/trview.app/Camera/Camera.cpp
@@ -93,6 +93,7 @@ namespace trview
 
     void Camera::set_rotation_pitch(float rotation)
     {
+        _last_rotation = 0.0f;
         _rotation_pitch = std::max(-DirectX::XM_PIDIV2, std::min(rotation, DirectX::XM_PIDIV2));
         _target_rotation_pitch.reset();
         _target_rotation_yaw.reset();
@@ -101,6 +102,7 @@ namespace trview
 
     void Camera::set_rotation_yaw(float rotation)
     {
+        _last_rotation = 0.0f;
         _rotation_yaw = rotation - static_cast<int>(rotation / maths::Pi2) * maths::Pi2;
         _target_rotation_pitch.reset();
         _target_rotation_yaw.reset();
@@ -135,6 +137,8 @@ namespace trview
     void Camera::update(float elapsed)
     {
         const float speed = 10.0f;
+
+        _last_rotation += elapsed;
 
         if (_target_rotation_yaw.has_value())
         {
@@ -235,5 +239,10 @@ namespace trview
         }
         _view_projection = _view * _projection;
         calculate_bounding_frustum();
+    }
+
+    bool Camera::idle_rotation() const
+    {
+        return _last_rotation > 0.3f;
     }
 }

--- a/trview.app/Camera/Camera.cpp
+++ b/trview.app/Camera/Camera.cpp
@@ -138,7 +138,10 @@ namespace trview
     {
         const float speed = 10.0f;
 
-        _last_rotation += elapsed;
+        if (_last_rotation.has_value())
+        {
+            _last_rotation = _last_rotation.value() + elapsed;
+        }
 
         if (_target_rotation_yaw.has_value())
         {
@@ -243,6 +246,6 @@ namespace trview
 
     bool Camera::idle_rotation() const
     {
-        return _last_rotation > 0.3f;
+        return !_last_rotation.has_value() || _last_rotation.value() > 0.3f;
     }
 }

--- a/trview.app/Camera/Camera.h
+++ b/trview.app/Camera/Camera.h
@@ -38,6 +38,7 @@ namespace trview
         virtual const DirectX::SimpleMath::Matrix view_projection() const override;
         virtual const Size view_size() const override;
         virtual float zoom() const override;
+        virtual bool idle_rotation() const override;
 
         /// Event raised when the view of the camera has changed.
         Event<> on_view_changed;
@@ -77,5 +78,6 @@ namespace trview
         std::optional<float> _target_rotation_yaw;
         std::optional<float> _target_rotation_pitch;
         float _ortho_size{ 10.0f };
+        float _last_rotation{ 0.0f };
     };
 }

--- a/trview.app/Camera/Camera.h
+++ b/trview.app/Camera/Camera.h
@@ -67,6 +67,7 @@ namespace trview
         float _rotation_pitch{ default_pitch };
         float _zoom{ default_zoom };
         ProjectionMode _projection_mode{ ProjectionMode::Perspective };
+        std::optional<float> _last_rotation;
     private:
         Size _view_size;
         DirectX::SimpleMath::Matrix _view;
@@ -78,6 +79,5 @@ namespace trview
         std::optional<float> _target_rotation_yaw;
         std::optional<float> _target_rotation_pitch;
         float _ortho_size{ 10.0f };
-        float _last_rotation{ 0.0f };
     };
 }

--- a/trview.app/Camera/ICamera.h
+++ b/trview.app/Camera/ICamera.h
@@ -97,5 +97,7 @@ namespace trview
         /// Gets the zoom level.
         /// @returns The zoom level.
         virtual float zoom() const = 0;
+
+        virtual bool idle_rotation() const = 0;
     };
 }

--- a/trview.app/Camera/OrbitCamera.cpp
+++ b/trview.app/Camera/OrbitCamera.cpp
@@ -14,6 +14,7 @@ namespace trview
         set_rotation_yaw(default_yaw);
         set_rotation_pitch(default_pitch);
         set_zoom(default_zoom);
+        _last_rotation.reset();
     }
 
     void OrbitCamera::set_target(const Vector3& target)

--- a/trview.app/Mocks/Camera/ICamera.h
+++ b/trview.app/Mocks/Camera/ICamera.h
@@ -30,6 +30,7 @@ namespace trview
             MOCK_METHOD(const DirectX::SimpleMath::Matrix, view_projection, (), (const, override));
             MOCK_METHOD(const Size, view_size, (), (const, override));
             MOCK_METHOD(float, zoom, (), (const, override));
+            MOCK_METHOD(bool, idle_rotation, (), (const, override));
         };
     }
 }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -224,7 +224,7 @@ namespace trview
 
     bool ViewerUI::is_cursor_over() const
     {
-        return (ImGui::GetCurrentContext() != nullptr && ImGui::GetIO().WantCaptureMouse) || (_map_renderer->loaded() && _map_renderer->cursor_is_over_control());
+        return (ImGui::GetCurrentContext() != nullptr && ImGui::GetIO().WantCaptureMouseUnlessPopupClose) || (_map_renderer->loaded() && _map_renderer->cursor_is_over_control());
     }
 
     void ViewerUI::generate_tool_window()

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -473,7 +473,7 @@ namespace trview
 
         _token_store += _mouse->mouse_click += [&](auto button)
         {
-            if (button == input::IMouse::Button::Right && _current_pick.hit && _current_pick.type != PickResult::Type::Compass)
+            if (button == input::IMouse::Button::Right && _current_pick.hit && _current_pick.type != PickResult::Type::Compass && current_camera().idle_rotation())
             {
                 _context_pick = _current_pick;
                 _ui->set_show_context_menu(true);
@@ -882,10 +882,7 @@ namespace trview
                 return;
             }
 
-            if (_ui->show_context_menu())
-            {
-                _ui->set_show_context_menu(false);
-            }
+            _ui->set_show_context_menu(false);
 
             ICamera& camera = current_camera();
             const float low_sensitivity = 200.0f;
@@ -927,15 +924,12 @@ namespace trview
         _token_store += _camera_input.on_pan += [&](bool vertical, float x, float y)
         {
             auto& io = ImGui::GetIO();
-            if (_ui->is_cursor_over() || io.WantCaptureMouse || _camera_mode != CameraMode::Orbit)
+            if (_ui->is_cursor_over() || _camera_mode != CameraMode::Orbit)
             {
                 return;
             }
 
-            if (_ui->show_context_menu())
-            {
-                _ui->set_show_context_menu(false);
-            }
+            _ui->set_show_context_menu(false);
 
             ICamera& camera = current_camera();
 


### PR DESCRIPTION
Use `WantCaptureMouseUnlessPopupClose` so that you can immediately go into a camera rotation without having to dismiss the context menu with a left click.
Add a short (0.3s) delay after camera rotation ends before context menu can be used again. This stops it appearing when you're rotating the camera.
Closes #898 