### PR TITLE
Fix hide checkbox breaking window list sorting

### DIFF
--- a/trview.app.tests/ItemsWindowManagerTests.cpp
+++ b/trview.app.tests/ItemsWindowManagerTests.cpp
@@ -137,7 +137,7 @@ TEST(ItemsWindowManager, SetItemsSetsItemsOnWindows)
 TEST(ItemsWindowManager, SetItemVisibilityUpdatesWindows)
 {
     auto mock_window = mock_shared<MockItemsWindow>();
-    EXPECT_CALL(*mock_window, update_items).Times(1);
+    EXPECT_CALL(*mock_window, update_item).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
     auto created_window = manager->create_window().lock();

--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -256,7 +256,7 @@ TEST(ItemsWindow, ItemsListUpdatedWhenNotFiltered)
         .push(ItemsWindow::Names::items_list).id("##hide-1")) & ImGuiItemStatusFlags_Checked);
 
     items[1].set_visible(false);
-    window->update_items(items);
+    window->update_item(items[1]);
 
     imgui.reset();
     imgui.render();

--- a/trview.app.tests/TriggersWindowManagerTests.cpp
+++ b/trview.app.tests/TriggersWindowManagerTests.cpp
@@ -207,21 +207,6 @@ TEST(TriggersWindowManager, SetTriggersClearsSelectedTrigger)
     ASSERT_EQ(manager->selected_trigger().lock(), nullptr);
 }
 
-TEST(TriggersWindowManager, SetTriggerVisibilityUpdatesWindows)
-{
-    auto mock_window = mock_shared<MockTriggersWindow>();
-    EXPECT_CALL(*mock_window, update_triggers).Times(1);
-    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
-
-    auto created_window = manager->create_window().lock();
-    ASSERT_NE(created_window, nullptr);
-    ASSERT_EQ(created_window, mock_window);
-
-    auto trigger = mock_shared<MockTrigger>();
-    manager->set_triggers({ trigger });
-    manager->set_trigger_visible(trigger, false);
-}
-
 TEST(TriggersWindowManager, SetRoomSetsRoomOnWindows)
 {
     auto mock_window = mock_shared<MockTriggersWindow>();

--- a/trview.app.tests/TriggersWindowTests.cpp
+++ b/trview.app.tests/TriggersWindowTests.cpp
@@ -236,28 +236,6 @@ TEST(TriggersWindow, ItemSelectedRaised)
     ASSERT_EQ(selected, trigger);
 }
 
-TEST(TriggersWindow, SetTriggerVisiblityUpdatesTrigger)
-{
-    auto window = register_test_module().build();
-
-    bool visible = true;
-    auto trigger = mock_shared<MockTrigger>()->with_visible([&]() { return visible; });
-    window->set_triggers({ trigger });
-
-    TestImgui imgui([&]() { window->render(); });
-    ASSERT_FALSE(imgui.status_flags(imgui.id("Triggers 0")
-        .push_child(TriggersWindow::Names::trigger_list_panel)
-        .push(TriggersWindow::Names::triggers_list).id("##hide-0")) & ImGuiItemStatusFlags_Checked);
-
-    visible = false;
-    window->update_triggers({ trigger });
-    imgui.render();
-
-    ASSERT_TRUE(imgui.status_flags(imgui.id("Triggers 0")
-        .push_child(TriggersWindow::Names::trigger_list_panel)
-        .push(TriggersWindow::Names::triggers_list).id("##hide-0")) & ImGuiItemStatusFlags_Checked);
-}
-
 TEST(TriggersWindow, FlipmapsFiltersAllFlipTriggers)
 {
     auto window = register_test_module().build();

--- a/trview.app.tests/Windows/LightsWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/LightsWindowManagerTests.cpp
@@ -138,18 +138,6 @@ TEST(LightsWindowManager, SetSelectedLightUpdatesNewWindows)
     manager->create_window();
 }
 
-TEST(LightsWindowManager, SetLightVisibilityUpdatesWindows)
-{
-    auto window = mock_shared<MockLightsWindow>();
-    EXPECT_CALL(*window, update_lights).Times(1);
-    auto light = mock_shared<MockLight>();
-
-    auto manager = register_test_module().with_window_source([&]() { return window; }).build();
-    manager->set_lights({ light });
-    manager->create_window();
-    manager->set_light_visible(light, true);
-}
-
 TEST(LightsWindowManager, SetLevelVersionUpdatesExistingWindows)
 {
     auto window = mock_shared<MockLightsWindow>();

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -561,7 +561,6 @@ namespace trview
             if (trigger_ptr->visible() != visible)
             {
                 _level->set_trigger_visibility(trigger_ptr->number(), visible);
-                _triggers_windows->set_trigger_visible(trigger, visible);
             }
         }
     }
@@ -578,7 +577,6 @@ namespace trview
             if (light_ptr->visible() != visible)
             {
                 _level->set_light_visibility(light_ptr->number(), visible);
-                _lights_windows->set_light_visible(light, visible);
             }
         }
     }

--- a/trview.app/Mocks/Windows/IItemsWindow.h
+++ b/trview.app/Mocks/Windows/IItemsWindow.h
@@ -10,7 +10,7 @@ namespace trview
         {
             virtual ~MockItemsWindow() = default;
             MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
-            MOCK_METHOD(void, update_items, (const std::vector<Item>&), (override));
+            MOCK_METHOD(void, update_item, (const Item&), (override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(void, clear_selected_item, (), (override));

--- a/trview.app/Mocks/Windows/ILightsWindow.h
+++ b/trview.app/Mocks/Windows/ILightsWindow.h
@@ -14,7 +14,6 @@ namespace trview
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, set_lights, (const std::vector<std::weak_ptr<ILight>>&), (override));
             MOCK_METHOD(void, set_selected_light, (const std::weak_ptr<ILight>&), (override));
-            MOCK_METHOD(void, update_lights, (const std::vector<std::weak_ptr<ILight>>&), (override));
             MOCK_METHOD(void, set_level_version, (trlevel::LevelVersion), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));
             MOCK_METHOD(void, set_current_room, (uint32_t), (override));

--- a/trview.app/Mocks/Windows/ILightsWindowManager.h
+++ b/trview.app/Mocks/Windows/ILightsWindowManager.h
@@ -14,7 +14,6 @@ namespace trview
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, set_selected_light, (const std::weak_ptr<ILight>&), (override));
-            MOCK_METHOD(void, set_light_visible, (const std::weak_ptr<ILight>&, bool), (override));
             MOCK_METHOD(void, set_level_version, (trlevel::LevelVersion), (override));
             MOCK_METHOD(void, set_room, (uint32_t), (override));
         };

--- a/trview.app/Mocks/Windows/ITriggersWindow.h
+++ b/trview.app/Mocks/Windows/ITriggersWindow.h
@@ -17,7 +17,6 @@ namespace trview
             MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
-            MOCK_METHOD(void, update_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(void, update, (float), (override));
         };
     }

--- a/trview.app/Mocks/Windows/ITriggersWindowManager.h
+++ b/trview.app/Mocks/Windows/ITriggersWindowManager.h
@@ -12,7 +12,6 @@ namespace trview
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
-            MOCK_METHOD(void, set_trigger_visible, (const std::weak_ptr<ITrigger>& trigger, bool), (override));
             MOCK_METHOD(void, set_room, (uint32_t), (override));
             MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&), (override));
             MOCK_METHOD(std::weak_ptr<ITriggersWindow>, create_window, (), (override));

--- a/trview.app/Windows/IItemsWindow.h
+++ b/trview.app/Windows/IItemsWindow.h
@@ -34,7 +34,7 @@ namespace trview
         virtual void set_items(const std::vector<Item>& items) = 0;
 
         /// Update the items - this doesn't reset the filters.
-        virtual void update_items(const std::vector<Item>& items) = 0;
+        virtual void update_item(const Item& items) = 0;
 
         /// Render the window.
         virtual void render() = 0;

--- a/trview.app/Windows/ILightsWindow.h
+++ b/trview.app/Windows/ILightsWindow.h
@@ -15,7 +15,6 @@ namespace trview
         virtual void update(float delta) = 0;
         virtual void set_lights(const std::vector<std::weak_ptr<ILight>>& lights) = 0;
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) = 0;
-        virtual void update_lights(const std::vector<std::weak_ptr<ILight>>& lights) = 0;
         virtual void set_level_version(trlevel::LevelVersion version) = 0;
         virtual void set_number(int32_t number) = 0;
         virtual void set_current_room(uint32_t room) = 0;

--- a/trview.app/Windows/ILightsWindowManager.h
+++ b/trview.app/Windows/ILightsWindowManager.h
@@ -15,7 +15,6 @@ namespace trview
         virtual void render() = 0;
         virtual void update(float delta) = 0;
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) = 0;
-        virtual void set_light_visible(const std::weak_ptr<ILight>& light, bool state) = 0;
         virtual void set_level_version(trlevel::LevelVersion version) = 0;
         virtual void set_room(uint32_t room) = 0;
 

--- a/trview.app/Windows/ITriggersWindow.h
+++ b/trview.app/Windows/ITriggersWindow.h
@@ -53,9 +53,6 @@ namespace trview
         /// @param triggers The triggers.
         /// @param reset_filters Whether to reset the trigger filters.
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
-
-        /// Update the trigers - this doesn't reset the filters.
-        virtual void update_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
         /// <summary>
         /// Update the window.
         /// </summary>

--- a/trview.app/Windows/ITriggersWindowManager.h
+++ b/trview.app/Windows/ITriggersWindowManager.h
@@ -30,11 +30,6 @@ namespace trview
         /// @param triggers The triggers in the level.
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
 
-        /// Set whether a trigger is visible.
-        /// @param trigger The trigger.
-        /// @param visible Whether the trigger is visible.
-        virtual void set_trigger_visible(const std::weak_ptr<ITrigger>& trigger, bool visible) = 0;
-
         /// Set the current room to filter trigger windows.
         /// @param room The current room.
         virtual void set_room(uint32_t room) = 0;

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -21,12 +21,15 @@ namespace trview
         setup_filters();
     }
 
-    void ItemsWindow::update_items(const std::vector<Item>& items)
+    void ItemsWindow::update_item(const Item& item)
     {
-        set_items(items);
-        if (_track_room)
+        for (auto& i : _all_items)
         {
-            set_current_room(_current_room);
+            if (i.number() == item.number())
+            {
+                i = item;
+                break;
+            }
         }
     }
 

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -31,7 +31,7 @@ namespace trview
         virtual ~ItemsWindow() = default;
         virtual void render() override;
         virtual void set_items(const std::vector<Item>& items) override;
-        virtual void update_items(const std::vector<Item>& items) override;
+        virtual void update_item(const Item& items) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void clear_selected_item() override;
         virtual void set_current_room(uint32_t room) override;

--- a/trview.app/Windows/ItemsWindowManager.cpp
+++ b/trview.app/Windows/ItemsWindowManager.cpp
@@ -60,7 +60,7 @@ namespace trview
         found->set_visible(visible);
         for (auto& window : _windows)
         {
-            window.second->update_items(_items);
+            window.second->update_item(*found);
         }
     }
 

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -52,15 +52,6 @@ namespace trview
         }
     }
 
-    void LightsWindow::update_lights(const std::vector<std::weak_ptr<ILight>>& lights)
-    {
-        set_lights(lights);
-        if (_track_room)
-        {
-            set_current_room(_current_room);
-        }
-    }
-
     void LightsWindow::set_level_version(trlevel::LevelVersion version)
     {
         _level_version = version;

--- a/trview.app/Windows/LightsWindow.h
+++ b/trview.app/Windows/LightsWindow.h
@@ -27,7 +27,6 @@ namespace trview
         virtual void update(float delta) override;
         virtual void set_lights(const std::vector<std::weak_ptr<ILight>>& lights) override;
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) override;
-        virtual void update_lights(const std::vector<std::weak_ptr<ILight>>& lights) override;
         virtual void set_level_version(trlevel::LevelVersion version) override;
         virtual void set_number(int32_t number) override;
         virtual void set_current_room(uint32_t room) override;

--- a/trview.app/Windows/LightsWindowManager.cpp
+++ b/trview.app/Windows/LightsWindowManager.cpp
@@ -29,26 +29,6 @@ namespace trview
         }
     }
 
-    void LightsWindowManager::set_light_visible(const std::weak_ptr<ILight>& light, bool state)
-    {
-        const auto light_ptr = light.lock();
-        auto found = std::find_if(_lights.begin(), _lights.end(),
-            [&](const auto& l)
-            {
-                return l.lock() == light_ptr;
-            });
-        if (found == _lights.end())
-        {
-            return;
-        }
-
-        light_ptr->set_visible(state);
-        for (auto& window : _windows)
-        {
-            window.second->update_lights(_lights);
-        }
-    }
-
     void LightsWindowManager::set_level_version(trlevel::LevelVersion version)
     {
         _level_version = version;

--- a/trview.app/Windows/LightsWindowManager.h
+++ b/trview.app/Windows/LightsWindowManager.h
@@ -14,7 +14,6 @@ namespace trview
         LightsWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const ILightsWindow::Source& lights_window_source);
         virtual ~LightsWindowManager() = default;
         virtual void set_lights(const std::vector<std::weak_ptr<ILight>>& lights) override;
-        virtual void set_light_visible(const std::weak_ptr<ILight>& light, bool state) override;
         virtual void set_level_version(trlevel::LevelVersion version) override;
         virtual void render() override;
         virtual void update(float delta) override;

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -33,12 +33,6 @@ namespace trview
         calculate_column_widths();
     }
 
-    void TriggersWindow::update_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers)
-    {
-        _all_triggers = triggers;
-        _need_filtering = true;
-    }
-
     void TriggersWindow::clear_selected_trigger()
     {
         _selected_trigger.reset();

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -32,7 +32,6 @@ namespace trview
         virtual ~TriggersWindow() = default;
         virtual void render() override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
-        virtual void update_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void clear_selected_trigger() override;
         virtual void set_current_room(uint32_t room) override;
         virtual void set_number(int32_t number) override;

--- a/trview.app/Windows/TriggersWindowManager.cpp
+++ b/trview.app/Windows/TriggersWindowManager.cpp
@@ -62,26 +62,6 @@ namespace trview
         }
     }
 
-    void TriggersWindowManager::set_trigger_visible(const std::weak_ptr<ITrigger>& trigger, bool visible)
-    {
-        const auto trigger_ptr = trigger.lock();
-        auto found = std::find_if(_triggers.begin(), _triggers.end(), 
-            [&](const auto& t) 
-            {
-                return t.lock() == trigger_ptr;
-            });
-        if (found == _triggers.end())
-        {
-            return;
-        }
-        
-        trigger_ptr->set_visible(visible);
-        for (auto& window : _windows)
-        {
-            window.second->update_triggers(_triggers);
-        }
-    }
-
     void TriggersWindowManager::set_room(uint32_t room)
     {
         _current_room = room;

--- a/trview.app/Windows/TriggersWindowManager.h
+++ b/trview.app/Windows/TriggersWindowManager.h
@@ -26,7 +26,6 @@ namespace trview
         const std::weak_ptr<ITrigger> selected_trigger() const;
         virtual void set_items(const std::vector<Item>& items) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
-        virtual void set_trigger_visible(const std::weak_ptr<ITrigger>& trigger, bool visible) override;
         virtual void set_room(uint32_t room) override;
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual std::weak_ptr<ITriggersWindow> create_window() override;


### PR DESCRIPTION
When an item/trigger/light was made invisible previously the window manager was passing the entire list again and this was replacing the current list. This meant that sorting was lost and also the list was being updated in the middle of an iteration, so there was a strange ordering in the output.

Change `update_items` to pass only the item that has changed and call it `update_item`. This updates one item and doesn't re-sort the elements. Remove this function from Triggers/Lights windows as they work with `shared_ptr` unlike `Item`.
Closes #952