### PR TITLE
Allow rooms to be hidden

### DIFF
--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -114,3 +114,22 @@ TEST(RoomsWindowManager, MapColoursPassedToNewWindows)
     manager->create_window();
 }
 
+TEST(RoomsWindowManager, OnRoomVisibilityRaised)
+{
+    auto manager = register_test_module().build();
+    auto room = mock_shared<MockRoom>();
+
+    std::optional<std::tuple<std::weak_ptr<IRoom>, bool>> raised;
+    auto token = manager->on_room_visibility += [&](auto&& value, auto&& visible)
+    {
+        raised = { value, visible };
+    };
+
+    auto window = manager->create_window().lock();
+    ASSERT_NE(window, nullptr);
+
+    window->on_room_visibility(room, true);
+    ASSERT_TRUE(raised.has_value());
+    ASSERT_EQ(std::get<0>(raised.value()).lock(), room);
+    ASSERT_TRUE(std::get<1>(raised.value()));
+}

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -18,6 +18,7 @@
 #include <trview.app/Mocks/Graphics/ISectorHighlight.h>
 #include <trlevel/Mocks/ILevel.h>
 #include <trview.app/Mocks/Routing/IWaypoint.h>
+#include <trview.app/Mocks/Elements/ILight.h>
 #include "TestImgui.h"
 
 using testing::Return;
@@ -683,4 +684,60 @@ TEST(Viewer, SetShowItems)
 
     viewer->open(&level);
     ui.on_toggle_changed(IViewer::Options::items, true);
+}
+
+TEST(Viewer, LightVisibilityRaised)
+{
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    auto [picking_ptr, picking] = create_mock<MockPicking>();
+    auto [mouse_ptr, mouse] = create_mock<MockMouse>();
+
+    NiceMock<MockLevel> level;
+    std::vector<std::weak_ptr<ILight>> lights_list(101);
+    auto light = mock_shared<MockLight>();
+    lights_list[100] = light;
+
+    EXPECT_CALL(level, lights).WillRepeatedly([&]() { return lights_list; });
+
+    auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
+    viewer->open(&level);
+
+    std::optional<std::tuple<std::weak_ptr<ILight>, bool>> raised_light;
+    auto token = viewer->on_light_visibility += [&raised_light](const auto& light, auto visible) { raised_light = { light, visible }; };
+
+    activate_context_menu(picking, mouse, PickResult::Type::Light, 100);
+
+    ui.on_hide();
+
+    ASSERT_TRUE(raised_light.has_value());
+    ASSERT_EQ(std::get<0>(raised_light.value()).lock(), light);
+    ASSERT_FALSE(std::get<1>(raised_light.value()));
+}
+
+TEST(Viewer, RoomVisibilityRaised)
+{
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    auto [picking_ptr, picking] = create_mock<MockPicking>();
+    auto [mouse_ptr, mouse] = create_mock<MockMouse>();
+
+    NiceMock<MockLevel> level;
+    std::vector<std::weak_ptr<IRoom>> rooms_list(101);
+    auto room = mock_shared<MockRoom>();
+    rooms_list[100] = room;
+
+    EXPECT_CALL(level, rooms).WillRepeatedly([&]() { return rooms_list; });
+
+    auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
+    viewer->open(&level);
+
+    std::optional<std::tuple<std::weak_ptr<IRoom>, bool>> raised_room;
+    auto token = viewer->on_room_visibility += [&raised_room](const auto& room, auto visible) { raised_room = { room, visible }; };
+
+    activate_context_menu(picking, mouse, PickResult::Type::Room, 100);
+
+    ui.on_hide();
+
+    ASSERT_TRUE(raised_room.has_value());
+    ASSERT_EQ(std::get<0>(raised_room.value()).lock(), room);
+    ASSERT_FALSE(std::get<1>(raised_room.value()));
 }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -298,8 +298,15 @@ namespace trview
         _token_store += _view_menu.on_show_tools += [&](bool show) { _viewer->set_show_tools(show); };
         _token_store += _view_menu.on_unhide_all += [&]()
         {
+            if (!_level)
+            {
+                return;
+            }
+
             for (const auto& item : _level->items()) { if (!item.visible()) { set_item_visibility(item, true); } }
             for (const auto& trigger : _level->triggers()) { set_trigger_visibility(trigger, true); }
+            for (const auto& light : _level->lights()) { set_light_visibility(light, true); }
+            for (const auto& room : _level->rooms()) { set_room_visibility(room, true); }
         };
     }
 
@@ -312,6 +319,7 @@ namespace trview
         _token_store += _viewer->on_trigger_visibility += [this](const auto& trigger, bool value) { set_trigger_visibility(trigger, value); };
         _token_store += _viewer->on_light_selected += [this](const auto& light) { select_light(light); };
         _token_store += _viewer->on_light_visibility += [this](const auto& light, bool value) { set_light_visibility(light, value); };
+        _token_store += _viewer->on_room_visibility += [this](const auto& room, bool value) { set_room_visibility(room, value); };
         _token_store += _viewer->on_waypoint_added += [this](const auto& position, const auto& normal, auto room, auto type, auto index) { add_waypoint(position, normal, room, type, index); };
         _token_store += _viewer->on_waypoint_selected += [this](auto index) { select_waypoint(index); };
         _token_store += _viewer->on_waypoint_removed += [this](auto index) { remove_waypoint(index); };
@@ -382,6 +390,7 @@ namespace trview
         _token_store += _rooms_windows->on_room_selected += [this](const auto& room) { select_room(room); };
         _token_store += _rooms_windows->on_item_selected += [this](const auto& item) { select_item(item); };
         _token_store += _rooms_windows->on_trigger_selected += [this](const auto& trigger) { select_trigger(trigger); };
+        _token_store += _rooms_windows->on_room_visibility += [this](const auto& room, bool value) { set_room_visibility(room, value); };
     }
 
     void Application::setup_route_window()
@@ -583,6 +592,22 @@ namespace trview
             if (light_ptr->visible() != visible)
             {
                 _level->set_light_visibility(light_ptr->number(), visible);
+            }
+        }
+    }
+
+    void Application::set_room_visibility(const std::weak_ptr<IRoom>& room, bool visible)
+    {
+        if (!_level)
+        {
+            return;
+        }
+
+        if (const auto room_ptr = room.lock())
+        {
+            if (room_ptr->visible() != visible)
+            {
+                _level->set_room_visibility(room_ptr->number(), visible);
             }
         }
     }

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -90,6 +90,7 @@ namespace trview
         void set_item_visibility(const Item& item, bool visible);
         void set_trigger_visibility(const std::weak_ptr<ITrigger>& trigger, bool visible);
         void set_light_visibility(const std::weak_ptr<ILight>& light, bool visible);
+        void set_room_visibility(const std::weak_ptr<IRoom>& room, bool visible);
         // Lua
         void register_lua();
         bool should_discard_changes();

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -92,6 +92,7 @@ namespace trview
         virtual void set_selected_room(uint16_t index) = 0;
         virtual void set_selected_item(uint32_t index) = 0;
         virtual void set_light_visibility(uint32_t index, bool state) = 0;
+        virtual void set_room_visibility(uint32_t index, bool state) = 0;
         virtual bool show_hidden_geometry() const = 0;
         virtual bool show_lights() const = 0;
         virtual bool show_triggers() const = 0;

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -294,6 +294,14 @@ namespace trview
         /// </summary>
         /// <returns>The X/Z scaled position of the room.</returns>
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
+        /// <summary>
+        /// Gets whether the room is visible.
+        /// </summary>
+        virtual bool visible() const = 0;
+        /// <summary>
+        /// Sets whether the room is visible.
+        /// </summary>
+        virtual void set_visible(bool visible) = 0;
     };
 }
 

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -357,7 +357,7 @@ namespace trview
             for (uint16_t i : _neighbours)
             {
                 const auto& room = _rooms[i];
-                if (is_alternate_mismatch(*room) || !in_view(*room))
+                if (!room->visible() || is_alternate_mismatch(*room) || !in_view(*room))
                 {
                     continue;
                 }
@@ -369,7 +369,7 @@ namespace trview
             for (std::size_t i = 0; i < _rooms.size(); ++i)
             {
                 const auto& room = _rooms[i].get();
-                if (is_alternate_mismatch(*room) || !in_view(*room))
+                if (!room->visible() || is_alternate_mismatch(*room) || !in_view(*room))
                 {
                     continue;
                 }
@@ -886,6 +886,13 @@ namespace trview
     void Level::set_light_visibility(uint32_t index, bool state)
     {
         _lights[index]->set_visible(state);
+        _regenerate_transparency = true;
+        on_level_changed();
+    }
+
+    void Level::set_room_visibility(uint32_t index, bool state)
+    {
+        _rooms[index]->set_visible(state);
         _regenerate_transparency = true;
         on_level_changed();
     }

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -88,6 +88,7 @@ namespace trview
         virtual void set_filename(const std::string& filename) override;
         virtual std::vector<std::weak_ptr<ILight>> lights() const override;
         virtual void set_light_visibility(uint32_t index, bool state) override;
+        virtual void set_room_visibility(uint32_t index, bool state) override;
         virtual void set_use_trle_colours(bool value) override;
         virtual bool use_trle_colours() const override;
         virtual MapColours map_colours() const override;

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -1021,4 +1021,14 @@ namespace trview
     {
         return Vector3(_info.x / trlevel::Scale_X, 0, _info.z / trlevel::Scale_Z);
     }
+
+    bool Room::visible() const
+    {
+        return _visible;
+    }
+
+    void Room::set_visible(bool visible)
+    {
+        _visible = visible;
+    }
 }

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -73,6 +73,8 @@ namespace trview
         virtual ISector::Portal sector_portal(int x1, int y1, int x2, int z2) const override;
         virtual void set_sector_triangle_rooms(const std::vector<uint32_t>& triangles) override;
         virtual DirectX::SimpleMath::Vector3 position() const override;
+        virtual bool visible() const override;
+        virtual void set_visible(bool visible) override;
     private:
         void generate_geometry(trlevel::LevelVersion level_version, const IMesh::Source& mesh_source, const trlevel::tr3_room& room);
         void generate_adjacency();
@@ -141,5 +143,7 @@ namespace trview
         IMesh::Source _mesh_source;
         std::vector<uint32_t> _trle_sector_rooms;
         std::function<std::shared_ptr<IMesh>()> _unmatched_mesh_generator;
+
+        bool _visible{ true };
     };
 }

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -47,6 +47,7 @@ namespace trview
             MOCK_METHOD(void, set_selected_room, (uint16_t), (override));
             MOCK_METHOD(void, set_selected_item, (uint32_t), (override));
             MOCK_METHOD(void, set_light_visibility, (uint32_t, bool), (override));
+            MOCK_METHOD(void, set_room_visibility, (uint32_t, bool), (override));
             MOCK_METHOD(bool, show_hidden_geometry, (), (const, override));
             MOCK_METHOD(bool, show_lights, (), (const, override));
             MOCK_METHOD(bool, show_triggers, (), (const, override));

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockRoom : public IRoom
+        struct MockRoom : public IRoom, public std::enable_shared_from_this<MockRoom>
         {
             virtual ~MockRoom() = default;
             MOCK_METHOD(void, add_entity, (const std::weak_ptr<IEntity>&), (override));
@@ -44,6 +44,14 @@ namespace trview
             MOCK_METHOD(ISector::Portal, sector_portal, (int, int, int, int), (const, override));
             MOCK_METHOD(void, set_sector_triangle_rooms, (const std::vector<uint32_t>&), (override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
+            MOCK_METHOD(bool, visible, (), (const, override));
+            MOCK_METHOD(void, set_visible, (bool visible), (override));
+
+            std::shared_ptr<MockRoom> with_number(uint32_t number)
+            {
+                ON_CALL(*this, number).WillByDefault(testing::Return(number));
+                return shared_from_this();
+            }
         };
     }
 }

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -27,6 +27,8 @@ namespace trview
         /// Event raised when the window is closed.
         Event<> on_window_closed;
 
+        Event<std::weak_ptr<IRoom>, bool> on_room_visibility;
+
         /// Clear the selected trigger.
         virtual void clear_selected_trigger() = 0;
 

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -17,6 +17,8 @@ namespace trview
         /// Event raised when the user has selected a trigger in the room window.
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
+        Event<std::weak_ptr<IRoom>, bool> on_room_visibility;
+
         /// Render all of the rooms windows.
         virtual void render() = 0;
 

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -62,6 +62,8 @@ namespace trview
         /// </summary>
         Event<std::weak_ptr<ILight>, bool> on_light_visibility;
 
+        Event<std::weak_ptr<IRoom>, bool> on_room_visibility;
+
         /// Event raised when the viewer wants to select a waypoint.
         Event<uint32_t> on_waypoint_selected;
 

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -18,18 +18,11 @@ namespace trview
     public:
         struct Names
         {
-            static const std::string sync_room;
-            static const std::string track_item;
-            static const std::string track_trigger;
-            static const std::string rooms_listbox;
-            static const std::string triggers_listbox;
-            static const std::string stats_listbox;
-            static const std::string minimap;
-            static const std::string neighbours_listbox;
-            static const std::string items_listbox;
             static inline const std::string details_panel = "Room Details";
             static inline const std::string properties = "Properties";
             static inline const std::string bottom = "##bottom";
+            static inline const std::string rooms_panel = "Rooms List";
+            static inline const std::string rooms_list = "##roomslist";
         };
 
         /// Create a rooms window as a child of the specified window.

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -109,6 +109,7 @@ namespace trview
         rooms_window->on_room_selected += on_room_selected;
         rooms_window->on_item_selected += on_item_selected;
         rooms_window->on_trigger_selected += on_trigger_selected;
+        rooms_window->on_room_visibility += on_room_visibility;
         rooms_window->set_level_version(_level_version);
         rooms_window->set_items(_all_items);
         rooms_window->set_triggers(_all_triggers);

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -167,6 +167,10 @@ namespace trview
             {
                 on_light_visibility(_level->lights()[_context_pick.index], false);
             }
+            else if (_context_pick.type == PickResult::Type::Room)
+            {
+                on_room_visibility(_level->rooms()[_context_pick.index], false);
+            }
         };
         _token_store += _ui->on_orbit += [&]()
         {
@@ -488,7 +492,7 @@ namespace trview
                 _ui->set_show_context_menu(true);
                 _camera_input.reset(true);
                 _ui->set_remove_waypoint_enabled(_current_pick.type == PickResult::Type::Waypoint);
-                _ui->set_hide_enabled(_current_pick.type == PickResult::Type::Entity || _current_pick.type == PickResult::Type::Trigger);
+                _ui->set_hide_enabled(equals_any(_current_pick.type, PickResult::Type::Entity, PickResult::Type::Trigger, PickResult::Type::Light, PickResult::Type::Room));
                 _ui->set_mid_waypoint_enabled(_current_pick.type == PickResult::Type::Room && _current_pick.triangle.normal.y < 0);
             }
         };

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -133,13 +133,7 @@
     <ClCompile Include="Graphics\TextureStorage.cpp">
       <Filter>Graphics</Filter>
     </ClCompile>
-    <ClCompile Include="Elements\Level.cpp">
-      <Filter>Elements</Filter>
-    </ClCompile>
     <ClCompile Include="Elements\Entity.cpp">
-      <Filter>Elements</Filter>
-    </ClCompile>
-    <ClCompile Include="Elements\Room.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
     <ClCompile Include="Elements\StaticMesh.cpp">
@@ -183,9 +177,6 @@
     <ClCompile Include="ApplicationLuaRegistry.cpp" />
     <ClCompile Include="UI\IViewerUI.cpp">
       <Filter>UI</Filter>
-    </ClCompile>
-    <ClCompile Include="Elements\ILevel.cpp">
-      <Filter>Elements</Filter>
     </ClCompile>
     <ClCompile Include="Geometry\IPicking.cpp">
       <Filter>Geometry</Filter>
@@ -236,9 +227,6 @@
       <Filter>Graphics</Filter>
     </ClCompile>
     <ClCompile Include="Elements\IEntity.cpp">
-      <Filter>Elements</Filter>
-    </ClCompile>
-    <ClCompile Include="Elements\IRoom.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
     <ClCompile Include="Settings\StartupOptions.cpp">
@@ -375,6 +363,18 @@
       <Filter>UI\Settings</Filter>
     </ClCompile>
     <ClCompile Include="ApplicationCreate.cpp" />
+    <ClCompile Include="Elements\IRoom.cpp">
+      <Filter>Elements\Room</Filter>
+    </ClCompile>
+    <ClCompile Include="Elements\Room.cpp">
+      <Filter>Elements\Room</Filter>
+    </ClCompile>
+    <ClCompile Include="Elements\ILevel.cpp">
+      <Filter>Elements\Level</Filter>
+    </ClCompile>
+    <ClCompile Include="Elements\Level.cpp">
+      <Filter>Elements\Level</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -461,9 +461,6 @@
     <ClInclude Include="Windows\WindowResizer.h">
       <Filter>Windows</Filter>
     </ClInclude>
-    <ClInclude Include="Elements\RoomInfo.h">
-      <Filter>Elements</Filter>
-    </ClInclude>
     <ClInclude Include="Elements\Item.h">
       <Filter>Elements</Filter>
     </ClInclude>
@@ -527,13 +524,7 @@
     <ClInclude Include="Graphics\TextureStorage.h">
       <Filter>Graphics</Filter>
     </ClInclude>
-    <ClInclude Include="Elements\Level.h">
-      <Filter>Elements</Filter>
-    </ClInclude>
     <ClInclude Include="Elements\Entity.h">
-      <Filter>Elements</Filter>
-    </ClInclude>
-    <ClInclude Include="Elements\Room.h">
       <Filter>Elements</Filter>
     </ClInclude>
     <ClInclude Include="Elements\StaticMesh.h">
@@ -585,9 +576,6 @@
     </ClInclude>
     <ClInclude Include="Mocks\UI\IViewerUI.h">
       <Filter>Mocks\UI</Filter>
-    </ClInclude>
-    <ClInclude Include="Elements\ILevel.h">
-      <Filter>Elements</Filter>
     </ClInclude>
     <ClInclude Include="Geometry\IPicking.h">
       <Filter>Geometry</Filter>
@@ -720,9 +708,6 @@
     </ClInclude>
     <ClInclude Include="Mocks\Elements\IEntity.h">
       <Filter>Mocks\Elements</Filter>
-    </ClInclude>
-    <ClInclude Include="Elements\IRoom.h">
-      <Filter>Elements</Filter>
     </ClInclude>
     <ClInclude Include="Mocks\Elements\IRoom.h">
       <Filter>Mocks\Elements</Filter>
@@ -921,6 +906,21 @@
     <ClInclude Include="Windows\WindowManager.hpp">
       <Filter>Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Elements\IRoom.h">
+      <Filter>Elements\Room</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\Room.h">
+      <Filter>Elements\Room</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\RoomInfo.h">
+      <Filter>Elements\Room</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\ILevel.h">
+      <Filter>Elements\Level</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\Level.h">
+      <Filter>Elements\Level</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">
@@ -1027,6 +1027,12 @@
     </Filter>
     <Filter Include="Filters">
       <UniqueIdentifier>{a6d785cd-7837-4b30-8a3f-85d4aa1b995b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Elements\Room">
+      <UniqueIdentifier>{c8bc7920-95a8-4a25-b9f1-f888a40a6eb3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Elements\Level">
+      <UniqueIdentifier>{9f0dcfc1-ab39-412a-92f2-2e75ae598aea}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Add hide functionality for rooms. Adds a checkbox in the rooms window and allows you to hide a room with the context menu.
Also adds to unhide all, along with lights which was missed before.
Closes #951