### PR TITLE
Apply rotation to waypoint bounding boxes

### DIFF
--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -2,29 +2,30 @@
 #include <trview.app/Camera/ICamera.h>
 #include <trview.common/Maths.h>
 
+using namespace DirectX;
 using namespace DirectX::SimpleMath;
 
 namespace trview
 {
     namespace
     {
+        const float PoleLength = 0.5f;
+        const float HalfPoleLength = 0.5f * PoleLength;
         const float PoleThickness = 0.05f;
         const float RopeThickness = 0.015f;
     }
 
-    Waypoint::Waypoint(std::shared_ptr<IMesh> mesh, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, Type type, uint32_t index, const Colour& route_colour)
+    Waypoint::Waypoint(std::shared_ptr<IMesh> mesh, const Vector3& position, const Vector3& normal, uint32_t room, Type type, uint32_t index, const Colour& route_colour)
         : _mesh(mesh), _position(position), _normal(normal), _type(type), _index(index), _room(room), _route_colour(route_colour)
     {
     }
 
     void Waypoint::render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const Color& colour)
     {
-        using namespace DirectX::SimpleMath;
-
         Matrix rotation = calculate_waypoint_rotation();
 
         // The pole
-        const auto pole_world = Matrix::CreateScale(PoleThickness, 0.5f, PoleThickness) * Matrix::CreateTranslation(0, -0.25f, 0) * rotation * Matrix::CreateTranslation(_position);
+        const auto pole_world = Matrix::CreateScale(PoleThickness, PoleLength, PoleThickness) * Matrix::CreateTranslation(0, -HalfPoleLength, 0) * rotation * Matrix::CreateTranslation(_position);
         auto light_direction = Vector3::TransformNormal(_position - camera.position(), pole_world.Invert());
         light_direction.Normalize();
 
@@ -32,11 +33,11 @@ namespace trview
         _mesh->render(pole_wvp, texture_storage, colour, 0.75f, light_direction);
 
         // The light blob.
-        auto blob_wvp = Matrix::CreateScale(PoleThickness, PoleThickness, PoleThickness) * Matrix::CreateTranslation(-Vector3(0, 0.5f + PoleThickness * 0.5f, 0)) * rotation * Matrix::CreateTranslation(_position) * camera.view_projection();
+        auto blob_wvp = Matrix::CreateScale(PoleThickness, PoleThickness, PoleThickness) * Matrix::CreateTranslation(-Vector3(0, PoleLength + PoleThickness * 0.5f, 0)) * rotation * Matrix::CreateTranslation(_position) * camera.view_projection();
         _mesh->render(blob_wvp, texture_storage, _route_colour);
     }
 
-    void Waypoint::render_join(const IWaypoint& next_waypoint, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour)
+    void Waypoint::render_join(const IWaypoint& next_waypoint, const ICamera& camera, const ILevelTextureStorage& texture_storage, const Color& colour)
     {
         const auto current = blob_position();
         const auto next_waypoint_pos = next_waypoint.blob_position();
@@ -45,35 +46,39 @@ namespace trview
         const auto matrix =
             (to.x == 0 && to.z == 0)
             ? Matrix::CreateRotationX(maths::Pi * 0.5f) * Matrix::CreateTranslation(mid)
-            : Matrix(DirectX::XMMatrixLookAtRH(mid, next_waypoint_pos, Vector3::Up)).Invert();
+            : Matrix(XMMatrixLookAtRH(mid, next_waypoint_pos, Vector3::Up)).Invert();
         const auto length = to.Length();
         const auto to_wvp = Matrix::CreateScale(RopeThickness, RopeThickness, length) * matrix * camera.view_projection();
         _mesh->render(to_wvp, texture_storage, colour);
     }
 
-    void Waypoint::get_transparent_triangles(ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&)
+    void Waypoint::get_transparent_triangles(ITransparencyBuffer&, const ICamera&, const Color&)
     {
     }
 
-    DirectX::BoundingBox Waypoint::bounding_box() const
+    BoundingBox Waypoint::bounding_box() const
     {
-        return DirectX::BoundingBox(position() - Vector3(0, 0.25f, 0), Vector3(PoleThickness, 0.5f, PoleThickness) * 0.5f);
+        const float length = PoleLength + PoleThickness;
+        BoundingBox box(Vector3(0, -0.5f * length, 0), Vector3(PoleThickness, length, PoleThickness) * 0.5f);
+        Matrix transform = calculate_waypoint_rotation() * Matrix::CreateTranslation(position());
+        box.Transform(box, transform);
+        return box;
     }
 
-    DirectX::SimpleMath::Vector3 Waypoint::position() const
+    Vector3 Waypoint::position() const
     {
         return _position;
     }
 
-    DirectX::SimpleMath::Vector3 Waypoint::blob_position() const
+    Vector3 Waypoint::blob_position() const
     {
-        auto matrix = Matrix::CreateTranslation(-Vector3(0, 0.5f + PoleThickness * 0.5f, 0)) * calculate_waypoint_rotation() * Matrix::CreateTranslation(_position);
+        auto matrix = Matrix::CreateTranslation(-Vector3(0, PoleLength + PoleThickness * 0.5f, 0)) * calculate_waypoint_rotation() * Matrix::CreateTranslation(_position);
         return Vector3::Transform(Vector3(), matrix);
     }
 
     Matrix Waypoint::calculate_waypoint_rotation() const
     {
-        Matrix rotation = Matrix(DirectX::XMMatrixLookAtRH(Vector3::Zero, _normal, Vector3::Up)).Invert();
+        Matrix rotation = Matrix(XMMatrixLookAtRH(Vector3::Zero, _normal, Vector3::Up)).Invert();
         rotation = Matrix::CreateRotationX(maths::Pi * 0.5f) * rotation;
 
         if (_normal == Vector3::Down)


### PR DESCRIPTION
Apply the current waypoint rotation to bounding boxes for waypoints so they can be reliably clicked on.
Add a few constants to waypoints since numbers were all over the place.
Add some `using namespace`s.
Closes #960