### PR TITLE
Disable waypoint selection rendering when selection is hidden

### DIFF
--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -294,7 +294,7 @@ TEST(Route, Render)
  
     NiceMock<MockCamera> camera;
     NiceMock<MockLevelTextureStorage> texture_storage;
-    route->render(camera, texture_storage);
+    route->render(camera, texture_storage, true);
 }
 
 TEST(Route, RenderDoesNotJoinWhenRandoEnabled)
@@ -331,5 +331,31 @@ TEST(Route, RenderDoesNotJoinWhenRandoEnabled)
 
     NiceMock<MockCamera> camera;
     NiceMock<MockLevelTextureStorage> texture_storage;
-    route->render(camera, texture_storage);
+    route->render(camera, texture_storage, true);
+}
+
+TEST(Route, RenderShowsSelection)
+{
+    auto [selection_renderer_ptr, selection_renderer] = create_mock<MockSelectionRenderer>();
+    EXPECT_CALL(selection_renderer, render).Times(1);
+
+    NiceMock<MockCamera> camera;
+    NiceMock<MockLevelTextureStorage> texture_storage;
+
+    auto route = register_test_module().with_selection_renderer(std::move(selection_renderer_ptr)).build();
+    route->add(Vector3::Zero, Vector3::Down, 0);
+    route->render(camera, texture_storage, true);
+}
+
+TEST(Route, RenderDoesNotShowSelection)
+{
+    auto [selection_renderer_ptr, selection_renderer] = create_mock<MockSelectionRenderer>();
+    EXPECT_CALL(selection_renderer, render).Times(0);
+
+    NiceMock<MockCamera> camera;
+    NiceMock<MockLevelTextureStorage> texture_storage;
+
+    auto route = register_test_module().with_selection_renderer(std::move(selection_renderer_ptr)).build();
+    route->add(Vector3::Zero, Vector3::Down, 0);
+    route->render(camera, texture_storage, false);
 }

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -20,6 +20,7 @@
 #include <trview.app/Mocks/Routing/IWaypoint.h>
 #include "TestImgui.h"
 
+using testing::A;
 using testing::Return;
 using testing::NiceMock;
 using namespace trview;
@@ -71,6 +72,12 @@ namespace
                 EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
                 return std::make_unique<Viewer>(window, device, std::move(ui), std::move(picking), std::move(mouse), shortcuts, route, sprite_source,
                     std::move(compass), std::move(measure), render_target_source, device_window_source, std::move(sector_highlight));
+            }
+
+            test_module& with_device(const std::shared_ptr<IDevice>& device)
+            {
+                this->device = device;
+                return *this;
             }
 
             test_module& with_ui(std::unique_ptr<IViewerUI> ui)
@@ -683,4 +690,45 @@ TEST(Viewer, SetShowItems)
 
     viewer->open(&level);
     ui.on_toggle_changed(IViewer::Options::items, true);
+}
+
+TEST(Viewer, SelectionRendered)
+{
+    auto device = mock_shared<MockDevice>();
+    Microsoft::WRL::ComPtr<ID3D11DeviceContext> context{ new NiceMock<MockD3D11DeviceContext>() };
+    EXPECT_CALL(*device, context).WillRepeatedly(Return(context));
+
+    auto viewer = register_test_module().with_device(device).build();
+
+    NiceMock<MockLevelTextureStorage> texture_storage;
+    NiceMock<MockLevel> level;
+    ON_CALL(level, texture_storage).WillByDefault(testing::ReturnRef(texture_storage));
+    EXPECT_CALL(level, render(A<const ICamera&>(), true)).Times(1);
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, render(A<const ICamera&>(), A<const ILevelTextureStorage&>(), true)).Times(1);
+
+    viewer->open(&level);
+    viewer->set_route(route);
+    viewer->render();
+}
+
+TEST(Viewer, SelectionNotRendered)
+{
+    auto device = mock_shared<MockDevice>();
+    Microsoft::WRL::ComPtr<ID3D11DeviceContext> context{ new NiceMock<MockD3D11DeviceContext>() };
+    EXPECT_CALL(*device, context).WillRepeatedly(Return(context));
+
+    auto viewer = register_test_module().with_device(device).build();
+
+    NiceMock<MockLevelTextureStorage> texture_storage;
+    NiceMock<MockLevel> level;
+    ON_CALL(level, texture_storage).WillByDefault(testing::ReturnRef(texture_storage));
+    EXPECT_CALL(level, render(A<const ICamera&>(), false)).Times(1);
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, render(A<const ICamera&>(), A<const ILevelTextureStorage&>(), false)).Times(1);
+
+    viewer->set_show_selection(false);
+    viewer->open(&level);
+    viewer->set_route(route);
+    viewer->render();
 }

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -21,7 +21,7 @@ namespace trview
             MOCK_METHOD(void, move, (int32_t, int32_t), (override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
             MOCK_METHOD(void, remove, (uint32_t), (override));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));
             MOCK_METHOD(uint32_t, selected_waypoint, (), (const, override));
             MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
             MOCK_METHOD(void, set_colour, (const Colour&), (override));

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -102,7 +102,8 @@ namespace trview
         /// </summary>
         /// <param name="camera">The camera to use to render.</param>
         /// <param name="texture_storage">Texture storage for the mesh.</param>
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage) = 0;
+        /// <param name="show_selection">Whether to show the selection outline.</param>
+        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) = 0;
         /// <summary>
         /// Get the index of the currently selected waypoint.
         /// </summary>

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -202,7 +202,7 @@ namespace trview
         set_unsaved(true);
     }
 
-    void Route::render(const ICamera& camera, const ILevelTextureStorage& texture_storage)
+    void Route::render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection)
     {
         for (std::size_t i = 0; i < _waypoints.size(); ++i)
         {
@@ -215,7 +215,7 @@ namespace trview
         }
 
         // Render selected waypoint...
-        if (_selected_index < _waypoints.size())
+        if (show_selection && _selected_index < _waypoints.size())
         {
             _selection_renderer->render(camera, texture_storage, *_waypoints[_selected_index], Color(1.0f, 1.0f, 1.0f));
         }

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -30,7 +30,7 @@ namespace trview
         virtual void move(int32_t left, int32_t right) override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
         virtual void remove(uint32_t index) override;
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage) override;
+        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) override;
         virtual uint32_t selected_waypoint() const override;
         virtual void select_waypoint(uint32_t index) override;
         virtual void set_colour(const Colour& colour) override;

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -82,9 +82,6 @@ namespace trview
         /// Event raised when a tool is selected.
         Event<Tool> on_tool_selected;
 
-        /// Event raised when something in the ui has changed.
-        Event<> on_ui_changed;
-
         /// Event raised when user edits camera position.
         Event<DirectX::SimpleMath::Vector3> on_camera_position;
 

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -183,7 +183,6 @@ namespace trview
         _map_renderer = map_renderer_source(window.size());
         _token_store += _map_renderer->on_sector_hover += [this](const std::shared_ptr<ISector>& sector)
         {
-            on_ui_changed();
             on_sector_hover(sector);
 
             if (!sector)

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -64,7 +64,6 @@ namespace trview
         std::unordered_map<std::string, std::function<void(int32_t)>> scalars;
         scalars[Options::depth] = [this](int32_t value) { if (_level) { _level->set_neighbour_depth(value); } };
 
-        _token_store += _ui->on_ui_changed += [&]() {_ui_changed = true; };
         _token_store += _ui->on_select_item += [&](uint32_t index)
         {
             if (_level && index < _level->items().size())
@@ -577,31 +576,25 @@ namespace trview
             _mouse_changed = false;
         }
 
-        _ui_changed = true;
+        _device->begin();
+        _main_window->begin();
+        _main_window->clear(Colour(_settings.background_colour));
 
-        if (_scene_changed || _ui_changed)
+        if (_scene_changed)
         {
-            _device->begin();
-            _main_window->begin();
-            _main_window->clear(Colour(_settings.background_colour));
+            _scene_target->clear(Colour::Transparent);
 
-            if (_scene_changed)
-            {
-                _scene_target->clear(Colour::Transparent);
+            graphics::RenderTargetStore rs_store(_device->context());
+            graphics::ViewportStore vp_store(_device->context());
+            _scene_target->apply();
 
-                graphics::RenderTargetStore rs_store(_device->context());
-                graphics::ViewportStore vp_store(_device->context());
-                _scene_target->apply();
-
-                render_scene();
-                _scene_changed = false;
-            }
-
-            _scene_sprite->render(_scene_target->texture(), 0, 0, window().size().width, window().size().height);
-            _ui->set_camera_position(current_camera().position());
-            _ui->set_camera_rotation(current_camera().rotation_yaw(), current_camera().rotation_pitch());
-            _ui_changed = false;
+            render_scene();
+            _scene_changed = false;
         }
+
+        _scene_sprite->render(_scene_target->texture(), 0, 0, window().size().width, window().size().height);
+        _ui->set_camera_position(current_camera().position());
+        _ui->set_camera_rotation(current_camera().rotation_yaw(), current_camera().rotation_pitch());
 
         lua_fire_event ( LuaEvent::ON_RENDER );
     }
@@ -641,7 +634,7 @@ namespace trview
 
             if (_show_route)
             {
-                _route->render(camera, _level->texture_storage());
+                _route->render(camera, _level->texture_storage(), _show_selection);
             }
 
             _level->render_transparency(camera);
@@ -777,7 +770,6 @@ namespace trview
     void Viewer::set_show_minimap(bool value)
     {
         _ui->set_show_minimap(value);
-        _ui_changed = true;
     }
 
     void Viewer::set_show_route(bool value)
@@ -801,13 +793,11 @@ namespace trview
     void Viewer::set_show_tooltip(bool value)
     {
         _ui->set_show_tooltip(value);
-        _ui_changed = true;
     }
 
     void Viewer::set_show_ui(bool value)
     {
         _ui->set_visible(value);
-        _ui_changed = true;
     }
 
     bool Viewer::ui_input_active() const

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -168,7 +168,6 @@ namespace trview
         std::unique_ptr<graphics::ISprite> _scene_sprite;
         bool _scene_changed{ true };
         bool _mouse_changed{ true };
-        bool _ui_changed{ true };
 
         std::vector<PickResult> _recent_orbits;
         std::size_t _recent_orbit_index{ 0u };

--- a/trview.graphics/IRenderTarget.h
+++ b/trview.graphics/IRenderTarget.h
@@ -37,7 +37,7 @@ namespace trview
 
             // Get the texture for the render target.
             // Returns: The texture.
-            virtual const Texture& texture() const = 0;
+            virtual Texture texture() const = 0;
 
             // Get the render target interface for the render target.
             // Returns: The render target.

--- a/trview.graphics/RenderTarget.cpp
+++ b/trview.graphics/RenderTarget.cpp
@@ -88,7 +88,7 @@ namespace trview
 
         // Get the texture for the render target.
         // Returns: The texture.
-        const Texture& RenderTarget::texture() const
+        Texture RenderTarget::texture() const
         {
             return _texture;
         }

--- a/trview.graphics/RenderTarget.h
+++ b/trview.graphics/RenderTarget.h
@@ -37,7 +37,7 @@ namespace trview
 
             // Get the texture for the render target.
             // Returns: The texture.
-            virtual const Texture& texture() const override;
+            virtual Texture texture() const override;
 
             // Get the render target interface for the render target.
             // Returns: The render target.

--- a/trview.graphics/mocks/IRenderTarget.h
+++ b/trview.graphics/mocks/IRenderTarget.h
@@ -13,7 +13,7 @@ namespace trview
                 virtual ~MockRenderTarget() = default;
                 MOCK_METHOD(void, clear, (const DirectX::SimpleMath::Color& colour), (override));
                 MOCK_METHOD(void, apply, (), (override));
-                MOCK_METHOD(const Texture&, texture, (), (const, override));
+                MOCK_METHOD(Texture, texture, (), (const, override));
                 MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11RenderTargetView>, render_target, (), (const, override));
                 MOCK_METHOD(uint32_t, width, (), (const, override));
                 MOCK_METHOD(uint32_t, height, (), (const, override));


### PR DESCRIPTION
When selection is disabled in the view menu, don't render the waypoint selection outline.
Closes #961