### PR TITLE
Fix Items, Rooms, Triggers window not storing closing window

### DIFF
--- a/trview.app/Windows/ItemsWindowManager.cpp
+++ b/trview.app/Windows/ItemsWindowManager.cpp
@@ -52,7 +52,7 @@ namespace trview
             items_window->set_selected_item(_selected_item.value());
         }
 
-        std::weak_ptr<IItemsWindow> items_window_weak;
+        std::weak_ptr<IItemsWindow> items_window_weak = items_window;
         _token_store += items_window->on_window_closed += [items_window_weak, this]()
         {
             _closing_windows.push_back(items_window_weak);

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -124,7 +124,7 @@ namespace trview
         rooms_window->on_item_selected += on_item_selected;
         rooms_window->on_trigger_selected += on_trigger_selected;
 
-        std::weak_ptr<IRoomsWindow> rooms_window_weak;
+        std::weak_ptr<IRoomsWindow> rooms_window_weak = rooms_window;
         _token_store += rooms_window->on_window_closed += [rooms_window_weak, this]()
         {
             _closing_windows.push_back(rooms_window_weak);

--- a/trview.app/Windows/TriggersWindowManager.cpp
+++ b/trview.app/Windows/TriggersWindowManager.cpp
@@ -49,7 +49,7 @@ namespace trview
         triggers_window->set_current_room(_current_room);
         triggers_window->set_selected_trigger(_selected_trigger);
 
-        std::weak_ptr<ITriggersWindow> triggers_window_weak;
+        std::weak_ptr<ITriggersWindow> triggers_window_weak = triggers_window;
         _token_store += triggers_window->on_window_closed += [triggers_window_weak, this]()
         {
             _closing_windows.push_back(triggers_window_weak);


### PR DESCRIPTION
As part of the fix in #925 they were supposed to store the window to close, but I forgot to actually add that to these lines.
Store the window to close so it can be closed.
#919