### PR TITLE
Ignore auto orbit setting when using 'Orbit Here'

### DIFF
--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -789,3 +789,22 @@ TEST(Viewer, RoomVisibilityRaised)
     ASSERT_EQ(std::get<0>(raised_room.value()).lock(), room);
     ASSERT_FALSE(std::get<1>(raised_room.value()));
 }
+
+TEST(Viewer, OrbitHereOrbitsWhenSettingDisabled)
+{
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    EXPECT_CALL(ui, set_camera_mode(CameraMode::Free)).Times(1);
+    EXPECT_CALL(ui, set_camera_mode(CameraMode::Orbit)).Times(2);
+
+    UserSettings settings;
+    settings.auto_orbit = false;
+
+    auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
+    viewer->set_camera_mode(CameraMode::Free);
+    viewer->set_settings(settings);
+
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
+
+    ui.on_orbit();
+    ASSERT_EQ(viewer->camera_mode(), CameraMode::Orbit);
+}

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -175,7 +175,7 @@ namespace trview
         {
             bool was_alternate_select = _was_alternate_select;
             on_room_selected(room_from_pick(_context_pick));
-            if (_settings.auto_orbit && !was_alternate_select)
+            if (!was_alternate_select)
             {
                 set_camera_mode(CameraMode::Orbit);
             }


### PR DESCRIPTION
If user has 'Switch to orbit on selection' disabled and was in free mode the 'Orbit Here' context menu command would not switch them to orbit mode.
Ignore this setting in this case.
Closes #966