### PR TITLE
Improve window numbering

### DIFF
--- a/trview.app/Windows/ItemsWindowManager.cpp
+++ b/trview.app/Windows/ItemsWindowManager.cpp
@@ -20,26 +20,12 @@ namespace trview
 
     void ItemsWindowManager::render()
     {
-        if (!_closing_windows.empty())
-        {
-            for (const auto window_number : _closing_windows)
-            {
-                _windows.erase(window_number);
-            }
-            _closing_windows.clear();
-        }
-
-        for (auto& window : _windows)
-        {
-            window.second->render();
-        }
+        WindowManager::render();
     }
 
     std::weak_ptr<IItemsWindow> ItemsWindowManager::create_window()
     {
-        int32_t number = next_id();
         auto items_window = _items_window_source();
-        items_window->set_number(number);
         items_window->on_item_selected += on_item_selected;
         items_window->on_item_visibility += on_item_visibility;
         items_window->on_trigger_selected += on_trigger_selected;
@@ -51,14 +37,7 @@ namespace trview
         {
             items_window->set_selected_item(_selected_item.value());
         }
-
-        _token_store += items_window->on_window_closed += [number, this]()
-        {
-            _closing_windows.push_back(number);
-        };
-
-        _windows[number] = items_window;
-        return items_window;
+        return add_window(items_window);
     }
 
     void ItemsWindowManager::set_items(const std::vector<Item>& items)
@@ -114,20 +93,6 @@ namespace trview
 
     void ItemsWindowManager::update(float delta)
     {
-        for (const auto& window : _windows)
-        {
-            window.second->update(delta);
-        }
-    }
-
-    int32_t ItemsWindowManager::next_id() const
-    {
-        for (int32_t i = 1;;++i)
-        {
-            if (_windows.find(i) == _windows.end())
-            {
-                return i;
-            }
-        }
+        WindowManager::update(delta);
     }
 }

--- a/trview.app/Windows/ItemsWindowManager.h
+++ b/trview.app/Windows/ItemsWindowManager.h
@@ -7,15 +7,15 @@
 #include <memory>
 #include <optional>
 
-#include "IItemsWindowManager.h"
 #include <trview.common/MessageHandler.h>
-#include <trview.common/TokenStore.h>
 #include <trview.common/Windows/Shortcuts.h>
+#include "IItemsWindowManager.h"
+#include "WindowManager.h"
 
 namespace trview
 {
     /// Controls and creates ItemsWindows.
-    class ItemsWindowManager final : public IItemsWindowManager, public MessageHandler
+    class ItemsWindowManager final : public IItemsWindowManager, public WindowManager<IItemsWindow>, public MessageHandler
     {
     public:
         /// Create an TriggersWindowManager.
@@ -34,13 +34,9 @@ namespace trview
         virtual std::weak_ptr<IItemsWindow> create_window() override;
         virtual void update(float delta) override;
     private:
-        int32_t next_id() const;
-        std::unordered_map<int32_t, std::shared_ptr<IItemsWindow>> _windows;
-        std::vector<int32_t> _closing_windows;
         std::vector<Item> _items;
         std::vector<std::weak_ptr<ITrigger>> _triggers;
         uint32_t _current_room{ 0u };
-        TokenStore _token_store;
         std::optional<Item> _selected_item;
         IItemsWindow::Source _items_window_source;
     };

--- a/trview.app/Windows/ItemsWindowManager.h
+++ b/trview.app/Windows/ItemsWindowManager.h
@@ -34,14 +34,14 @@ namespace trview
         virtual std::weak_ptr<IItemsWindow> create_window() override;
         virtual void update(float delta) override;
     private:
-        std::vector<std::shared_ptr<IItemsWindow>> _windows;
-        std::vector<std::weak_ptr<IItemsWindow>> _closing_windows;
+        int32_t next_id() const;
+        std::unordered_map<int32_t, std::shared_ptr<IItemsWindow>> _windows;
+        std::vector<int32_t> _closing_windows;
         std::vector<Item> _items;
         std::vector<std::weak_ptr<ITrigger>> _triggers;
         uint32_t _current_room{ 0u };
         TokenStore _token_store;
         std::optional<Item> _selected_item;
         IItemsWindow::Source _items_window_source;
-        uint32_t _window_count{ 0u };
     };
 }

--- a/trview.app/Windows/LightsWindowManager.cpp
+++ b/trview.app/Windows/LightsWindowManager.cpp
@@ -60,48 +60,24 @@ namespace trview
 
     std::weak_ptr<ILightsWindow> LightsWindowManager::create_window()
     {
-        int32_t number = next_id();
         auto lights_window = _lights_window_source();
-        lights_window->set_number(number);
         lights_window->set_level_version(_level_version);
         lights_window->set_lights(_lights);
         lights_window->set_selected_light(_selected_light);
         lights_window->set_current_room(_current_room);
-
-        _token_store += lights_window->on_window_closed += [number, this]()
-        {
-            _closing_windows.push_back(number);
-        };
         lights_window->on_light_selected += on_light_selected;
         lights_window->on_light_visibility += on_light_visibility;
-
-        _windows[number] = lights_window;
-        return lights_window;
+        return add_window(lights_window);
     }
 
     void LightsWindowManager::render()
     {
-        if (!_closing_windows.empty())
-        {
-            for (const auto window_number : _closing_windows)
-            {
-                _windows.erase(window_number);
-            }
-            _closing_windows.clear();
-        }
-
-        for (auto& window : _windows)
-        {
-            window.second->render();
-        }
+        WindowManager::render();
     }
     
     void LightsWindowManager::update(float delta)
     {
-        for (auto& window : _windows)
-        {
-            window.second->update(delta);
-        }
+        WindowManager::update(delta);
     }
 
     void LightsWindowManager::set_selected_light(const std::weak_ptr<ILight>& light)
@@ -119,17 +95,6 @@ namespace trview
         for (auto& window : _windows)
         {
             window.second->set_current_room(room);
-        }
-    }
-
-    int32_t LightsWindowManager::next_id() const
-    {
-        for (int32_t i = 1;; ++i)
-        {
-            if (_windows.find(i) == _windows.end())
-            {
-                return i;
-            }
         }
     }
 }

--- a/trview.app/Windows/LightsWindowManager.cpp
+++ b/trview.app/Windows/LightsWindowManager.cpp
@@ -24,8 +24,8 @@ namespace trview
         _selected_light.reset();
         for (auto& window : _windows)
         {
-            window->clear_selected_light();
-            window->set_lights(lights);
+            window.second->clear_selected_light();
+            window.second->set_lights(lights);
         }
     }
 
@@ -45,7 +45,7 @@ namespace trview
         light_ptr->set_visible(state);
         for (auto& window : _windows)
         {
-            window->update_lights(_lights);
+            window.second->update_lights(_lights);
         }
     }
 
@@ -54,28 +54,28 @@ namespace trview
         _level_version = version;
         for (auto& window : _windows)
         {
-            window->set_level_version(_level_version);
+            window.second->set_level_version(_level_version);
         }
     }
 
     std::weak_ptr<ILightsWindow> LightsWindowManager::create_window()
     {
+        int32_t number = next_id();
         auto lights_window = _lights_window_source();
-        lights_window->set_number(++_window_count);
+        lights_window->set_number(number);
         lights_window->set_level_version(_level_version);
         lights_window->set_lights(_lights);
         lights_window->set_selected_light(_selected_light);
         lights_window->set_current_room(_current_room);
 
-        std::weak_ptr<ILightsWindow> lights_window_weak = lights_window;
-        _token_store += lights_window->on_window_closed += [lights_window_weak, this]()
+        _token_store += lights_window->on_window_closed += [number, this]()
         {
-            _closing_windows.push_back(lights_window_weak);
+            _closing_windows.push_back(number);
         };
         lights_window->on_light_selected += on_light_selected;
         lights_window->on_light_visibility += on_light_visibility;
 
-        _windows.push_back(lights_window);
+        _windows[number] = lights_window;
         return lights_window;
     }
 
@@ -83,17 +83,16 @@ namespace trview
     {
         if (!_closing_windows.empty())
         {
-            for (const auto window_ptr : _closing_windows)
+            for (const auto window_number : _closing_windows)
             {
-                auto window = window_ptr.lock();
-                _windows.erase(std::remove(_windows.begin(), _windows.end(), window));
+                _windows.erase(window_number);
             }
             _closing_windows.clear();
         }
 
         for (auto& window : _windows)
         {
-            window->render();
+            window.second->render();
         }
     }
     
@@ -101,7 +100,7 @@ namespace trview
     {
         for (auto& window : _windows)
         {
-            window->update(delta);
+            window.second->update(delta);
         }
     }
 
@@ -110,7 +109,7 @@ namespace trview
         _selected_light = light;
         for (auto& window : _windows)
         {
-            window->set_selected_light(light);
+            window.second->set_selected_light(light);
         }
     }
 
@@ -119,7 +118,18 @@ namespace trview
         _current_room = room;
         for (auto& window : _windows)
         {
-            window->set_current_room(room);
+            window.second->set_current_room(room);
+        }
+    }
+
+    int32_t LightsWindowManager::next_id() const
+    {
+        for (int32_t i = 1;; ++i)
+        {
+            if (_windows.find(i) == _windows.end())
+            {
+                return i;
+            }
         }
     }
 }

--- a/trview.app/Windows/LightsWindowManager.h
+++ b/trview.app/Windows/LightsWindowManager.h
@@ -23,14 +23,14 @@ namespace trview
         virtual std::weak_ptr<ILightsWindow> create_window() override;
         virtual void set_room(uint32_t room) override;
     private:
+        int32_t next_id() const;
         TokenStore _token_store;
-        std::vector<std::shared_ptr<ILightsWindow>> _windows;
-        std::vector<std::weak_ptr<ILightsWindow>> _closing_windows;
+        std::unordered_map<int32_t, std::shared_ptr<ILightsWindow>> _windows;
+        std::vector<int32_t> _closing_windows;
         std::vector<std::weak_ptr<ILight>> _lights;
         ILightsWindow::Source _lights_window_source;
         std::weak_ptr<ILight> _selected_light;
         trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Tomb1 };
         uint32_t _current_room{ 0u };
-        uint32_t _window_count{ 0u };
     };
 }

--- a/trview.app/Windows/LightsWindowManager.h
+++ b/trview.app/Windows/LightsWindowManager.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "ILightsWindow.h"
-#include "ILightsWindowManager.h"
 #include <trview.common/Windows/IShortcuts.h>
 #include <trview.common/MessageHandler.h>
-#include <trview.common/TokenStore.h>
+#include "ILightsWindow.h"
+#include "ILightsWindowManager.h"
+#include "WindowManager.h"
 
 namespace trview
 {
-    class LightsWindowManager final : public ILightsWindowManager, public MessageHandler
+    class LightsWindowManager final : public ILightsWindowManager, WindowManager<ILightsWindow>, public MessageHandler
     {
     public:
         LightsWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const ILightsWindow::Source& lights_window_source);
@@ -23,10 +23,6 @@ namespace trview
         virtual std::weak_ptr<ILightsWindow> create_window() override;
         virtual void set_room(uint32_t room) override;
     private:
-        int32_t next_id() const;
-        TokenStore _token_store;
-        std::unordered_map<int32_t, std::shared_ptr<ILightsWindow>> _windows;
-        std::vector<int32_t> _closing_windows;
         std::vector<std::weak_ptr<ILight>> _lights;
         ILightsWindow::Source _lights_window_source;
         std::weak_ptr<ILight> _selected_light;

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -21,19 +21,7 @@ namespace trview
 
     void RoomsWindowManager::render()
     {
-        if (!_closing_windows.empty())
-        {
-            for (const auto window_number : _closing_windows)
-            {
-                _windows.erase(window_number);
-            }
-            _closing_windows.clear();
-        }
-
-        for (auto& window : _windows)
-        {
-            window.second->render();
-        }
+        WindowManager::render();
     }
 
     std::weak_ptr<ITrigger> RoomsWindowManager::selected_trigger() const
@@ -117,45 +105,21 @@ namespace trview
 
     std::weak_ptr<IRoomsWindow> RoomsWindowManager::create_window()
     {
-        int32_t number = next_id();
         auto rooms_window = _rooms_window_source();
-        rooms_window->set_number(number);
         rooms_window->on_room_selected += on_room_selected;
         rooms_window->on_item_selected += on_item_selected;
         rooms_window->on_trigger_selected += on_trigger_selected;
-
-        _token_store += rooms_window->on_window_closed += [number, this]()
-        {
-            _closing_windows.push_back(number);
-        };
-
         rooms_window->set_level_version(_level_version);
         rooms_window->set_items(_all_items);
         rooms_window->set_triggers(_all_triggers);
         rooms_window->set_rooms(_all_rooms);
         rooms_window->set_current_room(_current_room);
         rooms_window->set_map_colours(_map_colours);
-
-        _windows[number] = rooms_window;
-        return rooms_window;
+        return add_window(rooms_window);
     }
 
     void RoomsWindowManager::update(float delta)
     {
-        for (auto& window : _windows)
-        {
-            window.second->update(delta);
-        }
-    }
-
-    int32_t RoomsWindowManager::next_id() const
-    {
-        for (int32_t i = 1;; ++i)
-        {
-            if (_windows.find(i) == _windows.end())
-            {
-                return i;
-            }
-        }
+        WindowManager::update(delta);
     }
 }

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -42,8 +42,9 @@ namespace trview
         virtual std::weak_ptr<IRoomsWindow> create_window() override;
         virtual void update(float delta) override;
     private:
-        std::vector<std::shared_ptr<IRoomsWindow>> _windows;
-        std::vector<std::weak_ptr<IRoomsWindow>> _closing_windows;
+        int32_t next_id() const;
+        std::unordered_map<int32_t, std::shared_ptr<IRoomsWindow>> _windows;
+        std::vector<int32_t> _closing_windows;
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;
@@ -53,7 +54,6 @@ namespace trview
         std::optional<Item> _selected_item;
         IRoomsWindow::Source _rooms_window_source;
         trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Unknown };
-        uint32_t _window_count{ 0u };
         MapColours _map_colours;
     };
 }

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -7,11 +7,11 @@
 #include <memory>
 #include <optional>
 
-#include <trview.app/Windows/IRoomsWindowManager.h>
 #include <trview.common/MessageHandler.h>
-#include <trview.common/TokenStore.h>
-#include <trview.app/Elements/Item.h>
 #include <trview.common/Windows/IShortcuts.h>
+#include "../Elements/Item.h"
+#include "IRoomsWindowManager.h"
+#include "WindowManager.h"
 
 namespace trview
 {
@@ -19,7 +19,7 @@ namespace trview
     class Shortcuts;
 
     /// Controls and creates RoomsWindows.
-    class RoomsWindowManager final : public IRoomsWindowManager, public MessageHandler
+    class RoomsWindowManager final : public IRoomsWindowManager, public WindowManager<IRoomsWindow>, public MessageHandler
     {
     public:
         /// Create an RoomsWindowManager.
@@ -42,13 +42,9 @@ namespace trview
         virtual std::weak_ptr<IRoomsWindow> create_window() override;
         virtual void update(float delta) override;
     private:
-        int32_t next_id() const;
-        std::unordered_map<int32_t, std::shared_ptr<IRoomsWindow>> _windows;
-        std::vector<int32_t> _closing_windows;
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;
-        TokenStore _token_store;
         uint32_t _current_room{ 0u };
         std::weak_ptr<ITrigger> _selected_trigger;
         std::optional<Item> _selected_item;

--- a/trview.app/Windows/TriggersWindowManager.cpp
+++ b/trview.app/Windows/TriggersWindowManager.cpp
@@ -20,26 +20,12 @@ namespace trview
 
     void TriggersWindowManager::render()
     {
-        if (!_closing_windows.empty())
-        {
-            for (const auto window_number : _closing_windows)
-            {
-                _windows.erase(window_number);
-            }
-            _closing_windows.clear();
-        }
-
-        for (auto& window : _windows)
-        {
-            window.second->render();
-        }
+        WindowManager::render();
     }
 
     std::weak_ptr<ITriggersWindow> TriggersWindowManager::create_window()
     {
-        int32_t number = next_id();
         auto triggers_window = _triggers_window_source();
-        triggers_window->set_number(number);
         triggers_window->on_item_selected += on_item_selected;
         triggers_window->on_trigger_selected += on_trigger_selected;
         triggers_window->on_trigger_visibility += on_trigger_visibility;
@@ -48,14 +34,7 @@ namespace trview
         triggers_window->set_triggers(_triggers);
         triggers_window->set_current_room(_current_room);
         triggers_window->set_selected_trigger(_selected_trigger);
-
-        _token_store += triggers_window->on_window_closed += [number, this]()
-        {
-            _closing_windows.push_back(number);
-        };
-
-        _windows[number] = triggers_window;
-        return triggers_window;
+        return add_window(triggers_window);
     }
 
     const std::weak_ptr<ITrigger> TriggersWindowManager::selected_trigger() const
@@ -123,20 +102,6 @@ namespace trview
 
     void TriggersWindowManager::update(float delta)
     {
-        for (const auto& window : _windows)
-        {
-            window.second->update(delta);
-        }
-    }
-
-    int32_t TriggersWindowManager::next_id() const
-    {
-        for (int32_t i = 1;; ++i)
-        {
-            if (_windows.find(i) == _windows.end())
-            {
-                return i;
-            }
-        }
+        WindowManager::update(delta);
     }
 }

--- a/trview.app/Windows/TriggersWindowManager.cpp
+++ b/trview.app/Windows/TriggersWindowManager.cpp
@@ -22,24 +22,24 @@ namespace trview
     {
         if (!_closing_windows.empty())
         {
-            for (const auto window_ptr : _closing_windows)
+            for (const auto window_number : _closing_windows)
             {
-                auto window = window_ptr.lock();
-                _windows.erase(std::remove(_windows.begin(), _windows.end(), window));
+                _windows.erase(window_number);
             }
             _closing_windows.clear();
         }
 
         for (auto& window : _windows)
         {
-            window->render();
+            window.second->render();
         }
     }
 
     std::weak_ptr<ITriggersWindow> TriggersWindowManager::create_window()
     {
+        int32_t number = next_id();
         auto triggers_window = _triggers_window_source();
-        triggers_window->set_number(++_window_count);
+        triggers_window->set_number(number);
         triggers_window->on_item_selected += on_item_selected;
         triggers_window->on_trigger_selected += on_trigger_selected;
         triggers_window->on_trigger_visibility += on_trigger_visibility;
@@ -49,13 +49,12 @@ namespace trview
         triggers_window->set_current_room(_current_room);
         triggers_window->set_selected_trigger(_selected_trigger);
 
-        std::weak_ptr<ITriggersWindow> triggers_window_weak = triggers_window;
-        _token_store += triggers_window->on_window_closed += [triggers_window_weak, this]()
+        _token_store += triggers_window->on_window_closed += [number, this]()
         {
-            _closing_windows.push_back(triggers_window_weak);
+            _closing_windows.push_back(number);
         };
 
-        _windows.push_back(triggers_window);
+        _windows[number] = triggers_window;
         return triggers_window;
     }
 
@@ -69,7 +68,7 @@ namespace trview
         _items = items;
         for (auto& window : _windows)
         {
-            window->set_items(items);
+            window.second->set_items(items);
         }
     }
 
@@ -79,8 +78,8 @@ namespace trview
         _selected_trigger.reset();
         for (auto& window : _windows)
         {
-            window->clear_selected_trigger();
-            window->set_triggers(triggers);
+            window.second->clear_selected_trigger();
+            window.second->set_triggers(triggers);
         }
     }
 
@@ -100,7 +99,7 @@ namespace trview
         trigger_ptr->set_visible(visible);
         for (auto& window : _windows)
         {
-            window->update_triggers(_triggers);
+            window.second->update_triggers(_triggers);
         }
     }
 
@@ -109,7 +108,7 @@ namespace trview
         _current_room = room;
         for (auto& window : _windows)
         {
-            window->set_current_room(room);
+            window.second->set_current_room(room);
         }
     }
 
@@ -118,7 +117,7 @@ namespace trview
         _selected_trigger = trigger;
         for (auto& window : _windows)
         {
-            window->set_selected_trigger(trigger);
+            window.second->set_selected_trigger(trigger);
         }
     }
 
@@ -126,7 +125,18 @@ namespace trview
     {
         for (const auto& window : _windows)
         {
-            window->update(delta);
+            window.second->update(delta);
+        }
+    }
+
+    int32_t TriggersWindowManager::next_id() const
+    {
+        for (int32_t i = 1;; ++i)
+        {
+            if (_windows.find(i) == _windows.end())
+            {
+                return i;
+            }
         }
     }
 }

--- a/trview.app/Windows/TriggersWindowManager.h
+++ b/trview.app/Windows/TriggersWindowManager.h
@@ -32,14 +32,14 @@ namespace trview
         virtual std::weak_ptr<ITriggersWindow> create_window() override;
         virtual void update(float delta) override;
     private:
-        std::vector<std::shared_ptr<ITriggersWindow>> _windows;
-        std::vector<std::weak_ptr<ITriggersWindow>> _closing_windows;
+        int32_t next_id() const;
+        std::unordered_map<int32_t, std::shared_ptr<ITriggersWindow>> _windows;
+        std::vector<int32_t> _closing_windows;
         std::vector<Item> _items;
         std::vector<std::weak_ptr<ITrigger>> _triggers;
         uint32_t _current_room{ 0u };
         TokenStore _token_store;
         std::weak_ptr<ITrigger> _selected_trigger;
         ITriggersWindow::Source _triggers_window_source;
-        int32_t _window_count{ 0 };
     };
 }

--- a/trview.app/Windows/TriggersWindowManager.h
+++ b/trview.app/Windows/TriggersWindowManager.h
@@ -4,15 +4,15 @@
 #include <memory>
 #include <optional>
 
-#include <trview.app/Windows/ITriggersWindowManager.h>
 #include <trview.common/MessageHandler.h>
-#include <trview.common/TokenStore.h>
 #include <trview.common/Windows/IShortcuts.h>
+#include "ITriggersWindowManager.h"
+#include "WindowManager.h"
 
 namespace trview
 {
     /// Controls and creates TriggersWindows.
-    class TriggersWindowManager final : public ITriggersWindowManager, public MessageHandler
+    class TriggersWindowManager final : public ITriggersWindowManager, public WindowManager<ITriggersWindow>, public MessageHandler
     {
     public:
         /// Create an TriggersWindowManager.
@@ -32,13 +32,9 @@ namespace trview
         virtual std::weak_ptr<ITriggersWindow> create_window() override;
         virtual void update(float delta) override;
     private:
-        int32_t next_id() const;
-        std::unordered_map<int32_t, std::shared_ptr<ITriggersWindow>> _windows;
-        std::vector<int32_t> _closing_windows;
         std::vector<Item> _items;
         std::vector<std::weak_ptr<ITrigger>> _triggers;
         uint32_t _current_room{ 0u };
-        TokenStore _token_store;
         std::weak_ptr<ITrigger> _selected_trigger;
         ITriggersWindow::Source _triggers_window_source;
     };

--- a/trview.app/Windows/WindowManager.h
+++ b/trview.app/Windows/WindowManager.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <trview.common/TokenStore.h>
+
+namespace trview
+{
+    /// <summary>
+    /// Handles common functions for window managers.
+    /// </summary>
+    /// <typeparam name="T">The type of window to manage.</typeparam>
+    template <typename T>
+    class WindowManager
+    {
+    protected:
+        /// <summary>
+        /// Renders all managed windows.
+        /// </summary>
+        void render();
+        /// <summary>
+        /// Updates all managed windows.
+        /// </summary>
+        /// <param name="delta">The time elapsed since the previous update.</param>
+        void update(float delta);
+        /// <summary>
+        /// Adds and numbers a window.
+        /// </summary>
+        /// <param name="window">The new window to add.</param>
+        /// <returns>The added window.</returns>
+        std::weak_ptr<T> add_window(const std::shared_ptr<T>& window);
+        TokenStore _token_store;
+        std::unordered_map<int32_t, std::shared_ptr<T>> _windows;
+    private:
+        /// <summary>
+        /// Find the next ID.
+        /// </summary>
+        /// <returns>The next available window number.</returns>
+        int32_t next_id() const;
+        std::vector<int32_t> _closing_windows;
+    };
+}
+
+#include "WindowManager.hpp"

--- a/trview.app/Windows/WindowManager.hpp
+++ b/trview.app/Windows/WindowManager.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+namespace trview
+{
+    template <typename T>
+    void WindowManager<T>::render()
+    {
+        if (!_closing_windows.empty())
+        {
+            for (const auto window_number : _closing_windows)
+            {
+                _windows.erase(window_number);
+            }
+            _closing_windows.clear();
+        }
+
+        for (auto& window : _windows)
+        {
+            window.second->render();
+        }
+    }
+
+    template <typename T>
+    void WindowManager<T>::update(float delta)
+    {
+        for (auto& window : _windows)
+        {
+            window.second->update(delta);
+        }
+    }
+
+    template <typename T>
+    std::weak_ptr<T> WindowManager<T>::add_window(const std::shared_ptr<T>& window)
+    {
+        int32_t number = next_id();
+        window->set_number(number);
+        _token_store += window->on_window_closed += [number, this]()
+        {
+            _closing_windows.push_back(number);
+        };
+        _windows[number] = window;
+        return window;
+    }
+
+    template <typename T>
+    int32_t WindowManager<T>::next_id() const
+    {
+        for (int32_t i = 1;; ++i)
+        {
+            if (_windows.find(i) == _windows.end())
+            {
+                return i;
+            }
+        }
+    }
+}

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -344,6 +344,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Windows\TriggersWindowManager.h" />
     <ClInclude Include="Windows\Viewer.h" />
     <ClInclude Include="Windows\WindowIDs.h" />
+    <ClInclude Include="Windows\WindowManager.h" />
+    <ClInclude Include="Windows\WindowManager.hpp" />
     <ClInclude Include="Windows\WindowResizer.h" />
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -915,6 +915,12 @@
     <ClInclude Include="Filters\Filters.hpp">
       <Filter>Filters</Filter>
     </ClInclude>
+    <ClInclude Include="Windows\WindowManager.h">
+      <Filter>Windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Windows\WindowManager.hpp">
+      <Filter>Windows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">


### PR DESCRIPTION
Reuse previously used window numbers instead of counting to infinity.
As part of this move some of the common logic for window managers to a base class. `RouteWindowManager` is unaffected by this as it needs more work - it would need a sync checkbox which can come in #694.
Closes #940 