### PR TITLE
Fix event handler unregistering ownership loop

### DIFF
--- a/trview.app/Windows/ItemsWindowManager.cpp
+++ b/trview.app/Windows/ItemsWindowManager.cpp
@@ -52,9 +52,10 @@ namespace trview
             items_window->set_selected_item(_selected_item.value());
         }
 
-        _token_store += items_window->on_window_closed += [items_window, this]()
+        std::weak_ptr<IItemsWindow> items_window_weak;
+        _token_store += items_window->on_window_closed += [items_window_weak, this]()
         {
-            _closing_windows.push_back(items_window);
+            _closing_windows.push_back(items_window_weak);
         };
 
         _windows.push_back(items_window);

--- a/trview.app/Windows/LightsWindowManager.cpp
+++ b/trview.app/Windows/LightsWindowManager.cpp
@@ -67,9 +67,10 @@ namespace trview
         lights_window->set_selected_light(_selected_light);
         lights_window->set_current_room(_current_room);
 
-        _token_store += lights_window->on_window_closed += [lights_window, this]()
+        std::weak_ptr<ILightsWindow> lights_window_weak = lights_window;
+        _token_store += lights_window->on_window_closed += [lights_window_weak, this]()
         {
-            _closing_windows.push_back(lights_window);
+            _closing_windows.push_back(lights_window_weak);
         };
         lights_window->on_light_selected += on_light_selected;
         lights_window->on_light_visibility += on_light_visibility;

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -124,9 +124,10 @@ namespace trview
         rooms_window->on_item_selected += on_item_selected;
         rooms_window->on_trigger_selected += on_trigger_selected;
 
-        _token_store += rooms_window->on_window_closed += [rooms_window, this]()
+        std::weak_ptr<IRoomsWindow> rooms_window_weak;
+        _token_store += rooms_window->on_window_closed += [rooms_window_weak, this]()
         {
-            _closing_windows.push_back(rooms_window);
+            _closing_windows.push_back(rooms_window_weak);
         };
 
         rooms_window->set_level_version(_level_version);

--- a/trview.app/Windows/TriggersWindowManager.cpp
+++ b/trview.app/Windows/TriggersWindowManager.cpp
@@ -49,9 +49,10 @@ namespace trview
         triggers_window->set_current_room(_current_room);
         triggers_window->set_selected_trigger(_selected_trigger);
 
-        _token_store += triggers_window->on_window_closed += [triggers_window, this]()
+        std::weak_ptr<ITriggersWindow> triggers_window_weak;
+        _token_store += triggers_window->on_window_closed += [triggers_window_weak, this]()
         {
-            _closing_windows.push_back(triggers_window);
+            _closing_windows.push_back(triggers_window_weak);
         };
 
         _windows.push_back(triggers_window);

--- a/trview.common/Event.inl
+++ b/trview.common/Event.inl
@@ -94,6 +94,7 @@ namespace trview
                     this),
                 listener->_subscriptions.end());
         }
+        _listener_events.clear();
 
         for (auto& sub : _subscriptions)
         {
@@ -103,6 +104,7 @@ namespace trview
                     this),
                 sub->_listener_events.end());
         }
+        _subscriptions.clear();
     }
 
     template <typename... Args>


### PR DESCRIPTION
In the various window managers the `shared_ptr` for the newly created window was being captured in a lambda so that it could be removed from the window collection on an event when it was closed. Unfortunately capturing the `shared_ptr` meant it outlived where it was stored, so there was a crash.
Change to capture a `weak_ptr` instead - it should have been this in the first place as the `_closing_windows` field is a `vector` of `weak_ptr`s anyway.
Closes #919