### PR TITLE
Replicate ImGui fix for wide windows

### DIFF
--- a/external/imgui/imgui.cpp
+++ b/external/imgui/imgui.cpp
@@ -5596,7 +5596,7 @@ static ImGuiWindow* CreateNewWindow(const char* name, ImGuiWindowFlags flags)
             SetWindowConditionAllowFlags(window, ImGuiCond_FirstUseEver, false);
             ApplyWindowSettings(window, settings);
         }
-    window->DC.CursorStartPos = window->DC.CursorMaxPos = window->Pos; // So first call to CalcContentSize() doesn't return crazy values
+    window->DC.CursorStartPos = window->DC.CursorMaxPos = window->DC.IdealMaxPos = window->Pos; // So first call to CalcWindowContentSizes() doesn't return crazy values
 
     if ((flags & ImGuiWindowFlags_AlwaysAutoResize) != 0)
     {


### PR DESCRIPTION
Windows were starting very wide if the primary monitor was on the right of the secondary monitor.
Replicate a fix from ImGui over to trview.
Closes #939