### PR TITLE
Replace Geometry mode with TRLE mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ CTRL + M    | New Rooms window
 CTRL + L    | New Lights window
 F1          | Toggle settings window
 F           | Free camera
-G           | Toggle hidden geometry
+G           | Toggle geometry mode
 H           | Toggle room highlighting
 L           | Toggle lights visibility
 O           | Orbit camera
@@ -112,7 +112,7 @@ Option|Action
 ---|------
 Highlight           | Highlight the currently selected room
 Triggers            | Toggle trigger visibility
-Geometry            | Toggle hidden geometry visibility
+Geometry            | Toggle geometry mode
 Water               | Toggle water in water rooms
 Depth               | Toggle depth mode. This will show the currently selected depth of neighbours of the current room.
 Depth Selector      | Choose the depth of neighbours to show

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -258,14 +258,14 @@ TEST(Level, PickUsesCorrectOptionalFilters)
 
     auto room = mock_shared<MockRoom>();
     ON_CALL(*room, visible).WillByDefault(Return(true));
-    EXPECT_CALL(*room, pick(A<const Vector3&>(), A<const Vector3&>(), PickFilter::Geometry | PickFilter::Entities | PickFilter::StaticMeshes | PickFilter::Triggers | PickFilter::HiddenGeometry | PickFilter::Lights)).Times(1);
+    EXPECT_CALL(*room, pick(A<const Vector3&>(), A<const Vector3&>(), PickFilter::Geometry | PickFilter::Entities | PickFilter::StaticMeshes | PickFilter::Triggers | PickFilter::AllGeometry | PickFilter::Lights)).Times(1);
 
     auto level = register_test_module()
         .with_level(std::move(mock_level_ptr))
         .with_room_source([&](auto&&...) { return room; })
         .build();
     level->set_show_triggers(true);
-    level->set_show_hidden_geometry(true);
+    level->set_show_geometry(true);
     level->set_show_lights(true);
 
     NiceMock<MockCamera> camera;
@@ -286,7 +286,7 @@ TEST(Level, PickUsesCorrectMinimalFilters)
         .with_room_source([&](auto&&...) { return room; })
         .build();
     level->set_show_triggers(false);
-    level->set_show_hidden_geometry(false);
+    level->set_show_geometry(false);
     level->set_show_items(false);
 
     NiceMock<MockCamera> camera;
@@ -380,7 +380,7 @@ TEST(Level, ItemsNotRenderedWhenDisabled)
     auto shader_storage = mock_shared<MockShaderStorage>();
     EXPECT_CALL(*shader_storage, get).WillRepeatedly(Return(&shader));
 
-    EXPECT_CALL(*room, render(A<const ICamera&>(), A<IRoom::SelectionMode>(), false, A<bool>(), A<bool>(), A<bool>(), A<const std::unordered_set<uint32_t>&>())).Times(1);
+    EXPECT_CALL(*room, render(A<const ICamera&>(), A<IRoom::SelectionMode>(), false, A<bool>(), A<bool>(), A<const std::unordered_set<uint32_t>&>())).Times(1);
     EXPECT_CALL(*room, render_contained(A<const ICamera&>(), A<IRoom::SelectionMode>(), false, A<bool>())).Times(1);
 
     auto level = register_test_module()
@@ -413,7 +413,7 @@ TEST(Level, ItemsRenderedWhenEnabled)
     auto shader_storage = mock_shared<MockShaderStorage>();
     EXPECT_CALL(*shader_storage, get).WillRepeatedly(Return(&shader));
 
-    EXPECT_CALL(*room, render(A<const ICamera&>(), A<IRoom::SelectionMode>(), true, A<bool>(), A<bool>(), A<bool>(), A<const std::unordered_set<uint32_t>&>())).Times(1);
+    EXPECT_CALL(*room, render(A<const ICamera&>(), A<IRoom::SelectionMode>(), true, A<bool>(), A<bool>(), A<const std::unordered_set<uint32_t>&>())).Times(1);
     EXPECT_CALL(*room, render_contained(A<const ICamera&>(), A<IRoom::SelectionMode>(), true, A<bool>())).Times(1);
 
     auto level = register_test_module()
@@ -466,7 +466,7 @@ TEST(Level, RoomNotRenderedWhenNotVisible)
     auto shader_storage = mock_shared<MockShaderStorage>();
     EXPECT_CALL(*shader_storage, get).WillRepeatedly(Return(&shader));
 
-    EXPECT_CALL(*room, render(A<const ICamera&>(), A<IRoom::SelectionMode>(), true, A<bool>(), A<bool>(), A<bool>(), A<const std::unordered_set<uint32_t>&>())).Times(0);
+    EXPECT_CALL(*room, render(A<const ICamera&>(), A<IRoom::SelectionMode>(), true, A<bool>(), A<bool>(), A<const std::unordered_set<uint32_t>&>())).Times(0);
     EXPECT_CALL(*room, render_contained(A<const ICamera&>(), A<IRoom::SelectionMode>(), true, A<bool>())).Times(0);
 
     auto level = register_test_module()

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -441,7 +441,7 @@ TEST(Room, RendersContainedEntities)
     auto entity = mock_shared<MockEntity>();
     EXPECT_CALL(*entity, render).Times(1);
     room->add_entity(entity);
-    room->render(NiceMock<MockCamera>{}, IRoom::SelectionMode::NotSelected, true, true, true, false, {});
+    room->render(NiceMock<MockCamera>{}, IRoom::SelectionMode::NotSelected, true, true, false, {});
 }
 
 /// <summary>
@@ -453,7 +453,7 @@ TEST(Room, DoesNotRenderContainedEntitiesWhenShowItemsDisabled)
     auto entity = mock_shared<MockEntity>();
     EXPECT_CALL(*entity, render).Times(0);
     room->add_entity(entity);
-    room->render(NiceMock<MockCamera>{}, IRoom::SelectionMode::NotSelected, false, true, true, false, {});
+    room->render(NiceMock<MockCamera>{}, IRoom::SelectionMode::NotSelected, false, true, false, {});
 }
 
 /// <summary>

--- a/trview.app.tests/UI/ViewOptionsTests.cpp
+++ b/trview.app.tests/UI/ViewOptionsTests.cpp
@@ -75,10 +75,10 @@ TEST(ViewOptions, HiddenGeometryCheckboxToggle)
     };
 
     tests::TestImgui imgui([&]() { view_options.render(); });
-    imgui.click_element(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::hidden_geometry));
+    imgui.click_element(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::geometry));
 
     ASSERT_TRUE(clicked.has_value());
-    ASSERT_EQ(std::get<0>(clicked.value()), IViewer::Options::hidden_geometry);
+    ASSERT_EQ(std::get<0>(clicked.value()), IViewer::Options::geometry);
     ASSERT_TRUE(std::get<1>(clicked.value()));
 }
 
@@ -87,11 +87,11 @@ TEST(ViewOptions, HiddenGeometryCheckboxUpdated)
     ViewOptions view_options;
 
     tests::TestImgui imgui([&]() { view_options.render(); });
-    ASSERT_FALSE(imgui.status_flags(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::hidden_geometry)) & ImGuiItemStatusFlags_Checked);
+    ASSERT_FALSE(imgui.status_flags(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::geometry)) & ImGuiItemStatusFlags_Checked);
 
-    view_options.set_toggle(IViewer::Options::hidden_geometry, true);
+    view_options.set_toggle(IViewer::Options::geometry, true);
     imgui.render();
-    ASSERT_TRUE(imgui.status_flags(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::hidden_geometry)) & ImGuiItemStatusFlags_Checked);
+    ASSERT_TRUE(imgui.status_flags(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::geometry)) & ImGuiItemStatusFlags_Checked);
 }
 
 TEST(ViewOptions, WaterCheckboxToggle)
@@ -307,37 +307,6 @@ TEST(ViewOptions, FlipCheckboxHiddenWithAlternateGroups)
     imgui.reset();
     imgui.render();
     ASSERT_FALSE(imgui.element_present(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::flip)));
-}
-
-
-TEST(ViewOptions, TRLECheckboxToggle)
-{
-    ViewOptions view_options;
-
-    std::optional<std::tuple<std::string, bool>> clicked;
-    auto token = view_options.on_toggle_changed += [&](const std::string& name, bool value)
-    {
-        clicked = { name, value };
-    };
-
-    tests::TestImgui imgui([&]() { view_options.render(); });
-    imgui.click_element(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::trle_colours));
-
-    ASSERT_TRUE(clicked.has_value());
-    ASSERT_EQ(std::get<0>(clicked.value()), IViewer::Options::trle_colours);
-    ASSERT_TRUE(std::get<1>(clicked.value()));
-}
-
-TEST(ViewOptions, TRLECheckboxUpdated)
-{
-    ViewOptions view_options;
-
-    tests::TestImgui imgui([&]() { view_options.render(); });
-    ASSERT_FALSE(imgui.status_flags(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::trle_colours)) & ImGuiItemStatusFlags_Checked);
-
-    view_options.set_toggle(IViewer::Options::trle_colours, true);
-    imgui.render();
-    ASSERT_TRUE(imgui.status_flags(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::trle_colours)) & ImGuiItemStatusFlags_Checked);
 }
 
 TEST(ViewOptions, ItemsCheckboxToggle)

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -253,29 +253,3 @@ TEST(ViewerUI, OnMinimapColoursEventRaised)
     ASSERT_TRUE(raised);
 }
 
-TEST(ViewerUI, TRLEColoursEventRaised)
-{
-    auto [view_options_ptr, view_options] = create_mock<MockViewOptions>();
-    auto ui = register_test_module().with_view_options(std::move(view_options_ptr)).build();
-
-    std::optional<std::tuple<std::string, bool>> show;
-    auto token = ui->on_toggle_changed += [&](const auto& name, const auto& value)
-    {
-        show = { name, value };
-    };
-
-    view_options.on_toggle_changed(IViewer::Options::trle_colours, true);
-    ASSERT_TRUE(show.has_value());
-    ASSERT_EQ(std::get<0>(show.value()), IViewer::Options::trle_colours);
-    ASSERT_TRUE(std::get<1>(show.value()));
-}
-
-TEST(ViewerUI, TRLEColoursUpdatesViewOptions)
-{
-    auto [view_options_ptr, view_options] = create_mock<MockViewOptions>();
-    auto ui = register_test_module().with_view_options(std::move(view_options_ptr)).build();
-
-    EXPECT_CALL(view_options, set_toggle(IViewer::Options::trle_colours, true)).Times(1);
-
-    ui->set_toggle(IViewer::Options::trle_colours, true);
-}

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -663,21 +663,6 @@ TEST(Viewer, DepthViewOptionUpdatesLevel)
     ui.on_scalar_changed(IViewer::Options::depth, 6);
 }
 
-TEST(Viewer, SetUseTRLEColours)
-{
-    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [level_ptr, level] = create_mock<MockLevel>();
-    auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
-
-    EXPECT_CALL(level, set_use_trle_colours(false)).Times(1);
-    EXPECT_CALL(ui, set_toggle(testing::A<const std::string&>(), testing::A<bool>())).Times(testing::AtLeast(0));
-    EXPECT_CALL(ui, set_toggle(IViewer::Options::trle_colours, true)).Times(1);
-    EXPECT_CALL(level, set_use_trle_colours(true)).Times(1);
-
-    viewer->open(&level);
-    ui.on_toggle_changed(IViewer::Options::trle_colours, true);
-}
-
 TEST(Viewer, SetShowItems)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -80,7 +80,7 @@ namespace trview
         virtual void set_map_colours(const MapColours& map_colours) = 0;
         virtual void set_selected_trigger(uint32_t number) = 0;
         virtual void set_selected_light(uint32_t number) = 0;
-        virtual void set_show_hidden_geometry(bool show) = 0;
+        virtual void set_show_geometry(bool show) = 0;
         virtual void set_show_triggers(bool show) = 0;
         virtual void set_show_water(bool show) = 0;
         virtual void set_show_wireframe(bool show) = 0;
@@ -88,13 +88,12 @@ namespace trview
         virtual void set_show_lights(bool show) = 0;
         virtual void set_show_items(bool show) = 0;
         virtual void set_trigger_visibility(uint32_t index, bool state) = 0;
-        virtual void set_use_trle_colours(bool value) = 0;
         virtual void set_neighbour_depth(uint32_t depth) = 0;
         virtual void set_selected_room(uint16_t index) = 0;
         virtual void set_selected_item(uint32_t index) = 0;
         virtual void set_light_visibility(uint32_t index, bool state) = 0;
         virtual void set_room_visibility(uint32_t index, bool state) = 0;
-        virtual bool show_hidden_geometry() const = 0;
+        virtual bool show_geometry() const = 0;
         virtual bool show_lights() const = 0;
         virtual bool show_triggers() const = 0;
         virtual bool show_items() const = 0;
@@ -102,7 +101,6 @@ namespace trview
         /// Get the triggers in this level.
         /// @returns All triggers in the level.
         virtual std::vector<std::weak_ptr<ITrigger>> triggers() const = 0;
-        virtual bool use_trle_colours() const = 0;
         virtual trlevel::LevelVersion version() const = 0;
         // Event raised when the level needs to change the selected room.
         Event<uint16_t> on_room_selected;
@@ -113,6 +111,6 @@ namespace trview
         /// Event raised when something has changed in the appearance of the level or the
         /// items that are contained within.
         Event<> on_level_changed;
-        mutable Event<> on_trle_colours_changed;
+        mutable Event<> on_geometry_colours_changed;
     };
 }

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -159,8 +159,8 @@ namespace trview
         /// <param name="show_items">Whether to render items.</param>
         /// <param name="include_triggers">Whether to include triggers in the output.</param>
         /// <param name="show_water">Whether to render water effects.</param>
-        /// <param name="trle_mode">Whether TRLE mode is enabled.</param>
-        virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool show_items, bool include_triggers, bool show_water, bool trle_mode) = 0;
+        /// <param name="geometry_mode">Whether Geometry mode is enabled.</param>
+        virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool show_items, bool include_triggers, bool show_water, bool geometry_mode) = 0;
         /// <summary>
         /// Checks whether the room has the specified flag.
         /// </summary>
@@ -216,11 +216,10 @@ namespace trview
         /// <param name="camera">The current viewpoint.</param>
         /// <param name="selected">Whether the room is selected.</param>
         /// <param name="show_items">Whether to render items.</param>
-        /// <param name="show_hidden_geometry">Whether to render hidden geometry.</param>
         /// <param name="show_water">Whether to render water effects.</param>
-        /// <param name="use_trle_colours">Whether to use trle colours.</param>
+        /// <param name="geometry_mode">Whether to render in geometry mode.</param>
         /// <param name="visible_rooms">The rooms that are currently being rendered.</param>
-        virtual void render(const ICamera& camera, SelectionMode selected, bool show_items, bool show_hidden_geometry, bool show_water, bool use_trle_colours, const std::unordered_set<uint32_t>& visible_rooms) = 0;
+        virtual void render(const ICamera& camera, SelectionMode selected, bool show_items, bool show_water, bool geometry_mode, const std::unordered_set<uint32_t>& visible_rooms) = 0;
         /// <summary>
         /// Render the bounding boxes in the room.
         /// </summary>

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -70,8 +70,8 @@ namespace trview
         virtual bool alternate_mode() const override;
         virtual bool any_alternates() const override;
         virtual void set_show_triggers(bool show) override;
-        virtual void set_show_hidden_geometry(bool show) override;
-        virtual bool show_hidden_geometry() const override;
+        virtual void set_show_geometry(bool show) override;
+        virtual bool show_geometry() const override;
         virtual void set_show_water(bool show) override;
         virtual void set_show_wireframe(bool show) override;
         virtual void set_show_bounding_boxes(bool show) override;
@@ -90,8 +90,6 @@ namespace trview
         virtual std::vector<std::weak_ptr<ILight>> lights() const override;
         virtual void set_light_visibility(uint32_t index, bool state) override;
         virtual void set_room_visibility(uint32_t index, bool state) override;
-        virtual void set_use_trle_colours(bool value) override;
-        virtual bool use_trle_colours() const override;
         virtual MapColours map_colours() const override;
         virtual void set_map_colours(const MapColours& map_colours) override;
     private:
@@ -168,13 +166,12 @@ namespace trview
         bool _regenerate_transparency{ true };
         bool _alternate_mode{ false };
         bool _show_triggers{ true };
-        bool _show_hidden_geometry{ false };
         bool _show_water{ true };
         bool _show_wireframe{ false };
         bool _show_bounding_boxes{ false };
         bool _show_lights{ false };
         bool _show_items{ true };
-        bool _use_trle_colours{ false };
+        bool _show_geometry { false };
 
         std::unique_ptr<ISelectionRenderer> _selection_renderer;
         std::set<uint32_t> _alternate_groups;

--- a/trview.app/Elements/PickFilter.h
+++ b/trview.app/Elements/PickFilter.h
@@ -11,12 +11,11 @@ namespace trview
         Geometry = 0x1,
         Entities = 0x2,
         Triggers = 0x4,
-        HiddenGeometry = 0x8,
+        AllGeometry = 0x8,
         StaticMeshes = 0x10,
         Lights = 0x20,
-        TrleGeometry = 0x40,
         All = 0xffffffff,
-        Default = All & ~(HiddenGeometry | TrleGeometry)
+        Default = All & ~(AllGeometry)
     };
 
     PickFilter filter_flag(PickFilter filter, bool condition);

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -41,7 +41,7 @@ namespace trview
         virtual RoomInfo info() const override;
         virtual std::set<uint16_t> neighbours() const override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, PickFilter filters = PickFilter::Default) const override;
-        virtual void render(const ICamera& camera, SelectionMode selected, bool show_items, bool show_hidden_geometry, bool show_water, bool use_trle_colours, const std::unordered_set<uint32_t>& visible_rooms) override;
+        virtual void render(const ICamera& camera, SelectionMode selected, bool show_items, bool show_water, bool geometry_mode, const std::unordered_set<uint32_t>& visible_rooms) override;
         virtual void render_bounding_boxes(const ICamera& camera) override;
         virtual void render_lights(const ICamera& camera, const std::weak_ptr<ILight>& selected_light) override;
         virtual void render_contained(const ICamera& camera, SelectionMode selected, bool show_items, bool show_water) override;
@@ -50,7 +50,7 @@ namespace trview
         virtual void add_light(const std::weak_ptr<ILight>& light) override;
         virtual const std::vector<std::shared_ptr<ISector>> sectors() const override;
         virtual void generate_sector_triangles() override;
-        virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool show_items, bool include_triggers, bool show_water, bool trle_mode) override;
+        virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool show_items, bool include_triggers, bool show_water, bool geometry_mode) override;
         virtual void get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, bool show_items, bool show_water) override;
         virtual AlternateMode alternate_mode() const override;
         virtual int16_t alternate_room() const override;
@@ -91,20 +91,7 @@ namespace trview
         /// @param collision_triangles The collision output vector.
         void process_collision_transparency(const std::vector<TransparentTriangle>& transparent_triangles, std::vector<Triangle>& collision_triangles);
 
-        /// Process the sectors in the level and find where there are walkable floors that have no matching geometry.
-        /// @param data The room data to check against.
-        /// @param room_vertices The actual room vertices.
-        /// @param output_vertices Where to store vertices.
-        /// @param output_indices Where to store indices.
-        /// @param collision_triangles Where to store collision triangles.
-        void process_unmatched_geometry(const trlevel::tr3_room_data& data, 
-            const std::vector<trlevel::tr_vertex>& room_vertices,
-            const std::vector<TransparentTriangle>& transparent_triangles,
-            std::vector<MeshVertex>& output_vertices,
-            std::vector<uint32_t>& output_indices,
-            std::vector<Triangle>& collision_triangles);
-
-        void generate_trle_mesh(const IMesh::Source& mesh_source);
+        void generate_all_geometry_mesh(const IMesh::Source& mesh_source);
 
         void add_centroid_to_pick(const IMesh& mesh, PickResult& geometry_result) const;
 
@@ -115,8 +102,7 @@ namespace trview
         std::vector<std::shared_ptr<IStaticMesh>> _static_meshes;
 
         std::shared_ptr<IMesh> _mesh;
-        std::shared_ptr<IMesh> _unmatched_mesh;
-        std::unordered_map<uint32_t, std::shared_ptr<IMesh>> _trle_meshes;
+        std::unordered_map<uint32_t, std::shared_ptr<IMesh>> _all_geometry_meshes;
         DirectX::SimpleMath::Matrix _room_offset;
         DirectX::SimpleMath::Matrix _inverted_room_offset;
 
@@ -141,7 +127,7 @@ namespace trview
         std::shared_ptr<ILevelTextureStorage> _texture_storage;
         std::vector<std::weak_ptr<ILight>> _lights;
         IMesh::Source _mesh_source;
-        std::vector<uint32_t> _trle_sector_rooms;
+        std::vector<uint32_t> _all_geometry_sector_rooms;
         std::function<std::shared_ptr<IMesh>()> _unmatched_mesh_generator;
 
         bool _visible{ true };

--- a/trview.app/Geometry/IMesh.h
+++ b/trview.app/Geometry/IMesh.h
@@ -23,7 +23,7 @@ namespace trview
             const DirectX::SimpleMath::Color& colour,
             float light_intensity = 1.0f,
             DirectX::SimpleMath::Vector3 light_direction = DirectX::SimpleMath::Vector3::Zero,
-            bool use_trle_colours = false) = 0;
+            bool geometry_mode = false) = 0;
 
         virtual std::vector<TransparentTriangle> transparent_triangles() const = 0;
 

--- a/trview.app/Geometry/Mesh.cpp
+++ b/trview.app/Geometry/Mesh.cpp
@@ -115,7 +115,7 @@ namespace trview
         _bounding_box.Center = minimum + half_size;
     }
 
-    void Mesh::render(const Matrix& world_view_projection, const ILevelTextureStorage& texture_storage, const Color& colour, float light_intensity, Vector3 light_direction, bool use_trle_colours)
+    void Mesh::render(const Matrix& world_view_projection, const ILevelTextureStorage& texture_storage, const Color& colour, float light_intensity, Vector3 light_direction, bool geometry_mode)
     {
         // There are no vertices.
         if (!_vertex_buffer)
@@ -143,7 +143,7 @@ namespace trview
             auto& index_buffer = _index_buffers[i];
             if (index_buffer)
             {
-                auto texture = use_trle_colours ? texture_storage.trle_texture() : texture_storage.texture(i);
+                auto texture = geometry_mode ? texture_storage.geometry_texture() : texture_storage.texture(i);
                 context->PSSetShaderResources(0, 1, texture.view().GetAddressOf());
                 context->IASetIndexBuffer(index_buffer.Get(), DXGI_FORMAT_R32_UINT, 0);
                 context->DrawIndexed(_index_counts[i], 0, 0);

--- a/trview.app/Geometry/Mesh.h
+++ b/trview.app/Geometry/Mesh.h
@@ -39,7 +39,7 @@ namespace trview
             const DirectX::SimpleMath::Color& colour,
             float light_intensity = 1.0f,
             DirectX::SimpleMath::Vector3 light_direction = DirectX::SimpleMath::Vector3::Zero,
-            bool use_trle_colours = false) override;
+            bool geometry_mode = false) override;
 
         virtual std::vector<TransparentTriangle> transparent_triangles() const override;
 

--- a/trview.app/Graphics/ILevelTextureStorage.h
+++ b/trview.app/Graphics/ILevelTextureStorage.h
@@ -28,7 +28,7 @@ namespace trview
 
         virtual DirectX::SimpleMath::Color palette_from_texture(uint32_t texture) const = 0;
 
-        virtual graphics::Texture trle_texture() const = 0;
+        virtual graphics::Texture geometry_texture() const = 0;
     };
 }
 

--- a/trview.app/Graphics/LevelTextureStorage.cpp
+++ b/trview.app/Graphics/LevelTextureStorage.cpp
@@ -40,7 +40,7 @@ namespace trview
             pixels[y * 256] = 0xff000000;
             pixels[y * 256 + 255] = 0xff000000;
         }
-        _trle_texture = graphics::Texture(*device, 256, 256, pixels);
+        _geometry_texture = graphics::Texture(*device, 256, 256, pixels);
 
         determine_texture_mode();
     }
@@ -128,8 +128,8 @@ namespace trview
     {
     }
 
-    graphics::Texture LevelTextureStorage::trle_texture() const
+    graphics::Texture LevelTextureStorage::geometry_texture() const
     {
-        return _trle_texture;
+        return _geometry_texture;
     }
 }

--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -43,6 +43,6 @@ namespace trview
             Custom
         };
         TextureMode _texture_mode{ TextureMode::Official };
-        graphics::Texture _trle_texture;
+        graphics::Texture _geometry_texture;
     };
 }

--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -26,7 +26,7 @@ namespace trview
         virtual uint32_t          num_tiles() const override;
         virtual uint16_t attribute(uint32_t texture_index) const override;
         virtual DirectX::SimpleMath::Color palette_from_texture(uint32_t texture) const override;
-        virtual graphics::Texture trle_texture() const override;
+        virtual graphics::Texture geometry_texture() const override;
     private:
         void determine_texture_mode();
 

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -36,7 +36,7 @@ namespace trview
             MOCK_METHOD(void, set_item_visibility, (uint32_t, bool), (override));
             MOCK_METHOD(void, set_selected_trigger, (uint32_t), (override));
             MOCK_METHOD(void, set_selected_light, (uint32_t), (override));
-            MOCK_METHOD(void, set_show_hidden_geometry, (bool), (override));
+            MOCK_METHOD(void, set_show_geometry, (bool), (override));
             MOCK_METHOD(void, set_show_triggers, (bool), (override));
             MOCK_METHOD(void, set_show_water, (bool), (override));
             MOCK_METHOD(void, set_show_wireframe, (bool), (override));
@@ -49,15 +49,13 @@ namespace trview
             MOCK_METHOD(void, set_selected_item, (uint32_t), (override));
             MOCK_METHOD(void, set_light_visibility, (uint32_t, bool), (override));
             MOCK_METHOD(void, set_room_visibility, (uint32_t, bool), (override));
-            MOCK_METHOD(bool, show_hidden_geometry, (), (const, override));
+            MOCK_METHOD(bool, show_geometry, (), (const, override));
             MOCK_METHOD(bool, show_lights, (), (const, override));
             MOCK_METHOD(bool, show_triggers, (), (const, override));
             MOCK_METHOD(bool, show_items, (), (const, override));
             MOCK_METHOD(const ILevelTextureStorage&, texture_storage, (), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<ITrigger>>, triggers, (), (const, override));
             MOCK_METHOD(trlevel::LevelVersion, version, (), (const, override));
-            MOCK_METHOD(bool, use_trle_colours, (), (const, override));
-            MOCK_METHOD(void, set_use_trle_colours, (bool), (override));
             MOCK_METHOD(MapColours, map_colours, (), (const, override));
             MOCK_METHOD(void, set_map_colours, (const MapColours&), (override));
         };

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -29,7 +29,7 @@ namespace trview
             MOCK_METHOD(bool, outside, (), (const, override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, PickFilter), (const, override));
             MOCK_METHOD(bool, quicksand, (), (const, override));
-            MOCK_METHOD(void, render, (const ICamera&, SelectionMode, bool, bool, bool, bool, const std::unordered_set<uint32_t>&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, SelectionMode, bool, bool, bool, const std::unordered_set<uint32_t>&), (override));
             MOCK_METHOD(void, render_bounding_boxes, (const ICamera&), (override));
             MOCK_METHOD(void, render_lights, (const ICamera&, const std::weak_ptr<ILight>&), (override));
             MOCK_METHOD(void, render_contained, (const ICamera&, SelectionMode, bool, bool), (override));;

--- a/trview.app/Mocks/Graphics/ILevelTextureStorage.h
+++ b/trview.app/Mocks/Graphics/ILevelTextureStorage.h
@@ -19,7 +19,7 @@ namespace trview
             MOCK_METHOD(uint32_t, num_tiles, (), (const, override));
             MOCK_METHOD(uint16_t, attribute, (uint32_t), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Color, palette_from_texture, (uint32_t), (const, override));
-            MOCK_METHOD(graphics::Texture, trle_texture, (), (const, override));
+            MOCK_METHOD(graphics::Texture, geometry_texture, (), (const, override));
         };
     }
 }

--- a/trview.app/UI/IViewOptions.h
+++ b/trview.app/UI/IViewOptions.h
@@ -22,11 +22,6 @@ namespace trview
         Event<std::string, bool> on_toggle_changed;
         virtual void render() = 0;
         /// <summary>
-        /// Event raised when the user toggles TRLE colours.
-        /// </summary>
-        /// <remarks>This event is not raised by the set_use_trle_colours function.</remarks>
-        Event<bool> on_use_trle_colours;
-        /// <summary>
         /// Set whether an alternate group is enabled. This will not raise the on_alternate_group event.
         /// </summary>
         /// <param name="value">The group to change.</param>

--- a/trview.app/UI/MapColours.cpp
+++ b/trview.app/UI/MapColours.cpp
@@ -25,7 +25,7 @@ namespace trview
             { MapColours::Special::NoSpace, { 0.2f, 0.2f, 0.9f } },
             { MapColours::Special::RoomAbove, { 0.0f, 0.0f, 0.0f } },
             { MapColours::Special::RoomBelow, { 0.6f, 0.0f, 0.0f, 0.0f } },
-            { MapColours::Special::TrleWall, { 0.0f, 0.6f, 0.15f } }
+            { MapColours::Special::GeometryWall, { 0.0f, 0.6f, 0.15f } }
         };
     }
 

--- a/trview.app/UI/MapColours.h
+++ b/trview.app/UI/MapColours.h
@@ -15,7 +15,7 @@ namespace trview
             NoSpace,
             RoomAbove,
             RoomBelow,
-            TrleWall
+            GeometryWall
         };
 
         std::unordered_map<SectorFlag, Colour> override_colours() const;

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -104,7 +104,7 @@ namespace trview
                     add_special("Default", MapColours::Special::Default);
                     add_colour("Portal", SectorFlag::Portal);
                     add_colour("Wall", SectorFlag::Wall);
-                    add_special("TRLE Wall", MapColours::Special::TrleWall);
+                    add_special("Geometry Wall", MapColours::Special::GeometryWall);
                     add_colour("Trigger", SectorFlag::Trigger);
                     add_colour("Death", SectorFlag::Death);
                     add_colour("Minecart Left", SectorFlag::MinecartLeft);

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -7,14 +7,13 @@ namespace trview
     {
         _toggles[IViewer::Options::highlight] = false;
         _toggles[IViewer::Options::triggers] = true;
-        _toggles[IViewer::Options::hidden_geometry] = false;
+        _toggles[IViewer::Options::geometry] = false;
         _toggles[IViewer::Options::water] = true;
         _toggles[IViewer::Options::depth_enabled] = false;
         _toggles[IViewer::Options::wireframe] = false;
         _toggles[IViewer::Options::show_bounding_boxes] = false;
         _toggles[IViewer::Options::lights] = false;
         _toggles[IViewer::Options::flip] = false;
-        _toggles[IViewer::Options::trle_colours] = false;
         _toggles[IViewer::Options::items] = true;
     }
 
@@ -55,9 +54,8 @@ namespace trview
                 ImGui::PopItemWidth();
                 ImGui::TableNextRow();
                 add_toggle(IViewer::Options::wireframe);
-                add_toggle(IViewer::Options::hidden_geometry);
+                add_toggle(IViewer::Options::geometry);
                 ImGui::TableNextRow();
-                add_toggle(IViewer::Options::trle_colours);
                 if (!_use_alternate_groups)
                 {
                     ImGui::BeginDisabled(!_flip_enabled);

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -20,14 +20,13 @@ namespace trview
             inline static const std::string depth = "##DepthValue";
             inline static const std::string depth_enabled = "Depth";
             inline static const std::string flip = "Flip";
-            inline static const std::string hidden_geometry = "Geometry";
+            inline static const std::string geometry = "Geometry";
             inline static const std::string highlight = "Highlight";
             inline static const std::string show_bounding_boxes = "Bounds";
             inline static const std::string triggers = "Triggers";
             inline static const std::string water = "Water";
             inline static const std::string wireframe = "Wireframe";
             inline static const std::string lights = "Lights";
-            inline static const std::string trle_colours = "TRLE Colours";
             inline static const std::string items = "Items";
         };
 

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -50,7 +50,7 @@ namespace trview
 
         std::unordered_map<std::string, std::function<void(bool)>> toggles;
         toggles[Options::highlight] = [this](bool) { toggle_highlight(); };
-        toggles[Options::hidden_geometry] = [this](bool value) { set_show_hidden_geometry(value); };
+        toggles[Options::geometry] = [this](bool value) { set_show_geometry(value); };
         toggles[Options::water] = [this](bool value) { set_show_water(value); };
         toggles[Options::wireframe] = [this](bool value) { set_show_wireframe(value); };
         toggles[Options::triggers] = [this](bool value) { set_show_triggers(value); };
@@ -58,7 +58,6 @@ namespace trview
         toggles[Options::flip] = [this](bool value) { set_alternate_mode(value); };
         toggles[Options::depth_enabled] = [this](bool value) { if (_level) { _level->set_highlight_mode(ILevel::RoomHighlightMode::Neighbours, value); } };
         toggles[Options::lights] = [this](bool value) { set_show_lights(value); };
-        toggles[Options::trle_colours] = [this](bool value) { set_use_trle_colours(value); };
         toggles[Options::items] = [this](bool value) { set_show_items(value); };
 
         std::unordered_map<std::string, std::function<void(int32_t)>> scalars;
@@ -360,7 +359,7 @@ namespace trview
         });
         add_shortcut(false, 'I', [&]() { toggle_show_items(); });
         add_shortcut(false, 'T', [&]() { toggle_show_triggers(); });
-        add_shortcut(false, 'G', [&]() { toggle_show_hidden_geometry(); });
+        add_shortcut(false, 'G', [&]() { toggle_show_geometry(); });
         add_shortcut(false, VK_OEM_MINUS, [&]() { select_previous_orbit(); });
         add_shortcut(false, VK_OEM_PLUS, [&]() { select_next_orbit(); });
         add_shortcut(false, VK_F1, [&]() { _ui->toggle_settings_visibility(); });
@@ -522,12 +521,11 @@ namespace trview
         _token_store += _level->on_level_changed += [&]() { _scene_changed = true; };
 
         _level->set_show_triggers(_ui->toggle(Options::triggers));
-        _level->set_show_hidden_geometry(_ui->toggle(Options::hidden_geometry));
+        _level->set_show_geometry(_ui->toggle(Options::geometry));
         _level->set_show_water(_ui->toggle(Options::water));
         _level->set_show_wireframe(_ui->toggle(Options::wireframe)); 
         _level->set_show_bounding_boxes(_ui->toggle(Options::show_bounding_boxes));
         _level->set_show_lights(_ui->toggle(Options::lights));
-        _level->set_use_trle_colours(_ui->toggle(Options::trle_colours));
         _level->set_show_items(_ui->toggle(Options::items));
 
         // Set up the views.
@@ -1017,20 +1015,20 @@ namespace trview
         }
     }
 
-    void Viewer::set_show_hidden_geometry(bool show)
+    void Viewer::set_show_geometry(bool show)
     {
         if (_level)
         {
-            _level->set_show_hidden_geometry(show);
-            _ui->set_toggle(Options::hidden_geometry, show);
+            _level->set_show_geometry(show);
+            _ui->set_toggle(Options::geometry, show);
         }
     }
 
-    void Viewer::toggle_show_hidden_geometry()
+    void Viewer::toggle_show_geometry()
     {
         if (_level)
         {
-            set_show_hidden_geometry(!_level->show_hidden_geometry());
+            set_show_geometry(!_level->show_geometry());
         }
     }
 
@@ -1074,15 +1072,6 @@ namespace trview
         {
             _level->set_show_lights(show);
             _ui->set_toggle(Options::lights, show);
-        }
-    }
-
-    void Viewer::set_use_trle_colours(bool show)
-    {
-        if (_level)
-        {
-            _level->set_use_trle_colours(show);
-            _ui->set_toggle(Options::trle_colours, show);
         }
     }
 

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -109,14 +109,13 @@ namespace trview
         void toggle_show_triggers();
         void set_show_items(bool show);
         void toggle_show_items();
-        void set_show_hidden_geometry(bool show);
-        void toggle_show_hidden_geometry();
+        void set_show_geometry(bool show);
+        void toggle_show_geometry();
         void toggle_show_lights();
         void set_show_water(bool show);
         void set_show_wireframe(bool show);
         void set_show_bounding_boxes(bool show);
         void set_show_lights(bool show);
-        void set_use_trle_colours(bool show);
         uint32_t room_from_pick(const PickResult& pick) const;
         void add_recent_orbit(const PickResult& pick);
         void select_previous_orbit();


### PR DESCRIPTION
Replace hidden geometry mode with TRLE mode.
TRLE mode uses the G hotkey.
Remove all references to TRLE mode - just call it Geometry mode.
Closes #956