### PR TITLE
Scroll correctly to selected trigger

### DIFF
--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -239,6 +239,14 @@ namespace trview
                     }
                 }
 
+                const auto index = index_of_selected();
+                if (index.has_value())
+                {
+                    const float item_pos_y = clipper.StartPosY + clipper.ItemsHeight * index.value();
+                    ImGui::SetScrollFromPosY(item_pos_y - ImGui::GetWindowPos().y);
+                }
+
+                clipper.End();
                 ImGui::EndTable();
             }
         }
@@ -494,5 +502,24 @@ namespace trview
                     ImGui::CalcTextSize(to_utf8(trigger_type_name(trigger_ptr->type())).c_str()).x);
             }
         }
+    }
+
+    std::optional<int> TriggersWindow::index_of_selected() const
+    {
+        const auto selected = _selected_trigger.lock();
+        if (selected && _scroll_to_trigger)
+        {
+            const auto found = std::find_if(_filtered_triggers.begin(), _filtered_triggers.end(),
+                [&](auto&& t)
+                {
+                    auto t_l = t.lock();
+                    return t_l && t_l->number() == selected->number();
+                });
+            if (found != _filtered_triggers.end())
+            {
+                return found - _filtered_triggers.begin();
+            }
+        }
+        return std::nullopt;
     }
 }

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -49,6 +49,7 @@ namespace trview
         void setup_filters();
         void filter_triggers();
         void calculate_column_widths();
+        std::optional<int> index_of_selected() const;
 
         std::string _id{ "Triggers 0" };
         std::vector<Item> _all_items;


### PR DESCRIPTION
Since the trigger window uses the `ImGuiListClipper` we need to scroll differently to the selected trigger.
Closes #982