### PR TITLE
Remove wide strings where possible and switch to format

### DIFF
--- a/trlevel/tr_lights.cpp
+++ b/trlevel/tr_lights.cpp
@@ -259,22 +259,22 @@ namespace trlevel
         return 0;
     }
 
-    std::wstring light_type_name(LightType type)
+    std::string light_type_name(LightType type)
     {
         switch (type)
         {
         case LightType::Sun:
-            return L"Sun";
+            return "Sun";
         case LightType::Point:
-            return L"Point";
+            return "Point";
         case LightType::Spot:
-            return L"Spot";
+            return "Spot";
         case LightType::Shadow:
-            return L"Shadow";
+            return "Shadow";
         case LightType::FogBulb:
-            return L"Fog Bulb";
+            return "Fog Bulb";
         }
-        return L"Unknown";
+        return "Unknown";
     }
 
     std::vector<tr_x_room_light> convert_lights(std::vector<tr_room_light> lights)

--- a/trlevel/tr_lights.h
+++ b/trlevel/tr_lights.h
@@ -36,7 +36,7 @@ namespace trlevel
         float density() const;
     };
 
-    std::wstring light_type_name(LightType type);
+    std::string light_type_name(LightType type);
 
     std::vector<tr_x_room_light> convert_lights(std::vector<tr_room_light> lights);
     std::vector<tr_x_room_light> convert_lights(std::vector<tr2_room_light> lights);

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -17,6 +17,7 @@ namespace trlevel
         FogBulb = 4
     };
 
+    constexpr float Scale{ 1024.0f };
     constexpr float Scale_X { 1024.0f };
     constexpr float Scale_Y { 1024.0f };
     constexpr float Scale_Z { 1024.0f };

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -17,7 +17,7 @@ namespace trlevel
         FogBulb = 4
     };
 
-    constexpr float Scale{ 1024.0f };
+    constexpr float Scale { 1024.0f };
     constexpr float Scale_X { 1024.0f };
     constexpr float Scale_Y { 1024.0f };
     constexpr float Scale_Z { 1024.0f };

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -627,7 +627,7 @@ TEST(Application, ReloadSyncsProperties)
     std::vector<Item> items;
     for (int i = 0; i < 5; ++i) 
     {
-        items.push_back(Item(i, 0, 0, L"", 0, 0, {}, Vector3::Zero));
+        items.push_back(Item(i, 0, 0, "", 0, 0, {}, Vector3::Zero));
     }
     
     std::vector<std::shared_ptr<ITrigger>> triggers;

--- a/trview.app.tests/Elements/TypeNameLookupTests.cpp
+++ b/trview.app.tests/Elements/TypeNameLookupTests.cpp
@@ -10,7 +10,7 @@ TEST(TypeNameLookup, LookupTR1)
 
     TypeNameLookup lookup(json);
 
-    ASSERT_EQ(L"Test Name", lookup.lookup_type_name(LevelVersion::Tomb1, 123));
+    ASSERT_EQ("Test Name", lookup.lookup_type_name(LevelVersion::Tomb1, 123));
 }
 
 // Tests that if there are identical entries for different games, the correct result is returned.
@@ -20,8 +20,8 @@ TEST(TypeNameLookup, LookupMultipleGames)
 
     TypeNameLookup lookup(json);
 
-    ASSERT_EQ(L"Test Name TR1", lookup.lookup_type_name(LevelVersion::Tomb1, 123));
-    ASSERT_EQ(L"Test Name TR2", lookup.lookup_type_name(LevelVersion::Tomb2, 123));
+    ASSERT_EQ("Test Name TR1", lookup.lookup_type_name(LevelVersion::Tomb1, 123));
+    ASSERT_EQ("Test Name TR2", lookup.lookup_type_name(LevelVersion::Tomb2, 123));
 }
 
 // Tests that if the name is missing, it still returns the number.
@@ -31,5 +31,5 @@ TEST(TypeNameLookup, LookupMissingItem)
 
     TypeNameLookup lookup(json);
 
-    ASSERT_EQ(L"123", lookup.lookup_type_name(LevelVersion::Tomb3, 123));
+    ASSERT_EQ("123", lookup.lookup_type_name(LevelVersion::Tomb3, 123));
 }

--- a/trview.app.tests/ItemsWindowManagerTests.cpp
+++ b/trview.app.tests/ItemsWindowManagerTests.cpp
@@ -57,7 +57,7 @@ TEST(ItemsWindowManager, AddToRouteEventRaised)
     auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
-    Item test_item(100, 10, 1, L"Lara", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero);
+    Item test_item(100, 10, 1, "Lara", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero);
     created_window->on_add_to_route(test_item);
 
     ASSERT_TRUE(raised_item.has_value());
@@ -74,7 +74,7 @@ TEST(ItemsWindowManager, ItemSelectedEventRaised)
     auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
-    Item test_item(100, 10, 1, L"Lara", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero);
+    Item test_item(100, 10, 1, "Lara", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero);
     created_window->on_item_selected(test_item);
 
     ASSERT_TRUE(raised_item.has_value());
@@ -91,7 +91,7 @@ TEST(ItemsWindowManager, ItemVisibilityEventRaised)
     auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
-    Item test_item(100, 10, 1, L"Lara", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero);
+    Item test_item(100, 10, 1, "Lara", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero);
     created_window->on_item_visibility(test_item, true);
 
     ASSERT_TRUE(raised_item.has_value());
@@ -128,8 +128,8 @@ TEST(ItemsWindowManager, SetItemsSetsItemsOnWindows)
 
     std::vector<Item> items
     {
-        Item(0, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
-        Item(1, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero)
+        Item(0, 0, 0, "Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
+        Item(1, 0, 0, "Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero)
     };
     manager->set_items(items);
 }
@@ -146,7 +146,7 @@ TEST(ItemsWindowManager, SetItemVisibilityUpdatesWindows)
 
     std::vector<Item> items
     {
-        Item(0, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
+        Item(0, 0, 0, "Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
     };
     manager->set_items(items);
     manager->set_item_visible(items[0], false);
@@ -187,8 +187,8 @@ TEST(ItemsWindowManager, SetSelectedItemSetsSelectedItemOnWindows)
 
     std::vector<Item> items
     {
-        Item(0, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
-        Item(1, 1, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero)
+        Item(0, 0, 0, "Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
+        Item(1, 1, 0, "Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero)
     };
     manager->set_items(items);
 
@@ -206,8 +206,8 @@ TEST(ItemsWindowManager, CreateWindowCreatesNewWindowWithSavedValues)
 
     std::vector<Item> items
     {
-        Item(0, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
-        Item(1, 1, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero)
+        Item(0, 0, 0, "Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
+        Item(1, 1, 0, "Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero)
     };
 
     manager->set_items(items);

--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -42,8 +42,8 @@ TEST(ItemsWindow, AddToRouteEventRaised)
 
     std::vector<Item> items
     {
-        Item(0, 0, 0, L"Type", 0, 0, {}, Vector3::Zero),
-        Item(1, 0, 0, L"Type", 0, 0, {}, Vector3::Zero)
+        Item(0, 0, 0, "Type", 0, 0, {}, Vector3::Zero),
+        Item(1, 0, 0, "Type", 0, 0, {}, Vector3::Zero)
     };
     window->set_items(items);
     window->set_selected_item(items[1]);
@@ -65,8 +65,8 @@ TEST(ItemsWindow, ItemSelectedNotRaisedWhenSyncItemDisabled)
 
     std::vector<Item> items
     {
-        Item(0, 0, 0, L"Type", 0, 0, {}, Vector3::Zero),
-        Item(1, 0, 0, L"Type", 0, 0, {}, Vector3::Zero)
+        Item(0, 0, 0, "Type", 0, 0, {}, Vector3::Zero),
+        Item(1, 0, 0, "Type", 0, 0, {}, Vector3::Zero)
     };
     window->set_items(items);
 
@@ -91,8 +91,8 @@ TEST(ItemsWindow, ItemSelectedRaisedWhenSyncItemEnabled)
 
     std::vector<Item> items
     {
-        Item(0, 0, 0, L"Type", 0, 0, {}, Vector3::Zero),
-        Item(1, 0, 0, L"Type", 0, 0, {}, Vector3::Zero)
+        Item(0, 0, 0, "Type", 0, 0, {}, Vector3::Zero),
+        Item(1, 0, 0, "Type", 0, 0, {}, Vector3::Zero)
     };
     window->set_items(items);
 
@@ -118,8 +118,8 @@ TEST(ItemsWindow, ItemVisibilityRaised)
 
     std::vector<Item> items
     {
-        Item(0, 0, 0, L"Type", 0, 0, {}, Vector3::Zero),
-        Item(1, 0, 0, L"Type", 0, 0, {}, Vector3::Zero)
+        Item(0, 0, 0, "Type", 0, 0, {}, Vector3::Zero),
+        Item(1, 0, 0, "Type", 0, 0, {}, Vector3::Zero)
     };
     window->set_items(items);
 
@@ -142,8 +142,8 @@ TEST(ItemsWindow, ItemsListNotFilteredWhenRoomSetAndTrackRoomDisabled)
 
     std::vector<Item> items
     {
-        Item(0, 55, 0, L"Type", 0, 0, {}, Vector3::Zero),
-        Item(1, 78, 0, L"Type", 0, 0, {}, Vector3::Zero)
+        Item(0, 55, 0, "Type", 0, 0, {}, Vector3::Zero),
+        Item(1, 78, 0, "Type", 0, 0, {}, Vector3::Zero)
     };
     window->set_items(items);
     window->set_current_room(78);
@@ -166,8 +166,8 @@ TEST(ItemsWindow, ItemsListFilteredWhenRoomSetAndTrackRoomEnabled)
 
     std::vector<Item> items
     {
-        Item(0, 55, 0, L"Type", 0, 0, {}, Vector3::Zero),
-        Item(1, 78, 0, L"Type", 0, 0, {}, Vector3::Zero)
+        Item(0, 55, 0, "Type", 0, 0, {}, Vector3::Zero),
+        Item(1, 78, 0, "Type", 0, 0, {}, Vector3::Zero)
     };
     window->set_items(items);
     window->set_current_room(78);
@@ -192,8 +192,8 @@ TEST(ItemsWindow, ItemsListPopulatedOnSet)
 
     std::vector<Item> items
     {
-        Item(0, 55, 0, L"Lara", 0, 0, {}, Vector3::Zero),
-        Item(1, 78, 0, L"Winston", 0, 0, {}, Vector3::Zero)
+        Item(0, 55, 0, "Lara", 0, 0, {}, Vector3::Zero),
+        Item(1, 78, 0, "Winston", 0, 0, {}, Vector3::Zero)
     };
     window->set_items(items);
 
@@ -214,8 +214,8 @@ TEST(ItemsWindow, ItemsListUpdatedWhenFiltered)
 
     std::vector<Item> items
     {
-        Item(0, 55, 0, L"Type", 0, 0, {}, Vector3::Zero),
-        Item(1, 78, 0, L"Type", 0, 0, {}, Vector3::Zero)
+        Item(0, 55, 0, "Type", 0, 0, {}, Vector3::Zero),
+        Item(1, 78, 0, "Type", 0, 0, {}, Vector3::Zero)
     };
     window->set_items(items);
     window->set_current_room(78);
@@ -241,8 +241,8 @@ TEST(ItemsWindow, ItemsListUpdatedWhenNotFiltered)
 
     std::vector<Item> items
     {
-        Item(0, 55, 0, L"Type", 0, 0, {}, Vector3::Zero),
-        Item(1, 78, 0, L"Type", 0, 0, {}, Vector3::Zero)
+        Item(0, 55, 0, "Type", 0, 0, {}, Vector3::Zero),
+        Item(1, 78, 0, "Type", 0, 0, {}, Vector3::Zero)
     };
     window->set_items(items);
     TestImgui imgui([&]() { window->render(); });
@@ -274,8 +274,8 @@ TEST(ItemsWindow, TriggersLoadedForItem)
     auto trigger2 = mock_shared<MockTrigger>()->with_number(1);
     std::vector<Item> items
     {
-        Item(0, 0, 0, L"Type", 0, 0, {}, Vector3::Zero),
-        Item(1, 0, 0, L"Type", 0, 0, { trigger1, trigger2 }, Vector3::Zero)
+        Item(0, 0, 0, "Type", 0, 0, {}, Vector3::Zero),
+        Item(1, 0, 0, "Type", 0, 0, { trigger1, trigger2 }, Vector3::Zero)
     };
     window->set_items(items);
     window->set_triggers({ trigger1, trigger2 });
@@ -303,8 +303,8 @@ TEST(ItemsWindow, TriggerSelectedEventRaised)
     auto trigger = mock_shared<MockTrigger>();
     std::vector<Item> items
     {
-        Item(0, 0, 0, L"Type", 0, 0, {}, Vector3::Zero),
-        Item(1, 0, 0, L"Type", 0, 0, { trigger }, Vector3::Zero)
+        Item(0, 0, 0, "Type", 0, 0, {}, Vector3::Zero),
+        Item(1, 0, 0, "Type", 0, 0, { trigger }, Vector3::Zero)
     };
     window->set_items(items);
     window->set_triggers({ trigger });
@@ -331,7 +331,7 @@ TEST(ItemsWindow, ClickStatShowsBubbleAndCopies)
 
     std::vector<Item> items
     {
-        Item(0, 0, 0, L"Test Type", 0, 0, {}, Vector3::Zero)
+        Item(0, 0, 0, "Test Type", 0, 0, {}, Vector3::Zero)
     };
     window->set_items(items);
     window->set_selected_item(items[0]);

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -140,7 +140,7 @@ TEST(RouteWindow, AddingWaypointNotesMarksRouteUnsaved)
     const Vector3 waypoint_pos{ 130, 250, 325 };
     NiceMock<MockWaypoint> waypoint;
     EXPECT_CALL(waypoint, position).WillRepeatedly(Return(waypoint_pos));
-    EXPECT_CALL(waypoint, set_notes(std::wstring(L"Test"))).Times(1);
+    EXPECT_CALL(waypoint, set_notes(std::string("Test"))).Times(1);
 
     NiceMock<MockRoute> route;
     EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));

--- a/trview.app.tests/Routing/WaypointTests.cpp
+++ b/trview.app.tests/Routing/WaypointTests.cpp
@@ -27,8 +27,8 @@ TEST(Waypoint, EmptySave)
 TEST(Waypoint, Notes)
 {
     Waypoint waypoint(mock_shared<MockMesh>(), Vector3(1, 2, 3), Vector3::Down, 12, IWaypoint::Type::Trigger, 23, Colour::Red);
-    waypoint.set_notes(L"Test notes\nNew line");
-    ASSERT_EQ(waypoint.notes(), L"Test notes\nNew line");
+    waypoint.set_notes("Test notes\nNew line");
+    ASSERT_EQ(waypoint.notes(), "Test notes\nNew line");
 }
 
 TEST(Waypoint, SaveFile)

--- a/trview.app.tests/TestImGuiId.cpp
+++ b/trview.app.tests/TestImGuiId.cpp
@@ -1,5 +1,6 @@
 #include "TestImGuiId.h"
 #include <external/imgui/imgui_internal.h>
+#include <format>
 
 namespace trview
 {
@@ -7,26 +8,12 @@ namespace trview
     {
         TestImGuiId TestImGuiId::push_popup(const std::string& name) const
         {
-            auto context = ImGui::GetCurrentContext();
-            std::string popup_name;
-
-            std::stringstream stream;
-            stream << "##Popup_" << std::hex << std::setfill('0') << std::setw(8) << TestImGuiId("Debug##Default").id(name).id();
-            popup_name = stream.str();
-
-            return TestImGuiId(popup_name);
+            return TestImGuiId(std::format("##Popup_{:0>8x}", TestImGuiId("Debug##Default").id(name).id()));
         }
 
         TestImGuiId TestImGuiId::push_child(const std::string& name) const
         {
-            auto context = ImGui::GetCurrentContext();
-            auto id = GetID(name.c_str());
-
-            std::stringstream stream;
-            stream << _name << '/' << name << '_' << std::hex << std::uppercase << std::setfill('0') << std::setw(8) << id;
-            auto child_name = stream.str();
-
-            return TestImGuiId(child_name);
+            return TestImGuiId(std::format("{}/{}_{:0>8X}", _name, name, GetID(name.c_str())));
         }
 
         TestImGuiId TestImGuiId::push_override(const std::string& name) const
@@ -40,9 +27,7 @@ namespace trview
         {
             TestImGuiId copy = *this;
             auto new_id = copy.GetID(name.c_str());
-            std::stringstream stream;
-            stream << _name << '/' << name << '_' << std::hex << std::uppercase << std::setfill('0') << std::setw(8) << new_id;
-            copy._name = stream.str();
+            copy._name = std::format("{}/{}_{:0>8X}", _name, name, new_id);
             copy._stack.push_back(new_id);
             copy._hover_id = push_child(name).id();
             return copy;

--- a/trview.app.tests/TestImgui.cpp
+++ b/trview.app.tests/TestImgui.cpp
@@ -1,6 +1,7 @@
 #include "TestImgui.h"
 #include <trview.tests.common/Window.h>
 #include <trview.common/Strings.h>
+#include <format>
 
 using namespace trview::tests;
 
@@ -360,9 +361,7 @@ namespace trview
         TestImGuiId TestImgui::popup_id(const std::string& popup_name) const
         {
             auto id = TestImGuiId("Debug##Default").id(popup_name).id();
-            std::stringstream stream;
-            stream << "##Popup_" << std::hex << std::setfill('0') << std::setw(8) << id;
-            return TestImGuiId(stream.str());
+            return TestImGuiId(std::format("##Popup_{:0>8x}", id));
         }
     }
 }

--- a/trview.app.tests/TriggersWindowManagerTests.cpp
+++ b/trview.app.tests/TriggersWindowManagerTests.cpp
@@ -95,7 +95,7 @@ TEST(TriggersWindowManager, ItemSelectedEventRaised)
     auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
-    Item test_item(100, 10, 1, L"Lara", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero);
+    Item test_item(100, 10, 1, "Lara", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero);
     created_window->on_item_selected(test_item);
 
     ASSERT_TRUE(raised_item.has_value());
@@ -166,7 +166,7 @@ TEST(TriggersWindowManager, SetItemsSetsItemsOnWindows)
 
     std::vector<Item> items
     {
-        Item(0, 0, 0, L"Test Object", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
+        Item(0, 0, 0, "Test Object", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
     };
     manager->set_items(items);
 }

--- a/trview.app.tests/TriggersWindowTests.cpp
+++ b/trview.app.tests/TriggersWindowTests.cpp
@@ -217,8 +217,8 @@ TEST(TriggersWindow, ItemSelectedRaised)
 
     std::vector<Item> items
     {
-        Item(0, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
-        Item(1, 0, 0, L"Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero)
+        Item(0, 0, 0, "Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero),
+        Item(1, 0, 0, "Type", 0, 0, {}, DirectX::SimpleMath::Vector3::Zero)
     };
 
     auto trigger = mock_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Object, 1) });

--- a/trview.app.tests/UI/ConsoleTests.cpp
+++ b/trview.app.tests/UI/ConsoleTests.cpp
@@ -9,7 +9,7 @@ TEST(Console, CommandEventRaised)
     Console console;
     console.set_visible(true);
 
-    std::optional<std::wstring> raised;
+    std::optional<std::string> raised;
     auto token = console.on_command += [&](auto value)
     {
         raised = value;
@@ -23,7 +23,7 @@ TEST(Console, CommandEventRaised)
     imgui.render();
 
     ASSERT_TRUE(raised.has_value());
-    ASSERT_EQ(raised.value(), L"Test command");
+    ASSERT_EQ(raised.value(), "Test command");
     ASSERT_EQ(imgui.item_text(imgui.id("Console").id(Console::Names::input)), "");
 }
 
@@ -35,7 +35,7 @@ TEST(Console, PrintAddsLine)
     TestImgui imgui([&]() { console.render(); });
     ASSERT_EQ(imgui.item_text(imgui.id("Console").id(Console::Names::log)), "");
 
-    console.print(L"Test log entry");
+    console.print("Test log entry");
     imgui.render();
     ASSERT_EQ(imgui.item_text(imgui.id("Console").id(Console::Names::log)), "Test log entry");
 }

--- a/trview.app.tests/UI/GoToTests.cpp
+++ b/trview.app.tests/UI/GoToTests.cpp
@@ -9,9 +9,9 @@ TEST(GoTo, Name)
     GoTo window;
     window.toggle_visible(0);
 
-    ASSERT_EQ(window.name(), L"");
-    window.set_name(L"Item");
-    ASSERT_EQ(window.name(), L"Item");
+    ASSERT_EQ(window.name(), "");
+    window.set_name("Item");
+    ASSERT_EQ(window.name(), "Item");
 
     TestImgui imgui([&]() { window.render(); });
     ASSERT_NE(imgui.find_window(imgui.popup_id("Go To Item").name()), nullptr);
@@ -21,7 +21,7 @@ TEST(GoTo, OnSelectedWithPlusRaised)
 {
     GoTo window;
     window.toggle_visible(0);
-    window.set_name(L"Item");
+    window.set_name("Item");
 
     std::optional<uint32_t> raised;
     auto token = window.on_selected += [&](auto value)
@@ -43,7 +43,7 @@ TEST(GoTo, OnSelectedWithMinusRaised)
 {
     GoTo window;
     window.toggle_visible(0);
-    window.set_name(L"Item");
+    window.set_name("Item");
 
     std::vector<uint32_t> raised;
     auto token = window.on_selected += [&](auto value)
@@ -68,7 +68,7 @@ TEST(GoTo, OnSelectedNotRaisedWhenMinusPressedAtZero)
 {
     GoTo window;
     window.toggle_visible(0);
-    window.set_name(L"Item");
+    window.set_name("Item");
 
     std::optional<uint32_t> raised;
     auto token = window.on_selected += [&](auto value)
@@ -89,7 +89,7 @@ TEST(GoTo, OnSelectedRaised)
 {
     GoTo window;
     window.toggle_visible(0);
-    window.set_name(L"Item");
+    window.set_name("Item");
 
     std::optional<uint32_t> raised;
     auto token = window.on_selected += [&](auto value)
@@ -114,7 +114,7 @@ TEST(GoTo, OnZeroSelectedRaised)
 {
     GoTo window;
     window.toggle_visible(0);
-    window.set_name(L"Item");
+    window.set_name("Item");
 
     std::optional<uint32_t> raised;
     auto token = window.on_selected += [&](auto value)
@@ -139,7 +139,7 @@ TEST(GoTo, OnSelectedNotRaisedWhenCancelled)
 {
     GoTo window;
     window.toggle_visible(0);
-    window.set_name(L"Item");
+    window.set_name("Item");
 
     std::optional<uint32_t> raised;
     auto token = window.on_selected += [&](auto value)
@@ -159,7 +159,7 @@ TEST(GoTo, OnSelectedNotRaisedOnNegative)
 {
     GoTo window;
     window.toggle_visible(0);
-    window.set_name(L"Item");
+    window.set_name("Item");
 
     std::optional<uint32_t> raised;
     auto token = window.on_selected += [&](auto value)

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -108,7 +108,7 @@ TEST(Viewer, SelectItemRaisedForValidItem)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
 
-    Item item(123, 0, 0, L"Test", 0, 0, {}, Vector3::Zero);
+    Item item(123, 0, 0, "Test", 0, 0, {}, Vector3::Zero);
     NiceMock<MockLevel> level;
     EXPECT_CALL(level, item(123)).WillRepeatedly(Return(item));
 
@@ -141,7 +141,7 @@ TEST(Viewer, SelectItemNotRaisedForInvalidItem)
 /// Tests that the on_hide event from the UI is observed and forwarded when the item is valid.
 TEST(Viewer, ItemVisibilityRaisedForValidItem)
 {
-    Item item(123, 0, 0, L"Test", 0, 0, {}, Vector3::Zero);
+    Item item(123, 0, 0, "Test", 0, 0, {}, Vector3::Zero);
     NiceMock<MockLevel> level;
     EXPECT_CALL(level, item(123)).WillRepeatedly(Return(item));
 
@@ -321,7 +321,7 @@ TEST(Viewer, AddWaypointRaisedUsesItemPosition)
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
 
     NiceMock<MockLevel> level;
-    Item item(50, 10, 0, L"Test", 0, 0, {}, Vector3::Zero);
+    Item item(50, 10, 0, "Test", 0, 0, {}, Vector3::Zero);
     EXPECT_CALL(level, item(50)).WillRepeatedly(Return(item));
 
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -176,7 +176,7 @@
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
@@ -198,7 +198,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
@@ -218,7 +218,7 @@
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
@@ -240,7 +240,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>

--- a/trview.app/Elements/ITrigger.cpp
+++ b/trview.app/Elements/ITrigger.cpp
@@ -43,22 +43,22 @@ namespace trview
             { TriggerCommandType::Cutscene, "Cutscene" }
         };
 
-        const std::unordered_map<std::wstring, TriggerCommandType> command_type_lookup
+        const std::unordered_map<std::string, TriggerCommandType> command_type_lookup
         {
-            { L"Object", TriggerCommandType::Object },
-            { L"Camera", TriggerCommandType::Camera },
-            { L"Current", TriggerCommandType::UnderwaterCurrent },
-            { L"Flip Map", TriggerCommandType::FlipMap },
-            { L"Flip On", TriggerCommandType::FlipOn },
-            { L"Flip Off", TriggerCommandType::FlipOff },
-            { L"Look at Item", TriggerCommandType::LookAtItem },
-            { L"End Level", TriggerCommandType::EndLevel },
-            { L"Music", TriggerCommandType::PlaySoundtrack },
-            { L"Flipeffect", TriggerCommandType::Flipeffect },
-            { L"Secret", TriggerCommandType::SecretFound },
-            { L"Clear Bodies", TriggerCommandType::ClearBodies },
-            { L"Flyby", TriggerCommandType::Flyby },
-            { L"Cutscene", TriggerCommandType::Cutscene }
+            { "Object", TriggerCommandType::Object },
+            { "Camera", TriggerCommandType::Camera },
+            { "Current", TriggerCommandType::UnderwaterCurrent },
+            { "Flip Map", TriggerCommandType::FlipMap },
+            { "Flip On", TriggerCommandType::FlipOn },
+            { "Flip Off", TriggerCommandType::FlipOff },
+            { "Look at Item", TriggerCommandType::LookAtItem },
+            { "End Level", TriggerCommandType::EndLevel },
+            { "Music", TriggerCommandType::PlaySoundtrack },
+            { "Flipeffect", TriggerCommandType::Flipeffect },
+            { "Secret", TriggerCommandType::SecretFound },
+            { "Clear Bodies", TriggerCommandType::ClearBodies },
+            { "Flyby", TriggerCommandType::Flyby },
+            { "Cutscene", TriggerCommandType::Cutscene }
         };
     }
 
@@ -97,7 +97,7 @@ namespace trview
         return name->second;
     }
 
-    TriggerCommandType command_from_name(const std::wstring& name)
+    TriggerCommandType command_from_name(const std::string& name)
     {
         auto type = command_type_lookup.find(name);
         if (type == command_type_lookup.end())
@@ -106,12 +106,6 @@ namespace trview
         }
         return type->second;
     }
-
-    TriggerCommandType command_from_name(const std::string& name)
-    {
-        return command_from_name(to_utf16(name));
-    }
-
 
     bool command_has_index(TriggerCommandType type)
     {

--- a/trview.app/Elements/ITrigger.cpp
+++ b/trview.app/Elements/ITrigger.cpp
@@ -21,7 +21,7 @@ namespace trview
             { TriggerType::Monkey, "Monkey" },
             { TriggerType::Skeleton, "Skeleton" },
             { TriggerType::Tightrope, "Tightrope" },
-            { TriggerType::Crawl, "Craw" },
+            { TriggerType::Crawl, "Crawl" },
             { TriggerType::Climb, "Climb"}
         };
 

--- a/trview.app/Elements/ITrigger.cpp
+++ b/trview.app/Elements/ITrigger.cpp
@@ -4,43 +4,43 @@ namespace trview
 {
     namespace
     {
-        const std::unordered_map<TriggerType, std::wstring> trigger_type_names
+        const std::unordered_map<TriggerType, std::string> trigger_type_names
         {
-            { TriggerType::Trigger, L"Trigger" },
-            { TriggerType::Pad, L"Pad" },
-            { TriggerType::Switch, L"Switch" },
-            { TriggerType::Key, L"Key" },
-            { TriggerType::Pickup, L"Pickup" },
-            { TriggerType::HeavyTrigger, L"Heavy Trigger" },
-            { TriggerType::Antipad, L"Antipad" },
-            { TriggerType::Combat, L"Combat" },
-            { TriggerType::Dummy, L"Dummy" },
-            { TriggerType::AntiTrigger, L"Antitrigger" },
-            { TriggerType::HeavySwitch, L"Heavy Switch" },
-            { TriggerType::HeavyAntiTrigger, L"Heavy Antitrigger" },
-            { TriggerType::Monkey, L"Monkey" },
-            { TriggerType::Skeleton, L"Skeleton" },
-            { TriggerType::Tightrope, L"Tightrope" },
-            { TriggerType::Crawl, L"Crawl" },
-            { TriggerType::Climb, L"Climb"}
+            { TriggerType::Trigger, "Trigger" },
+            { TriggerType::Pad, "Pad" },
+            { TriggerType::Switch, "Switch" },
+            { TriggerType::Key, "Key" },
+            { TriggerType::Pickup, "Pickup" },
+            { TriggerType::HeavyTrigger, "Heavy Trigger" },
+            { TriggerType::Antipad, "Antipad" },
+            { TriggerType::Combat, "Combat" },
+            { TriggerType::Dummy, "Dummy" },
+            { TriggerType::AntiTrigger, "Antitrigger" },
+            { TriggerType::HeavySwitch, "Heavy Switch" },
+            { TriggerType::HeavyAntiTrigger, "Heavy Antitrigger" },
+            { TriggerType::Monkey, "Monkey" },
+            { TriggerType::Skeleton, "Skeleton" },
+            { TriggerType::Tightrope, "Tightrope" },
+            { TriggerType::Crawl, "Craw" },
+            { TriggerType::Climb, "Climb"}
         };
 
-        const std::unordered_map<TriggerCommandType, std::wstring> command_type_names
+        const std::unordered_map<TriggerCommandType, std::string> command_type_names
         {
-            { TriggerCommandType::Object, L"Item" },
-            { TriggerCommandType::Camera, L"Camera" },
-            { TriggerCommandType::UnderwaterCurrent, L"Current" },
-            { TriggerCommandType::FlipMap, L"Flip Map" },
-            { TriggerCommandType::FlipOn, L"Flip On" },
-            { TriggerCommandType::FlipOff, L"Flip Off" },
-            { TriggerCommandType::LookAtItem, L"Look at Item" },
-            { TriggerCommandType::EndLevel, L"End Level" },
-            { TriggerCommandType::PlaySoundtrack, L"Music" },
-            { TriggerCommandType::Flipeffect, L"Flipeffect" },
-            { TriggerCommandType::SecretFound, L"Secret" },
-            { TriggerCommandType::ClearBodies, L"Clear Bodies" },
-            { TriggerCommandType::Flyby, L"Flyby" },
-            { TriggerCommandType::Cutscene, L"Cutscene" }
+            { TriggerCommandType::Object, "Item" },
+            { TriggerCommandType::Camera, "Camera" },
+            { TriggerCommandType::UnderwaterCurrent, "Current" },
+            { TriggerCommandType::FlipMap, "Flip Map" },
+            { TriggerCommandType::FlipOn, "Flip On" },
+            { TriggerCommandType::FlipOff, "Flip Off" },
+            { TriggerCommandType::LookAtItem, "Look at Item" },
+            { TriggerCommandType::EndLevel, "End Level" },
+            { TriggerCommandType::PlaySoundtrack, "Music" },
+            { TriggerCommandType::Flipeffect, "Flipeffect" },
+            { TriggerCommandType::SecretFound, "Secret" },
+            { TriggerCommandType::ClearBodies, "Clear Bodies" },
+            { TriggerCommandType::Flyby, "Flyby" },
+            { TriggerCommandType::Cutscene, "Cutscene" }
         };
 
         const std::unordered_map<std::wstring, TriggerCommandType> command_type_lookup
@@ -77,29 +77,24 @@ namespace trview
         return std::any_of(types.begin(), types.end(), [&](const auto& type) { return has_command(trigger, type); });
     }
 
-    std::wstring trigger_type_name(TriggerType type)
+    std::string trigger_type_name(TriggerType type)
     {
         auto name = trigger_type_names.find(type);
         if (name == trigger_type_names.end())
         {
-            return L"Unknown";
+            return "Unknown";
         }
         return name->second;
     }
 
-    std::wstring command_type_name(TriggerCommandType type)
+    std::string command_type_name(TriggerCommandType type)
     {
         auto name = command_type_names.find(type);
         if (name == command_type_names.end())
         {
-            return L"Unknown";
+            return "Unknown";
         }
         return name->second;
-    }
-
-    std::string command_type_name_8(TriggerCommandType type)
-    {
-        return to_utf8(command_type_name(type));
     }
 
     TriggerCommandType command_from_name(const std::wstring& name)

--- a/trview.app/Elements/ITrigger.h
+++ b/trview.app/Elements/ITrigger.h
@@ -35,13 +35,12 @@ namespace trview
     /// Get the string representation of the trigger type specified.
     /// @param type The type to test.
     /// @returns The string version of the enum.
-    std::wstring trigger_type_name(TriggerType type);
+    std::string trigger_type_name(TriggerType type);
 
     /// Get the string representation of the command type specified.
     /// @param type The type to test.
     /// @returns The string version of the enum.
-    std::wstring command_type_name(TriggerCommandType type);
-    std::string command_type_name_8(TriggerCommandType type);
+    std::string command_type_name(TriggerCommandType type);
 
     /// Get the trigger command type from a string.
     /// @param name The string to convert.

--- a/trview.app/Elements/ITrigger.h
+++ b/trview.app/Elements/ITrigger.h
@@ -45,7 +45,6 @@ namespace trview
     /// Get the trigger command type from a string.
     /// @param name The string to convert.
     /// @returns The trigger command type.
-    TriggerCommandType command_from_name(const std::wstring& name);
     TriggerCommandType command_from_name(const std::string& name);
 
     bool has_command(const ITrigger& trigger, TriggerCommandType type);

--- a/trview.app/Elements/ITypeNameLookup.h
+++ b/trview.app/Elements/ITypeNameLookup.h
@@ -10,7 +10,7 @@ namespace trview
     {
     public:
         virtual ~ITypeNameLookup() = 0;
-        virtual std::wstring lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id) const = 0;
+        virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id) const = 0;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const = 0;
     };
 }

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -2,7 +2,7 @@
 
 namespace trview
 {
-    Item::Item(uint32_t number, uint32_t room, uint32_t type_id, const std::wstring& type, int32_t ocb, uint16_t flags, const std::vector<std::weak_ptr<ITrigger>>& triggers, const DirectX::SimpleMath::Vector3& position)
+    Item::Item(uint32_t number, uint32_t room, uint32_t type_id, const std::string& type, int32_t ocb, uint16_t flags, const std::vector<std::weak_ptr<ITrigger>>& triggers, const DirectX::SimpleMath::Vector3& position)
         : _number(number), _room(room), _type_id(type_id), _type(type), _ocb(ocb), _flags(flags), _triggers(triggers), _position(position)
     {
     }
@@ -22,7 +22,7 @@ namespace trview
         return _type_id;
     }
 
-    const std::wstring& Item::type() const
+    std::string Item::type() const
     {
         return _type;
     }

--- a/trview.app/Elements/Item.h
+++ b/trview.app/Elements/Item.h
@@ -22,7 +22,7 @@ namespace trview
         /// @param flags The flags for the entity.
         /// @param triggers The triggers that affect this entity.
         /// @param position The position of the entity.
-        explicit Item(uint32_t number, uint32_t room, const uint32_t type_id, const std::wstring& type, int32_t ocb, uint16_t flags, const std::vector<std::weak_ptr<ITrigger>>& triggers, const DirectX::SimpleMath::Vector3& position);
+        explicit Item(uint32_t number, uint32_t room, const uint32_t type_id, const std::string& type, int32_t ocb, uint16_t flags, const std::vector<std::weak_ptr<ITrigger>>& triggers, const DirectX::SimpleMath::Vector3& position);
 
         /// Get the item number.
         /// @returns The item number.
@@ -38,7 +38,7 @@ namespace trview
 
         /// Get the type name of the item.
         /// @returns The type name of the item.
-        const std::wstring& type() const;
+        std::string type() const;
 
         /// Get the OCB value of the item.
         /// @returns The OCB value of the item.
@@ -76,7 +76,7 @@ namespace trview
         uint32_t _number{ 0u };
         uint32_t _room{ 0u };
         uint32_t _type_id{ 0u };
-        std::wstring _type;
+        std::string _type;
         uint32_t _ocb{ 0u };
         uint16_t _flags{ 0u };
         bool _visible{ true };

--- a/trview.app/Elements/TypeNameLookup.cpp
+++ b/trview.app/Elements/TypeNameLookup.cpp
@@ -38,7 +38,7 @@ namespace trview
                 auto name = element.at("name").get<std::string>();
                 type_names.insert({ element.at("id").get<uint32_t>(), 
                     {
-                        std::wstring(name.begin(), name.end()),
+                        name,
                         read_attribute<bool>(element, "pickup")
                     } });
             }
@@ -52,18 +52,18 @@ namespace trview
         load_game_types(LevelVersion::Tomb5);
     }
 
-    std::wstring TypeNameLookup::lookup_type_name(LevelVersion level_version, uint32_t type_id) const
+    std::string TypeNameLookup::lookup_type_name(LevelVersion level_version, uint32_t type_id) const
     {
         const auto& game_types = _type_names.find(level_version);
         if (game_types == _type_names.end())
         {
-            return std::to_wstring(type_id);
+            return std::to_string(type_id);
         }
 
         const auto found_type = game_types->second.find(type_id);
         if (found_type == game_types->second.end())
         {
-            return std::to_wstring(type_id);
+            return std::to_string(type_id);
         }
         return found_type->second.name;
     }

--- a/trview.app/Elements/TypeNameLookup.h
+++ b/trview.app/Elements/TypeNameLookup.h
@@ -10,12 +10,12 @@ namespace trview
     public:
         explicit TypeNameLookup(const std::string& type_name_json);
         virtual ~TypeNameLookup() = default;
-        virtual std::wstring lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id) const override;
+        virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id) const override;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const override;
     private:
         struct Type
         {
-            std::wstring name;
+            std::string name;
             bool pickup{ false };
         };
 

--- a/trview.app/Geometry/PickResult.cpp
+++ b/trview.app/Geometry/PickResult.cpp
@@ -8,46 +8,46 @@ namespace trview
 {
     namespace
     {
-        std::wstring pick_type_to_string(PickResult::Type type)
+        std::string pick_type_to_string(PickResult::Type type)
         {
             switch (type)
             {
             case PickResult::Type::Entity:
-                return L"Item";
+                return "Item";
             case PickResult::Type::Trigger:
-                return L"Trigger";
+                return "Trigger";
             case PickResult::Type::Room:
-                return L"Room";
+                return "Room";
             case PickResult::Type::Waypoint:
-                return L"Waypoint";
+                return "Waypoint";
             case PickResult::Type::Light:
-                return L"Light";
+                return "Light";
             }
-            return L"?";
+            return "?";
         }
 
-        std::wstring axis_to_string(Compass::Axis axis)
+        std::string axis_to_string(Compass::Axis axis)
         {
             switch (axis)
             {
             case Compass::Axis::Pos_X:
-                return L"+X";
+                return "+X";
             case Compass::Axis::Pos_Y:
-                return L"+Y";
+                return "+Y";
             case Compass::Axis::Pos_Z:
-                return L"+Z";
+                return "+Z";
             case Compass::Axis::Neg_X:
-                return L"-X";
+                return "-X";
             case Compass::Axis::Neg_Y:
-                return L"-Y";
+                return "-Y";
             case Compass::Axis::Neg_Z:
-                return L"-Z";
+                return "-Z";
             }
-            return L"?";
+            return "?";
         }
     }
 
-    std::wstring pick_to_string(const PickResult& pick)
+    std::string pick_to_string(const PickResult& pick)
     {
         if (!pick.text.empty())
         {
@@ -59,7 +59,7 @@ namespace trview
             return axis_to_string(static_cast<Compass::Axis>(pick.index));
         }
 
-        return pick_type_to_string(pick.type) + L" " + std::to_wstring(pick.index);
+        return std::format("{} {}", pick_type_to_string(pick.type), pick.index);
     }
 
     Colour pick_to_colour(const PickResult& pick)
@@ -84,9 +84,9 @@ namespace trview
         return current;
     }
 
-    std::wstring generate_pick_message(const PickResult& result, const ILevel& level, const IRoute& route)
+    std::string generate_pick_message(const PickResult& result, const ILevel& level, const IRoute& route)
     {
-        std::wstringstream stream;
+        std::stringstream stream;
 
         switch (result.type)
         {
@@ -95,7 +95,7 @@ namespace trview
                 const auto item = level.item(result.index);
                 if (item.has_value())
                 {
-                    stream << L"Item " << result.index << L" - " << item.value().type();
+                    stream << "Item " << result.index << " - " << item.value().type();
                 }
                 break;
             }
@@ -103,17 +103,17 @@ namespace trview
             {
                 if (auto trigger = level.trigger(result.index).lock())
                 {
-                    stream << trigger_type_name(trigger->type()) << L" " << result.index;
+                    stream << trigger_type_name(trigger->type()) << " " << result.index;
                     for (const auto command : trigger->commands())
                     {
-                        stream << L"\n  " << command_type_name(command.type());
+                        stream << "\n  " << command_type_name(command.type());
                         if (command_has_index(command.type()))
                         {
-                            stream << L" " << command.index();
+                            stream << " " << command.index();
                             if (command_is_item(command.type()))
                             {
                                 const auto item = level.item(command.index());
-                                stream << L" - " << (item.has_value() ? item.value().type() : L"No Item");
+                                stream << " - " << (item.has_value() ? item.value().type() : "No Item");
                             }
                         }
                     }
@@ -124,7 +124,7 @@ namespace trview
             {
                 if (const auto light = level.light(result.index).lock())
                 {
-                    stream << L"Light " << result.index << L" - " << light_type_name(light->type());
+                    stream << "Light " << result.index << " - " << light_type_name(light->type());
                 }
                 break;
             }
@@ -136,28 +136,28 @@ namespace trview
             case PickResult::Type::Waypoint:
             {
                 auto& waypoint = route.waypoint(result.index);
-                stream << L"Waypoint " << result.index;
+                stream << "Waypoint " << result.index;
 
                 if (waypoint.type() == IWaypoint::Type::Entity)
                 {
                     const auto item = level.item(waypoint.index());
                     if (item.has_value())
                     {
-                        stream << L" - " << item.value().type();
+                        stream << " - " << item.value().type();
                     }
                 }
                 else if (waypoint.type() == IWaypoint::Type::Trigger)
                 {
                     if (const auto trigger = level.trigger(waypoint.index()).lock())
                     {
-                        stream << L" - " << trigger_type_name(trigger->type()) << L" " << waypoint.index();
+                        stream << " - " << trigger_type_name(trigger->type()) << " " << waypoint.index();
                     }
                 }
 
                 const auto notes = waypoint.notes();
                 if (!notes.empty())
                 {
-                    stream << L"\n\n" << notes;
+                    stream << "\n\n" << notes;
                 }
                 break;
             }

--- a/trview.app/Geometry/PickResult.h
+++ b/trview.app/Geometry/PickResult.h
@@ -30,14 +30,14 @@ namespace trview
         Type                         type{ Type::Room };
         uint32_t                     index{ 0u };
         bool                         stop{ false };
-        std::wstring                 text;
+        std::string                  text;
         bool                         override_centre{ false };
         Triangle                     triangle;
     };
 
     /// Convert the pick result to a display string.
     /// @param pick The result to convert.
-    std::wstring pick_to_string(const PickResult& pick);
+    std::string pick_to_string(const PickResult& pick);
 
     /// Get the appropriate colour for a pick.
     /// @param pick The result to test.
@@ -46,5 +46,5 @@ namespace trview
     /// If the next pick is nearer than the current and is a hit, choose that one.
     PickResult nearest_result(const PickResult& current, const PickResult& next);
 
-    std::wstring generate_pick_message(const PickResult& result, const ILevel& level, const IRoute& route);
+    std::string generate_pick_message(const PickResult& result, const ILevel& level, const IRoute& route);
 }

--- a/trview.app/Mocks/Elements/ITypeNameLookup.h
+++ b/trview.app/Mocks/Elements/ITypeNameLookup.h
@@ -9,7 +9,7 @@ namespace trview
         struct MockTypeNameLookup : public ITypeNameLookup
         {
             virtual ~MockTypeNameLookup() = default;
-            MOCK_METHOD(std::wstring, lookup_type_name, (trlevel::LevelVersion, uint32_t), (const, override));
+            MOCK_METHOD(std::string, lookup_type_name, (trlevel::LevelVersion, uint32_t), (const, override));
             MOCK_METHOD(bool, is_pickup, (trlevel::LevelVersion, uint32_t), (const, override));
         };
     }

--- a/trview.app/Mocks/Routing/IWaypoint.h
+++ b/trview.app/Mocks/Routing/IWaypoint.h
@@ -14,10 +14,10 @@ namespace trview
             MOCK_METHOD(Type, type, (), (const, override));
             MOCK_METHOD(bool, has_save, (), (const, override));
             MOCK_METHOD(uint32_t, index, (), (const, override));
-            MOCK_METHOD(std::wstring, notes, (), (const, override));
+            MOCK_METHOD(std::string, notes, (), (const, override));
             MOCK_METHOD(uint32_t, room, (), (const, override));
             MOCK_METHOD(std::vector<uint8_t>, save_file, (), (const, override));
-            MOCK_METHOD(void, set_notes, (const std::wstring&), (override));
+            MOCK_METHOD(void, set_notes, (const std::string&), (override));
             MOCK_METHOD(void, set_route_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_save_file, (const std::vector<uint8_t>&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));

--- a/trview.app/Mocks/Tools/IMeasure.h
+++ b/trview.app/Mocks/Tools/IMeasure.h
@@ -13,7 +13,7 @@ namespace trview
             MOCK_METHOD(bool, add, (const DirectX::SimpleMath::Vector3&), (override));
             MOCK_METHOD(void, set, (const DirectX::SimpleMath::Vector3&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&), (override));
-            MOCK_METHOD(std::wstring, distance, (), (const, override));
+            MOCK_METHOD(std::string, distance, (), (const, override));
             MOCK_METHOD(bool, measuring, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));
         };

--- a/trview.app/Mocks/UI/IViewerUI.h
+++ b/trview.app/Mocks/UI/IViewerUI.h
@@ -41,7 +41,7 @@ namespace trview
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(bool, show_context_menu, (), (const, override));
             MOCK_METHOD(void, toggle_settings_visibility, (), (override));
-            MOCK_METHOD(void, print_console, (const std::wstring&), (override));
+            MOCK_METHOD(void, print_console, (const std::string&), (override));
             MOCK_METHOD(void, set_mid_waypoint_enabled, (bool), (override));
             MOCK_METHOD(void, set_toggle, (const std::string&, bool), (override));
             MOCK_METHOD(bool, toggle, (const std::string&), (const, override));

--- a/trview.app/Routing/IWaypoint.cpp
+++ b/trview.app/Routing/IWaypoint.cpp
@@ -21,17 +21,17 @@ namespace trview
         return IWaypoint::Type::Position;
     }
 
-    std::wstring waypoint_type_to_string(IWaypoint::Type type)
+    std::string waypoint_type_to_string(IWaypoint::Type type)
     {
         switch (type)
         {
             case IWaypoint::Type::Entity:
-                return L"Entity";
+                return "Entity";
             case IWaypoint::Type::Position:
-                return L"Position";
+                return "Position";
             case IWaypoint::Type::Trigger:
-                return L"Trigger";
+                return "Trigger";
         }
-        return L"Unknown";
+        return "Unknown";
     }
 }

--- a/trview.app/Routing/IWaypoint.h
+++ b/trview.app/Routing/IWaypoint.h
@@ -67,7 +67,7 @@ namespace trview
         /// <summary>
         /// Get any notes associated with the waypoint.
         /// </summary>
-        virtual std::wstring notes() const = 0;
+        virtual std::string notes() const = 0;
         /// <summary>
         /// Get the room number that the waypoint is in.
         /// </summary>
@@ -86,7 +86,7 @@ namespace trview
         virtual std::vector<uint8_t> save_file() const = 0;
         /// Set the notes associated with the waypoint.
         /// @param notes The notes to save.
-        virtual void set_notes(const std::wstring& notes) = 0;
+        virtual void set_notes(const std::string& notes) = 0;
         /// Set the route colour for the waypoint blob.
         /// @param colour The colour of the route.
         virtual void set_route_colour(const Colour& colour) = 0;
@@ -115,5 +115,5 @@ namespace trview
     /// </summary>
     /// <param name="type">The type to convert.</param>
     /// <returns>The string value.</returns>
-    std::wstring waypoint_type_to_string(IWaypoint::Type type);
+    std::string waypoint_type_to_string(IWaypoint::Type type);
 }

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -382,7 +382,7 @@ namespace trview
         auto route = route_source();
         if (json["colour"].is_string())
         {
-            route->set_colour(from_colour_code(to_utf16(json["colour"].get<std::string>())));
+            route->set_colour(from_colour_code(json["colour"].get<std::string>()));
         }
 
         for (const auto& waypoint : json["waypoints"])
@@ -547,7 +547,7 @@ namespace trview
     void export_trview_route(const IRoute& route, std::shared_ptr<IFiles>& files, const std::string& route_filename, const RandomizerSettings& randomizer_settings)
     {
         nlohmann::json json;
-        json["colour"] = to_utf8(route.colour().code());
+        json["colour"] = route.colour().code();
 
         std::vector<nlohmann::json> waypoints;
 

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -399,7 +399,7 @@ namespace trview
             route->add(position, normal, room, type, index);
 
             auto& new_waypoint = route->waypoint(route->waypoints() - 1);
-            new_waypoint.set_notes(to_utf16(notes));
+            new_waypoint.set_notes(notes);
             new_waypoint.set_save_file(from_base64(waypoint.value("save", "")));
             new_waypoint.set_randomizer_settings(import_trview_randomizer_settings(waypoint, randomizer_settings));
         }
@@ -555,7 +555,7 @@ namespace trview
         {
             const IWaypoint& waypoint = route.waypoint(i);
             nlohmann::json waypoint_json;
-            waypoint_json["type"] = to_utf8(waypoint_type_to_string(waypoint.type()));
+            waypoint_json["type"] = waypoint_type_to_string(waypoint.type());
 
             const auto pos = waypoint.position();
             waypoint_json["position"] = std::format("{},{},{}", pos.x, pos.y, pos.z);
@@ -563,7 +563,7 @@ namespace trview
             waypoint_json["normal"] = std::format("{},{},{}", normal.x, normal.y, normal.z);
             waypoint_json["room"] = waypoint.room();
             waypoint_json["index"] = waypoint.index();
-            waypoint_json["notes"] = to_utf8(waypoint.notes());
+            waypoint_json["notes"] = waypoint.notes();
 
             if (waypoint.has_save())
             {

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -4,6 +4,7 @@
 #include <trview.common/Maths.h>
 #include <trview.common/Json.h>
 #include <trview.app/Elements/ILevel.h>
+#include <format>
 
 using namespace DirectX;
 using namespace DirectX::SimpleMath;
@@ -556,14 +557,10 @@ namespace trview
             nlohmann::json waypoint_json;
             waypoint_json["type"] = to_utf8(waypoint_type_to_string(waypoint.type()));
 
-            std::stringstream pos_string;
-            auto pos = waypoint.position();
-            pos_string << pos.x << "," << pos.y << "," << pos.z;
-            waypoint_json["position"] = pos_string.str();
-            std::stringstream normal_string;
-            auto normal = waypoint.normal();
-            normal_string << normal.x << "," << normal.y << "," << normal.z;
-            waypoint_json["normal"] = normal_string.str();
+            const auto pos = waypoint.position();
+            waypoint_json["position"] = std::format("{},{},{}", pos.x, pos.y, pos.z);
+            const auto normal = waypoint.normal();
+            waypoint_json["normal"] = std::format("{},{},{}", normal.x, normal.y, normal.z);
             waypoint_json["room"] = waypoint.room();
             waypoint_json["index"] = waypoint.index();
             waypoint_json["notes"] = to_utf8(waypoint.notes());

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -112,7 +112,7 @@ namespace trview
         return _room;
     }
 
-    std::wstring Waypoint::notes() const
+    std::string Waypoint::notes() const
     {
         return _notes;
     }
@@ -122,7 +122,7 @@ namespace trview
         return _save_data;
     }
 
-    void Waypoint::set_notes(const std::wstring& notes)
+    void Waypoint::set_notes(const std::string& notes)
     {
         _notes = notes;
     }

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -32,10 +32,10 @@ namespace trview
         virtual Type type() const override;
         virtual bool has_save() const override;
         virtual uint32_t index() const override;
-        virtual std::wstring notes() const override;
+        virtual std::string notes() const override;
         virtual uint32_t room() const override;
         virtual std::vector<uint8_t> save_file() const override;
-        virtual void set_notes(const std::wstring& notes) override;
+        virtual void set_notes(const std::string& notes) override;
         virtual void set_route_colour(const Colour& colour) override;
         virtual void set_save_file(const std::vector<uint8_t>& data) override;
         virtual DirectX::SimpleMath::Vector3 blob_position() const override;
@@ -47,7 +47,7 @@ namespace trview
     private:
         DirectX::SimpleMath::Matrix calculate_waypoint_rotation() const;
 
-        std::wstring _notes;
+        std::string _notes;
         std::vector<uint8_t> _save_data;
         DirectX::SimpleMath::Vector3 _position;
         DirectX::SimpleMath::Vector3 _normal;

--- a/trview.app/Tools/Compass.cpp
+++ b/trview.app/Tools/Compass.cpp
@@ -17,14 +17,14 @@ namespace trview
         const float View_Size = 200;
         const float Nodule_Size = 0.05f;
 
-        const std::unordered_map<Compass::Axis, std::wstring> axis_type_names
+        const std::unordered_map<Compass::Axis, std::string> axis_type_names
         {
-            { Compass::Axis::Pos_X, L"+X" },
-            { Compass::Axis::Pos_Y, L"+Y" },
-            { Compass::Axis::Pos_Z, L"+Z" },
-            { Compass::Axis::Neg_X, L"-X" },
-            { Compass::Axis::Neg_Y, L"-Y" },
-            { Compass::Axis::Neg_Z, L"-Z" },
+            { Compass::Axis::Pos_X, "+X" },
+            { Compass::Axis::Pos_Y, "+Y" },
+            { Compass::Axis::Pos_Z, "+Z" },
+            { Compass::Axis::Neg_X, "-X" },
+            { Compass::Axis::Neg_Y, "-Y" },
+            { Compass::Axis::Neg_Z, "-Z" },
         };
 
         const std::unordered_map<Compass::Axis, BoundingBox> nodule_boxes
@@ -135,12 +135,12 @@ namespace trview
         _visible = value;
     }
 
-    std::wstring axis_name(Compass::Axis axis)
+    std::string axis_name(Compass::Axis axis)
     {
         auto name = axis_type_names.find(axis);
         if (name == axis_type_names.end())
         {
-            return L"Unknown";
+            return "Unknown";
         }
         return name->second;
     }

--- a/trview.app/Tools/Compass.h
+++ b/trview.app/Tools/Compass.h
@@ -46,7 +46,7 @@ namespace trview
     /// Get a string representation of a compass axis.
     /// @param axis The axis.
     /// @returns The name of the axis.
-    std::wstring axis_name(Compass::Axis axis);
+    std::string axis_name(Compass::Axis axis);
 
     /// Align a camera to a particular axis.
     /// @param camera The camera to adjust.

--- a/trview.app/Tools/IMeasure.h
+++ b/trview.app/Tools/IMeasure.h
@@ -39,7 +39,7 @@ namespace trview
 
         /// Get the current text version of the distance measured.
         /// @returns The text version of the distance.
-        virtual std::wstring distance() const = 0;
+        virtual std::string distance() const = 0;
 
         /// Get whether a distance is actively being measured.
         /// @returns True if start and end is set.

--- a/trview.app/Tools/Measure.cpp
+++ b/trview.app/Tools/Measure.cpp
@@ -92,11 +92,9 @@ namespace trview
         on_position(Point(point.x, point.y));
     }
 
-    std::wstring Measure::distance() const
+    std::string Measure::distance() const
     {
-        std::wstringstream stream;
-        stream << std::fixed << std::setprecision(2) << (_end.value() - _start.value()).Length();
-        return stream.str();
+        return std::format("{:.2f}", (_end.value() - _start.value()).Length());
     }
 
     bool Measure::measuring() const

--- a/trview.app/Tools/Measure.h
+++ b/trview.app/Tools/Measure.h
@@ -35,7 +35,7 @@ namespace trview
 
         /// Get the current text version of the distance measured.
         /// @returns The text version of the distance.
-        virtual std::wstring distance() const override;
+        virtual std::string distance() const override;
 
         /// Get whether a distance is actively being measured.
         /// @returns True if start and end is set.

--- a/trview.app/Tools/Toolbar.cpp
+++ b/trview.app/Tools/Toolbar.cpp
@@ -2,9 +2,9 @@
 
 namespace trview
 {
-    void Toolbar::add_tool(const std::wstring& name, const std::wstring& text)
+    void Toolbar::add_tool(const std::string& name, const std::string& text)
     {
-        _tools.push_back(to_utf8(name));
+        _tools.push_back(name);
     }
 
     void Toolbar::render()
@@ -17,7 +17,7 @@ namespace trview
             {
                 if (ImGui::Button(tool.c_str()))
                 {
-                    on_tool_clicked(to_utf16(tool));
+                    on_tool_clicked(tool);
                 }
                 ImGui::SameLine();
             }

--- a/trview.app/Tools/Toolbar.h
+++ b/trview.app/Tools/Toolbar.h
@@ -14,13 +14,13 @@ namespace trview
         /// Add a new tool to the toolbar.
         /// @param name The name of the tool
         /// @param text The text to show in the button.
-        void add_tool(const std::wstring& name, const std::wstring& text);
+        void add_tool(const std::string& name, const std::string& text);
 
         void render();
 
         /// Event raised when a tool button is clicked.
         /// @remarks The name of the tool is passed as a parameter.
-        Event<const std::wstring&> on_tool_clicked;
+        Event<const std::string&> on_tool_clicked;
     private:
         std::vector<std::string> _tools;
     };

--- a/trview.app/UI/Console.cpp
+++ b/trview.app/UI/Console.cpp
@@ -7,13 +7,13 @@ namespace trview
         return _visible;
     }
 
-    void Console::print(const std::wstring& text)
+    void Console::print(const std::string& text)
     {
         if (!_text.empty())
         {
             _text += '\n';
         }
-        _text += to_utf8(text);
+        _text += text;
     }
 
     void Console::set_visible(bool value)
@@ -39,7 +39,7 @@ namespace trview
                 if (ImGui::InputText(Names::input.c_str(), &vec[0], vec.size(), ImGuiInputTextFlags_EnterReturnsTrue))
                 {
                     auto command = std::string(&vec[0]);
-                    on_command(to_utf16(command));
+                    on_command(command);
                 }
                 ImGui::PopItemWidth();
             }

--- a/trview.app/UI/Console.h
+++ b/trview.app/UI/Console.h
@@ -15,9 +15,9 @@ namespace trview
 
         void render();
         bool visible() const;
-        void print(const std::wstring& text);
+        void print(const std::string& text);
         void set_visible(bool value);
-        Event<std::wstring> on_command;
+        Event<std::string> on_command;
     private:
         std::string _text;
         bool _visible{ false };

--- a/trview.app/UI/GoTo.cpp
+++ b/trview.app/UI/GoTo.cpp
@@ -14,12 +14,12 @@ namespace trview
         _shown = false;
     }
 
-    std::wstring GoTo::name() const
+    std::string GoTo::name() const
     {
         return _name;
     }
 
-    void GoTo::set_name(const std::wstring& name)
+    void GoTo::set_name(const std::string& name)
     {
         _name = name;
     }
@@ -31,7 +31,7 @@ namespace trview
             const auto viewport = ImGui::GetMainViewport();
             ImGui::SetNextWindowPos(viewport->Pos + viewport->Size * 0.5f, 0, ImVec2(0.5f, 0.5f));
 
-            const std::string id = (std::string("Go To ") + to_utf8(_name));
+            const std::string id = std::format("Go To {}", _name);
             if (!_shown)
             {
                 ImGui::OpenPopup(id.c_str());

--- a/trview.app/UI/GoTo.h
+++ b/trview.app/UI/GoTo.h
@@ -29,14 +29,14 @@ namespace trview
         Event<uint32_t> on_selected;
 
         /// Get the name of the type of thing being selected.
-        std::wstring name() const;
+        std::string name() const;
 
         void render();
 
         /// Set the name of the type of thing that is being gone to.
-        void set_name(const std::wstring& name);
+        void set_name(const std::string& name);
     private:
-        std::wstring  _name;
+        std::string  _name;
         bool _visible{ false };
         int _index{ 0 };
         bool _shown{ false };

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -91,7 +91,7 @@ namespace trview
         Event<float, float> on_camera_rotation;
 
         /// Event raised when user enters a command.
-        Event<std::wstring> on_command;
+        Event<std::string> on_command;
 
         /// <summary>
         /// Event raised when the user changes a toggle.
@@ -219,7 +219,7 @@ namespace trview
         /// Write the text to the console.
         /// </summary>
         /// <param name="text">The text to write.</param>
-        virtual void print_console(const std::wstring& text) = 0;
+        virtual void print_console(const std::string& text) = 0;
         /// <summary>
         /// Set whether the mid waypoint button is enabled.
         /// </summary>

--- a/trview.app/UI/RoomNavigator.cpp
+++ b/trview.app/UI/RoomNavigator.cpp
@@ -8,7 +8,7 @@ namespace trview
         if (ImGui::Begin("Room Navigator", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
             const uint32_t previous_selection = _selected_room;
-            if (ImGui::InputInt(std::string("of " + std::to_string(_max_rooms) +  "##roomnumber").c_str(), &_selected_room, 1, 10, ImGuiInputTextFlags_EnterReturnsTrue))
+            if (ImGui::InputInt(std::format("of {}##roomnumber", _max_rooms).c_str(), &_selected_room, 1, 10, ImGuiInputTextFlags_EnterReturnsTrue))
             {
                 _selected_room = std::clamp(_selected_room, 0, _max_rooms);
                 if (_selected_room != previous_selection)

--- a/trview.app/UI/Tooltip.cpp
+++ b/trview.app/UI/Tooltip.cpp
@@ -2,9 +2,9 @@
 
 namespace trview
 {
-    void Tooltip::set_text(const std::wstring& text)
+    void Tooltip::set_text(const std::string& text)
     {
-        _text = to_utf8(text);
+        _text = text;
     }
 
     void Tooltip::set_text_colour(const Colour& colour)

--- a/trview.app/UI/Tooltip.h
+++ b/trview.app/UI/Tooltip.h
@@ -11,7 +11,7 @@ namespace trview
     public:
         /// Set the tooltip text.
         /// @param text The text to show.
-        void set_text(const std::wstring& text);
+        void set_text(const std::string& text);
 
         /// Set the colour of the text.
         /// @param colour The text colour.

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -191,15 +191,14 @@ namespace trview
                 return;
             }
 
-            std::wstring text = L"X: " + std::to_wstring(sector->x()) + L", Z:" + std::to_wstring(sector->z()) + L"\n";
+            std::string text = std::format("X: {}, Z: {}\n", sector->x(), sector->z());
             if (has_flag(sector->flags(), SectorFlag::RoomAbove))
             {
-                text += L"Above: " + std::to_wstring(sector->room_above());
+                text += std::format("Above: {}", sector->room_above());
             }
             if (has_flag(sector->flags(), SectorFlag::RoomBelow))
             {
-                text += (has_flag(sector->flags(), SectorFlag::RoomAbove) ? L", " : L"") +
-                    std::wstring(L"Below: ") + std::to_wstring(sector->room_below());
+                text += std::format("{}Below: {}", has_flag(sector->flags(), SectorFlag::RoomAbove) ? ", " : "", sector->room_below());
             }
             _map_tooltip->set_text(text);
             _map_tooltip->set_visible(!text.empty());

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -26,7 +26,7 @@ namespace trview
         {
             if (!is_input_active())
             {
-                _go_to->set_name(L"Room");
+                _go_to->set_name("Room");
                 _go_to->toggle_visible(_selected_room);
             }
         };
@@ -35,7 +35,7 @@ namespace trview
         {
             if (!is_input_active())
             {
-                _go_to->set_name(L"Item");
+                _go_to->set_name("Item");
                 _go_to->toggle_visible(_selected_item);
             }
         };
@@ -53,7 +53,7 @@ namespace trview
         _go_to = std::make_unique<GoTo>();
         _token_store += _go_to->on_selected += [&](uint32_t index)
         {
-            if (_go_to->name() == L"Item")
+            if (_go_to->name() == "Item")
             {
                 on_select_item(index);
             }
@@ -64,10 +64,10 @@ namespace trview
         };
 
         _toolbar = std::make_unique<Toolbar>();
-        _toolbar->add_tool(L"Measure", L"|....|");
-        _token_store += _toolbar->on_tool_clicked += [this](const std::wstring& tool)
+        _toolbar->add_tool("Measure", "|....|");
+        _token_store += _toolbar->on_tool_clicked += [this](const std::string& tool)
         {
-            if (tool == L"Measure")
+            if (tool == "Measure")
             {
                 on_tool_selected(Tool::Measure);
             }
@@ -333,9 +333,7 @@ namespace trview
 
     void ViewerUI::set_measure_distance(float distance)
     {
-        std::wstringstream stream;
-        stream << std::fixed << std::setprecision(2) << distance;
-        _measure_text = to_utf8(stream.str());
+        _measure_text = std::format("{:.2f}", distance);
     }
 
     void ViewerUI::set_measure_position(const Point& position)

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -445,7 +445,7 @@ namespace trview
         _settings_window->toggle_visibility();
     }
 
-    void ViewerUI::print_console(const std::wstring& text)
+    void ViewerUI::print_console(const std::string& text)
     {
         _console->print(text);
     }

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -64,7 +64,7 @@ namespace trview
         virtual void set_visible(bool value) override;
         virtual bool show_context_menu() const override;
         virtual void toggle_settings_visibility() override;
-        virtual void print_console(const std::wstring& text) override;
+        virtual void print_console(const std::string& text) override;
         virtual void set_mid_waypoint_enabled(bool value) override;
         virtual void set_scalar(const std::string& name, int32_t value) override;
         virtual void set_toggle(const std::string& name, bool value) override;

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -139,7 +139,7 @@ namespace trview
                         _scroll_to_item = false;
                     }
 
-                    if (ImGui::Selectable((std::to_string(item.number()) + std::string("##") + std::to_string(item.number())).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav | ImGuiTableFlags_SizingFixedFit))
+                    if (ImGui::Selectable(std::format("{0}##{0}", item.number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav | ImGuiTableFlags_SizingFixedFit))
                     {
                         scroller.fix_scroll();
 
@@ -161,7 +161,7 @@ namespace trview
                     ImGui::TableNextColumn();
                     bool hidden = !item.visible();
                     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
-                    if (ImGui::Checkbox((std::string("##hide-") + std::to_string(item.number())).c_str(), &hidden))
+                    if (ImGui::Checkbox(std::format("##hide-{}", item.number()).c_str(), &hidden))
                     {
                         on_item_visibility(item, !hidden);
                     }

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -190,15 +190,6 @@ namespace trview
 
                     auto add_stat = [&]<typename T>(const std::string& name, const T&& value)
                     {
-                        constexpr auto get_string = [](auto &&v)
-                        {
-                            if constexpr (std::is_same<T, std::string>::value)
-                            {
-                                return v;
-                            }
-                            return std::format("{}", v);
-                        };
-
                         const auto string_value = get_string(value);
                         ImGui::TableNextColumn();
                         if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -188,12 +188,22 @@ namespace trview
                 {
                     const auto& item = _selected_item.value();
 
-                    auto add_stat = [&](const std::string& name, const std::string& value)
+                    auto add_stat = [&]<typename T>(const std::string& name, const T&& value)
                     {
+                        constexpr auto get_string = [](auto &&v)
+                        {
+                            if constexpr (std::is_same<T, std::string>::value)
+                            {
+                                return v;
+                            }
+                            return std::format("{}", v);
+                        };
+
+                        const auto string_value = get_string(value);
                         ImGui::TableNextColumn();
                         if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
                         {
-                            _clipboard->write(to_utf16(value));
+                            _clipboard->write(to_utf16(string_value));
                             _tooltip_timer = 0.0f;
                         }
                         if (ImGui::IsItemHovered() && _tips.find(name) != _tips.end())
@@ -202,15 +212,15 @@ namespace trview
                             ImGui::Text(_tips[name].c_str());
                             ImGui::EndTooltip();
                         }
-                        if (ImGui::IsItemHovered() && _tips.find(value) != _tips.end())
+                        if (ImGui::IsItemHovered() && _tips.find(string_value) != _tips.end())
                         {
                             ImGui::BeginTooltip();
-                            ImGui::Text(_tips[value].c_str());
+                            ImGui::Text(_tips[string_value].c_str());
                             ImGui::EndTooltip();
                         }
 
                         ImGui::TableNextColumn();
-                        ImGui::Text(value.c_str());
+                        ImGui::Text(string_value.c_str());
                     };
 
                     auto position_text = [&item]()
@@ -220,14 +230,14 @@ namespace trview
                     };
 
                     add_stat("Type", item.type());
-                    add_stat("#", std::to_string(item.number()));
+                    add_stat("#", item.number());
                     add_stat("Position", position_text());
-                    add_stat("Type ID", std::to_string(item.type_id()));
-                    add_stat("Room", std::to_string(item.room()));
-                    add_stat("Clear Body", std::format("{}", item.clear_body_flag()));
-                    add_stat("Invisible", std::format("{}", item.invisible_flag()));
+                    add_stat("Type ID", item.type_id());
+                    add_stat("Room", item.room());
+                    add_stat("Clear Body", item.clear_body_flag());
+                    add_stat("Invisible", item.invisible_flag());
                     add_stat("Flags", format_binary(item.activation_flags()));
-                    add_stat("OCB", std::to_string(item.ocb()));
+                    add_stat("OCB", item.ocb());
                 }
 
                 ImGui::EndTable();

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -226,7 +226,7 @@ namespace trview
                     add_stat("Room", std::to_string(item.room()));
                     add_stat("Clear Body", std::format("{}", item.clear_body_flag()));
                     add_stat("Invisible", std::format("{}", item.invisible_flag()));
-                    add_stat("Flags", to_utf8(format_binary(item.activation_flags())));
+                    add_stat("Flags", format_binary(item.activation_flags()));
                     add_stat("OCB", std::to_string(item.ocb()));
                 }
 
@@ -352,7 +352,7 @@ namespace trview
         _filters.add_getter<float>("Room", [](auto&& item) { return item.room(); });
         _filters.add_getter<bool>("Clear Body", [](auto&& item) { return item.clear_body_flag(); });
         _filters.add_getter<bool>("Invisible", [](auto&& item) { return item.invisible_flag(); });
-        _filters.add_getter<std::string>("Flags", [](auto&& item) { return to_utf8(format_binary(item.activation_flags())); });
+        _filters.add_getter<std::string>("Flags", [](auto&& item) { return format_binary(item.activation_flags()); });
         _filters.add_getter<float>("OCB", [](auto&& item) { return item.ocb(); });
         _filters.add_multi_getter<float>("Triggered By", [](auto&& item)
             {

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -157,7 +157,7 @@ namespace trview
                     ImGui::TableNextColumn();
                     ImGui::Text(std::to_string(item.type_id()).c_str());
                     ImGui::TableNextColumn();
-                    ImGui::Text(to_utf8(item.type()).c_str());
+                    ImGui::Text(item.type().c_str());
                     ImGui::TableNextColumn();
                     bool hidden = !item.visible();
                     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
@@ -219,7 +219,7 @@ namespace trview
                         return std::format("{:.0f}, {:.0f}, {:.0f}", pos.x, pos.y, pos.z);
                     };
 
-                    add_stat("Type", to_utf8(item.type()));
+                    add_stat("Type", item.type());
                     add_stat("#", std::to_string(item.number()));
                     add_stat("Position", position_text());
                     add_stat("Type ID", std::to_string(item.type_id()));
@@ -272,7 +272,7 @@ namespace trview
                     ImGui::TableNextColumn();
                     ImGui::Text(std::to_string(trigger_ptr->room()).c_str());
                     ImGui::TableNextColumn();
-                    ImGui::Text(to_utf8(trigger_type_name(trigger_ptr->type())).c_str());
+                    ImGui::Text(trigger_type_name(trigger_ptr->type()).c_str());
                 }
 
                 ImGui::EndTable();
@@ -341,9 +341,9 @@ namespace trview
         std::set<std::string> available_types;
         for (const auto& item : _all_items)
         {
-            available_types.insert(to_utf8(item.type()));
+            available_types.insert(item.type());
         }
-        _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& item) { return to_utf8(item.type()); });
+        _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& item) { return item.type(); });
         _filters.add_getter<float>("#", [](auto&& item) { return item.number(); });
         _filters.add_getter<float>("X", [](auto&& item) { return item.position().x * trlevel::Scale_X; });
         _filters.add_getter<float>("Y", [](auto&& item) { return item.position().y * trlevel::Scale_Y; });

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -215,12 +215,8 @@ namespace trview
 
                     auto position_text = [&item]()
                     {
-                        std::stringstream stream;
-                        stream << std::fixed << std::setprecision(0) <<
-                            item.position().x * trlevel::Scale_X << ", " <<
-                            item.position().y * trlevel::Scale_Y << ", " <<
-                            item.position().z * trlevel::Scale_Z;
-                        return stream.str();
+                        const auto pos = item.position() * trlevel::Scale;
+                        return std::format("{:.0f}, {:.0f}, {:.0f}", pos.x, pos.y, pos.z);
                     };
 
                     add_stat("Type", to_utf8(item.type()));
@@ -228,8 +224,8 @@ namespace trview
                     add_stat("Position", position_text());
                     add_stat("Type ID", std::to_string(item.type_id()));
                     add_stat("Room", std::to_string(item.room()));
-                    add_stat("Clear Body", to_utf8(format_bool(item.clear_body_flag())));
-                    add_stat("Invisible", to_utf8(format_bool(item.invisible_flag())));
+                    add_stat("Clear Body", std::format("{}", item.clear_body_flag()));
+                    add_stat("Invisible", std::format("{}", item.invisible_flag()));
                     add_stat("Flags", to_utf8(format_binary(item.activation_flags())));
                     add_stat("OCB", std::to_string(item.ocb()));
                 }

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -180,16 +180,7 @@ namespace trview
                 {
                     auto add_stat = [&]<typename T>(const std::string& name, const T&& value, Colour colour = Colour::White)
                     {
-                        constexpr auto get_string = [](auto&& v)
-                        {
-                            if constexpr (std::is_same<T, std::string>::value)
-                            {
-                                return v;
-                            }
-                            return std::format("{}", v);
-                        };
                         const auto string_value = get_string(value);
-
                         ImGui::TableNextColumn();
                         if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
                         {

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -1,5 +1,6 @@
 #include "LightsWindow.h"
 #include "../trview_imgui.h"
+#include <format>
 
 namespace trview
 {
@@ -212,26 +213,6 @@ namespace trview
                             " B:" + std::to_string(static_cast<int>(colour.b * 255));
                     };
 
-                    auto position_text = [](const auto& vec)
-                    {
-                        std::stringstream stream;
-                        stream << std::fixed << std::setprecision(0) <<
-                            vec.x * trlevel::Scale_X << ", " <<
-                            vec.y * trlevel::Scale_Y << ", " <<
-                            vec.z * trlevel::Scale_Z;
-                        return stream.str();
-                    };
-
-                    auto direction_text = [](const auto& vec)
-                    {
-                        std::stringstream stream;
-                        stream << std::fixed << std::setprecision(3) <<
-                            vec.x * trlevel::Scale_X << ", " <<
-                            vec.y * trlevel::Scale_Y << ", " <<
-                            vec.z * trlevel::Scale_Z;
-                        return stream.str();
-                    };
-
                     add_stat("Type", to_utf8(light_type_name(selected_light->type())));
                     add_stat("#", std::to_string(selected_light->number()));
                     add_stat("Room", std::to_string(selected_light->room()));
@@ -243,12 +224,14 @@ namespace trview
 
                     if (has_position(*selected_light))
                     {
-                        add_stat("Position", position_text(selected_light->position()));
+                        const auto pos = selected_light->position() * trlevel::Scale;
+                        add_stat("Position", std::format("{:.0f}, {:.0f}, {:.0f}", pos.x, pos.y, pos.z));
                     }
 
                     if (has_direction(*selected_light))
                     {
-                        add_stat("Direction", direction_text(selected_light->direction()));
+                        const auto dir = selected_light->direction() * trlevel::Scale;
+                        add_stat("Direction", std::format("{:.3f}, {:.3f}, {:.3f}", dir.x, dir.y, dir.z));
                     }
 
                     add_stat_with_condition("Intensity", intensity, has_intensity);

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -131,7 +131,7 @@ namespace trview
                         _scroll_to_light = false;
                     }
 
-                    if (ImGui::Selectable((std::to_string(light->number()) + std::string("##") + std::to_string(light->number())).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav | ImGuiTableFlags_SizingFixedFit))
+                    if (ImGui::Selectable(std::format("{0}##{0}", light->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav | ImGuiTableFlags_SizingFixedFit))
                     {
                         scroller.fix_scroll();
 
@@ -152,7 +152,7 @@ namespace trview
                     ImGui::TableNextColumn();
                     bool hidden = !light->visible();
                     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
-                    if (ImGui::Checkbox((std::string("##hide-") + std::to_string(light->number())).c_str(), &hidden))
+                    if (ImGui::Checkbox(std::format("##hide-{}", light->number()).c_str(), &hidden))
                     {
                         on_light_visibility(light, !hidden);
                     }
@@ -208,9 +208,7 @@ namespace trview
 
                     auto format_colour = [](const Colour& colour)
                     {
-                        return "R:" + std::to_string(static_cast<int>(colour.r * 255)) +
-                            " G:" + std::to_string(static_cast<int>(colour.g * 255)) +
-                            " B:" + std::to_string(static_cast<int>(colour.b * 255));
+                        return std::format("R: {}, G: {}, B: {}", static_cast<int>(colour.r * 255), static_cast<int>(colour.g * 255), static_cast<int>(colour.b * 255));
                     };
 
                     add_stat("Type", light_type_name(selected_light->type()));

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -178,12 +178,22 @@ namespace trview
                 auto selected_light = _selected_light.lock();
                 if (selected_light)
                 {
-                    auto add_stat = [&](const std::string& name, const std::string& value, Colour colour = Colour::White)
+                    auto add_stat = [&]<typename T>(const std::string& name, const T&& value, Colour colour = Colour::White)
                     {
+                        constexpr auto get_string = [](auto&& v)
+                        {
+                            if constexpr (std::is_same<T, std::string>::value)
+                            {
+                                return v;
+                            }
+                            return std::format("{}", v);
+                        };
+                        const auto string_value = get_string(value);
+
                         ImGui::TableNextColumn();
                         if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
                         {
-                            _clipboard->write(to_utf16(value));
+                            _clipboard->write(to_utf16(string_value));
                             _tooltip_timer = 0.0f;
                         }
                         if (_level_version == trlevel::LevelVersion::Tomb4 && ImGui::IsItemHovered() && _tips.find(name) != _tips.end())
@@ -194,7 +204,7 @@ namespace trview
                         }
                         ImGui::TableNextColumn();
                         ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(colour.r, colour.g, colour.b, colour.a));
-                        ImGui::Text(value.c_str());
+                        ImGui::Text(string_value.c_str());
                         ImGui::PopStyleColor();
                     };
 
@@ -202,7 +212,7 @@ namespace trview
                     {
                         if (condition(*selected_light))
                         {
-                            add_stat(name, std::to_string(stat(*selected_light)));
+                            add_stat(name, stat(*selected_light));
                         }
                     };
 
@@ -212,8 +222,8 @@ namespace trview
                     };
 
                     add_stat("Type", light_type_name(selected_light->type()));
-                    add_stat("#", std::to_string(selected_light->number()));
-                    add_stat("Room", std::to_string(selected_light->room()));
+                    add_stat("#", selected_light->number());
+                    add_stat("Room", selected_light->room());
 
                     if (has_colour(*selected_light))
                     {

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -148,7 +148,7 @@ namespace trview
                     ImGui::TableNextColumn();
                     ImGui::Text(std::to_string(light->room()).c_str());
                     ImGui::TableNextColumn();
-                    ImGui::Text(to_utf8(light_type_name(light->type())).c_str());
+                    ImGui::Text(light_type_name(light->type()).c_str());
                     ImGui::TableNextColumn();
                     bool hidden = !light->visible();
                     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
@@ -213,7 +213,7 @@ namespace trview
                             " B:" + std::to_string(static_cast<int>(colour.b * 255));
                     };
 
-                    add_stat("Type", to_utf8(light_type_name(selected_light->type())));
+                    add_stat("Type", light_type_name(selected_light->type()));
                     add_stat("#", std::to_string(selected_light->number()));
                     add_stat("Room", std::to_string(selected_light->room()));
 
@@ -298,10 +298,10 @@ namespace trview
         {
             if (auto light_ptr = light.lock())
             {
-                available_types.insert(to_utf8(light_type_name(light_ptr->type())));
+                available_types.insert(light_type_name(light_ptr->type()));
             }
         }
-        _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& light) { return to_utf8(light_type_name(light.type())); });
+        _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& light) { return light_type_name(light.type()); });
         _filters.add_getter<float>("#", [](auto&& light) { return light.number(); });
         _filters.add_getter<float>("Room", [](auto&& light) { return light.room(); });
         _filters.add_getter<float>("X", [](auto&& light) { return light.position().x * trlevel::Scale_X; }, has_position);

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -12,49 +12,49 @@ namespace trview
         void add_room_flags(IClipboard& clipboard, trlevel::LevelVersion version, const IRoom& room)
         {
             using trlevel::LevelVersion;
-            const auto add_flag = [&](const std::wstring& name, bool flag) 
+            const auto add_flag = [&](const std::string& name, bool flag) 
             {
                 auto value = std::format("{}", flag);
                 ImGui::TableNextColumn();
-                if (ImGui::Selectable(to_utf8(name).c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
+                if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
                 {
                     clipboard.write(to_utf16(value));
                 }
                 ImGui::TableNextColumn();
                 ImGui::Text(value.c_str());
             };
-            const auto add_flag_min = [&](LevelVersion min_version, const std::wstring& name, const std::wstring& alt_name, bool flag)
+            const auto add_flag_min = [&](LevelVersion min_version, const std::string& name, const std::string& alt_name, bool flag)
             {
                 add_flag(version >= min_version ? name : alt_name, flag);
             };
 
-            add_flag(L"Water", room.water());
-            add_flag(L"Bit 1", room.flag(IRoom::Flag::Bit1));
-            add_flag(L"Bit 2", room.flag(IRoom::Flag::Bit2));
-            add_flag_min(LevelVersion::Tomb2, L"Outside / 3", L"Bit 3", room.outside());
-            add_flag(L"Bit 4", room.flag(IRoom::Flag::Bit4));
-            add_flag_min(LevelVersion::Tomb2, L"Wind / 5", L"Bit 5", room.flag(IRoom::Flag::Wind));
-            add_flag(L"Bit 6", room.flag(IRoom::Flag::Bit6));
+            add_flag("Water", room.water());
+            add_flag("Bit 1", room.flag(IRoom::Flag::Bit1));
+            add_flag("Bit 2", room.flag(IRoom::Flag::Bit2));
+            add_flag_min(LevelVersion::Tomb2, "Outside / 3", "Bit 3", room.outside());
+            add_flag("Bit 4", room.flag(IRoom::Flag::Bit4));
+            add_flag_min(LevelVersion::Tomb2, "Wind / 5", "Bit 5", room.flag(IRoom::Flag::Wind));
+            add_flag("Bit 6", room.flag(IRoom::Flag::Bit6));
             if (version == LevelVersion::Tomb3)
             {
-                add_flag(L"Quicksand / 7", room.flag(IRoom::Flag::Quicksand));
+                add_flag("Quicksand / 7", room.flag(IRoom::Flag::Quicksand));
             }
             else if (version > LevelVersion::Tomb3)
             {
-                add_flag(L"Block Lens Flare / 7", room.flag(IRoom::Flag::NoLensFlare));
+                add_flag("Block Lens Flare / 7", room.flag(IRoom::Flag::NoLensFlare));
             }
             else
             {
-                add_flag(L"Bit 7", room.flag(IRoom::Flag::Bit7));
+                add_flag("Bit 7", room.flag(IRoom::Flag::Bit7));
             }
-            add_flag_min(LevelVersion::Tomb3, L"Caustics / 8", L"Bit 8", room.flag(IRoom::Flag::Caustics));
-            add_flag_min(LevelVersion::Tomb3, L"Reflectivity / 9", L"Bit 9", room.flag(IRoom::Flag::WaterReflectivity));
-            add_flag_min(LevelVersion::Tomb4, L"Snow (NGLE) / 10", L"Bit 10", room.flag(IRoom::Flag::Bit10));
-            add_flag_min(LevelVersion::Tomb4, L"D / Rain / 11", L"Bit 11", room.flag(IRoom::Flag::Bit11));
-            add_flag_min(LevelVersion::Tomb4, L"P / Cold / 12", L"Bit 12", room.flag(IRoom::Flag::Bit12));
-            add_flag(L"Bit 13", room.flag(IRoom::Flag::Bit13));
-            add_flag(L"Bit 14", room.flag(IRoom::Flag::Bit14));
-            add_flag(L"Bit 15", room.flag(IRoom::Flag::Bit15));
+            add_flag_min(LevelVersion::Tomb3, "Caustics / 8", "Bit 8", room.flag(IRoom::Flag::Caustics));
+            add_flag_min(LevelVersion::Tomb3, "Reflectivity / 9", "Bit 9", room.flag(IRoom::Flag::WaterReflectivity));
+            add_flag_min(LevelVersion::Tomb4, "Snow (NGLE) / 10", "Bit 10", room.flag(IRoom::Flag::Bit10));
+            add_flag_min(LevelVersion::Tomb4, "D / Rain / 11", "Bit 11", room.flag(IRoom::Flag::Bit11));
+            add_flag_min(LevelVersion::Tomb4, "P / Cold / 12", "Bit 12", room.flag(IRoom::Flag::Bit12));
+            add_flag("Bit 13", room.flag(IRoom::Flag::Bit13));
+            add_flag("Bit 14", room.flag(IRoom::Flag::Bit14));
+            add_flag("Bit 15", room.flag(IRoom::Flag::Bit15));
         }
     }
 

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -326,7 +326,7 @@ namespace trview
                         _scroll_to_room = false;
                     }
 
-                    if (ImGui::Selectable((std::to_string(room_ptr->number()) + std::string("##") + std::to_string(room_ptr->number())).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                    if (ImGui::Selectable(std::format("{0}##{0}", room_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
                     {
                         scroller.fix_scroll();
                         _selected_room = room_ptr->number();
@@ -345,7 +345,7 @@ namespace trview
                     ImGui::TableNextColumn();
                     bool hidden = !room_ptr->visible();
                     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
-                    if (ImGui::Checkbox((std::string("##hide-") + std::to_string(room_ptr->number())).c_str(), &hidden))
+                    if (ImGui::Checkbox(std::format("##hide-{}", room_ptr->number()).c_str(), &hidden))
                     {
                         on_room_visibility(room, !hidden);
                     }
@@ -585,7 +585,7 @@ namespace trview
                                         _scroll_to_trigger = false;
                                     }
 
-                                    if (ImGui::Selectable((std::to_string(trigger_ptr->number()) + std::string("##") + std::to_string(trigger_ptr->number())).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                                    if (ImGui::Selectable(std::format("{0}##{0}", trigger_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
                                     {
                                         scroller.fix_scroll();
                                         _local_selected_trigger = trigger_ptr;

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -444,16 +444,7 @@ namespace trview
 
                     auto add_stat = [&]<typename T>(const std::string& name, const T&& value)
                     {
-                        constexpr auto get_string = [](auto&& v)
-                        {
-                            if constexpr (std::is_same<T, std::string>::value)
-                            {
-                                return v;
-                            }
-                            return std::format("{}", v);
-                        };
                         const auto string_value = get_string(value);
-
                         ImGui::TableNextColumn();
                         if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
                         {

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -442,16 +442,17 @@ namespace trview
                         ImGui::Separator();
                     }
 
-                    auto add_stat = [&](const std::string& name, const std::string& value)
+                    auto add_stat = [&]<typename T>(const std::string& name, const T& value)
                     {
+                        const auto string_value = std::format("{}", value);
                         ImGui::TableNextColumn();
                         if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
                         {
-                            _clipboard->write(to_utf16(value));
+                            _clipboard->write(to_utf16(string_value));
                             _tooltip_timer = 0.0f;
                         }
                         ImGui::TableNextColumn();
-                        ImGui::Text(value.c_str());
+                        ImGui::Text(string_value.c_str());
                     };
 
                     if (ImGui::BeginTable(Names::bottom.c_str(), 2))
@@ -466,15 +467,15 @@ namespace trview
                             ImGui::TableSetupColumn("Value");
                             ImGui::TableNextRow();
 
-                            add_stat("X", std::to_string(room->info().x));
-                            add_stat("Y", std::to_string(room->info().yBottom));
-                            add_stat("Z", std::to_string(room->info().z));
+                            add_stat("X", room->info().x);
+                            add_stat("Y", room->info().yBottom);
+                            add_stat("Z", room->info().z);
                             if (room->alternate_mode() != Room::AlternateMode::None)
                             {
-                                add_stat("Alternate", std::to_string(room->alternate_room()));
+                                add_stat("Alternate", room->alternate_room());
                                 if (room->alternate_group() != 0xff)
                                 {
-                                    add_stat("Alternate Group", std::to_string(room->alternate_group()));
+                                    add_stat("Alternate Group", room->alternate_group());
                                 }
                             }
                             add_room_flags(*_clipboard, _level_version, *room);

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -442,9 +442,18 @@ namespace trview
                         ImGui::Separator();
                     }
 
-                    auto add_stat = [&]<typename T>(const std::string& name, const T& value)
+                    auto add_stat = [&]<typename T>(const std::string& name, const T&& value)
                     {
-                        const auto string_value = std::format("{}", value);
+                        constexpr auto get_string = [](auto&& v)
+                        {
+                            if constexpr (std::is_same<T, std::string>::value)
+                            {
+                                return v;
+                            }
+                            return std::format("{}", v);
+                        };
+                        const auto string_value = get_string(value);
+
                         ImGui::TableNextColumn();
                         if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
                         {

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -70,15 +70,14 @@ namespace trview
                 return;
             }
 
-            std::wstring text = L"X: " + std::to_wstring(sector->x()) + L", Z:" + std::to_wstring(sector->z()) + L"\n";
+            std::string text = std::format("X: {}, Z: {}\n", sector->x(), sector->z());
             if (has_flag(sector->flags(), SectorFlag::RoomAbove))
             {
-                text += L"Above: " + std::to_wstring(sector->room_above());
+                text += std::format("Above: {}", sector->room_above());
             }
             if (has_flag(sector->flags(), SectorFlag::RoomBelow))
             {
-                text += (has_flag(sector->flags(), SectorFlag::RoomAbove) ? L", " : L"") +
-                    std::wstring(L"Below: ") + std::to_wstring(sector->room_below());
+                text += std::format("{}Below: {}", has_flag(sector->flags(), SectorFlag::RoomAbove) ? ", " : "", sector->room_below());
             }
             _map_tooltip.set_text(text);
             _map_tooltip.set_visible(!text.empty());
@@ -521,7 +520,7 @@ namespace trview
                                     }
 
                                     ImGui::TableNextColumn();
-                                    ImGui::Text(to_utf8(item.type()).c_str());
+                                    ImGui::Text(item.type().c_str());
                                 }
                             }
 
@@ -595,7 +594,7 @@ namespace trview
                                     }
 
                                     ImGui::TableNextColumn();
-                                    ImGui::Text(to_utf8(trigger_type_name(trigger_ptr->type())).c_str());
+                                    ImGui::Text(trigger_type_name(trigger_ptr->type()).c_str());
                                 }
                             }
 
@@ -665,7 +664,7 @@ namespace trview
         {
             if (auto trigger_ptr = trigger.lock())
             {
-                available_trigger_types.insert(to_utf8(trigger_type_name(trigger_ptr->type())));
+                available_trigger_types.insert(trigger_type_name(trigger_ptr->type()));
             }
         }
         _filters.add_multi_getter<std::string>("Trigger Type", { available_trigger_types.begin(), available_trigger_types.end() }, [&](auto&& room)
@@ -676,7 +675,7 @@ namespace trview
                     const auto trigger_ptr = trigger.lock();
                     if (trigger_ptr && trigger_ptr->room() == room.number())
                     {
-                        results.push_back(to_utf8(trigger_type_name(trigger_ptr->type())));
+                        results.push_back(trigger_type_name(trigger_ptr->type()));
                     }
                 }
                 return results;
@@ -697,7 +696,7 @@ namespace trview
         std::set<std::string> available_item_types;
         for (const auto& item : _all_items)
         {
-            available_item_types.insert(to_utf8(item.type()));
+            available_item_types.insert(item.type());
         }
         _filters.add_multi_getter<std::string>("Item Type", { available_item_types.begin(), available_item_types.end() }, [&](auto&& room)
             {
@@ -706,7 +705,7 @@ namespace trview
                 {
                     if (item.room() == room.number())
                     {
-                        results.push_back(to_utf8(item.type()));
+                        results.push_back(item.type());
                     }
                 }
                 return results;

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -14,7 +14,7 @@ namespace trview
             using trlevel::LevelVersion;
             const auto add_flag = [&](const std::wstring& name, bool flag) 
             {
-                auto value = to_utf8(format_bool(flag));
+                auto value = std::format("{}", flag);
                 ImGui::TableNextColumn();
                 if (ImGui::Selectable(to_utf8(name).c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
                 {

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -158,16 +158,27 @@ namespace trview
                     ImGui::TableSetupColumn("Value");
                     ImGui::TableNextRow();
 
-                    auto add_stat = [&](const std::string& name, const std::string& value)
+                    auto add_stat = [&]<typename T>(const std::string& name, const T&& value)
                     {
+                        constexpr auto get_string = [](auto&& v)
+                        {
+                            if constexpr (std::is_same<T, std::string>::value)
+                            {
+                                return v;
+                            }
+                            return std::format("{}", v);
+                        };
+
+                        const auto string_value = get_string(value);
+
                         ImGui::TableNextColumn();
                         if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
                         {
-                            _clipboard->write(to_utf16(value));
+                            _clipboard->write(to_utf16(string_value));
                             _tooltip_timer = 0.0f;
                         }
                         ImGui::TableNextColumn();
-                        ImGui::Text(value.c_str());
+                        ImGui::Text(string_value.c_str());
                     };
 
                     auto get_room_pos = [&waypoint, this]()
@@ -194,7 +205,7 @@ namespace trview
 
                     add_stat("Type", waypoint_type_to_string(waypoint.type()));
                     add_stat("Position", position_text(waypoint.position()));
-                    add_stat("Room", std::to_string(waypoint.room()));
+                    add_stat("Room", waypoint.room());
                     add_stat("Room Position", position_text(get_room_pos()));
                     ImGui::EndTable();
                 }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -3,6 +3,7 @@
 #include <trview.common/Strings.h>
 #include <trview.common/Windows/IClipboard.h>
 #include "../trview_imgui.h"
+#include <format>
 
 namespace trview
 {
@@ -187,12 +188,8 @@ namespace trview
 
                     auto position_text = [](const auto& pos)
                     {
-                        std::stringstream stream;
-                        stream << std::fixed << std::setprecision(0) <<
-                            pos.x * trlevel::Scale_X << ", " <<
-                            pos.y * trlevel::Scale_Y << ", " <<
-                            pos.z * trlevel::Scale_Z;
-                        return stream.str();
+                        const auto p = pos * trlevel::Scale;
+                        return std::format("{:.0f}, {:.0f}, {:.0f}", p.x, p.y, p.z);
                     };
 
                     add_stat("Type", to_utf8(waypoint_type_to_string(waypoint.type())));

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -192,7 +192,7 @@ namespace trview
                         return std::format("{:.0f}, {:.0f}, {:.0f}", p.x, p.y, p.z);
                     };
 
-                    add_stat("Type", to_utf8(waypoint_type_to_string(waypoint.type())));
+                    add_stat("Type", waypoint_type_to_string(waypoint.type()));
                     add_stat("Position", position_text(waypoint.position()));
                     add_stat("Room", std::to_string(waypoint.room()));
                     add_stat("Room Position", position_text(get_room_pos()));
@@ -265,10 +265,10 @@ namespace trview
                     }
 
                     ImGui::Text("Notes");
-                    std::string notes = to_utf8(waypoint.notes());
+                    std::string notes = waypoint.notes();
                     if (ImGui::InputTextMultiline(Names::notes.c_str(), &notes, ImVec2(-1, -1)))
                     {
-                        waypoint.set_notes(to_utf16(notes));
+                        waypoint.set_notes(notes);
                         _route->set_unsaved(true);
                     }
                 }
@@ -452,7 +452,7 @@ namespace trview
         {
             if (waypoint.index() < _all_items.size())
             {
-                return to_utf8(_all_items[waypoint.index()].type());
+                return _all_items[waypoint.index()].type();
             }
             else
             {
@@ -465,7 +465,7 @@ namespace trview
             {
                 if (auto trigger = _all_triggers[waypoint.index()].lock())
                 {
-                    return to_utf8(trigger_type_name(trigger->type()));
+                    return trigger_type_name(trigger->type());
                 }
             }
             else
@@ -473,6 +473,6 @@ namespace trview
                 return "Invalid trigger";
             }
         }
-        return to_utf8(waypoint_type_to_string(waypoint.type()));
+        return waypoint_type_to_string(waypoint.type());
     }
 }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -160,17 +160,7 @@ namespace trview
 
                     auto add_stat = [&]<typename T>(const std::string& name, const T&& value)
                     {
-                        constexpr auto get_string = [](auto&& v)
-                        {
-                            if constexpr (std::is_same<T, std::string>::value)
-                            {
-                                return v;
-                            }
-                            return std::format("{}", v);
-                        };
-
                         const auto string_value = get_string(value);
-
                         ImGui::TableNextColumn();
                         if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
                         {

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -282,16 +282,26 @@ namespace trview
                 auto selected_trigger = _selected_trigger.lock();
                 if (selected_trigger)
                 {
-                    auto add_stat = [&](const std::string& name, const std::string& value)
+                    auto add_stat = [&]<typename T>(const std::string& name, const T&& value)
                     {
+                        constexpr auto get_string = [](auto&& v)
+                        {
+                            if constexpr (std::is_same<T, std::string>::value)
+                            {
+                                return v;
+                            }
+                            return std::format("{}", v);
+                        };
+                        const auto string_value = get_string(value);
+
                         ImGui::TableNextColumn();
                         if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
                         {
-                            _clipboard->write(to_utf16(value));
+                            _clipboard->write(to_utf16(string_value));
                             _tooltip_timer = 0.0f;
                         }
                         ImGui::TableNextColumn();
-                        ImGui::Text(value.c_str());
+                        ImGui::Text(string_value.c_str());
                     };
 
                     auto position_text = [=]()
@@ -301,12 +311,12 @@ namespace trview
                     };
 
                     add_stat("Type", trigger_type_name(selected_trigger->type()));
-                    add_stat("#", std::to_string(selected_trigger->number()));
+                    add_stat("#", selected_trigger->number());
                     add_stat("Position", position_text());
-                    add_stat("Room", std::to_string(selected_trigger->room()));
+                    add_stat("Room", selected_trigger->room());
                     add_stat("Flags", format_binary(selected_trigger->flags()));
-                    add_stat("Only once", std::format("{}", selected_trigger->only_once()));
-                    add_stat("Timer", std::to_string(selected_trigger->timer()));
+                    add_stat("Only once", selected_trigger->only_once());
+                    add_stat("Timer", selected_trigger->timer());
                 }
 
                 ImGui::EndTable();

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -284,16 +284,7 @@ namespace trview
                 {
                     auto add_stat = [&]<typename T>(const std::string& name, const T&& value)
                     {
-                        constexpr auto get_string = [](auto&& v)
-                        {
-                            if constexpr (std::is_same<T, std::string>::value)
-                            {
-                                return v;
-                            }
-                            return std::format("{}", v);
-                        };
                         const auto string_value = get_string(value);
-
                         ImGui::TableNextColumn();
                         if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
                         {

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -26,7 +26,7 @@ namespace trview
             }
         }
         std::vector<std::string> all_commands{ "All", "Flipmaps" };
-        std::transform(command_set.begin(), command_set.end(), std::back_inserter(all_commands), command_type_name_8);
+        std::transform(command_set.begin(), command_set.end(), std::back_inserter(all_commands), command_type_name);
         _all_commands = all_commands;
 
         setup_filters();
@@ -213,7 +213,8 @@ namespace trview
                             _scroll_to_trigger = false;
                         }
 
-                        if (ImGui::Selectable((std::to_string(trigger_ptr->number()) + std::string("##") + std::to_string(trigger_ptr->number())).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                        
+                        if (ImGui::Selectable(std::format("{0}##{0}", trigger_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
                         {
                             scroller.fix_scroll();
                             set_local_selected_trigger(trigger_ptr);
@@ -228,11 +229,11 @@ namespace trview
                         ImGui::TableNextColumn();
                         ImGui::Text(std::to_string(trigger_ptr->room()).c_str());
                         ImGui::TableNextColumn();
-                        ImGui::Text(to_utf8(trigger_type_name(trigger_ptr->type())).c_str());
+                        ImGui::Text(trigger_type_name(trigger_ptr->type()).c_str());
                         ImGui::TableNextColumn();
                         bool hidden = !trigger_ptr->visible();
                         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
-                        if (ImGui::Checkbox((std::string("##hide-") + std::to_string(trigger_ptr->number())).c_str(), &hidden))
+                        if (ImGui::Checkbox(std::format("##hide-{}", trigger_ptr->number()).c_str(), &hidden))
                         {
                             on_trigger_visibility(trigger_ptr, !hidden);
                         }
@@ -264,9 +265,9 @@ namespace trview
                 {
                     return _all_items[command.index()].type();
                 }
-                return std::wstring(L"No Item");
+                return std::string("No Item");
             }
-            return std::wstring();
+            return std::string();
         };
 
         if (ImGui::BeginChild(Names::details_panel.c_str(), ImVec2(), true))
@@ -299,7 +300,7 @@ namespace trview
                         return std::format("{:.0f}, {:.0f}, {:.0f}", p.x, p.y, p.z);
                     };
 
-                    add_stat("Type", to_utf8(trigger_type_name(selected_trigger->type())));
+                    add_stat("Type", trigger_type_name(selected_trigger->type()));
                     add_stat("#", std::to_string(selected_trigger->number()));
                     add_stat("Position", position_text());
                     add_stat("Room", std::to_string(selected_trigger->room()));
@@ -335,7 +336,7 @@ namespace trview
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
                     bool selected = false;
-                    if (ImGui::Selectable((to_utf8(command_type_name(command.type())) + "##" + std::to_string(command.number())).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                    if (ImGui::Selectable(std::format("{}##{}", command_type_name(command.type()), command.number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
                     {
                         if (command.type() == TriggerCommandType::LookAtItem || command.type() == TriggerCommandType::Object && command.index() < _all_items.size())
                         {
@@ -346,7 +347,7 @@ namespace trview
                     ImGui::TableNextColumn();
                     ImGui::Text(std::to_string(command.index()).c_str());
                     ImGui::TableNextColumn();
-                    ImGui::Text(to_utf8(get_command_display(command)).c_str());;
+                    ImGui::Text(get_command_display(command).c_str());;
                 }
 
                 ImGui::EndTable();
@@ -396,10 +397,10 @@ namespace trview
         {
             if (auto trigger_ptr = trigger.lock())
             {
-                available_types.insert(to_utf8(trigger_type_name(trigger_ptr->type())));
+                available_types.insert(trigger_type_name(trigger_ptr->type()));
             }
         }
-        _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& trigger) { return to_utf8(trigger_type_name(trigger.type())); });
+        _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& trigger) { return trigger_type_name(trigger.type()); });
         _filters.add_getter<float>("#", [](auto&& trigger) { return trigger.number(); });
         _filters.add_getter<float>("Room", [](auto&& trigger) { return trigger.room(); });
         _filters.add_getter<std::string>("Flags", [](auto&& trigger) { return to_utf8(format_binary(trigger.flags())); });
@@ -441,7 +442,7 @@ namespace trview
         {
             if (any_of_command(type))
             {
-                _filters.add_multi_getter<float>(command_type_name_8(type), [=](auto&& trigger) { return all_trigger_indices(type, trigger); });
+                _filters.add_multi_getter<float>(command_type_name(type), [=](auto&& trigger) { return all_trigger_indices(type, trigger); });
             }
         };
 
@@ -496,7 +497,7 @@ namespace trview
                 _required_number_width = std::max(_required_number_width,
                     ImGui::CalcTextSize(std::to_string(trigger_ptr->number()).c_str()).x);
                 _required_type_width = std::max(_required_type_width,
-                    ImGui::CalcTextSize(to_utf8(trigger_type_name(trigger_ptr->type())).c_str()).x);
+                    ImGui::CalcTextSize(trigger_type_name(trigger_ptr->type()).c_str()).x);
             }
         }
     }

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -304,7 +304,7 @@ namespace trview
                     add_stat("#", std::to_string(selected_trigger->number()));
                     add_stat("Position", position_text());
                     add_stat("Room", std::to_string(selected_trigger->room()));
-                    add_stat("Flags", to_utf8(format_binary(selected_trigger->flags())));
+                    add_stat("Flags", format_binary(selected_trigger->flags()));
                     add_stat("Only once", std::format("{}", selected_trigger->only_once()));
                     add_stat("Timer", std::to_string(selected_trigger->timer()));
                 }
@@ -403,7 +403,7 @@ namespace trview
         _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& trigger) { return trigger_type_name(trigger.type()); });
         _filters.add_getter<float>("#", [](auto&& trigger) { return trigger.number(); });
         _filters.add_getter<float>("Room", [](auto&& trigger) { return trigger.room(); });
-        _filters.add_getter<std::string>("Flags", [](auto&& trigger) { return to_utf8(format_binary(trigger.flags())); });
+        _filters.add_getter<std::string>("Flags", [](auto&& trigger) { return format_binary(trigger.flags()); });
         _filters.add_getter<bool>("Only once", [](auto&& trigger) { return trigger.only_once(); });
         _filters.add_getter<float>("Timer", [](auto&& trigger) { return trigger.timer(); });
 

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -1,6 +1,7 @@
 #include "TriggersWindow.h"
 #include <trview.common/Strings.h>
 #include "../trview_imgui.h"
+#include <format>
 
 namespace trview
 {
@@ -292,14 +293,10 @@ namespace trview
                         ImGui::Text(value.c_str());
                     };
 
-                    auto position_text = [&selected_trigger]()
+                    auto position_text = [=]()
                     {
-                        std::stringstream stream;
-                        stream << std::fixed << std::setprecision(0) <<
-                            selected_trigger->position().x * trlevel::Scale_X << ", " <<
-                            selected_trigger->position().y * trlevel::Scale_Y << ", " <<
-                            selected_trigger->position().z * trlevel::Scale_Z;
-                        return stream.str();
+                        const auto p = selected_trigger->position() * trlevel::Scale;
+                        return std::format("{:.0f}, {:.0f}, {:.0f}", p.x, p.y, p.z);
                     };
 
                     add_stat("Type", to_utf8(trigger_type_name(selected_trigger->type())));
@@ -307,7 +304,7 @@ namespace trview
                     add_stat("Position", position_text());
                     add_stat("Room", std::to_string(selected_trigger->room()));
                     add_stat("Flags", to_utf8(format_binary(selected_trigger->flags())));
-                    add_stat("Only once", to_utf8(format_bool(selected_trigger->only_once())));
+                    add_stat("Only once", std::format("{}", selected_trigger->only_once()));
                     add_stat("Timer", std::to_string(selected_trigger->timer()));
                 }
 

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -224,10 +224,7 @@ namespace trview
             current_camera().set_rotation_pitch(pitch);
         };
 
-        _token_store += _ui->on_command += [&](const auto& command)
-        {
-            lua_execute ( to_utf8 ( command ) );
-        };
+        _token_store += _ui->on_command += lua_execute;
 
         _ui->set_settings(_settings);
         _ui->set_camera_mode(CameraMode::Orbit);

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -290,7 +290,7 @@ namespace trview
                 }
                 else
                 {
-                    result.text = L"|....|";
+                    result.text = "|....|";
                 }
             }
         };
@@ -974,7 +974,6 @@ namespace trview
 
         _token_store += _camera_input.on_pan += [&](bool vertical, float x, float y)
         {
-            auto& io = ImGui::GetIO();
             if (_ui->is_cursor_over() || _camera_mode != CameraMode::Orbit)
             {
                 return;

--- a/trview.app/Windows/ViewerLuaRegistry.cpp
+++ b/trview.app/Windows/ViewerLuaRegistry.cpp
@@ -121,7 +121,7 @@ namespace trview
 
         lua_registry.print = [this] ( const std::string& text )
             {
-            _ui->print_console ( to_utf16 ( text ) );
+            _ui->print_console (text);
             };
 
         lua_registry.on_crazy = [this] () -> bool

--- a/trview.app/stdafx.h
+++ b/trview.app/stdafx.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <format>
 
 #include <SimpleMath.h>
 #include <DirectXCollision.h>

--- a/trview.common/Colour.cpp
+++ b/trview.common/Colour.cpp
@@ -40,10 +40,10 @@ namespace trview
     {
     }
 
-    std::wstring Colour::code() const
+    std::string Colour::code() const
     {
         uint32_t value = *this;
-        return std::to_wstring(value);
+        return std::to_string(value);
     }
 
     Colour::operator DirectX::SimpleMath::Color() const
@@ -68,7 +68,7 @@ namespace trview
         return *this;
     }
 
-    Colour from_colour_code(const std::wstring& name)
+    Colour from_colour_code(const std::string& name)
     {
         uint32_t value = std::stoul(name);
         return Colour(

--- a/trview.common/Colour.h
+++ b/trview.common/Colour.h
@@ -21,7 +21,7 @@ namespace trview
 
         Colour(uint32_t colour);
 
-        std::wstring code() const;
+        std::string code() const;
 
         operator DirectX::SimpleMath::Color() const;
 
@@ -45,7 +45,7 @@ namespace trview
         static Colour Cyan;
     };
 
-    Colour from_colour_code(const std::wstring& name);
+    Colour from_colour_code(const std::string& name);
     Colour from_named_colour(const std::string& name);
 
     Colour operator+(const Colour& left, const Colour& right);

--- a/trview.common/Strings.cpp
+++ b/trview.common/Strings.cpp
@@ -1,5 +1,6 @@
 #include "Strings.h"
 #include <algorithm>
+#include <format>
 
 namespace trview
 {
@@ -23,13 +24,6 @@ namespace trview
         return &output[0];
     }
 
-    std::wstring format_bool(bool value)
-    {
-        std::wstringstream stream;
-        stream << std::boolalpha << value;
-        return stream.str();
-    }
-
     std::wstring format_binary(uint16_t value)
     {
         std::wstringstream stream;
@@ -46,7 +40,7 @@ namespace trview
     std::string to_lowercase(const std::string& value)
     {
         std::string result;
-        std::transform(value.begin(), value.end(), std::back_inserter(result), std::tolower);
+        std::transform(value.begin(), value.end(), std::back_inserter(result), ::tolower);
         return result;
     }
 }

--- a/trview.common/Strings.cpp
+++ b/trview.common/Strings.cpp
@@ -24,12 +24,9 @@ namespace trview
         return &output[0];
     }
 
-    std::wstring format_binary(uint16_t value)
+    std::string format_binary(uint16_t value)
     {
-        std::wstringstream stream;
-        stream << std::bitset<5>(value);
-        const auto result = stream.str();
-        return std::wstring(result.rbegin(), result.rend());
+        return std::format("{}", std::bitset<5>(value).to_string());
     }
 
     bool is_link(const std::wstring& text)

--- a/trview.common/Strings.cpp
+++ b/trview.common/Strings.cpp
@@ -26,7 +26,7 @@ namespace trview
 
     std::string format_binary(uint16_t value)
     {
-        return std::format("{}", std::bitset<5>(value).to_string());
+        return std::bitset<5>(value).to_string();
     }
 
     bool is_link(const std::wstring& text)

--- a/trview.common/Strings.h
+++ b/trview.common/Strings.h
@@ -14,11 +14,6 @@ namespace trview
     /// @returns The converted string.
     std::wstring to_utf16(const std::string& value);
 
-    /// Convert a boolean to true/false.
-    /// @param value The bool to convert.
-    /// @returns The converted string.
-    std::wstring format_bool(bool value);
-
     /// Convert a value to a binary - only shows 5 bits.
     /// @param value The value to convert.
     /// @returns The converted string.

--- a/trview.common/Strings.h
+++ b/trview.common/Strings.h
@@ -30,4 +30,12 @@ namespace trview
     /// <param name="value">The string to convert.</param>
     /// <returns>The converted string.</returns>
     std::string to_lowercase(const std::string& value);
+
+    /// <summary>
+    /// Converts to a string (or does nothing if it is already a string).
+    /// </summary>
+    template <typename T>
+    constexpr std::string get_string(T&& value);
 }
+
+#include "Strings.inl"

--- a/trview.common/Strings.h
+++ b/trview.common/Strings.h
@@ -17,7 +17,7 @@ namespace trview
     /// Convert a value to a binary - only shows 5 bits.
     /// @param value The value to convert.
     /// @returns The converted string.
-    std::wstring format_binary(uint16_t value);
+    std::string format_binary(uint16_t value);
 
     /// Check whether text is a link.
     /// @param value The value to check.

--- a/trview.common/Strings.inl
+++ b/trview.common/Strings.inl
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <format>
+
+namespace trview
+{
+    template <typename T>
+    constexpr std::string get_string(T&& value)
+    {
+        if constexpr (std::is_same<T, std::string>::value)
+        {
+            return value;
+        }
+        return std::format("{}", value);
+    }
+}
+

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -90,6 +90,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="Event.inl" />
+    <None Include="Strings.inl" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>

--- a/trview.common/trview.common.vcxproj.filters
+++ b/trview.common/trview.common.vcxproj.filters
@@ -157,5 +157,6 @@
     <None Include="Event.inl">
       <Filter>Events</Filter>
     </None>
+    <None Include="Strings.inl" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Remove wide strings where possible.
Switch to std::format instead of adding std::to_string together or stringstreams.
Closes #888 