### PR TITLE
Move Window parameter to constructor where possible

### DIFF
--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -22,7 +22,6 @@ namespace
             std::shared_ptr<IClipboard> clipboard{ mock_shared<MockClipboard>() };
             std::shared_ptr<IDialogs> dialogs{ mock_shared<MockDialogs>() };
             std::shared_ptr<IFiles> files{ mock_shared<MockFiles>() };
-            trview::Window parent{ create_test_window(L"RouteWindowTests") };
 
             test_module& with_clipboard(const std::shared_ptr<IClipboard>& clipboard)
             {
@@ -45,7 +44,7 @@ namespace
 
             std::unique_ptr<RouteWindow> build()
             {
-                return std::make_unique<RouteWindow>(parent, clipboard, dialogs, files);
+                return std::make_unique<RouteWindow>(clipboard, dialogs, files);
             }
         };
         return test_module{};

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -143,12 +143,12 @@ namespace trview
         }
         catch (trlevel::LevelEncryptedException&)
         {
-            _dialogs->message_box(window(), L"Level is encrypted and cannot be loaded", L"Error", IDialogs::Buttons::OK);
+            _dialogs->message_box(L"Level is encrypted and cannot be loaded", L"Error", IDialogs::Buttons::OK);
             return;
         }
         catch (...)
         {
-            _dialogs->message_box(window(), L"Failed to load level", L"Error", IDialogs::Buttons::OK);
+            _dialogs->message_box(L"Failed to load level", L"Error", IDialogs::Buttons::OK);
             return;
         }
 
@@ -647,7 +647,7 @@ namespace trview
     {
         if (_route->is_unsaved())
         {
-            return _dialogs->message_box(window(), L"Route has unsaved changes. Do you want to continue and lose changes?", L"Unsaved Route Changes", IDialogs::Buttons::Yes_No);
+            return _dialogs->message_box(L"Route has unsaved changes. Do you want to continue and lose changes?", L"Unsaved Route Changes", IDialogs::Buttons::Yes_No);
         }
         return true;
     }

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -170,12 +170,12 @@ namespace trview
             std::make_unique<SectorHighlight>(mesh_source));
 
         auto files = std::make_shared<Files>();
-        auto dialogs = std::make_shared<Dialogs>();
+        auto dialogs = std::make_shared<Dialogs>(window);
         auto clipboard = std::make_shared<Clipboard>(window);
 
         auto items_window_source = [=]() { return std::make_shared<ItemsWindow>(clipboard); };
         auto triggers_window_source = [=]() { return std::make_shared<TriggersWindow>(clipboard); };
-        auto route_window_source = [=]() { return std::make_shared<RouteWindow>(window, clipboard, dialogs, files); };
+        auto route_window_source = [=]() { return std::make_shared<RouteWindow>(clipboard, dialogs, files); };
         auto rooms_window_source = [=]() { return std::make_shared<RoomsWindow>(map_renderer_source, clipboard); };
         auto lights_window_source = [=]() { return std::make_shared<LightsWindow>(clipboard); };
 

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -158,7 +158,7 @@ namespace trview
             window,
             device,
             std::move(viewer_ui),
-            std::make_unique<Picking>(),
+            std::make_unique<Picking>(window),
             std::make_unique<input::Mouse>(window, std::make_unique<input::WindowTester>(window)),
             shortcuts,
             route_source(),

--- a/trview.app/Geometry/IPicking.h
+++ b/trview.app/Geometry/IPicking.h
@@ -7,14 +7,13 @@
 
 namespace trview
 {
-    class Window;
     struct ICamera;
 
     struct IPicking
     {
         virtual ~IPicking() = 0;
 
-        virtual void pick(const Window& window, const ICamera& camera) = 0;
+        virtual void pick(const ICamera& camera) = 0;
 
         /// The sources of pick information.
         Event<PickInfo, PickResult&> pick_sources;

--- a/trview.app/Geometry/Picking.cpp
+++ b/trview.app/Geometry/Picking.cpp
@@ -9,15 +9,20 @@ using namespace DirectX::SimpleMath;
 
 namespace trview
 {
-    void Picking::pick(const Window& window, const ICamera& camera)
+    Picking::Picking(const Window& window)
+        : _window(window)
+    {
+    }
+
+    void Picking::pick(const ICamera& camera)
     {
         Vector3 position = camera.position();
         const auto world = Matrix::CreateTranslation(position);
         const auto projection = camera.projection();
         const auto view = camera.view();
-        const auto window_size = window.size();
+        const auto window_size = _window.size();
 
-        const Point mouse_pos = client_cursor_position(window);
+        const Point mouse_pos = client_cursor_position(_window);
         Vector3 direction = XMVector3Unproject(Vector3(mouse_pos.x, mouse_pos.y, 1), 0, 0,
             window_size.width, window_size.height, 0, 1.0f, projection, view, world);
         direction.Normalize();

--- a/trview.app/Geometry/Picking.h
+++ b/trview.app/Geometry/Picking.h
@@ -9,9 +9,14 @@ namespace trview
     public:
         virtual ~Picking() = default;
 
+        explicit Picking(const Window& window);
+
+        /// <summary>
         /// Perform a pick operation.
-        /// @param window The window that the scene is being rendered in.
-        /// @param camera The current scene camera.
-        virtual void pick(const Window& window, const ICamera& camera) override;
+        /// </summary>
+        /// <param name="camera">The current scene camera.</param>
+        virtual void pick(const ICamera& camera) override;
+    private:
+        Window _window;
     };
 }

--- a/trview.app/Mocks/Geometry/IPicking.h
+++ b/trview.app/Mocks/Geometry/IPicking.h
@@ -9,7 +9,7 @@ namespace trview
         struct MockPicking : public IPicking
         {
             virtual ~MockPicking() = default;
-            MOCK_METHOD(void, pick, (const Window&, const ICamera&), (override));
+            MOCK_METHOD(void, pick, (const ICamera&), (override));
         };
     }
 }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -20,6 +20,12 @@ namespace trview
 
     void RouteWindow::render_waypoint_list()
     {
+        if (_need_focus)
+        {
+            ImGui::SetNextWindowFocus();
+            _need_focus = false;
+        }
+
         if (ImGui::BeginChild(Names::waypoint_list_panel.c_str(), ImVec2(150, 0), true))
         {
             auto colour = _route ? _route->colour() : Colour::Green;
@@ -333,6 +339,11 @@ namespace trview
     void RouteWindow::set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers)
     {
         _all_triggers = triggers;
+    }
+
+    void RouteWindow::focus()
+    {
+        _need_focus = true;
     }
 
     void RouteWindow::update(float delta)

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -12,9 +12,9 @@ namespace trview
 
     using namespace graphics;
 
-    RouteWindow::RouteWindow(const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard, const std::shared_ptr<IDialogs>& dialogs,
+    RouteWindow::RouteWindow(const std::shared_ptr<IClipboard>& clipboard, const std::shared_ptr<IDialogs>& dialogs,
         const std::shared_ptr<IFiles>& files)
-        : _clipboard(clipboard), _dialogs(dialogs), _files(files), _window(parent)
+        : _clipboard(clipboard), _dialogs(dialogs), _files(files)
     {
     }
 
@@ -216,7 +216,7 @@ namespace trview
                             }
                             catch (...)
                             {
-                                _dialogs->message_box(_window, L"Failed to attach save", L"Error", IDialogs::Buttons::OK);
+                                _dialogs->message_box(L"Failed to attach save", L"Error", IDialogs::Buttons::OK);
                             }
                         }
                     }
@@ -231,7 +231,7 @@ namespace trview
                             }
                             catch (...)
                             {
-                                _dialogs->message_box(_window, L"Failed to export save", L"Error", IDialogs::Buttons::OK);
+                                _dialogs->message_box(L"Failed to export save", L"Error", IDialogs::Buttons::OK);
                             }
                         }
                     }
@@ -333,11 +333,6 @@ namespace trview
     void RouteWindow::set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers)
     {
         _all_triggers = triggers;
-    }
-
-    void RouteWindow::focus()
-    {
-        SetForegroundWindow(_window);
     }
 
     void RouteWindow::update(float delta)

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -33,11 +33,7 @@ namespace trview
             static const inline std::string waypoint_details_panel = "Waypoint Details";
         };
 
-        /// Create a route window as a child of the specified window.
-        /// @param device The graphics device
-        /// @param renderer_source The function to call to get a renderer.
-        /// @param parent The parent window.
-        explicit RouteWindow(const trview::Window& parent, const std::shared_ptr<IClipboard>& clipboard, const std::shared_ptr<IDialogs>& dialogs,
+        explicit RouteWindow(const std::shared_ptr<IClipboard>& clipboard, const std::shared_ptr<IDialogs>& dialogs,
             const std::shared_ptr<IFiles>& files);
         virtual ~RouteWindow() = default;
         virtual void render() override;
@@ -46,7 +42,6 @@ namespace trview
         virtual void set_items(const std::vector<Item>& items) override;
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& rooms) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
-        virtual void focus() override;
         virtual void update(float delta) override;
         virtual void set_randomizer_enabled(bool value) override;
         virtual void set_randomizer_settings(const RandomizerSettings& settings) override;
@@ -68,7 +63,6 @@ namespace trview
         std::shared_ptr<IFiles> _files;
         bool _randomizer_enabled{ false };
         RandomizerSettings _randomizer_settings;
-        trview::Window _window;
         bool _scroll_to_waypoint{ false };
         std::optional<float> _tooltip_timer;
     };

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -42,6 +42,7 @@ namespace trview
         virtual void set_items(const std::vector<Item>& items) override;
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& rooms) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
+        virtual void focus() override;
         virtual void update(float delta) override;
         virtual void set_randomizer_enabled(bool value) override;
         virtual void set_randomizer_settings(const RandomizerSettings& settings) override;
@@ -65,5 +66,6 @@ namespace trview
         RandomizerSettings _randomizer_settings;
         bool _scroll_to_waypoint{ false };
         std::optional<float> _tooltip_timer;
+        bool _need_focus{ false };
     };
 }

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -568,7 +568,7 @@ namespace trview
 
         if (_mouse_changed || _scene_changed)
         {
-            _picking->pick(_window, current_camera());
+            _picking->pick(current_camera());
             _mouse_changed = false;
         }
 

--- a/trview.common/Mocks/Windows/IDialogs.h
+++ b/trview.common/Mocks/Windows/IDialogs.h
@@ -9,7 +9,7 @@ namespace trview
         struct MockDialogs : public IDialogs
         {
             virtual ~MockDialogs() = default;
-            MOCK_METHOD(bool, message_box, (const Window&, const std::wstring&, const std::wstring&, Buttons), (const, override));
+            MOCK_METHOD(bool, message_box, (const std::wstring&, const std::wstring&, Buttons), (const, override));
             MOCK_METHOD(std::optional<FileResult>, open_file, (const std::wstring&, const std::vector<FileFilter>&, uint32_t), (const, override));
             MOCK_METHOD(std::optional<FileResult>, save_file, (const std::wstring&, const std::vector<FileFilter>&, uint32_t), (const, override));
         };

--- a/trview.common/Windows/Dialogs.cpp
+++ b/trview.common/Windows/Dialogs.cpp
@@ -61,9 +61,14 @@ namespace trview
         }
     }
 
-    bool Dialogs::message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons) const
+    Dialogs::Dialogs(const Window& window)
+        : _window(window)
     {
-        return convert_response(MessageBox(window, message.c_str(), title.c_str(), convert_button(buttons)));
+    }
+
+    bool Dialogs::message_box(const std::wstring& message, const std::wstring& title, Buttons buttons) const
+    {
+        return convert_response(MessageBox(_window, message.c_str(), title.c_str(), convert_button(buttons)));
     }
 
     std::optional<IDialogs::FileResult> Dialogs::open_file(const std::wstring& title, const std::vector<FileFilter>& filters, uint32_t flags) const

--- a/trview.common/Windows/Dialogs.h
+++ b/trview.common/Windows/Dialogs.h
@@ -7,9 +7,12 @@ namespace trview
     class Dialogs final : public IDialogs
     {
     public:
+        explicit Dialogs(const Window& window);
         virtual ~Dialogs() = default;
-        virtual bool message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons) const override;
+        virtual bool message_box(const std::wstring& message, const std::wstring& title, Buttons buttons) const override;
         virtual std::optional<FileResult> open_file(const std::wstring& title, const std::vector<FileFilter>& filters, uint32_t flags) const override;
         virtual std::optional<FileResult> save_file(const std::wstring& title, const std::vector<FileFilter>& filters, uint32_t filter_index) const override;
+    private:
+        Window _window;
     };
 }

--- a/trview.common/Windows/IDialogs.h
+++ b/trview.common/Windows/IDialogs.h
@@ -32,12 +32,11 @@ namespace trview
         /// <summary>
         /// Show a modal message box.
         /// </summary>
-        /// <param name="window">The window that owns the message box.</param>
         /// <param name="message">The message of the message box.</param>
         /// <param name="title">The title of the message box.</param>
         /// <param name="buttons">The buttons to show on the message box.</param>
         /// <returns>True if the positive result was chosen.</returns>
-        virtual bool message_box(const Window& window, const std::wstring& message, const std::wstring& title, Buttons buttons) const = 0;
+        virtual bool message_box(const std::wstring& message, const std::wstring& title, Buttons buttons) const = 0;
         /// <summary>
         /// Prompt the user to select a file to open.
         /// </summary>


### PR DESCRIPTION
In cases where it makes sense move the `Window` parameter to the constructor of classes and create it at the start of the application. This is usually fine because there is now only one window that we manage.
Closes #938 