### PR TITLE
Add handling for missing static mesh and items

### DIFF
--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include "trtypes.h"
 #include "tr_rooms.h"
 #include "LevelVersion.h"
@@ -122,7 +123,7 @@ namespace trlevel
         // Get the static mesh at the specfied index.
         // index: The index of the model to get.
         // Returns: The model.
-        virtual tr_staticmesh get_static_mesh(uint32_t index) const = 0;
+        virtual std::optional<tr_staticmesh> get_static_mesh(uint32_t index) const = 0;
 
         /// Get the number of mesh pointers in the level.
         virtual uint32_t num_mesh_pointers() const = 0;
@@ -169,5 +170,7 @@ namespace trlevel
         /// @param type The type id to check.
         /// @returns The mesh index for the type.
         virtual int16_t get_mesh_from_type_id(int16_t type) const = 0;
+
+        virtual std::string name() const = 0;
     };
 }

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -349,9 +349,9 @@ namespace trlevel
     {
         // Load the level from the file.
         auto last_index = std::min(filename.find_last_of('\\'), filename.find_last_of('/'));
-        auto name = last_index == filename.npos ? filename : filename.substr(std::min(last_index + 1, filename.size()));
+        _name = last_index == filename.npos ? filename : filename.substr(std::min(last_index + 1, filename.size()));
 
-        trview::Activity activity(log, "IO", "Load Level " + name);
+        trview::Activity activity(log, "IO", "Load Level " + _name);
 
         try
         {
@@ -647,9 +647,14 @@ namespace trlevel
         return static_cast<uint32_t>(_static_meshes.size());
     }
 
-    tr_staticmesh Level::get_static_mesh(uint32_t mesh_id) const
+    std::optional<tr_staticmesh> Level::get_static_mesh(uint32_t mesh_id) const
     {
-        return _static_meshes.find(mesh_id)->second;
+        auto mesh = _static_meshes.find(mesh_id);
+        if (mesh == _static_meshes.end())
+        {
+            return std::nullopt;
+        }
+        return mesh->second;
     }
 
     uint32_t Level::num_mesh_pointers() const
@@ -1164,5 +1169,10 @@ namespace trlevel
             return LaraSkinPostTR3;
         }
         return LaraSkinTR3;
+    }
+
+    std::string Level::name() const
+    {
+        return _name;
     }
 }

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -122,7 +122,7 @@ namespace trlevel
         // Get the static mesh at the specfied index.
         // index: The mesh ID of the model to get.
         // Returns: The model.
-        virtual tr_staticmesh get_static_mesh(uint32_t mesh_id) const override;
+        virtual std::optional<tr_staticmesh> get_static_mesh(uint32_t mesh_id) const override;
 
         /// Get the number of mesh pointers in the level.
         virtual uint32_t num_mesh_pointers() const override;
@@ -169,6 +169,8 @@ namespace trlevel
         /// @param type The type id to check.
         /// @returns The mesh index for the type.
         virtual int16_t get_mesh_from_type_id(int16_t type) const override;
+
+        virtual std::string name() const override;
     private:
         void generate_meshes(const std::vector<uint16_t>& mesh_data);
 
@@ -208,5 +210,7 @@ namespace trlevel
         std::vector<uint16_t>                 _frames;
         std::vector<tr_sprite_texture>        _sprite_textures;
         std::vector<tr_sprite_sequence>       _sprite_sequences;
+
+        std::string _name;
     };
 }

--- a/trlevel/Mocks/ILevel.h
+++ b/trlevel/Mocks/ILevel.h
@@ -32,7 +32,7 @@ namespace trlevel
             MOCK_METHOD(tr_model, get_model, (uint32_t), (const, override));
             MOCK_METHOD(bool, get_model_by_id, (uint32_t, tr_model&), (const, override));
             MOCK_METHOD(uint32_t, num_static_meshes, (), (const, override));
-            MOCK_METHOD(tr_staticmesh, get_static_mesh, (uint32_t), (const, override));
+            MOCK_METHOD(std::optional<tr_staticmesh>, get_static_mesh, (uint32_t), (const, override));
             MOCK_METHOD(uint32_t, num_mesh_pointers, (), (const, override));
             MOCK_METHOD(tr_mesh, get_mesh_by_pointer, (uint32_t), (const, override));
             MOCK_METHOD(std::vector<tr_meshtree_node>, get_meshtree, (uint32_t, uint32_t), (const, override));
@@ -42,6 +42,7 @@ namespace trlevel
             MOCK_METHOD(tr_sprite_texture, get_sprite_texture, (uint32_t), (const, override));
             MOCK_METHOD(bool, find_first_entity_by_type, (int16_t, tr2_entity&), (const, override));
             MOCK_METHOD(int16_t, get_mesh_from_type_id, (int16_t), (const, override));
+            MOCK_METHOD(std::string, name, (), (const, override));
         };
     }
 }

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -15,6 +15,7 @@
 #include <trview.graphics/mocks/D3D/ID3D11DeviceContext.h>
 #include <trview.graphics/mocks/IShader.h>
 #include <trview.common/Algorithms.h>
+#include <trview.common/Mocks/Logs/ILog.h>
 
 using namespace trview;
 using namespace trview::mocks;
@@ -47,11 +48,12 @@ namespace
             IRoom::Source room_source{ [](auto&&...) { return mock_shared<MockRoom>(); } };
             ITrigger::Source trigger_source{ [](auto&&...) {return mock_shared<MockTrigger>(); } };
             ILight::Source light_source{ [](auto&&...) { return std::make_shared<MockLight>(); } };
+            std::shared_ptr<ILog> log{ mock_shared<MockLog>() };
 
             std::unique_ptr<Level> build()
             {
                 return std::make_unique<Level>(device, shader_storage, std::move(level), level_texture_storage, std::move(mesh_storage), std::move(transparency_buffer),
-                    std::move(selection_renderer), type_name_lookup, entity_source, ai_source, room_source, trigger_source, light_source);
+                    std::move(selection_renderer), type_name_lookup, entity_source, ai_source, room_source, trigger_source, light_source, log);
             }
 
             test_module& with_type_name_lookup(const std::shared_ptr<ITypeNameLookup>& type_name_lookup)

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -120,6 +120,8 @@ namespace trview
             return std::make_shared<Entity>(mesh_source, level, entity, mesh_storage, index);
         };
 
+        auto log = std::make_shared<Log>();
+
         auto bounding_mesh = create_cube_mesh(mesh_source);
         auto static_mesh_source = [=](auto&&... args) { return std::make_shared<StaticMesh>(args..., bounding_mesh); };
         auto static_mesh_position_source = [=](auto&&... args) { return std::make_shared<StaticMesh>(args...); };
@@ -144,7 +146,8 @@ namespace trview
                 ai_source,
                 room_source,
                 trigger_source,
-                light_source);
+                light_source,
+                log);
         };
 
         auto viewer_ui = std::make_unique<ViewerUI>(
@@ -182,7 +185,6 @@ namespace trview
         auto rooms_window_source = [=]() { return std::make_shared<RoomsWindow>(map_renderer_source, clipboard); };
         auto lights_window_source = [=]() { return std::make_shared<LightsWindow>(clipboard); };
 
-        auto log = std::make_shared<Log>();
         auto log_window_source = [=]() { return std::make_shared<LogWindow>(log, dialogs, files); };
 
         auto trlevel_source = [=](auto&& filename) { return std::make_unique<trlevel::Level>(filename, log); };

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -16,6 +16,7 @@
 #include <trview.app/Geometry/PickInfo.h>
 #include <trview.app/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Graphics/IMeshStorage.h>
+#include <trview.common/Logs/Activity.h>
 
 namespace trview
 {
@@ -87,7 +88,7 @@ namespace trview
         /// Create a new implementation of <see cref="IRoom"/>.
         /// </summary>
         using Source = std::function<std::shared_ptr<IRoom>(const trlevel::ILevel&, const trlevel::tr3_room&,
-            const std::shared_ptr<ILevelTextureStorage>&, const IMeshStorage&, uint32_t, const ILevel&)>;
+            const std::shared_ptr<ILevelTextureStorage>&, const IMeshStorage&, uint32_t, const ILevel&, const Activity& activity)>;
         /// <summary>
         /// Destructor for <see cref="IRoom"/>.
         /// </summary>

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -7,6 +7,7 @@
 #include <trview.app/Camera/ICamera.h>
 #include <trview.app/Elements/ITypeNameLookup.h>
 #include <trview.graphics/RasterizerStateStore.h>
+#include <format>
 
 using namespace DirectX;
 using namespace DirectX::SimpleMath;
@@ -25,9 +26,10 @@ namespace trview
         const IEntity::AiSource& ai_source,
         const IRoom::Source& room_source,
         const ITrigger::Source& trigger_source,
-        const ILight::Source& light_source)
+        const ILight::Source& light_source,
+        const std::shared_ptr<ILog>& log)
         : _device(device), _version(level->get_version()), _texture_storage(level_texture_storage),
-        _transparency(std::move(transparency_buffer)), _selection_renderer(std::move(selection_renderer))
+        _transparency(std::move(transparency_buffer)), _selection_renderer(std::move(selection_renderer)), _log(log)
     {
         _vertex_shader = shader_storage->get("level_vertex_shader");
         _pixel_shader = shader_storage->get("level_pixel_shader");
@@ -388,11 +390,13 @@ namespace trview
 
     void Level::generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage)
     {
+        Activity generate_rooms_activity(_log, "Level", level.name());
         const auto num_rooms = level.num_rooms();
         for (uint32_t i = 0u; i < num_rooms; ++i)
         {
+            Activity room_activity(generate_rooms_activity, std::format("Room {}", i));
             auto room = level.get_room(i);
-            _rooms.push_back(room_source(level, room, _texture_storage, mesh_storage, i, *this));
+            _rooms.push_back(room_source(level, room, _texture_storage, mesh_storage, i, *this, room_activity));
         }
 
         std::set<uint32_t> alternate_groups;

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -41,7 +41,8 @@ namespace trview
             const IEntity::AiSource& ai_source,
             const IRoom::Source& room_source,
             const ITrigger::Source& trigger_source,
-            const ILight::Source& light_source);
+            const ILight::Source& light_source,
+            const std::shared_ptr<ILog>& log);
         virtual ~Level() = default;
         virtual std::vector<RoomInfo> room_info() const override;
         virtual RoomInfo room_info(uint32_t room) const override;
@@ -177,6 +178,7 @@ namespace trview
         std::set<uint32_t> _alternate_groups;
         trlevel::LevelVersion _version;
         std::string _filename;
+        std::shared_ptr<ILog> _log;
     };
 
     /// Find the first item with the type id specified.

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -19,6 +19,7 @@
 #include "IRoom.h"
 
 #include <trview.common/TokenStore.h>
+#include <trview.common/Logs/ILog.h>
 
 namespace trview
 {
@@ -32,6 +33,7 @@ namespace trview
             const IMeshStorage& mesh_storage,
             uint32_t index,
             const ILevel& parent_level,
+            const Activity& activity,
             const IStaticMesh::MeshSource& static_mesh_mesh_source,
             const IStaticMesh::PositionSource& static_mesh_position_source,
             const ISector::Source& sector_source);
@@ -79,7 +81,7 @@ namespace trview
         void generate_geometry(trlevel::LevelVersion level_version, const IMesh::Source& mesh_source, const trlevel::tr3_room& room);
         void generate_adjacency();
         void generate_static_meshes(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr3_room& room, const IMeshStorage& mesh_storage,
-            const IStaticMesh::MeshSource& static_mesh_mesh_source, const IStaticMesh::PositionSource& static_mesh_position_source);
+            const IStaticMesh::MeshSource& static_mesh_mesh_source, const IStaticMesh::PositionSource& static_mesh_position_source, const Activity& activity);
         void render_contained(const ICamera& camera, const DirectX::SimpleMath::Color& colour, bool show_items);
         void get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour, bool show_items);
         void generate_sectors(const trlevel::ILevel& level, const trlevel::tr3_room& room, const ISector::Source& sector_source);

--- a/trview.app/Geometry/PickResult.cpp
+++ b/trview.app/Geometry/PickResult.cpp
@@ -110,8 +110,8 @@ namespace trview
                             stream << L" " << command.index();
                             if (command_is_item(command.type()))
                             {
-                                const auto item = level.items()[command.index()];
-                                stream << L" - " << item.type();
+                                const auto items = level.items();
+                                stream << L" - " << (command.index() < items.size() ? items[command.index()].type() : L"No Item");
                             }
                         }
                     }

--- a/trview.app/Windows/Log/LogWindow.cpp
+++ b/trview.app/Windows/Log/LogWindow.cpp
@@ -24,6 +24,18 @@ namespace trview
 
     bool LogWindow::render_log_window()
     {
+        const auto get_colour = [&](auto&& message)
+        {
+            switch (message.status)
+            {
+            case Message::Status::Warning:
+                return ImVec4(1, 1, 0, 1);
+            case Message::Status::Error:
+                return ImVec4(1, 0, 0, 1);
+            }
+            return ImVec4(1, 1, 1, 1);
+        };
+
         bool stay_open = true;
         ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(520, 400));
         if (ImGui::Begin(_id.c_str(), &stay_open))
@@ -48,7 +60,9 @@ namespace trview
                                 activities += "[" + activity + "]";
                             }
 
+                            ImGui::PushStyleColor(ImGuiCol_Text, get_colour(message));
                             ImGui::Text("[%s] [%s] %s - %s", message.topic.c_str(), message.timestamp.c_str(), activities.c_str(), message.text.c_str());
+                            ImGui::PopStyleColor();
                         }
                     }
                     ImGui::EndChild();
@@ -81,19 +95,7 @@ namespace trview
                                                 activities += "[" + *iter + "]";
                                             }
 
-                                            auto get_colour = [&]()
-                                            {
-                                                switch (message.status)
-                                                {
-                                                case Message::Status::Warning:
-                                                    return ImVec4(1, 1, 0, 1);
-                                                case Message::Status::Error:
-                                                    return ImVec4(1, 0, 0, 1);
-                                                }
-                                                return ImVec4(1, 1, 1, 1);
-                                            };
-
-                                            ImGui::PushStyleColor(ImGuiCol_Text, get_colour());
+                                            ImGui::PushStyleColor(ImGuiCol_Text, get_colour(message));
                                             ImGui::Text("[%s] %s - %s", message.timestamp.c_str(), activities.c_str(), message.text.c_str());
                                             ImGui::PopStyleColor();
                                         }

--- a/trview.common/Logs/Activity.cpp
+++ b/trview.common/Logs/Activity.cpp
@@ -21,12 +21,12 @@ namespace trview
         _log->log(Message::Status::Information, _topic, _names, "Activity Ended");
     }
 
-    void Activity::log(const std::string& text)
+    void Activity::log(const std::string& text) const
     {
         _log->log(Message::Status::Information, _topic, _names, text);
     }
 
-    void Activity::log(Message::Status status, const std::string& text)
+    void Activity::log(Message::Status status, const std::string& text) const
     {
         _log->log(status, _topic, _names, text);
     }

--- a/trview.common/Logs/Activity.h
+++ b/trview.common/Logs/Activity.h
@@ -25,10 +25,10 @@ namespace trview
         Activity(const Activity&) = delete;
         Activity operator=(const Activity&) = delete;
         ~Activity();
-        void log(const std::string& text);
-        void log(Message::Status status, const std::string& text);
+        void log(const std::string& text) const;
+        void log(Message::Status status, const std::string& text) const;
     private:
-        std::shared_ptr<ILog> _log;
+        mutable std::shared_ptr<ILog> _log;
         std::string _topic;
         std::vector<std::string> _names;
     };


### PR DESCRIPTION
If a static mesh is missing when loading the level then log an error and continue without it.
If a trigger references an item that doesn't exist then don't try to access an invalid element.
Closes #979 