### PR TITLE
Always convert camera rotation from deg to rad

### DIFF
--- a/trview.app.tests/UI/CameraPositionTests.cpp
+++ b/trview.app.tests/UI/CameraPositionTests.cpp
@@ -155,3 +155,26 @@ TEST(CameraPosition, CoordinatesNotUpdatedWithInvalidValues)
 
     ASSERT_FALSE(raised);
 }
+
+TEST(CameraPosition, RotationsCorrectlyConverted)
+{
+    CameraPosition subject;
+    subject.set_rotation(1, 2);
+    subject.set_display_degrees(true);
+
+    TestImgui imgui([&]() { subject.render(); });
+
+    std::optional<std::tuple<float, float>> value;
+    auto token = subject.on_rotation_changed += [&](auto yaw, auto pitch)
+    {
+        value = { yaw, pitch };
+    };
+
+    imgui.click_element(imgui.id("Camera Position").id(CameraPosition::Names::yaw));
+    imgui.enter_text("90");
+    imgui.press_key(ImGuiKey_Enter);
+
+    ASSERT_TRUE(value.has_value());
+    ASSERT_FLOAT_EQ(std::get<0>(value.value()), 1.5707963267948966192313216916398);
+    ASSERT_FLOAT_EQ(std::get<1>(value.value()), 2);
+}

--- a/trview.app.tests/UI/CameraPositionTests.cpp
+++ b/trview.app.tests/UI/CameraPositionTests.cpp
@@ -160,7 +160,6 @@ TEST(CameraPosition, RotationsCorrectlyConverted)
 {
     CameraPosition subject;
     subject.set_rotation(1, 2);
-    subject.set_display_degrees(true);
 
     TestImgui imgui([&]() { subject.render(); });
 

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -11,7 +11,6 @@ namespace trview
         if (ImGui::Begin("Camera Position", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
             bool rotation_changed = false;
-
             if (ImGui::InputFloat("Yaw", &_rotation_yaw, 0.0f, 0.0f, "%.4f", ImGuiInputTextFlags_EnterReturnsTrue))
             {
                 rotation_changed = true;
@@ -36,12 +35,14 @@ namespace trview
 
             if (rotation_changed)
             {
+                float rotation_yaw = _rotation_yaw;
+                float rotation_pitch = _rotation_pitch;
                 if (_display_degrees)
                 {
-                    _rotation_yaw = DirectX::XMConvertToRadians(_rotation_yaw);
-                    _rotation_pitch = DirectX::XMConvertToRadians(_rotation_pitch);
+                    rotation_yaw = DirectX::XMConvertToRadians(rotation_yaw);
+                    rotation_pitch = DirectX::XMConvertToRadians(rotation_pitch);
                 }
-                on_rotation_changed(_rotation_yaw, _rotation_pitch);
+                on_rotation_changed(rotation_yaw, rotation_pitch);
             }
         }
         ImGui::End();

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -39,14 +39,8 @@ namespace trview
             {
                 if (_display_degrees)
                 {
-                    if (yaw_changed)
-                    {
-                        _rotation_yaw = DirectX::XMConvertToRadians(_rotation_yaw);
-                    }
-                    if (pitch_changed)
-                    {
-                        _rotation_pitch = DirectX::XMConvertToRadians(_rotation_pitch);
-                    }
+                    _rotation_yaw = DirectX::XMConvertToRadians(_rotation_yaw);
+                    _rotation_pitch = DirectX::XMConvertToRadians(_rotation_pitch);
                 }
                 on_rotation_changed(_rotation_yaw, _rotation_pitch);
             }

--- a/trview.app/UI/CameraPosition.cpp
+++ b/trview.app/UI/CameraPosition.cpp
@@ -10,16 +10,15 @@ namespace trview
         ImGui::SetNextWindowPos(ImGui::GetMainViewport()->Pos + ImVec2(4, ImGui::GetMainViewport()->Size.y - 148), ImGuiCond_FirstUseEver);
         if (ImGui::Begin("Camera Position", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
-            bool yaw_changed = false;
-            bool pitch_changed = false;
+            bool rotation_changed = false;
 
             if (ImGui::InputFloat("Yaw", &_rotation_yaw, 0.0f, 0.0f, "%.4f", ImGuiInputTextFlags_EnterReturnsTrue))
             {
-                yaw_changed = true;
+                rotation_changed = true;
             }
             if (ImGui::InputFloat("Pitch", &_rotation_pitch, 0.0f, 0.0f, "%.4f", ImGuiInputTextFlags_EnterReturnsTrue))
             {
-                pitch_changed = true;
+                rotation_changed = true;
             }
             ImGui::Separator();
             if (ImGui::InputFloat("X", &_position.x, 0.0f, 0.0f, "%.3f", ImGuiInputTextFlags_EnterReturnsTrue))
@@ -35,7 +34,7 @@ namespace trview
                 on_position_changed(_position / trlevel::Scale_X);
             }
 
-            if (yaw_changed || pitch_changed)
+            if (rotation_changed)
             {
                 if (_display_degrees)
                 {


### PR DESCRIPTION
Always convert both camera rotation fields from degrees to radians if the setting is enabled.
Previously only the one that was edited was converted, which meant that the degrees value of the other angle was used as radians without conversion.
Closes #928