### PR TITLE
Rename Climbable sector flags

### DIFF
--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -448,7 +448,7 @@ namespace trview
         std::function<void(std::shared_ptr<ISector>)> add_ladders;
         add_ladders = [&](auto&& sector)
         {
-            if (has_any_flag(sector->flags(), SectorFlag::ClimbableUp, SectorFlag::ClimbableDown, SectorFlag::ClimbableLeft, SectorFlag::ClimbableRight) && sector->room_above() != 0xff)
+            if (has_any_flag(sector->flags(), SectorFlag::ClimbableNorth, SectorFlag::ClimbableSouth, SectorFlag::ClimbableWest, SectorFlag::ClimbableEast) && sector->room_above() != 0xff)
             {
                 auto portal = _rooms[sector->room()]->sector_portal(sector->x(), sector->z(), -1, -1);
                 portal.sector_above->add_flag(sector->flags() & SectorFlag::Climbable);

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -931,7 +931,7 @@ namespace trview
             {
                 return colours.colour(SectorFlag::Death);
             }
-            else if (has_any_flag(tri.type, SectorFlag::ClimbableDown, SectorFlag::ClimbableLeft, SectorFlag::ClimbableRight, SectorFlag::ClimbableUp))
+            else if (has_any_flag(tri.type, SectorFlag::ClimbableSouth, SectorFlag::ClimbableWest, SectorFlag::ClimbableEast, SectorFlag::ClimbableNorth))
             {
                 return colours.colour(tri.type & SectorFlag::Climbable);
             }

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -458,22 +458,22 @@ namespace trview
 
             if (north && !north.is_wall() && (ceiling(Corner::NW) != north.ceiling(Corner::SW) || ceiling(Corner::NE) != north.ceiling(Corner::SE)))
             {
-                add_quad(self, Quad(ceiling(Corner::NW), north.ceiling(Corner::SE), north.ceiling(Corner::SW), ceiling(Corner::NE), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableUp), _room));
+                add_quad(self, Quad(ceiling(Corner::NW), north.ceiling(Corner::SE), north.ceiling(Corner::SW), ceiling(Corner::NE), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableNorth), _room));
             }
 
             if (south && !south.is_wall() && (ceiling(Corner::SW) != south.ceiling(Corner::NW) || ceiling(Corner::SE) != south.ceiling(Corner::NE)))
             {
-                add_quad(self, Quad(south.ceiling(Corner::NW), ceiling(Corner::SE), ceiling(Corner::SW), south.ceiling(Corner::NE), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableDown), _room));
+                add_quad(self, Quad(south.ceiling(Corner::NW), ceiling(Corner::SE), ceiling(Corner::SW), south.ceiling(Corner::NE), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableSouth), _room));
             }
 
             if (east && !east.is_wall() && (ceiling(Corner::NE) != east.ceiling(Corner::NW) || ceiling(Corner::SE) != east.ceiling(Corner::SW)))
             {
-                add_quad(self, Quad(east.ceiling(Corner::SW), ceiling(Corner::NE), ceiling(Corner::SE), east.ceiling(Corner::NW), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableLeft), _room));
+                add_quad(self, Quad(east.ceiling(Corner::SW), ceiling(Corner::NE), ceiling(Corner::SE), east.ceiling(Corner::NW), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableWest), _room));
             }
 
             if (west && !west.is_wall() && (ceiling(Corner::NW) != west.ceiling(Corner::NE) || ceiling(Corner::SW) != west.ceiling(Corner::SE)))
             {
-                add_quad(self, Quad(ceiling(Corner::SW), west.ceiling(Corner::NE), west.ceiling(Corner::SE), ceiling(Corner::NW), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableRight), _room));
+                add_quad(self, Quad(ceiling(Corner::SW), west.ceiling(Corner::NE), west.ceiling(Corner::SE), ceiling(Corner::NW), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableEast), _room));
             }
         }
 
@@ -481,22 +481,22 @@ namespace trview
         {
             if (north && !north.is_wall() && !north.is_portal())
             {
-                add_quad(self, Quad(north.ceiling(Corner::SE), north.corner(Corner::SW), north.corner(Corner::SE), north.ceiling(Corner::SW), (wall_flags & ~SectorFlag::Climbable) | (SectorFlag::ClimbableDown & north.direct->flags()), _room));
+                add_quad(self, Quad(north.ceiling(Corner::SE), north.corner(Corner::SW), north.corner(Corner::SE), north.ceiling(Corner::SW), (wall_flags & ~SectorFlag::Climbable) | (SectorFlag::ClimbableSouth & north.direct->flags()), _room));
             }
 
             if (south && !south.is_wall() && !south.is_portal())
             {
-                add_quad(self, Quad(south.ceiling(Corner::NW), south.corner(Corner::NE), south.corner(Corner::NW), south.ceiling(Corner::NE), (wall_flags & ~SectorFlag::Climbable) | (SectorFlag::ClimbableUp & south.direct->flags()), _room));
+                add_quad(self, Quad(south.ceiling(Corner::NW), south.corner(Corner::NE), south.corner(Corner::NW), south.ceiling(Corner::NE), (wall_flags & ~SectorFlag::Climbable) | (SectorFlag::ClimbableNorth & south.direct->flags()), _room));
             }
 
             if (east && !east.is_wall() && !east.is_portal())
             {
-                add_quad(self, Quad(east.ceiling(Corner::SW), east.corner(Corner::NW), east.corner(Corner::SW), east.ceiling(Corner::NW), (wall_flags & ~SectorFlag::Climbable) | (SectorFlag::ClimbableLeft & east.direct->flags()), _room));
+                add_quad(self, Quad(east.ceiling(Corner::SW), east.corner(Corner::NW), east.corner(Corner::SW), east.ceiling(Corner::NW), (wall_flags & ~SectorFlag::Climbable) | (SectorFlag::ClimbableWest & east.direct->flags()), _room));
             }
 
             if (west && !west.is_wall() && !west.is_portal())
             {
-                add_quad(self, Quad(west.ceiling(Corner::NE), west.corner(Corner::SE), west.corner(Corner::NE), west.ceiling(Corner::SE), (wall_flags & ~SectorFlag::Climbable) | (SectorFlag::ClimbableRight & west.direct->flags()), _room));
+                add_quad(self, Quad(west.ceiling(Corner::NE), west.corner(Corner::SE), west.corner(Corner::NE), west.ceiling(Corner::SE), (wall_flags & ~SectorFlag::Climbable) | (SectorFlag::ClimbableEast & west.direct->flags()), _room));
             }
         }
         else if (!is_portal())
@@ -505,7 +505,7 @@ namespace trview
             {
                 if (corner(Corner::NW) != north.corner(Corner::SW) || corner(Corner::NE) != north.corner(Corner::SE))
                 {
-                    add_quad(self, Quad(north.corner(Corner::SW), corner(Corner::NE), corner(Corner::NW), north.corner(Corner::SE), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableUp), _room));
+                    add_quad(self, Quad(north.corner(Corner::SW), corner(Corner::NE), corner(Corner::NW), north.corner(Corner::SE), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableNorth), _room));
                 }
             }
 
@@ -513,7 +513,7 @@ namespace trview
             {
                 if (corner(Corner::SW) != south.corner(Corner::NW) || corner(Corner::SE) != south.corner(Corner::NE))
                 {
-                    add_quad(self, Quad(corner(Corner::SW), south.corner(Corner::NE), south.corner(Corner::NW), corner(Corner::SE), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableDown), _room));
+                    add_quad(self, Quad(corner(Corner::SW), south.corner(Corner::NE), south.corner(Corner::NW), corner(Corner::SE), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableSouth), _room));
                 }
             }
 
@@ -521,7 +521,7 @@ namespace trview
             {
                 if (corner(Corner::NE) != east.corner(Corner::NW) || corner(Corner::SE) != east.corner(Corner::SW))
                 {
-                    add_quad(self, Quad(corner(Corner::SE), east.corner(Corner::NW), east.corner(Corner::SW), corner(Corner::NE), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableRight), _room));
+                    add_quad(self, Quad(corner(Corner::SE), east.corner(Corner::NW), east.corner(Corner::SW), corner(Corner::NE), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableEast), _room));
                 }
             }
 
@@ -529,7 +529,7 @@ namespace trview
             {
                 if (corner(Corner::NW) != west.corner(Corner::NE) || corner(Corner::SW) != west.corner(Corner::SE))
                 {
-                    add_quad(self, Quad(west.corner(Corner::SE), corner(Corner::NW), corner(Corner::SW), west.corner(Corner::NE), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableLeft), _room));
+                    add_quad(self, Quad(west.corner(Corner::SE), corner(Corner::NW), corner(Corner::SW), west.corner(Corner::NE), wall_flags & (~SectorFlag::Climbable | SectorFlag::ClimbableWest), _room));
                 }
             }
         }

--- a/trview.app/Elements/Types.h
+++ b/trview.app/Elements/Types.h
@@ -14,16 +14,16 @@ namespace trview
         Death = 0x8,
         FloorSlant = 0x10,
         CeilingSlant = 0x20,
-        ClimbableUp = 0x40, // Top edge is climbable 
-        ClimbableRight = 0x80, // Right edge is climbable 
-        ClimbableDown = 0x100, // Bottom edge is climbable 
-        ClimbableLeft = 0x200, // Left edge is climbable
+        ClimbableNorth = 0x40, // Top edge is climbable 
+        ClimbableEast = 0x80, // Right edge is climbable 
+        ClimbableSouth = 0x100, // Bottom edge is climbable 
+        ClimbableWest = 0x200, // Left edge is climbable
         MonkeySwing = 0x400,
         RoomAbove = 0x800, // There is a ceiling portal above
         RoomBelow = 0x1000, // There is a floor portal 
         MinecartLeft = 0x2000, // Minecart turns left, Trigger Triggerer in TR4+
         MinecartRight = 0x4000, // Minecart turns right
-        Climbable = ClimbableUp | ClimbableRight | ClimbableDown | ClimbableLeft
+        Climbable = ClimbableNorth | ClimbableEast | ClimbableSouth | ClimbableWest
     };
 
     enum ClimbableWalls

--- a/trview.app/UI/MapColours.cpp
+++ b/trview.app/UI/MapColours.cpp
@@ -14,10 +14,10 @@ namespace trview
             { SectorFlag::MinecartLeft, { 0.0f, 0.9f, 0.9f } },
             { SectorFlag::MinecartRight, { 0.0f, 0.9f, 0.9f } },
             { SectorFlag::MonkeySwing, { 0.9f, 0.9f, 0.4f } },
-            { SectorFlag::ClimbableUp, { 0.6f, 0.0f, 0.9f, 0.0f } },
-            { SectorFlag::ClimbableDown, { 0.6f, 0.0f, 0.9f, 0.0f } },
-            { SectorFlag::ClimbableRight, { 0.6f, 0.0f, 0.9f, 0.0f } },
-            { SectorFlag::ClimbableLeft, { 0.6f, 0.0f, 0.9f, 0.0f } },
+            { SectorFlag::ClimbableNorth, { 0.6f, 0.0f, 0.9f, 0.0f } },
+            { SectorFlag::ClimbableSouth, { 0.6f, 0.0f, 0.9f, 0.0f } },
+            { SectorFlag::ClimbableEast, { 0.6f, 0.0f, 0.9f, 0.0f } },
+            { SectorFlag::ClimbableWest, { 0.6f, 0.0f, 0.9f, 0.0f } },
         };
 
         const std::unordered_map<MapColours::Special, Colour> default_special_colours = {
@@ -80,7 +80,7 @@ namespace trview
                 auto key = color.first;
                 if (has_flag(flags, key)
                     && (static_cast<int>(key) < minimum_flag_enabled || minimum_flag_enabled == -1)
-                    && (key < SectorFlag::ClimbableUp || key > SectorFlag::ClimbableLeft)) // climbable flag handled separately
+                    && (key < SectorFlag::ClimbableNorth || key > SectorFlag::ClimbableWest)) // climbable flag handled separately
                 {
                     minimum_flag_enabled = static_cast<int>(key);
                     auto override_colour = _override_colours.find(key);

--- a/trview.app/UI/MapRenderer.cpp
+++ b/trview.app/UI/MapRenderer.cpp
@@ -86,14 +86,14 @@ namespace trview
             // In the future I'd like to just draw a hollow square instead.
             const float thickness = _DRAW_SCALE / 4;
 
-            if (has_flag(tile.sector->flags(), SectorFlag::ClimbableUp))
-                draw(tile.position, Size(tile.size.width, thickness), _colours.colour(SectorFlag::ClimbableUp));
-            if (has_flag(tile.sector->flags(), SectorFlag::ClimbableRight))
-                draw(Point(tile.position.x + _DRAW_SCALE - thickness, tile.position.y), Size(thickness, tile.size.height), _colours.colour(SectorFlag::ClimbableRight));
-            if (has_flag(tile.sector->flags(), SectorFlag::ClimbableDown))
-                draw(Point(tile.position.x, tile.position.y + _DRAW_SCALE - thickness), Size(tile.size.width, thickness), _colours.colour(SectorFlag::ClimbableDown));
-            if (has_flag(tile.sector->flags(), SectorFlag::ClimbableLeft))
-                draw(tile.position, Size(thickness, tile.size.height), _colours.colour(SectorFlag::ClimbableLeft));
+            if (has_flag(tile.sector->flags(), SectorFlag::ClimbableNorth))
+                draw(tile.position, Size(tile.size.width, thickness), _colours.colour(SectorFlag::ClimbableNorth));
+            if (has_flag(tile.sector->flags(), SectorFlag::ClimbableEast))
+                draw(Point(tile.position.x + _DRAW_SCALE - thickness, tile.position.y), Size(thickness, tile.size.height), _colours.colour(SectorFlag::ClimbableEast));
+            if (has_flag(tile.sector->flags(), SectorFlag::ClimbableSouth))
+                draw(Point(tile.position.x, tile.position.y + _DRAW_SCALE - thickness), Size(tile.size.width, thickness), _colours.colour(SectorFlag::ClimbableSouth));
+            if (has_flag(tile.sector->flags(), SectorFlag::ClimbableWest))
+                draw(tile.position, Size(thickness, tile.size.height), _colours.colour(SectorFlag::ClimbableWest));
 
             // If sector is a down portal, draw a transparent black square over it 
             if (has_flag(tile.sector->flags(), SectorFlag::RoomBelow))

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -110,10 +110,10 @@ namespace trview
                     add_colour("Minecart Left", SectorFlag::MinecartLeft);
                     add_colour("Minecart Right", SectorFlag::MinecartRight);
                     add_colour("Monkey Swing", SectorFlag::MonkeySwing);
-                    add_colour("Climbable Up", SectorFlag::ClimbableUp);
-                    add_colour("Climbable Down", SectorFlag::ClimbableDown);
-                    add_colour("Climbable Right", SectorFlag::ClimbableRight);
-                    add_colour("Climbable Left", SectorFlag::ClimbableLeft);
+                    add_colour("Climbable North", SectorFlag::ClimbableNorth);
+                    add_colour("Climbable South", SectorFlag::ClimbableSouth);
+                    add_colour("Climbable East", SectorFlag::ClimbableEast);
+                    add_colour("Climbable West", SectorFlag::ClimbableWest);
                     add_special("No Space", MapColours::Special::NoSpace);
                     add_special("Room Above", MapColours::Special::RoomAbove);
                     add_special("Room Below", MapColours::Special::RoomBelow);


### PR DESCRIPTION
Rename Climbable Up/Right/Down/Left to North/Eath/South/West as this makes more sense when dealing with level geometry. The previous version made sense when only dealing with the minimap.
Closes #948