### PR TITLE
Make timer on Trigger signed on TR4+

### DIFF
--- a/trview.app.tests/Elements/TriggerTests.cpp
+++ b/trview.app.tests/Elements/TriggerTests.cpp
@@ -1,0 +1,59 @@
+#include <trview.app/Elements/Trigger.h>
+#include <trview.tests.common/Mocks.h>
+
+using namespace trlevel;
+using namespace trview;
+using namespace trview::mocks;
+using namespace trview::tests;
+
+namespace
+{
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            uint32_t number{ 0 };
+            uint32_t room{ 0 };
+            uint16_t x{ 0 };
+            uint16_t z{ 0 };
+            TriggerInfo trigger_info{};
+            trlevel::LevelVersion level_version{ trlevel::LevelVersion::Tomb3 };
+            IMesh::TransparentSource mesh_source{ [](auto&&...) { return mock_shared<MockMesh>(); } };
+
+            std::unique_ptr<Trigger> build()
+            {
+                return std::make_unique<Trigger>(number, room, x, z, trigger_info, level_version, mesh_source);
+            }
+
+            test_module& with_info(const TriggerInfo& info)
+            {
+                trigger_info = info;
+                return *this;
+            }
+
+            test_module& with_level_version(trlevel::LevelVersion version)
+            {
+                level_version = version;
+                return *this;
+            }
+        };
+
+        return test_module{};
+    }
+}
+
+TEST(Trigger, TimerUnsignedInTR3)
+{
+    TriggerInfo info{};
+    info.timer = 248;
+    auto trigger = register_test_module().with_level_version(LevelVersion::Tomb3).with_info(info).build();
+    ASSERT_EQ(trigger->timer(), 248);
+}
+
+TEST(Trigger, TimerSignedInTR4)
+{
+    TriggerInfo info{};
+    info.timer = 248;
+    auto trigger = register_test_module().with_level_version(LevelVersion::Tomb4).with_info(info).build();
+    ASSERT_EQ(trigger->timer(), -8);
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="Elements\LightTests.cpp" />
     <ClCompile Include="Elements\RoomTests.cpp" />
     <ClCompile Include="Elements\StaticMeshTests.cpp" />
+    <ClCompile Include="Elements\TriggerTests.cpp" />
     <ClCompile Include="Elements\TypeNameLookupTests.cpp" />
     <ClCompile Include="FileDropperTests.cpp" />
     <ClCompile Include="Filters\FiltersTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -147,6 +147,9 @@
     <ClCompile Include="Filters\FiltersTests.cpp">
       <Filter>Filters</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\TriggerTests.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Elements/ITrigger.h
+++ b/trview.app/Elements/ITrigger.h
@@ -11,7 +11,7 @@ namespace trview
 {
     struct ITrigger : public IRenderable
     {
-        using Source = std::function<std::shared_ptr<ITrigger>(uint32_t, uint32_t, uint16_t, uint16_t, const TriggerInfo&)>;
+        using Source = std::function<std::shared_ptr<ITrigger>(uint32_t, uint32_t, uint16_t, uint16_t, const TriggerInfo&, trlevel::LevelVersion)>;
 
         virtual ~ITrigger() = 0;
         virtual uint32_t number() const = 0;
@@ -22,7 +22,7 @@ namespace trview
         virtual TriggerType type() const = 0;
         virtual bool only_once() const = 0;
         virtual uint16_t flags() const = 0;
-        virtual uint8_t timer() const = 0;
+        virtual int16_t timer() const = 0;
         virtual uint16_t sector_id() const = 0;
         virtual const std::vector<Command> commands() const = 0;
         virtual void set_triangles(const std::vector<TransparentTriangle>& transparent_triangles) = 0;

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -398,7 +398,7 @@ namespace trview
             {
                 if (sector->flags() & SectorFlag::Trigger)
                 {
-                    _triggers.push_back(trigger_source(_triggers.size(), i, sector->x(), sector->z(), sector->trigger()));
+                    _triggers.push_back(trigger_source(_triggers.size(), i, sector->x(), sector->z(), sector->trigger(), _version));
                     room->add_trigger(_triggers.back());
                 }
             }

--- a/trview.app/Elements/Trigger.cpp
+++ b/trview.app/Elements/Trigger.cpp
@@ -23,9 +23,10 @@ namespace trview
         return _index;
     }
 
-    Trigger::Trigger(uint32_t number, uint32_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info, const IMesh::TransparentSource& mesh_source)
-        : _number(number), _room(room), _x(x), _z(z), _type(trigger_info.type), _only_once(trigger_info.oneshot), _flags(trigger_info.mask), _timer(trigger_info.timer), _sector_id(trigger_info.sector_id),
-        _mesh_source(mesh_source)
+    Trigger::Trigger(uint32_t number, uint32_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info, trlevel::LevelVersion level_version, const IMesh::TransparentSource& mesh_source)
+        : _number(number), _room(room), _x(x), _z(z), _type(trigger_info.type), _only_once(trigger_info.oneshot), _flags(trigger_info.mask),
+        _timer(level_version >= trlevel::LevelVersion::Tomb4 ? static_cast<int8_t>(trigger_info.timer) : trigger_info.timer), _sector_id(trigger_info.sector_id),
+        _level_version(level_version), _mesh_source(mesh_source)
     {
         uint32_t command_index = 0;
         for (auto action : trigger_info.commands)
@@ -79,7 +80,7 @@ namespace trview
         return _flags;
     }
 
-    uint8_t Trigger::timer() const
+    int16_t Trigger::timer() const
     {
         return _timer;
     }

--- a/trview.app/Elements/Trigger.h
+++ b/trview.app/Elements/Trigger.h
@@ -11,7 +11,7 @@ namespace trview
     class Trigger final : public ITrigger
     {
     public:
-        explicit Trigger(uint32_t number, uint32_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info, const IMesh::TransparentSource& mesh_source);
+        explicit Trigger(uint32_t number, uint32_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info, trlevel::LevelVersion level_version, const IMesh::TransparentSource& mesh_source);
         virtual ~Trigger() = default;
         virtual uint32_t number() const override;
         virtual uint32_t room() const override;
@@ -21,7 +21,7 @@ namespace trview
         virtual TriggerType type() const override;
         virtual bool only_once() const override;
         virtual uint16_t flags() const override;
-        virtual uint8_t timer() const override;
+        virtual int16_t timer() const override;
         virtual uint16_t sector_id() const override;
         virtual const std::vector<Command> commands() const override;
         virtual void set_triangles(const std::vector<TransparentTriangle>& transparent_triangles) override;
@@ -45,8 +45,9 @@ namespace trview
         uint16_t _z;
         bool _only_once;
         uint16_t _flags;
-        uint8_t _timer;
+        int16_t _timer;
         uint16_t _sector_id;
         bool _visible{ true };
+        trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Unknown };
     };
 }

--- a/trview.app/Mocks/Elements/ITrigger.h
+++ b/trview.app/Mocks/Elements/ITrigger.h
@@ -21,7 +21,7 @@ namespace trview
             MOCK_METHOD(TriggerType, type, (), (const, override));
             MOCK_METHOD(bool, only_once, (), (const, override));
             MOCK_METHOD(uint16_t, flags, (), (const, override));
-            MOCK_METHOD(uint8_t, timer, (), (const, override));
+            MOCK_METHOD(int16_t, timer, (), (const, override));
             MOCK_METHOD(uint16_t, sector_id, (), (const, override));
             MOCK_METHOD(const std::vector<Command>, commands, (), (const, override));
             MOCK_METHOD(void, set_triangles, (const std::vector<TransparentTriangle>&), (override));


### PR DESCRIPTION
If the level version is TR4 or 5 then the `timer` field should be a signed value.
Make this change and add a test.
Closes #926