### PR TITLE
Add menu command to reset ImGui layout

### DIFF
--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -225,6 +225,15 @@ namespace trview
                         }
                         break;
                     }
+                    case ID_WINDOWS_RESET_LAYOUT:
+                    {
+                        auto& io = ImGui::GetIO();
+                        _files->delete_file(io.IniFilename);
+                        io.IniFilename = nullptr;
+                        _imgui_setup = false;
+                        _imgui_backend->shutdown();
+                        break;
+                    }
                 }
                 break;
             }
@@ -587,6 +596,11 @@ namespace trview
         {
             // Setup Dear ImGui context
             IMGUI_CHECKVERSION();
+            auto existing_context = ImGui::GetCurrentContext();
+            if (existing_context)
+            {
+                ImGui::DestroyContext(existing_context);
+            }
             ImGui::CreateContext();
             ImGuiIO& io = ImGui::GetIO();
             io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
@@ -621,12 +635,12 @@ namespace trview
 
         ImGui::PushFont(_font);
 
+        _viewer->render_ui();
         _items_windows->render();
         _triggers_windows->render();
         _rooms_windows->render();
         _route_window->render();
         _lights_windows->render();
-        _viewer->render_ui();
 
         ImGui::PopFont();
         ImGui::Render();

--- a/trview.app/Resources/resource.h
+++ b/trview.app/Resources/resource.h
@@ -43,6 +43,7 @@
 #define ID_WINDOWS_LIGHTS               ID_APP_WINDOWS_LIGHTS
 #define IDC_STATIC                      -1
 #define ID_WINDOWS_ROOMS                ID_APP_WINDOWS_ROOMS
+#define ID_WINDOWS_RESET_LAYOUT         33019
 
 // Next default values for new objects
 // 

--- a/trview.app/Resources/trview.app.rc
+++ b/trview.app/Resources/trview.app.rc
@@ -69,6 +69,8 @@ BEGIN
         MENUITEM "Roo&ms\tCtrl+M",              ID_WINDOWS_ROOMS
         MENUITEM "&Route\tCtrl+R",              ID_WINDOWS_ROUTE
         MENUITEM "&Lights\tCtrl+L"              ID_WINDOWS_LIGHTS
+        MENUITEM SEPARATOR
+        MENUITEM "Reset Layout"                 ID_WINDOWS_RESET_LAYOUT
     END
     POPUP "&Help"
     BEGIN

--- a/trview.app/UI/DX11ImGuiBackend.cpp
+++ b/trview.app/UI/DX11ImGuiBackend.cpp
@@ -16,6 +16,7 @@ namespace trview
     {
         ImGui_ImplWin32_Init(_window);
         ImGui_ImplDX11_Init(_device->device().Get(), _device->context().Get());
+        _active = true;
     }
 
     void DX11ImGuiBackend::new_frame()
@@ -33,10 +34,15 @@ namespace trview
     {
         ImGui_ImplDX11_Shutdown();
         ImGui_ImplWin32_Shutdown();
+        _active = false;
     }
 
     bool DX11ImGuiBackend::window_procedure(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     {
-        return ImGui_ImplWin32_WndProcHandler(hWnd, message, wParam, lParam);
+        if (_active)
+        {
+            return ImGui_ImplWin32_WndProcHandler(hWnd, message, wParam, lParam);
+        }
+        return false;
     }
 }

--- a/trview.app/UI/DX11ImGuiBackend.h
+++ b/trview.app/UI/DX11ImGuiBackend.h
@@ -18,5 +18,6 @@ namespace trview
     private:
         std::shared_ptr<graphics::IDevice> _device;
         Window _window;
+        bool _active{ false };
     };
 }

--- a/trview.common/Files.cpp
+++ b/trview.common/Files.cpp
@@ -39,6 +39,11 @@ namespace trview
         return to_utf8(path.path);
     }
 
+    void Files::delete_file(const std::string& filename) const
+    {
+        DeleteFile(to_utf16(filename).c_str());
+    }
+
     bool Files::create_directory(const std::string& directory) const
     {
         return CreateDirectory(to_utf16(directory).c_str(), nullptr) || GetLastError() == ERROR_ALREADY_EXISTS;

--- a/trview.common/Files.h
+++ b/trview.common/Files.h
@@ -11,6 +11,7 @@ namespace trview
         virtual std::string appdata_directory() const override;
         virtual std::string fonts_directory() const override;
         virtual bool create_directory(const std::string& directory) const override;
+        virtual void delete_file(const std::string& filename) const override;
         virtual std::optional<std::vector<uint8_t>> load_file(const std::string& filename) const override;
         virtual void save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const override;
         virtual void save_file(const std::string& filename, const std::string& text) const override;

--- a/trview.common/IFiles.h
+++ b/trview.common/IFiles.h
@@ -13,6 +13,7 @@ namespace trview
         virtual std::string appdata_directory() const = 0;
         virtual std::string fonts_directory() const = 0;
         virtual bool create_directory(const std::string& directory) const = 0;
+        virtual void delete_file(const std::string& filename) const = 0;
         virtual std::optional<std::vector<uint8_t>> load_file(const std::string& filename) const = 0;
         virtual void save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const = 0;
         virtual void save_file(const std::string& filename, const std::string& text) const = 0;

--- a/trview.common/Mocks/IFiles.h
+++ b/trview.common/Mocks/IFiles.h
@@ -12,6 +12,7 @@ namespace trview
             MOCK_METHOD(std::string, appdata_directory, (), (const, override));
             MOCK_METHOD(std::string, fonts_directory, (), (const, override));
             MOCK_METHOD(bool, create_directory, (const std::string&), (const, override));
+            MOCK_METHOD(void, delete_file, (const std::string&), (const, override));
             MOCK_METHOD(std::optional<std::vector<uint8_t>>, load_file, (const std::string&), (const, override));
             MOCK_METHOD(void, save_file, (const std::string&, const std::vector<uint8_t>&), (const, override));
             MOCK_METHOD(void, save_file, (const std::string&, const std::string&), (const, override));


### PR DESCRIPTION
Resetting the layout will delete the ini file, disable ini file saving (so it doesn't just get restored) and recreate ImGui on the next frame. Ini saving will be restored in this new ImGui as it will be a brand new context.
Closes #943