### PR TITLE
Use identity matrix if transform stack is empty

### DIFF
--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -147,8 +147,15 @@ namespace trview
 
                 if (node.Flags & 0x1)
                 {
-                    parent_world = world_stack.top();
-                    world_stack.pop();
+                    if (!world_stack.empty())
+                    {
+                        parent_world = world_stack.top();
+                        world_stack.pop();
+                    }
+                    else
+                    {
+                        parent_world = Matrix::Identity;
+                    }
                 }
                 if (node.Flags & 0x2)
                 {


### PR DESCRIPTION
If a model asks to pop the matrix from the top of the stack but there's nothing on the stack use the identity matrix instead of crashing the program.
Closes #985