### PR TITLE
Reset camera input when window is deactivated

### DIFF
--- a/trview.app/Camera/CameraInput.cpp
+++ b/trview.app/Camera/CameraInput.cpp
@@ -162,4 +162,14 @@ namespace trview
         _panning = false;
         _panning_vertical = false;
     }
+
+    void CameraInput::reset_input()
+    {
+        _free_forward = false;
+        _free_left = false;
+        _free_right = false;
+        _free_backward = false;
+        _free_up = false;
+        _free_down = false;
+    }
 }

--- a/trview.app/Camera/CameraInput.h
+++ b/trview.app/Camera/CameraInput.h
@@ -60,6 +60,11 @@ namespace trview
 
         /// Event raised when the camera mode needs to change.
         Event<CameraMode> on_mode_change;
+
+        /// <summary>
+        /// Relase all pressed keys.
+        /// </summary>
+        void reset_input();
     private:
         bool _free_forward{ false };
         bool _free_left{ false };

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1166,7 +1166,7 @@ namespace trview
         _scene_changed = true;
     }
 
-    std::optional<int> Viewer::process_message(UINT message, WPARAM wParam, LPARAM lParam)
+    std::optional<int> Viewer::process_message(UINT message, WPARAM, LPARAM)
     {
         if (message == WM_ACTIVATE)
         {

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -46,7 +46,7 @@ namespace trview
     }
 
     /// Class that coordinates all the parts of the application.
-    class Viewer : public IViewer
+    class Viewer : public IViewer, public MessageHandler
     {
     public:
         /// Create a new viewer.
@@ -87,6 +87,7 @@ namespace trview
         virtual void set_show_ui(bool value) override;
         virtual bool ui_input_active() const override;
         virtual void select_light(const std::weak_ptr<ILight>& light) override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         const ICamera& current_camera() const;
         ICamera& current_camera();
     private:
@@ -123,7 +124,6 @@ namespace trview
         void apply_acceleration_settings();
 
         const std::shared_ptr<graphics::IDevice> _device;
-        Window _window;
         const std::shared_ptr<IShortcuts>& _shortcuts;
         std::unique_ptr<graphics::IDeviceWindow> _main_window;
         ILevel* _level{ nullptr };

--- a/trview.app/Windows/ViewerLuaRegistry.cpp
+++ b/trview.app/Windows/ViewerLuaRegistry.cpp
@@ -127,7 +127,7 @@ namespace trview
         lua_registry.on_crazy = [this] () -> bool
             {
             const int result = MessageBox ( 
-                _window, 
+                window(), 
                 L"Script has been running for a long time and may have gone crazy. Do you want to kill it?", 
                 L"Lua Script error", 
                 MB_YESNO );


### PR DESCRIPTION
When the user deactivates the window (leaves it, alt-tabs or similar) then reset the pressed key states in camera input. This stops the camera from moving if they were pressing a movement key.
Closes #949