### PR TITLE
Get fonts folder using known folder path

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -20,6 +20,7 @@
 #include <trlevel/Mocks/ILevel.h>
 #include <trview.app/Resources/resource.h>
 #include "NullImGuiBackend.h"
+#include <trview.common/Strings.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -30,6 +31,18 @@ using testing::_;
 
 namespace
 {
+    std::string fonts_directory()
+    {
+        wchar_t* path;
+        if (S_OK != SHGetKnownFolderPath(FOLDERID_Fonts, 0, nullptr, &path))
+        {
+            return std::string();
+        }
+        auto result = trview::to_utf8(path);
+        CoTaskMemFree(path);
+        return result;
+    }
+
     Event<> shortcut_handler;
 
     auto register_test_module()
@@ -480,6 +493,8 @@ TEST(Application, WindowManagersUpdated)
     EXPECT_CALL(triggers_window_manager, update).Times(1);
     auto [lights_window_manager_ptr, lights_window_manager] = create_mock<MockLightsWindowManager>();
     EXPECT_CALL(lights_window_manager, update).Times(1);
+    auto files = mock_shared<MockFiles>();
+    EXPECT_CALL(*files, fonts_directory()).Times(1).WillRepeatedly(Return(fonts_directory()));
 
     auto application = register_test_module()
         .with_route_window_manager(std::move(route_window_manager_ptr))
@@ -487,6 +502,7 @@ TEST(Application, WindowManagersUpdated)
         .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
         .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
         .with_lights_window_manager(std::move(lights_window_manager_ptr))
+        .with_files(files)
         .build();
     application->render();
 }
@@ -505,6 +521,8 @@ TEST(Application, WindowManagersAndViewerRendered)
     EXPECT_CALL(lights_window_manager, render).Times(1);
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
     EXPECT_CALL(viewer, render).Times(1);
+    auto files = mock_shared<MockFiles>();
+    EXPECT_CALL(*files, fonts_directory()).Times(1).WillRepeatedly(Return(fonts_directory()));
 
     auto application = register_test_module()
         .with_route_window_manager(std::move(route_window_manager_ptr))
@@ -513,6 +531,7 @@ TEST(Application, WindowManagersAndViewerRendered)
         .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
         .with_lights_window_manager(std::move(lights_window_manager_ptr))
         .with_viewer(std::move(viewer_ptr))
+        .with_files(files)
         .build();
     application->render();
 }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -616,7 +616,7 @@ namespace trview
             // Setup Dear ImGui style
             ImGui::StyleColorsDark();
 
-            _font = io.Fonts->AddFontFromFileTTF("C:\\Windows\\Fonts\\Arial.ttf", 12.0f);
+            _font = io.Fonts->AddFontFromFileTTF((_files->fonts_directory() + "\\Arial.ttf").c_str(), 12.0f);
 
             // Setup Platform/Renderer backends
             _imgui_backend->initialise();
@@ -692,7 +692,6 @@ namespace trview
         using namespace boost;
         using namespace graphics;
 
-        static Window w2 = window;
         const auto injector = di::make_injector(
             graphics::register_module(),
             input::register_module(),
@@ -706,12 +705,7 @@ namespace trview
             register_app_tools_module(),
             register_app_ui_module(),
             register_app_windows_module(),
-            di::bind<Window>.to(
-                []()
-                {
-                    return w2;
-                }
-            ),
+            di::bind<Window>.to(window),
             di::bind<IClipboard>.to<Clipboard>(),
             di::bind<IShortcuts>.to<Shortcuts>(),
             di::bind<IShortcuts::Source>.to(

--- a/trview.common/Files.cpp
+++ b/trview.common/Files.cpp
@@ -29,6 +29,16 @@ namespace trview
         return to_utf8(path.path);
     }
 
+    std::string Files::fonts_directory() const
+    {
+        SafePath path;
+        if (S_OK != SHGetKnownFolderPath(FOLDERID_Fonts, 0, nullptr, &path.path))
+        {
+            return std::string();
+        }
+        return to_utf8(path.path);
+    }
+
     bool Files::create_directory(const std::string& directory) const
     {
         return CreateDirectory(to_utf16(directory).c_str(), nullptr) || GetLastError() == ERROR_ALREADY_EXISTS;

--- a/trview.common/Files.h
+++ b/trview.common/Files.h
@@ -9,6 +9,7 @@ namespace trview
     public:
         virtual ~Files() = default;
         virtual std::string appdata_directory() const override;
+        virtual std::string fonts_directory() const override;
         virtual bool create_directory(const std::string& directory) const override;
         virtual std::optional<std::vector<uint8_t>> load_file(const std::string& filename) const override;
         virtual void save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const override;

--- a/trview.common/IFiles.h
+++ b/trview.common/IFiles.h
@@ -11,6 +11,7 @@ namespace trview
     {
         virtual ~IFiles() = 0;
         virtual std::string appdata_directory() const = 0;
+        virtual std::string fonts_directory() const = 0;
         virtual bool create_directory(const std::string& directory) const = 0;
         virtual std::optional<std::vector<uint8_t>> load_file(const std::string& filename) const = 0;
         virtual void save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const = 0;

--- a/trview.common/Mocks/IFiles.h
+++ b/trview.common/Mocks/IFiles.h
@@ -10,6 +10,7 @@ namespace trview
         {
             virtual ~MockFiles() = default;
             MOCK_METHOD(std::string, appdata_directory, (), (const, override));
+            MOCK_METHOD(std::string, fonts_directory, (), (const, override));
             MOCK_METHOD(bool, create_directory, (const std::string&), (const, override));
             MOCK_METHOD(std::optional<std::vector<uint8_t>>, load_file, (const std::string&), (const, override));
             MOCK_METHOD(void, save_file, (const std::string&, const std::vector<uint8_t>&), (const, override));

--- a/trview/trview.cpp
+++ b/trview/trview.cpp
@@ -27,8 +27,7 @@ void ImGuiTrviewTestEngineHook_RenderedText(ImGuiContext* ctx, ImGuiID id, const
 }
 
 
-int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR, _In_ int nCmdShow)
-{
+int APIENTRY wWinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE, _In_ LPWSTR, _In_ int nCmdShow){
     auto window = trview::create_window(hInstance, nCmdShow);
     auto application = trview::create_application(window, GetCommandLine());
     return application->run();


### PR DESCRIPTION
Use SHGetKnownFolderPath to get the fonts folder instead of hardcoding it.
Also removed the static window hack from Application DI as it suddenly started causing trouble.
Closes #917