### PR TITLE
Fix Go To window not raising event on index 0

### DIFF
--- a/trview.app.tests/UI/GoToTests.cpp
+++ b/trview.app.tests/UI/GoToTests.cpp
@@ -110,6 +110,31 @@ TEST(GoTo, OnSelectedRaised)
     ASSERT_FALSE(window.visible());
 }
 
+TEST(GoTo, OnZeroSelectedRaised)
+{
+    GoTo window;
+    window.toggle_visible();
+    window.set_name(L"Item");
+
+    std::optional<uint32_t> raised;
+    auto token = window.on_selected += [&](auto value)
+    {
+        raised = value;
+    };
+
+    TestImgui imgui([&]() { window.render(); });
+    imgui.click_element(imgui.popup_id("Go To Item").id("##gotoentry"));
+    imgui.enter_text("0");
+    imgui.press_key(ImGuiKey_Enter);
+
+    imgui.reset();
+    imgui.render();
+
+    ASSERT_TRUE(raised.has_value());
+    ASSERT_EQ(raised.value(), 0u);
+    ASSERT_FALSE(window.visible());
+}
+
 TEST(GoTo, OnSelectedNotRaisedWhenCancelled)
 {
     GoTo window;

--- a/trview.app.tests/UI/GoToTests.cpp
+++ b/trview.app.tests/UI/GoToTests.cpp
@@ -7,7 +7,7 @@ using namespace trview::tests;
 TEST(GoTo, Name)
 {
     GoTo window;
-    window.toggle_visible();
+    window.toggle_visible(0);
 
     ASSERT_EQ(window.name(), L"");
     window.set_name(L"Item");
@@ -20,7 +20,7 @@ TEST(GoTo, Name)
 TEST(GoTo, OnSelectedWithPlusRaised)
 {
     GoTo window;
-    window.toggle_visible();
+    window.toggle_visible(0);
     window.set_name(L"Item");
 
     std::optional<uint32_t> raised;
@@ -42,7 +42,7 @@ TEST(GoTo, OnSelectedWithPlusRaised)
 TEST(GoTo, OnSelectedWithMinusRaised)
 {
     GoTo window;
-    window.toggle_visible();
+    window.toggle_visible(0);
     window.set_name(L"Item");
 
     std::vector<uint32_t> raised;
@@ -67,7 +67,7 @@ TEST(GoTo, OnSelectedWithMinusRaised)
 TEST(GoTo, OnSelectedNotRaisedWhenMinusPressedAtZero)
 {
     GoTo window;
-    window.toggle_visible();
+    window.toggle_visible(0);
     window.set_name(L"Item");
 
     std::optional<uint32_t> raised;
@@ -88,7 +88,7 @@ TEST(GoTo, OnSelectedNotRaisedWhenMinusPressedAtZero)
 TEST(GoTo, OnSelectedRaised)
 {
     GoTo window;
-    window.toggle_visible();
+    window.toggle_visible(0);
     window.set_name(L"Item");
 
     std::optional<uint32_t> raised;
@@ -113,7 +113,7 @@ TEST(GoTo, OnSelectedRaised)
 TEST(GoTo, OnZeroSelectedRaised)
 {
     GoTo window;
-    window.toggle_visible();
+    window.toggle_visible(0);
     window.set_name(L"Item");
 
     std::optional<uint32_t> raised;
@@ -138,7 +138,7 @@ TEST(GoTo, OnZeroSelectedRaised)
 TEST(GoTo, OnSelectedNotRaisedWhenCancelled)
 {
     GoTo window;
-    window.toggle_visible();
+    window.toggle_visible(0);
     window.set_name(L"Item");
 
     std::optional<uint32_t> raised;

--- a/trview.app.tests/UI/GoToTests.cpp
+++ b/trview.app.tests/UI/GoToTests.cpp
@@ -154,3 +154,27 @@ TEST(GoTo, OnSelectedNotRaisedWhenCancelled)
     ASSERT_FALSE(raised.has_value());
     ASSERT_FALSE(window.visible());
 }
+
+TEST(GoTo, OnSelectedNotRaisedOnNegative)
+{
+    GoTo window;
+    window.toggle_visible(0);
+    window.set_name(L"Item");
+
+    std::optional<uint32_t> raised;
+    auto token = window.on_selected += [&](auto value)
+    {
+        raised = value;
+    };
+
+    TestImgui imgui([&]() { window.render(); });
+    imgui.click_element(imgui.popup_id("Go To Item").id("##gotoentry"));
+    imgui.enter_text("-10");
+    imgui.press_key(ImGuiKey_Enter);
+
+    imgui.reset();
+    imgui.render();
+
+    ASSERT_FALSE(raised.has_value());
+    ASSERT_FALSE(window.visible());
+}

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -33,7 +33,7 @@ namespace trview
         virtual ~Entity() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual uint16_t room() const override;
-        uint32_t index() const;
+        virtual uint32_t index() const override;
 
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
 

--- a/trview.app/Elements/IEntity.h
+++ b/trview.app/Elements/IEntity.h
@@ -18,6 +18,7 @@ namespace trview
             std::function<std::shared_ptr<IEntity>(const trlevel::ILevel&, const trlevel::tr4_ai_object&, uint32_t, const IMeshStorage&)>;
 
         virtual ~IEntity() = 0;
+        virtual uint32_t index() const = 0;
         virtual uint16_t room() const = 0;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
         virtual DirectX::BoundingBox bounding_box() const = 0;

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -65,6 +65,7 @@ namespace trview
         virtual std::vector<RoomInfo> room_info() const = 0;
         virtual RoomInfo room_info(uint32_t room) const = 0;
         virtual std::vector<std::weak_ptr<IRoom>> rooms() const = 0;
+        virtual uint32_t selected_item() const = 0;
         virtual uint16_t selected_room() const = 0;
         // Set whether to render the alternate mode (the flipmap) or the regular room.
         // enabled: Whether to render the flipmap.

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -100,6 +100,12 @@ namespace trview
         return textures;
     }
 
+    uint32_t Level::selected_item() const
+    {
+        auto entity = _selected_item.lock();
+        return entity ? entity->index() : 0u;
+    }
+
     uint16_t Level::selected_room() const
     {
         return _selected_room;

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -46,6 +46,7 @@ namespace trview
         virtual std::vector<RoomInfo> room_info() const override;
         virtual RoomInfo room_info(uint32_t room) const override;
         virtual std::vector<graphics::Texture> level_textures() const override;
+        virtual uint32_t selected_item() const override;
         virtual uint16_t selected_room() const override;
         virtual std::vector<Item> items() const override;
         virtual uint32_t number_of_rooms() const override;

--- a/trview.app/Mocks/Elements/IEntity.h
+++ b/trview.app/Mocks/Elements/IEntity.h
@@ -13,6 +13,7 @@ namespace trview
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(bool, visible, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));
+            MOCK_METHOD(uint32_t, index, (), (const, override));
             MOCK_METHOD(uint16_t, room, (), (const, override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
             MOCK_METHOD(DirectX::BoundingBox, bounding_box, (), (const, override));

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -27,6 +27,7 @@ namespace trview
             MOCK_METHOD(std::vector<RoomInfo>, room_info, (), (const, override));
             MOCK_METHOD(RoomInfo, room_info, (uint32_t), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<IRoom>>, rooms, (), (const, override));
+            MOCK_METHOD(uint32_t, selected_item, (), (const, override));
             MOCK_METHOD(uint16_t, selected_room, (), (const, override));
             MOCK_METHOD(void, set_alternate_mode, (bool), (override));
             MOCK_METHOD(void, set_alternate_group, (uint32_t, bool), (override));

--- a/trview.app/Mocks/UI/IViewerUI.h
+++ b/trview.app/Mocks/UI/IViewerUI.h
@@ -30,6 +30,7 @@ namespace trview
             MOCK_METHOD(void, set_minimap_highlight, (uint16_t, uint16_t), (override));
             MOCK_METHOD(void, set_pick, (const PickInfo&, const PickResult&), (override));
             MOCK_METHOD(void, set_remove_waypoint_enabled, (bool), (override));
+            MOCK_METHOD(void, set_selected_item, (uint32_t), (override));
             MOCK_METHOD(void, set_selected_room, (const std::shared_ptr<IRoom>&), (override));
             MOCK_METHOD(void, set_settings, (const UserSettings&), (override));
             MOCK_METHOD(void, set_show_context_menu, (bool), (override));

--- a/trview.app/UI/GoTo.cpp
+++ b/trview.app/UI/GoTo.cpp
@@ -7,10 +7,10 @@ namespace trview
         return _visible;
     }
 
-    void GoTo::toggle_visible()
+    void GoTo::toggle_visible(int32_t value)
     {
         _visible = !_visible;
-        _index = 0;
+        _index = value;
         _shown = false;
     }
 
@@ -44,7 +44,8 @@ namespace trview
                 {
                     ImGui::SetKeyboardFocusHere();
                 }
-                if(ImGui::InputInt("##gotoentry", &_index, 1, 100, ImGuiInputTextFlags_EnterReturnsTrue))
+
+                if (ImGui::InputInt("##gotoentry", &_index, 1, 100, ImGuiInputTextFlags_EnterReturnsTrue))
                 {
                     if (_index < 0)
                     {
@@ -57,9 +58,13 @@ namespace trview
                 }
 
                 ImGui::EndPopup();
-                
+
                 if (ImGui::IsKeyPressed(ImGuiKey_Escape) || ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter))
                 {
+                    if (!ImGui::IsKeyPressed(ImGuiKey_Escape))
+                    {
+                        on_selected(_index);
+                    }
                     _visible = false;
                     ImGui::FocusWindow(nullptr);
                 }

--- a/trview.app/UI/GoTo.cpp
+++ b/trview.app/UI/GoTo.cpp
@@ -47,11 +47,7 @@ namespace trview
 
                 if (ImGui::InputInt("##gotoentry", &_index, 1, 100, ImGuiInputTextFlags_EnterReturnsTrue))
                 {
-                    if (_index < 0)
-                    {
-                        _index = 0;
-                    }
-                    else
+                    if (_index >= 0)
                     {
                         on_selected(_index);
                     }
@@ -61,7 +57,7 @@ namespace trview
 
                 if (ImGui::IsKeyPressed(ImGuiKey_Escape) || ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter))
                 {
-                    if (!ImGui::IsKeyPressed(ImGuiKey_Escape))
+                    if (!ImGui::IsKeyPressed(ImGuiKey_Escape) && _index >= 0)
                     {
                         on_selected(_index);
                     }

--- a/trview.app/UI/GoTo.h
+++ b/trview.app/UI/GoTo.h
@@ -22,7 +22,7 @@ namespace trview
         bool visible() const;
 
         /// Toggle whether the window is visible.
-        void toggle_visible();
+        void toggle_visible(int32_t value);
 
         /// Event raised when the user selects a new room. The newly selected room is passed as
         /// a parameter when the event is raised.

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -171,6 +171,12 @@ namespace trview
         /// "param value Whether the button is enabled.
         virtual void set_remove_waypoint_enabled(bool value) = 0;
 
+        /// <summary>
+        /// Set the currently selected item index.
+        /// </summary>
+        /// <param name="item">The selected item number.</param>
+        virtual void set_selected_item(uint32_t index) = 0;
+
         /// Set the selected room.
         /// @param room The selected room.
         virtual void set_selected_room(const std::shared_ptr<IRoom>& room) = 0;

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -27,7 +27,7 @@ namespace trview
             if (!is_input_active())
             {
                 _go_to->set_name(L"Room");
-                _go_to->toggle_visible();
+                _go_to->toggle_visible(_selected_room);
             }
         };
 
@@ -36,7 +36,7 @@ namespace trview
             if (!is_input_active())
             {
                 _go_to->set_name(L"Item");
-                _go_to->toggle_visible();
+                _go_to->toggle_visible(_selected_item);
             }
         };
 
@@ -390,9 +390,15 @@ namespace trview
         _map_renderer->set_colours(settings.map_colours);
     }
 
+    void ViewerUI::set_selected_item(uint32_t index)
+    {
+        _selected_item = index;
+    }
+
     void ViewerUI::set_selected_room(const std::shared_ptr<IRoom>& room)
     {
         _room_navigator->set_selected_room(room->number());
+        _selected_room = room->number();
         _map_renderer->load(room);
     }
 

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -53,6 +53,7 @@ namespace trview
         virtual void set_minimap_highlight(uint16_t x, uint16_t z) override;
         virtual void set_pick(const PickInfo& info, const PickResult& pick_result) override;
         virtual void set_remove_waypoint_enabled(bool value) override;
+        virtual void set_selected_item(uint32_t index) override;
         virtual void set_selected_room(const std::shared_ptr<IRoom>& room) override;
         virtual void set_settings(const UserSettings& settings) override;
         virtual void set_show_context_menu(bool value) override;
@@ -93,5 +94,7 @@ namespace trview
         std::string _measure_text;
         Point _measure_position;
         bool _visible{ true };
+        uint32_t _selected_room{ 0u };
+        uint32_t _selected_item{ 0u };
     };
 }

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -531,7 +531,7 @@ namespace trview
         _level->set_show_items(_ui->toggle(Options::items));
 
         // Set up the views.
-        auto rooms = _level->room_info();
+        auto rooms = _level->rooms();
         _camera.reset();
 
         // Reset UI buttons
@@ -555,7 +555,10 @@ namespace trview
         _ui->set_toggle(Options::depth_enabled, false);
         _ui->set_scalar(Options::depth, 1);
 
-        _ui->set_selected_room(level->rooms()[level->selected_room()].lock());
+        if (level->selected_room() < rooms.size())
+        {
+            _ui->set_selected_room(rooms[level->selected_room()].lock());
+        }
         _ui->set_selected_item(level->selected_item());
 
         // Strip the last part of the path away.

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -555,6 +555,9 @@ namespace trview
         _ui->set_toggle(Options::depth_enabled, false);
         _ui->set_scalar(Options::depth, 1);
 
+        _ui->set_selected_room(level->rooms()[level->selected_room()].lock());
+        _ui->set_selected_item(level->selected_item());
+
         // Strip the last part of the path away.
         const auto filename = _level->filename();
         auto last_index = std::min(filename.find_last_of('\\'), filename.find_last_of('/'));
@@ -731,6 +734,7 @@ namespace trview
     void Viewer::select_item(const Item& item)
     {
         _target = item.position();
+        _ui->set_selected_item(item.number());
         if (_settings.auto_orbit)
         {
             set_camera_mode(CameraMode::Orbit);


### PR DESCRIPTION
If the user entered 0 as the index in the `GoTo` window ImGui would not return true for that - so the `on_selected` event was never raised. Instead we also raise the event in the section that closes the dialog on escape/enter - it is still raised in the `InputInt` check as the +/- arrows trigger that path.

Also change `ViewerUI` to pass the currently selected room/item as an initial value when making the `GoTo` window visible. This is a bit nicer than it always being at 0.

Bug reported by @TempleOfHorus

Closes #968