### PR TITLE
Allow custom colour for waypoint

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -701,3 +701,20 @@ TEST(Application, ReloadSyncsProperties)
     application->open("test.tr2", ILevel::OpenMode::Full);
     application->open("test.tr2", ILevel::OpenMode::Reload);
 }
+
+TEST(Application, RouteSetToDefaultColoursOnReset)
+{
+    UserSettings settings;
+    settings.route_colour = Colour::Yellow;
+    settings.waypoint_colour = Colour::Cyan;
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, set_colour(Colour::Yellow)).Times(1);
+    EXPECT_CALL(*route, set_waypoint_colour(Colour::Cyan)).Times(1);
+    auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
+    ON_CALL(settings_loader, load_user_settings).WillByDefault(Return(settings));
+    auto application = register_test_module()
+        .with_settings_loader(std::move(settings_loader_ptr))
+        .with_route_source([&](auto&&...) {return route; })
+        .build();
+    application->open("test.tr2", ILevel::OpenMode::Full);
+}

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -361,3 +361,23 @@ TEST(Route, RenderDoesNotShowSelection)
     route->add(Vector3::Zero, Vector3::Down, 0);
     route->render(camera, texture_storage, false);
 }
+
+TEST(Route, AddWaypointUsesColours)
+{
+    FAIL();
+}
+
+TEST(Route, RouteUsesDefaultColours)
+{
+    FAIL();
+}
+
+TEST(Route, SetColourUpdatesWaypoints)
+{
+    FAIL();
+}
+
+TEST(Route, SetWaypointColourUpdatesWaypoints)
+{
+    FAIL();
+}

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -20,6 +20,7 @@ namespace
         {
             std::unique_ptr<ISelectionRenderer> selection_renderer = mock_unique<MockSelectionRenderer>();
             IWaypoint::Source waypoint_source = [](auto&&...) { return mock_unique<MockWaypoint>(); };
+            UserSettings settings;
 
             test_module& with_selection_renderer(std::unique_ptr<ISelectionRenderer> selection_renderer)
             {
@@ -35,7 +36,7 @@ namespace
 
             std::unique_ptr<Route> build()
             {
-                return std::make_unique<Route>(std::move(selection_renderer), waypoint_source);
+                return std::make_unique<Route>(std::move(selection_renderer), waypoint_source, settings);
             }
         };
         return test_module{};

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -49,6 +49,7 @@ namespace
         IWaypoint::Type type;
         uint32_t index;
         Colour colour;
+        Colour stick_colour;
     };
 
     /// <summary>
@@ -85,9 +86,9 @@ namespace
 TEST(Route, Add)
 {
     std::optional<WaypointDetails> waypoint_values;
-    auto source = [&](auto&& position, auto&& normal, auto&& room, auto&& type, auto&& index, auto&& colour)
+    auto source = [&](auto&&... args)
     {
-        waypoint_values = { position, normal, room, type, index, colour };
+        waypoint_values = { args... };
         return mock_unique<MockWaypoint>();
     };
 
@@ -105,9 +106,9 @@ TEST(Route, Add)
 TEST(Route, AddSpecificType)
 {
     std::optional<WaypointDetails> waypoint_values;
-    auto source = [&](auto&& position, auto&& normal, auto&& room, auto&& type, auto&& index, auto&& colour)
+    auto source = [&](auto&&... args)
     {
-        waypoint_values = { position, normal, room, type, index, colour };
+        waypoint_values = { args... };
         return mock_unique<MockWaypoint>();
     };
     auto route = register_test_module().with_waypoint_source(source).build();

--- a/trview.app.tests/Routing/WaypointTests.cpp
+++ b/trview.app.tests/Routing/WaypointTests.cpp
@@ -8,7 +8,7 @@ using namespace DirectX::SimpleMath;
 
 TEST(Waypoint, ConstructorProperties)
 {
-    Waypoint waypoint(mock_shared<MockMesh>(), Vector3(1, 2, 3), Vector3::Down, 12, IWaypoint::Type::Trigger, 23, Colour::Red);
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3(1, 2, 3), Vector3::Down, 12, IWaypoint::Type::Trigger, 23, Colour::Red, Colour::Green);
     ASSERT_EQ(waypoint.position(), Vector3(1, 2, 3));
     ASSERT_EQ(waypoint.normal(), Vector3::Down);
     ASSERT_EQ(waypoint.room(), 12);
@@ -18,7 +18,7 @@ TEST(Waypoint, ConstructorProperties)
 
 TEST(Waypoint, EmptySave)
 {
-    Waypoint waypoint(mock_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red);
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red, Colour::Green);
     ASSERT_FALSE(waypoint.has_save());
     waypoint.set_save_file({});
     ASSERT_FALSE(waypoint.has_save());
@@ -26,14 +26,14 @@ TEST(Waypoint, EmptySave)
 
 TEST(Waypoint, Notes)
 {
-    Waypoint waypoint(mock_shared<MockMesh>(), Vector3(1, 2, 3), Vector3::Down, 12, IWaypoint::Type::Trigger, 23, Colour::Red);
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3(1, 2, 3), Vector3::Down, 12, IWaypoint::Type::Trigger, 23, Colour::Red, Colour::Green);
     waypoint.set_notes("Test notes\nNew line");
     ASSERT_EQ(waypoint.notes(), "Test notes\nNew line");
 }
 
 TEST(Waypoint, SaveFile)
 {
-    Waypoint waypoint(mock_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red);
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red, Colour::Green);
     ASSERT_FALSE(waypoint.has_save());
     waypoint.set_save_file({ 0x1 });
     ASSERT_TRUE(waypoint.has_save());
@@ -42,7 +42,7 @@ TEST(Waypoint, SaveFile)
 
 TEST(Waypoint, Visibility)
 {
-    Waypoint waypoint(mock_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red);
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red, Colour::Green);
     ASSERT_TRUE(waypoint.visible());
     waypoint.set_visible(false);
     ASSERT_FALSE(waypoint.visible());
@@ -52,7 +52,7 @@ TEST(Waypoint, Visibility)
 
 TEST(Waypoint, RandomizerProperties)
 {
-    Waypoint waypoint(mock_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red);
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 0, IWaypoint::Type::Position, 0, Colour::Red, Colour::Green);
     auto existing = waypoint.randomizer_settings();
     ASSERT_TRUE(existing.empty());
     existing["test1"] = std::string("Test");

--- a/trview.app.tests/Settings/SettingsLoaderTests.cpp
+++ b/trview.app.tests/Settings/SettingsLoaderTests.cpp
@@ -506,3 +506,23 @@ TEST(SettingsLoader, MapColoursSaved)
     EXPECT_THAT(output, HasSubstr("\"special\":[[0,{\"a\":1.0,\"b\":0.0,\"g\":0.0,\"r\":1.0}]]"));
     EXPECT_THAT(output, HasSubstr("\"colours\":[[8,{\"a\":1.0,\"b\":1.0,\"g\":0.0,\"r\":0.0}]]"));
 }
+
+TEST(SettingsLoader, RouteColourSaved)
+{
+    FAIL();
+}
+
+TEST(SettingsLoader, WaypointColourSaved)
+{
+    FAIL();
+}
+
+TEST(SettingsLoader, RouteColourLoaded)
+{
+    FAIL();
+}
+
+TEST(SettingsLoader, WaypointColourLoaded)
+{
+    FAIL();
+}

--- a/trview.app.tests/Settings/SettingsLoaderTests.cpp
+++ b/trview.app.tests/Settings/SettingsLoaderTests.cpp
@@ -529,10 +529,22 @@ TEST(SettingsLoader, WaypointColourSaved)
 
 TEST(SettingsLoader, RouteColourLoaded)
 {
-    FAIL();
+    auto loader = setup_setting("{\"routecolour\":{\"a\":1.0,\"b\":1.0,\"g\":0.0,\"r\":0.0}}");
+    auto settings_blue = loader->load_user_settings();
+    ASSERT_EQ(settings_blue.route_colour, Colour::Blue);
+
+    auto loader_yellow = setup_setting("{\"routecolour\":{\"a\":1.0,\"b\":0.0,\"g\":1.0,\"r\":1.0}}");
+    auto settings_yellow = loader_yellow->load_user_settings();
+    ASSERT_EQ(settings_yellow.route_colour, Colour::Yellow);
 }
 
 TEST(SettingsLoader, WaypointColourLoaded)
 {
-    FAIL();
+    auto loader = setup_setting("{\"waypointcolour\":{\"a\":1.0,\"b\":1.0,\"g\":0.0,\"r\":0.0}}");
+    auto settings_blue = loader->load_user_settings();
+    ASSERT_EQ(settings_blue.waypoint_colour, Colour::Blue);
+
+    auto loader_yellow = setup_setting("{\"waypointcolour\":{\"a\":1.0,\"b\":0.0,\"g\":1.0,\"r\":1.0}}");
+    auto settings_yellow = loader_yellow->load_user_settings();
+    ASSERT_EQ(settings_yellow.waypoint_colour, Colour::Yellow);
 }

--- a/trview.app.tests/Settings/SettingsLoaderTests.cpp
+++ b/trview.app.tests/Settings/SettingsLoaderTests.cpp
@@ -509,12 +509,22 @@ TEST(SettingsLoader, MapColoursSaved)
 
 TEST(SettingsLoader, RouteColourSaved)
 {
-    FAIL();
+    std::string output;
+    auto loader = setup_save_setting(output);
+    UserSettings settings;
+    settings.route_colour = Colour::Yellow;
+    loader->save_user_settings(settings);
+    EXPECT_THAT(output, HasSubstr("\"routecolour\":{\"a\":1.0,\"b\":0.0,\"g\":1.0,\"r\":1.0}"));
 }
 
 TEST(SettingsLoader, WaypointColourSaved)
 {
-    FAIL();
+    std::string output;
+    auto loader = setup_save_setting(output);
+    UserSettings settings;
+    settings.waypoint_colour = Colour::Yellow;
+    loader->save_user_settings(settings);
+    EXPECT_THAT(output, HasSubstr("\"waypointcolour\":{\"a\":1.0,\"b\":0.0,\"g\":1.0,\"r\":1.0}"));
 }
 
 TEST(SettingsLoader, RouteColourLoaded)

--- a/trview.app.tests/SettingsWindowTests.cpp
+++ b/trview.app.tests/SettingsWindowTests.cpp
@@ -634,29 +634,20 @@ TEST(SettingsWindow, OnMinimapColoursRaisedOnResetNormal)
     ASSERT_EQ(map_colours.value().override_colours().size(), 0.0f);
 }
 
-TEST(SettingsWindow, OnDefaultRouteColourRaised)
+TEST(SettingsWindow, SetDefaultRouteColourUpdatesColours)
 {
     SettingsWindow window;
     window.toggle_visibility();
 
-    window.set_default_route_colour(Colour::Black);
-
-    std::optional<Colour> raised;
-    auto token = window.on_default_route_colour += [&](const auto& colour)
-    {
-        raised = colour;
-    };
+    window.set_default_route_colour(Colour(0.5f, 0.75f, 1.0f));
 
     tests::TestImgui imgui([&]() { window.render(); });
     imgui.click_element(imgui.id("Settings").push("TabBar").id("Route"));
     imgui.render();
 
-    imgui.double_click_element(imgui.id("Settings").push("TabBar").push("Route").push(SettingsWindow::Names::default_route_colour).id("##X"));
-    imgui.enter_text("255");
-    imgui.press_key(ImGuiKey_Enter);
-
-    ASSERT_TRUE(raised.has_value());
-    ASSERT_EQ(raised.value(), Colour::Red);
+    ASSERT_THAT(imgui.item_text(imgui.id("Settings").push("TabBar").push("Route").push(SettingsWindow::Names::default_route_colour).id("##X")), HasSubstr("128"));
+    ASSERT_THAT(imgui.item_text(imgui.id("Settings").push("TabBar").push("Route").push(SettingsWindow::Names::default_route_colour).id("##Y")), HasSubstr("191"));
+    ASSERT_THAT(imgui.item_text(imgui.id("Settings").push("TabBar").push("Route").push(SettingsWindow::Names::default_route_colour).id("##Z")), HasSubstr("255"));
 }
 
 TEST(SettingsWindow, SetDefaultWaypointColourUpdatesColours)

--- a/trview.app.tests/SettingsWindowTests.cpp
+++ b/trview.app.tests/SettingsWindowTests.cpp
@@ -633,3 +633,23 @@ TEST(SettingsWindow, OnMinimapColoursRaisedOnResetNormal)
     ASSERT_TRUE(map_colours.has_value());
     ASSERT_EQ(map_colours.value().override_colours().size(), 0.0f);
 }
+
+TEST(SettingsWindow, OnDefaultRouteColourRaised)
+{
+    FAIL();
+}
+
+TEST(SettingsWindow, OnDefaultWaypointColourRaised)
+{
+    FAIL();
+}
+
+TEST(SettingsWindow, SetDefaultRouteColourUpdatesColours)
+{
+    FAIL();
+}
+
+TEST(SettingsWindow, SetDefaultWaypointColourUpdatesColours)
+{
+    FAIL();
+}

--- a/trview.app.tests/SettingsWindowTests.cpp
+++ b/trview.app.tests/SettingsWindowTests.cpp
@@ -636,20 +636,41 @@ TEST(SettingsWindow, OnMinimapColoursRaisedOnResetNormal)
 
 TEST(SettingsWindow, OnDefaultRouteColourRaised)
 {
-    FAIL();
-}
+    SettingsWindow window;
+    window.toggle_visibility();
 
-TEST(SettingsWindow, OnDefaultWaypointColourRaised)
-{
-    FAIL();
-}
+    window.set_default_route_colour(Colour::Black);
 
-TEST(SettingsWindow, SetDefaultRouteColourUpdatesColours)
-{
-    FAIL();
+    std::optional<Colour> raised;
+    auto token = window.on_default_route_colour += [&](const auto& colour)
+    {
+        raised = colour;
+    };
+
+    tests::TestImgui imgui([&]() { window.render(); });
+    imgui.click_element(imgui.id("Settings").push("TabBar").id("Route"));
+    imgui.render();
+
+    imgui.double_click_element(imgui.id("Settings").push("TabBar").push("Route").push(SettingsWindow::Names::default_route_colour).id("##X"));
+    imgui.enter_text("255");
+    imgui.press_key(ImGuiKey_Enter);
+
+    ASSERT_TRUE(raised.has_value());
+    ASSERT_EQ(raised.value(), Colour::Red);
 }
 
 TEST(SettingsWindow, SetDefaultWaypointColourUpdatesColours)
 {
-    FAIL();
+    SettingsWindow window;
+    window.toggle_visibility();
+
+    window.set_default_waypoint_colour(Colour(0.5f, 0.75f, 1.0f));
+
+    tests::TestImgui imgui([&]() { window.render(); });
+    imgui.click_element(imgui.id("Settings").push("TabBar").id("Route"));
+    imgui.render();
+
+    ASSERT_THAT(imgui.item_text(imgui.id("Settings").push("TabBar").push("Route").push(SettingsWindow::Names::default_waypoint_colour).id("##X")), HasSubstr("128"));
+    ASSERT_THAT(imgui.item_text(imgui.id("Settings").push("TabBar").push("Route").push(SettingsWindow::Names::default_waypoint_colour).id("##Y")), HasSubstr("191"));
+    ASSERT_THAT(imgui.item_text(imgui.id("Settings").push("TabBar").push("Route").push(SettingsWindow::Names::default_waypoint_colour).id("##Z")), HasSubstr("255"));
 }

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -255,20 +255,56 @@ TEST(ViewerUI, OnMinimapColoursEventRaised)
 
 TEST(ViewerUI, OnDefaultRouteColourEventRaised)
 {
-    FAIL();
+    auto [settings_window_ptr, settings_window] = create_mock<MockSettingsWindow>();
+    auto window = register_test_module().with_settings_window(std::move(settings_window_ptr)).build();
+
+    std::optional<UserSettings> raised;
+    auto token = window->on_settings += [&](auto&& settings)
+    {
+        raised = settings;
+    };
+
+    settings_window.on_default_route_colour(Colour::Yellow);
+
+    ASSERT_TRUE(raised.has_value());
+    ASSERT_EQ(raised.value().route_colour, Colour::Yellow);
 }
 
 TEST(ViewerUI, OnDefaultWaypointColourRaised)
 {
-    FAIL();
+    auto [settings_window_ptr, settings_window] = create_mock<MockSettingsWindow>();
+    auto window = register_test_module().with_settings_window(std::move(settings_window_ptr)).build();
+
+    std::optional<UserSettings> raised;
+    auto token = window->on_settings += [&](auto&& settings)
+    {
+        raised = settings;
+    };
+
+    settings_window.on_default_waypoint_colour(Colour::Yellow);
+
+    ASSERT_TRUE(raised.has_value());
+    ASSERT_EQ(raised.value().waypoint_colour, Colour::Yellow);
 }
 
 TEST(ViewerUI, SetDefaultRouteColourCalled)
 {
-    FAIL();
+    auto [settings_window_ptr, settings_window] = create_mock<MockSettingsWindow>();
+    auto window = register_test_module().with_settings_window(std::move(settings_window_ptr)).build();
+    EXPECT_CALL(settings_window, set_default_route_colour(Colour::Yellow)).Times(1);
+
+    UserSettings settings;
+    settings.route_colour = Colour::Yellow;
+    window->set_settings(settings);
 }
 
 TEST(ViewerUI, SetDefaultWaypointColourCalled)
 {
-    FAIL();
+    auto [settings_window_ptr, settings_window] = create_mock<MockSettingsWindow>();
+    auto window = register_test_module().with_settings_window(std::move(settings_window_ptr)).build();
+    EXPECT_CALL(settings_window, set_default_waypoint_colour(Colour::Yellow)).Times(1);
+
+    UserSettings settings;
+    settings.waypoint_colour = Colour::Yellow;
+    window->set_settings(settings);
 }

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -253,3 +253,22 @@ TEST(ViewerUI, OnMinimapColoursEventRaised)
     ASSERT_TRUE(raised);
 }
 
+TEST(ViewerUI, OnDefaultRouteColourEventRaised)
+{
+    FAIL();
+}
+
+TEST(ViewerUI, OnDefaultWaypointColourRaised)
+{
+    FAIL();
+}
+
+TEST(ViewerUI, SetDefaultRouteColourCalled)
+{
+    FAIL();
+}
+
+TEST(ViewerUI, SetDefaultWaypointColourCalled)
+{
+    FAIL();
+}

--- a/trview.app.tests/Windows/RouteWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/RouteWindowManagerTests.cpp
@@ -109,3 +109,13 @@ TEST(RouteWindowManager, WaypointReorderedEventRaised)
     ASSERT_EQ(std::get<0>(raised.value()), 1);
     ASSERT_EQ(std::get<1>(raised.value()), 2);
 }
+
+TEST(RouteWindowManager, OnColourChangeEventRaised)
+{
+    FAIL();
+}
+
+TEST(RouteWindowManager, OnWaypointColourChangedEventRaised)
+{
+    FAIL();
+}

--- a/trview.app.tests/Windows/RouteWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/RouteWindowManagerTests.cpp
@@ -112,10 +112,36 @@ TEST(RouteWindowManager, WaypointReorderedEventRaised)
 
 TEST(RouteWindowManager, OnColourChangeEventRaised)
 {
-    FAIL();
+    auto mock_window = mock_shared<MockRouteWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+
+    std::optional<Colour> raised;
+    auto token = manager->on_colour_changed += [&](const Colour& colour)
+    {
+        raised = colour;
+    };
+
+    manager->create_window();
+    mock_window->on_colour_changed(Colour::Yellow);
+
+    ASSERT_TRUE(raised.has_value());
+    ASSERT_EQ(raised.value(), Colour::Yellow);
 }
 
 TEST(RouteWindowManager, OnWaypointColourChangedEventRaised)
 {
-    FAIL();
+    auto mock_window = mock_shared<MockRouteWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+
+    std::optional<Colour> raised;
+    auto token = manager->on_waypoint_colour_changed += [&](const Colour& colour)
+    {
+        raised = colour;
+    };
+
+    manager->create_window();
+    mock_window->on_waypoint_colour_changed(Colour::Yellow);
+
+    ASSERT_TRUE(raised.has_value());
+    ASSERT_EQ(raised.value(), Colour::Yellow);
 }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -446,6 +446,11 @@ namespace trview
             _route->set_colour(colour);
             _viewer->set_route(_route);
         };
+        _token_store += _route_window->on_stick_colour_changed += [&](const Colour& colour)
+        {
+            _route->set_stick_colour(colour);
+            _viewer->set_route(_route);
+        };
         _token_store += _route_window->on_waypoint_reordered += [&](int32_t from, int32_t to)
         {
             _route->move(from, to);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -446,9 +446,9 @@ namespace trview
             _route->set_colour(colour);
             _viewer->set_route(_route);
         };
-        _token_store += _route_window->on_stick_colour_changed += [&](const Colour& colour)
+        _token_store += _route_window->on_waypoint_colour_changed += [&](const Colour& colour)
         {
-            _route->set_stick_colour(colour);
+            _route->set_waypoint_colour(colour);
             _viewer->set_route(_route);
         };
         _token_store += _route_window->on_waypoint_reordered += [&](int32_t from, int32_t to)

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -69,7 +69,7 @@ namespace trview
 
     Application::Application(const Window& application_window,
         std::unique_ptr<IUpdateChecker> update_checker,
-        std::unique_ptr<ISettingsLoader> settings_loader,
+        std::shared_ptr<ISettingsLoader> settings_loader,
         const trlevel::ILevel::Source& trlevel_source,
         std::unique_ptr<IFileMenu> file_menu,
         std::unique_ptr<IViewer> viewer,
@@ -87,7 +87,7 @@ namespace trview
         std::unique_ptr<ILightsWindowManager> lights_window_manager,
         std::unique_ptr<ILogWindowManager> log_window_manager)
         : MessageHandler(application_window), _instance(GetModuleHandle(nullptr)),
-        _file_menu(std::move(file_menu)), _update_checker(std::move(update_checker)), _view_menu(window()), _settings_loader(std::move(settings_loader)), _trlevel_source(trlevel_source),
+        _file_menu(std::move(file_menu)), _update_checker(std::move(update_checker)), _view_menu(window()), _settings_loader(settings_loader), _trlevel_source(trlevel_source),
         _viewer(std::move(viewer)), _route_source(route_source), _route(route_source()), _shortcuts(shortcuts), _items_windows(std::move(items_window_manager)),
         _triggers_windows(std::move(triggers_window_manager)), _route_window(std::move(route_window_manager)), _rooms_windows(std::move(rooms_window_manager)), _level_source(level_source),
         _dialogs(dialogs), _files(files), _timer(default_time_source()), _imgui_backend(std::move(imgui_backend)), _lights_windows(std::move(lights_window_manager)), _log_windows(std::move(log_window_manager))
@@ -176,6 +176,8 @@ namespace trview
         if (open_mode == ILevel::OpenMode::Full)
         {
             _route->clear();
+            _route->set_colour(_settings.route_colour);
+            _route->set_waypoint_colour(_settings.waypoint_colour);
             _route->set_unsaved(false);
             _route_window->set_route(_route.get());
         }

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -41,7 +41,7 @@ namespace trview
         explicit Application(
             const Window& application_window,
             std::unique_ptr<IUpdateChecker> update_checker,
-            std::unique_ptr<ISettingsLoader> settings_loader,
+            std::shared_ptr<ISettingsLoader> settings_loader,
             const trlevel::ILevel::Source& trlevel_source,
             std::unique_ptr<IFileMenu> file_menu,
             std::unique_ptr<IViewer> viewer,
@@ -101,7 +101,7 @@ namespace trview
         TokenStore _token_store;
 
         // Window message related components.
-        std::unique_ptr<ISettingsLoader> _settings_loader;
+        std::shared_ptr<ISettingsLoader> _settings_loader;
         UserSettings _settings;
         trlevel::ILevel::Source _trlevel_source;
         std::unique_ptr<IFileMenu> _file_menu;

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -72,6 +72,8 @@ namespace trview
         auto texture_storage = std::make_shared<TextureStorage>(device);
         auto shader_storage = std::make_shared<graphics::ShaderStorage>();
         auto font_factory = std::make_shared<graphics::FontFactory>();
+        auto files = std::make_shared<Files>();
+        auto settings_loader = std::make_shared<SettingsLoader>(files);
 
         Resource type_list = get_resource_memory(IDR_TYPE_NAMES, L"TEXT");
         auto type_name_lookup = std::make_shared<TypeNameLookup>(std::string(type_list.data, type_list.data + type_list.size));
@@ -106,7 +108,7 @@ namespace trview
         {
             return std::make_shared<Route>(
                 std::make_unique<SelectionRenderer>(device, shader_storage, std::make_unique<TransparencyBuffer>(device), render_target_source),
-                waypoint_source);
+                waypoint_source, settings_loader->load_user_settings());
         };
 
         auto entity_source = [=](auto&& level, auto&& entity, auto&& index, auto&& mesh_storage)
@@ -174,7 +176,6 @@ namespace trview
             device_window_source,
             std::make_unique<SectorHighlight>(mesh_source));
 
-        auto files = std::make_shared<Files>();
         auto dialogs = std::make_shared<Dialogs>(window);
         auto clipboard = std::make_shared<Clipboard>(window);
 
@@ -192,7 +193,7 @@ namespace trview
         return std::make_unique<Application>(
             window,
             std::make_unique<UpdateChecker>(window),
-            std::make_unique<SettingsLoader>(files),
+            settings_loader,
             trlevel_source,
             std::make_unique<FileMenu>(window, shortcuts, dialogs),
             std::move(viewer),

--- a/trview.app/Geometry/IRenderable.h
+++ b/trview.app/Geometry/IRenderable.h
@@ -31,5 +31,7 @@ namespace trview
 
         /// Set whether the object is visible.
         virtual void set_visible(bool value) = 0;
+
+        static const inline DirectX::SimpleMath::Color SelectionFill{ 0.0f, 0.0f, 0.0f, 0.999f };
     };
 }

--- a/trview.app/Graphics/SelectionRenderer.cpp
+++ b/trview.app/Graphics/SelectionRenderer.cpp
@@ -129,11 +129,11 @@ namespace trview
             // Draw the regular faces of the item with a black colouring.
             const bool was_visible = selected_item.visible();
             selected_item.set_visible(true);
-            selected_item.render(camera, texture_storage, Color(0.0f, 0.0f, 0.0f));
+            selected_item.render(camera, texture_storage, IRenderable::SelectionFill);
 
             // Also render the transparent parts of the meshes, again with black.
             _transparency->reset();
-            selected_item.get_transparent_triangles(*_transparency, camera, Color(0.0f, 0.0f, 0.0f));
+            selected_item.get_transparent_triangles(*_transparency, camera, IRenderable::SelectionFill);
             _transparency->sort(camera.rendering_position());
             _transparency->render(camera, texture_storage, true);
             selected_item.set_visible(was_visible);

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -27,8 +27,8 @@ namespace trview
             MOCK_METHOD(void, set_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_randomizer_enabled, (bool), (override));
             MOCK_METHOD(void, set_unsaved, (bool), (override));
-            MOCK_METHOD(void, set_stick_colour, (const Colour&), (override));
-            MOCK_METHOD(Colour, stick_colour, (), (const, override));
+            MOCK_METHOD(void, set_waypoint_colour, (const Colour&), (override));
+            MOCK_METHOD(Colour, waypoint_colour, (), (const, override));
             MOCK_METHOD(const IWaypoint&, waypoint, (uint32_t), (const, override));
             MOCK_METHOD(IWaypoint&, waypoint, (uint32_t), (override));
             MOCK_METHOD(uint32_t, waypoints, (), (const, override));

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -27,6 +27,8 @@ namespace trview
             MOCK_METHOD(void, set_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_randomizer_enabled, (bool), (override));
             MOCK_METHOD(void, set_unsaved, (bool), (override));
+            MOCK_METHOD(void, set_stick_colour, (const Colour&), (override));
+            MOCK_METHOD(Colour, stick_colour, (), (const, override));
             MOCK_METHOD(const IWaypoint&, waypoint, (uint32_t), (const, override));
             MOCK_METHOD(IWaypoint&, waypoint, (uint32_t), (override));
             MOCK_METHOD(uint32_t, waypoints, (), (const, override));

--- a/trview.app/Mocks/Routing/IWaypoint.h
+++ b/trview.app/Mocks/Routing/IWaypoint.h
@@ -19,6 +19,7 @@ namespace trview
             MOCK_METHOD(std::vector<uint8_t>, save_file, (), (const, override));
             MOCK_METHOD(void, set_notes, (const std::string&), (override));
             MOCK_METHOD(void, set_route_colour, (const Colour&), (override));
+            MOCK_METHOD(void, set_stick_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_save_file, (const std::vector<uint8_t>&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, render_join, (const IWaypoint&, const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));

--- a/trview.app/Mocks/Routing/IWaypoint.h
+++ b/trview.app/Mocks/Routing/IWaypoint.h
@@ -19,7 +19,7 @@ namespace trview
             MOCK_METHOD(std::vector<uint8_t>, save_file, (), (const, override));
             MOCK_METHOD(void, set_notes, (const std::string&), (override));
             MOCK_METHOD(void, set_route_colour, (const Colour&), (override));
-            MOCK_METHOD(void, set_stick_colour, (const Colour&), (override));
+            MOCK_METHOD(void, set_waypoint_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_save_file, (const std::vector<uint8_t>&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, render_join, (const IWaypoint&, const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));

--- a/trview.app/Mocks/UI/ISettingsWindow.h
+++ b/trview.app/Mocks/UI/ISettingsWindow.h
@@ -19,6 +19,8 @@ namespace trview
             MOCK_METHOD(void, set_auto_orbit, (bool), (override));
             MOCK_METHOD(void, set_camera_acceleration, (bool), (override));
             MOCK_METHOD(void, set_camera_acceleration_rate, (float), (override));
+            MOCK_METHOD(void, set_default_route_colour, (const Colour&), (override));
+            MOCK_METHOD(void, set_default_waypoint_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_movement_speed, (float), (override));
             MOCK_METHOD(void, set_sensitivity, (float), (override));
             MOCK_METHOD(void, set_invert_vertical_pan, (bool), (override));

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -128,7 +128,7 @@ namespace trview
         /// Set the colour for the stick.
         /// </summary>
         /// <param name="colour">The colour to use.</param>
-        virtual void set_stick_colour(const Colour& colour) = 0;
+        virtual void set_waypoint_colour(const Colour& colour) = 0;
         /// <summary>
         /// Set whether the route has unsaved changes.
         /// </summary>
@@ -137,7 +137,7 @@ namespace trview
         /// <summary>
         /// Get the colour to use for the stick.
         /// </summary>
-        virtual Colour stick_colour() const = 0;
+        virtual Colour waypoint_colour() const = 0;
         /// <summary>
         /// Get the waypoint at the specified index.
         /// </summary>

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -125,10 +125,19 @@ namespace trview
         /// <param name="enabled">Whether randomizer tools are enabled.</param>
         virtual void set_randomizer_enabled(bool enabled) = 0;
         /// <summary>
+        /// Set the colour for the stick.
+        /// </summary>
+        /// <param name="colour">The colour to use.</param>
+        virtual void set_stick_colour(const Colour& colour) = 0;
+        /// <summary>
         /// Set whether the route has unsaved changes.
         /// </summary>
         /// <param name="value">Whether the route has unsaved changes.</param>
         virtual void set_unsaved(bool value) = 0;
+        /// <summary>
+        /// Get the colour to use for the stick.
+        /// </summary>
+        virtual Colour stick_colour() const = 0;
         /// <summary>
         /// Get the waypoint at the specified index.
         /// </summary>

--- a/trview.app/Routing/IWaypoint.h
+++ b/trview.app/Routing/IWaypoint.h
@@ -37,7 +37,7 @@ namespace trview
         /// <summary>
         /// Create a waypoint.
         /// </summary>
-        using Source = std::function<std::unique_ptr<IWaypoint>(const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, Type, uint32_t, const Colour&)>;
+        using Source = std::function<std::unique_ptr<IWaypoint>(const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, Type, uint32_t, const Colour&, const Colour&)>;
         /// <summary>
         /// Destructor for IWaypoint.
         /// </summary>
@@ -92,6 +92,10 @@ namespace trview
         virtual void set_route_colour(const Colour& colour) = 0;
         /// Set the contents of the attached save file.
         virtual void set_save_file(const std::vector<uint8_t>& data) = 0;
+        /// <summary>
+        /// Set the colour for the waypoint stick.
+        /// </summary>
+        virtual void set_stick_colour(const Colour& colour) = 0;
         /// <summary>
         /// Get the position of the blob on top of the waypoint pole for rendering.
         /// </summary>

--- a/trview.app/Routing/IWaypoint.h
+++ b/trview.app/Routing/IWaypoint.h
@@ -95,7 +95,7 @@ namespace trview
         /// <summary>
         /// Set the colour for the waypoint stick.
         /// </summary>
-        virtual void set_stick_colour(const Colour& colour) = 0;
+        virtual void set_waypoint_colour(const Colour& colour) = 0;
         /// <summary>
         /// Get the position of the blob on top of the waypoint pole for rendering.
         /// </summary>

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -99,7 +99,7 @@ namespace trview
 
     void Route::add(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, IWaypoint::Type type, uint32_t type_index)
     {
-        _waypoints.push_back(_waypoint_source(position, normal, room, type, type_index, _colour, _stick_colour));
+        _waypoints.push_back(_waypoint_source(position, normal, room, type, type_index, _colour, _waypoint_colour));
         set_unsaved(true);
     }
 
@@ -137,7 +137,7 @@ namespace trview
 
     void Route::insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index, IWaypoint::Type type, uint32_t type_index)
     {
-        _waypoints.insert(_waypoints.begin() + index, _waypoint_source(position, normal, room, type, type_index, _colour, _stick_colour));
+        _waypoints.insert(_waypoints.begin() + index, _waypoint_source(position, normal, room, type, type_index, _colour, _waypoint_colour));
         set_unsaved(true);
     }
 
@@ -208,7 +208,7 @@ namespace trview
         for (std::size_t i = 0; i < _waypoints.size(); ++i)
         {
             auto& waypoint = _waypoints[i];
-            waypoint->render(camera, texture_storage, _stick_colour);
+            waypoint->render(camera, texture_storage, _waypoint_colour);
             if (!_randomizer_enabled && i < _waypoints.size() - 1)
             {
                 waypoint->render_join(*_waypoints[i + 1], camera, texture_storage, _colour);
@@ -247,12 +247,12 @@ namespace trview
         _randomizer_enabled = enabled;
     }
 
-    void Route::set_stick_colour(const Colour& colour)
+    void Route::set_waypoint_colour(const Colour& colour)
     {
-        _stick_colour = colour;
+        _waypoint_colour = colour;
         for (auto& waypoint : _waypoints)
         {
-            waypoint->set_stick_colour(colour);
+            waypoint->set_waypoint_colour(colour);
         }
         set_unsaved(true);
     }
@@ -262,9 +262,9 @@ namespace trview
         _is_unsaved = value;
     }
 
-    Colour Route::stick_colour() const 
+    Colour Route::waypoint_colour() const 
     {
-        return _stick_colour;
+        return _waypoint_colour;
     }
 
     const IWaypoint& Route::waypoint(uint32_t index) const
@@ -400,9 +400,9 @@ namespace trview
             route->set_colour(from_colour_code(json["colour"].get<std::string>()));
         }
 
-        if (json["stick_colour"].is_string())
+        if (json["waypoint_colour"].is_string())
         {
-            route->set_stick_colour(from_colour_code(json["stick_colour"].get<std::string>()));
+            route->set_waypoint_colour(from_colour_code(json["waypoint_colour"].get<std::string>()));
         }
 
         for (const auto& waypoint : json["waypoints"])
@@ -568,7 +568,7 @@ namespace trview
     {
         nlohmann::json json;
         json["colour"] = route.colour().code();
-        json["stick_colour"] = route.stick_colour().code();
+        json["stick_colour"] = route.waypoint_colour().code();
 
         std::vector<nlohmann::json> waypoints;
 

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -208,7 +208,7 @@ namespace trview
         for (std::size_t i = 0; i < _waypoints.size(); ++i)
         {
             auto& waypoint = _waypoints[i];
-            waypoint->render(camera, texture_storage, Color(1.0f, 1.0f, 1.0f));
+            waypoint->render(camera, texture_storage, _stick_colour);
             if (!_randomizer_enabled && i < _waypoints.size() - 1)
             {
                 waypoint->render_join(*_waypoints[i + 1], camera, texture_storage, _colour);
@@ -218,7 +218,7 @@ namespace trview
         // Render selected waypoint...
         if (show_selection && _selected_index < _waypoints.size())
         {
-            _selection_renderer->render(camera, texture_storage, *_waypoints[_selected_index], Color(1.0f, 1.0f, 1.0f));
+            _selection_renderer->render(camera, texture_storage, *_waypoints[_selected_index], Colour::White);
         }
     }
 

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -247,9 +247,20 @@ namespace trview
         _randomizer_enabled = enabled;
     }
 
+    void Route::set_stick_colour(const Colour& colour)
+    {
+        _stick_colour = colour;
+        set_unsaved(true);
+    }
+
     void Route::set_unsaved(bool value)
     {
         _is_unsaved = value;
+    }
+
+    Colour Route::stick_colour() const 
+    {
+        return _stick_colour;
     }
 
     const IWaypoint& Route::waypoint(uint32_t index) const
@@ -383,6 +394,11 @@ namespace trview
         if (json["colour"].is_string())
         {
             route->set_colour(from_colour_code(json["colour"].get<std::string>()));
+        }
+
+        if (json["stick_colour"].is_string())
+        {
+            route->set_stick_colour(from_colour_code(json["stick_colour"].get<std::string>()));
         }
 
         for (const auto& waypoint : json["waypoints"])
@@ -548,6 +564,7 @@ namespace trview
     {
         nlohmann::json json;
         json["colour"] = route.colour().code();
+        json["stick_colour"] = route.stick_colour().code();
 
         std::vector<nlohmann::json> waypoints;
 

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -78,8 +78,8 @@ namespace trview
         }
     }
 
-    Route::Route(std::unique_ptr<ISelectionRenderer> selection_renderer, const IWaypoint::Source& waypoint_source)
-        : _selection_renderer(std::move(selection_renderer)), _waypoint_source(waypoint_source)
+    Route::Route(std::unique_ptr<ISelectionRenderer> selection_renderer, const IWaypoint::Source& waypoint_source, const UserSettings& settings)
+        : _selection_renderer(std::move(selection_renderer)), _waypoint_source(waypoint_source), _colour(settings.route_colour), _waypoint_colour(settings.waypoint_colour)
     {
     }
 

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -99,7 +99,7 @@ namespace trview
 
     void Route::add(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, IWaypoint::Type type, uint32_t type_index)
     {
-        _waypoints.push_back(_waypoint_source(position, normal, room, type, type_index, _colour));
+        _waypoints.push_back(_waypoint_source(position, normal, room, type, type_index, _colour, _stick_colour));
         set_unsaved(true);
     }
 
@@ -137,7 +137,7 @@ namespace trview
 
     void Route::insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index, IWaypoint::Type type, uint32_t type_index)
     {
-        _waypoints.insert(_waypoints.begin() + index, _waypoint_source(position, normal, room, type, type_index, _colour));
+        _waypoints.insert(_waypoints.begin() + index, _waypoint_source(position, normal, room, type, type_index, _colour, _stick_colour));
         set_unsaved(true);
     }
 
@@ -250,6 +250,10 @@ namespace trview
     void Route::set_stick_colour(const Colour& colour)
     {
         _stick_colour = colour;
+        for (auto& waypoint : _waypoints)
+        {
+            waypoint->set_stick_colour(colour);
+        }
         set_unsaved(true);
     }
 

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -568,7 +568,7 @@ namespace trview
     {
         nlohmann::json json;
         json["colour"] = route.colour().code();
-        json["stick_colour"] = route.waypoint_colour().code();
+        json["waypoint_colour"] = route.waypoint_colour().code();
 
         std::vector<nlohmann::json> waypoints;
 

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -35,9 +35,9 @@ namespace trview
         virtual void select_waypoint(uint32_t index) override;
         virtual void set_colour(const Colour& colour) override;
         virtual void set_randomizer_enabled(bool enabled) override;
-        virtual void set_stick_colour(const Colour& colour) override;
+        virtual void set_waypoint_colour(const Colour& colour) override;
         virtual void set_unsaved(bool value) override;
-        virtual Colour stick_colour() const override;
+        virtual Colour waypoint_colour() const override;
         virtual const IWaypoint& waypoint(uint32_t index) const override;
         virtual IWaypoint& waypoint(uint32_t index) override;
         virtual uint32_t waypoints() const override;
@@ -49,7 +49,7 @@ namespace trview
         std::unique_ptr<ISelectionRenderer> _selection_renderer;
         uint32_t _selected_index{ 0u };
         Colour _colour{ Colour::Green };
-        Colour _stick_colour{ Colour::White };
+        Colour _waypoint_colour{ Colour::White };
         bool _is_unsaved{ false };
         bool _randomizer_enabled{ false };
     };

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -6,6 +6,7 @@
 #include <trview.app/Camera/ICamera.h>
 #include <trview.common/IFiles.h>
 #include <trview.app/Settings/RandomizerSettings.h>
+#include "../Settings/UserSettings.h"
 
 namespace trview
 {
@@ -15,7 +16,7 @@ namespace trview
     class Route final : public IRoute
     {
     public:
-        explicit Route(const std::unique_ptr<ISelectionRenderer> selection_renderer, const IWaypoint::Source& waypoint_source);
+        explicit Route(const std::unique_ptr<ISelectionRenderer> selection_renderer, const IWaypoint::Source& waypoint_source, const UserSettings& settings);
         virtual ~Route() = default;
         Route& operator=(const Route& other);
         virtual void add(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room) override;

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -35,7 +35,9 @@ namespace trview
         virtual void select_waypoint(uint32_t index) override;
         virtual void set_colour(const Colour& colour) override;
         virtual void set_randomizer_enabled(bool enabled) override;
+        virtual void set_stick_colour(const Colour& colour) override;
         virtual void set_unsaved(bool value) override;
+        virtual Colour stick_colour() const override;
         virtual const IWaypoint& waypoint(uint32_t index) const override;
         virtual IWaypoint& waypoint(uint32_t index) override;
         virtual uint32_t waypoints() const override;
@@ -47,6 +49,7 @@ namespace trview
         std::unique_ptr<ISelectionRenderer> _selection_renderer;
         uint32_t _selected_index{ 0u };
         Colour _colour{ Colour::Green };
+        Colour _stick_colour{ Colour::White };
         bool _is_unsaved{ false };
         bool _randomizer_enabled{ false };
     };

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -30,11 +30,11 @@ namespace trview
         light_direction.Normalize();
 
         auto pole_wvp = pole_world * camera.view_projection();
-        _mesh->render(pole_wvp, texture_storage, _stick_colour, 0.75f, light_direction);
+        _mesh->render(pole_wvp, texture_storage, colour, 0.75f, light_direction);
 
         // The light blob.
         auto blob_wvp = Matrix::CreateScale(PoleThickness, PoleThickness, PoleThickness) * Matrix::CreateTranslation(-Vector3(0, PoleLength + PoleThickness * 0.5f, 0)) * rotation * Matrix::CreateTranslation(_position) * camera.view_projection();
-        _mesh->render(blob_wvp, texture_storage, _route_colour);
+        _mesh->render(blob_wvp, texture_storage, colour == static_cast<Color>(Colour::Black) ? colour : static_cast<Color>(_route_colour));
     }
 
     void Waypoint::render_join(const IWaypoint& next_waypoint, const ICamera& camera, const ILevelTextureStorage& texture_storage, const Color& colour)

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -15,8 +15,8 @@ namespace trview
         const float RopeThickness = 0.015f;
     }
 
-    Waypoint::Waypoint(std::shared_ptr<IMesh> mesh, const Vector3& position, const Vector3& normal, uint32_t room, Type type, uint32_t index, const Colour& route_colour)
-        : _mesh(mesh), _position(position), _normal(normal), _type(type), _index(index), _room(room), _route_colour(route_colour)
+    Waypoint::Waypoint(std::shared_ptr<IMesh> mesh, const Vector3& position, const Vector3& normal, uint32_t room, Type type, uint32_t index, const Colour& route_colour, const Colour& stick_colour)
+        : _mesh(mesh), _position(position), _normal(normal), _type(type), _index(index), _room(room), _route_colour(route_colour), _stick_colour(stick_colour)
     {
     }
 
@@ -30,7 +30,7 @@ namespace trview
         light_direction.Normalize();
 
         auto pole_wvp = pole_world * camera.view_projection();
-        _mesh->render(pole_wvp, texture_storage, colour, 0.75f, light_direction);
+        _mesh->render(pole_wvp, texture_storage, _stick_colour, 0.75f, light_direction);
 
         // The light blob.
         auto blob_wvp = Matrix::CreateScale(PoleThickness, PoleThickness, PoleThickness) * Matrix::CreateTranslation(-Vector3(0, PoleLength + PoleThickness * 0.5f, 0)) * rotation * Matrix::CreateTranslation(_position) * camera.view_projection();
@@ -135,6 +135,11 @@ namespace trview
     void Waypoint::set_save_file(const std::vector<uint8_t>& data)
     {
         _save_data = data;
+    }
+
+    void Waypoint::set_stick_colour(const Colour& colour)
+    {
+        _stick_colour = colour;
     }
 
     bool Waypoint::visible() const

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -15,8 +15,8 @@ namespace trview
         const float RopeThickness = 0.015f;
     }
 
-    Waypoint::Waypoint(std::shared_ptr<IMesh> mesh, const Vector3& position, const Vector3& normal, uint32_t room, Type type, uint32_t index, const Colour& route_colour, const Colour& stick_colour)
-        : _mesh(mesh), _position(position), _normal(normal), _type(type), _index(index), _room(room), _route_colour(route_colour), _stick_colour(stick_colour)
+    Waypoint::Waypoint(std::shared_ptr<IMesh> mesh, const Vector3& position, const Vector3& normal, uint32_t room, Type type, uint32_t index, const Colour& route_colour, const Colour& waypoint_colour)
+        : _mesh(mesh), _position(position), _normal(normal), _type(type), _index(index), _room(room), _route_colour(route_colour), _waypoint_colour(waypoint_colour)
     {
     }
 
@@ -137,9 +137,9 @@ namespace trview
         _save_data = data;
     }
 
-    void Waypoint::set_stick_colour(const Colour& colour)
+    void Waypoint::set_waypoint_colour(const Colour& colour)
     {
-        _stick_colour = colour;
+        _waypoint_colour = colour;
     }
 
     bool Waypoint::visible() const

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -34,7 +34,7 @@ namespace trview
 
         // The light blob.
         auto blob_wvp = Matrix::CreateScale(PoleThickness, PoleThickness, PoleThickness) * Matrix::CreateTranslation(-Vector3(0, PoleLength + PoleThickness * 0.5f, 0)) * rotation * Matrix::CreateTranslation(_position) * camera.view_projection();
-        _mesh->render(blob_wvp, texture_storage, colour == static_cast<Color>(Colour::Black) ? colour : static_cast<Color>(_route_colour));
+        _mesh->render(blob_wvp, texture_storage, colour == IRenderable::SelectionFill ? colour : static_cast<Color>(_route_colour));
     }
 
     void Waypoint::render_join(const IWaypoint& next_waypoint, const ICamera& camera, const ILevelTextureStorage& texture_storage, const Color& colour)

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -22,7 +22,7 @@ namespace trview
         /// <param name="type">The type of waypoint.</param>
         /// <param name="index">The index of the entity or trigger being referenced if this is a non-position type.</param>
         /// <param name="route_colour">The colour of the route.</param>
-        explicit Waypoint(std::shared_ptr<IMesh> mesh, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, Type type, uint32_t index, const Colour& route_colour);
+        explicit Waypoint(std::shared_ptr<IMesh> mesh, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, Type type, uint32_t index, const Colour& route_colour, const Colour& stick_colour);
         virtual ~Waypoint() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual void render_join(const IWaypoint& next_waypoint, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
@@ -38,6 +38,7 @@ namespace trview
         virtual void set_notes(const std::string& notes) override;
         virtual void set_route_colour(const Colour& colour) override;
         virtual void set_save_file(const std::vector<uint8_t>& data) override;
+        virtual void set_stick_colour(const Colour& colour) override;
         virtual DirectX::SimpleMath::Vector3 blob_position() const override;
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;
@@ -56,6 +57,7 @@ namespace trview
         uint32_t _index;
         uint32_t _room;
         Colour _route_colour;
+        Colour _stick_colour;
         bool _visible{ true };
         WaypointRandomizerSettings _randomizer_settings;
     };    

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -38,7 +38,7 @@ namespace trview
         virtual void set_notes(const std::string& notes) override;
         virtual void set_route_colour(const Colour& colour) override;
         virtual void set_save_file(const std::vector<uint8_t>& data) override;
-        virtual void set_stick_colour(const Colour& colour) override;
+        virtual void set_waypoint_colour(const Colour& colour) override;
         virtual DirectX::SimpleMath::Vector3 blob_position() const override;
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;
@@ -57,7 +57,7 @@ namespace trview
         uint32_t _index;
         uint32_t _room;
         Colour _route_colour;
-        Colour _stick_colour;
+        Colour _waypoint_colour;
         bool _visible{ true };
         WaypointRandomizerSettings _randomizer_settings;
     };    

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -1,6 +1,7 @@
 #include "SettingsLoader.h"
 #include <trview.common/Json.h>
 #include <trview.common/Strings.h>
+#include <trview.common/JsonSerializers.h>
 
 namespace trview
 {

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -40,6 +40,8 @@ namespace trview
             read_attribute(json, settings.randomizer_tools, "randomizertools");
             read_attribute(json, settings.max_recent_files, "maxrecentfiles");
             read_attribute(json, settings.map_colours, "mapcolours");
+            read_attribute(json, settings.route_colour, "routecolour");
+            read_attribute(json, settings.waypoint_colour, "waypointcolour");
 
             settings.recent_files.resize(std::min<std::size_t>(settings.recent_files.size(), settings.max_recent_files));
         }
@@ -94,6 +96,8 @@ namespace trview
             json["randomizertools"] = settings.randomizer_tools;
             json["maxrecentfiles"] = settings.max_recent_files;
             json["mapcolours"] = settings.map_colours;
+            json["routecolour"] = settings.route_colour;
+            json["waypointcolour"] = settings.waypoint_colour;
             _files->save_file(file_path, json.dump());
         }
         catch (...)

--- a/trview.app/Settings/UserSettings.cpp
+++ b/trview.app/Settings/UserSettings.cpp
@@ -36,6 +36,8 @@ namespace trview
             camera_display_degrees == other.camera_display_degrees &&
             randomizer_tools == other.randomizer_tools &&
             recent_files == other.recent_files &&
-            max_recent_files == other.max_recent_files;
+            max_recent_files == other.max_recent_files &&
+            route_colour == other.route_colour &&
+            waypoint_colour == other.waypoint_colour;
     }
 }

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -30,6 +30,8 @@ namespace trview
         RandomizerSettings randomizer;
         uint32_t max_recent_files{ 10u };
         MapColours map_colours;
+        uint32_t route_colour{ Colour::Green };
+        uint32_t waypoint_colour{ Colour::White };
 
         bool operator==(const UserSettings& other) const;
     };

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -30,8 +30,8 @@ namespace trview
         RandomizerSettings randomizer;
         uint32_t max_recent_files{ 10u };
         MapColours map_colours;
-        uint32_t route_colour{ Colour::Green };
-        uint32_t waypoint_colour{ Colour::White };
+        Colour route_colour{ Colour::Green };
+        Colour waypoint_colour{ Colour::White };
 
         bool operator==(const UserSettings& other) const;
     };

--- a/trview.app/UI/ISettingsWindow.h
+++ b/trview.app/UI/ISettingsWindow.h
@@ -72,6 +72,10 @@ namespace trview
         Event<uint32_t> on_max_recent_files;
         Event<Colour> on_background_colour;
         Event<MapColours> on_minimap_colours;
+
+        Event<Colour> on_default_route_colour;
+        Event<Colour> on_default_waypoint_colour;
+
         virtual void render() = 0;
         /// <summary>
         /// Set the new value of the vsync setting. This will not raise the on_vsync event.

--- a/trview.app/UI/ISettingsWindow.h
+++ b/trview.app/UI/ISettingsWindow.h
@@ -123,6 +123,16 @@ namespace trview
         /// <param name="value">The new 'camera acceleration rate' setting.</param>
         virtual void set_camera_acceleration_rate(float value) = 0;
         /// <summary>
+        /// Set the new value of the 'default route colour' setting. This will not raise the on_default_route_colour event.
+        /// </summary>
+        /// <param name="colour">The new 'default route colour' setting.</param>
+        virtual void set_default_route_colour(const Colour& colour) = 0;
+        /// <summary>
+        /// Set the new value of the 'default waypoint colour' setting. This will not raise the on_default_waypoint_colour event.
+        /// </summary>
+        /// <param name="colour">The new 'default waypoint colour' setting.</param>
+        virtual void set_default_waypoint_colour(const Colour& colour) = 0;
+        /// <summary>
         /// Set the movement speed slider to specified value.
         /// </summary>
         /// <param name="value">The movement speed between 0 and 1.</param>

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -120,6 +120,21 @@ namespace trview
                     ImGui::EndTabItem();
                 }
 
+                if (ImGui::BeginTabItem("Route"))
+                {
+                    if (ImGui::ColorEdit3(Names::default_route_colour.c_str(), &_default_route_colour.r))
+                    {
+                        on_default_route_colour(_default_route_colour);
+                    }
+
+                    if (ImGui::ColorEdit3(Names::default_waypoint_colour.c_str(), &_default_waypoint_colour.r))
+                    {
+                        on_default_waypoint_colour(_default_waypoint_colour);
+                    }
+
+                    ImGui::EndTabItem();
+                }
+
                 ImGui::EndTabBar();
             }
         }

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -9,8 +9,6 @@ namespace trview
             return;
         }
 
-        ImGui::ShowStackToolWindow();
-
         const auto checkbox = [](const std::string& name, bool& setting, Event<bool>& event)
         {
             if (ImGui::Checkbox(name.c_str(), &setting))

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -9,6 +9,8 @@ namespace trview
             return;
         }
 
+        ImGui::ShowStackToolWindow();
+
         const auto checkbox = [](const std::string& name, bool& setting, Event<bool>& event)
         {
             if (ImGui::Checkbox(name.c_str(), &setting))

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -232,4 +232,14 @@ namespace trview
     {
         _colours = colours;
     }
+
+    void SettingsWindow::set_default_route_colour(const Colour& colour)
+    {
+        _default_route_colour = colour;
+    }
+
+    void SettingsWindow::set_default_waypoint_colour(const Colour& colour)
+    {
+        _default_waypoint_colour = colour;
+    }
 }

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -53,6 +53,8 @@ namespace trview
         virtual void set_background_colour(const Colour& colour) override;
         virtual void set_map_colours(const MapColours& colours) override;
         virtual void toggle_visibility() override;
+        virtual void set_default_route_colour(const Colour& colour) override;
+        virtual void set_default_waypoint_colour(const Colour& colour) override;
     private:
         bool _visible{ false };
         bool _vsync{ false };

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -29,6 +29,8 @@ namespace trview
             static inline const std::string acceleration = "Acceleration";
             static inline const std::string acceleration_rate = "Acceleration Rate";
             static inline const std::string background_colour = "Background Colour";
+            static inline const std::string default_route_colour = "Default Route Colour";
+            static inline const std::string default_waypoint_colour = "Default Waypoint Colour";
         };
 
         virtual ~SettingsWindow() = default;
@@ -69,6 +71,8 @@ namespace trview
         float _movement_speed{ 1.0f };
         int _max_recent_files{ 10 };
         float _colour[3];
+        Colour _default_route_colour{ Colour::Green };
+        Colour _default_waypoint_colour{ Colour::White };
         MapColours _colours;
     };
 }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -393,6 +393,8 @@ namespace trview
         _settings_window->set_max_recent_files(settings.max_recent_files);
         _settings_window->set_background_colour(settings.background_colour);
         _settings_window->set_map_colours(settings.map_colours);
+        _settings_window->set_default_route_colour(settings.route_colour);
+        _settings_window->set_default_waypoint_colour(settings.waypoint_colour);
         _camera_position->set_display_degrees(settings.camera_display_degrees);
         _map_renderer->set_colours(settings.map_colours);
     }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -172,6 +172,16 @@ namespace trview
             _settings.map_colours = colours;
             on_settings(_settings);
         };
+        _token_store += _settings_window->on_default_route_colour += [&](const Colour& colour)
+        {
+            _settings.route_colour = colour;
+            on_settings(_settings);
+        };
+        _token_store += _settings_window->on_default_waypoint_colour += [&](const Colour& colour)
+        {
+            _settings.waypoint_colour = colour;
+            on_settings(_settings);
+        };
 
         _camera_position = std::make_unique<CameraPosition>();
         _camera_position->on_position_changed += on_camera_position;

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -30,7 +30,7 @@ namespace trview
         /// <summary>
         /// Event raised when the route stick colour has been changed.
         /// </summary>
-        Event<Colour> on_stick_colour_changed;
+        Event<Colour> on_waypoint_colour_changed;
 
         /// <summary>
         /// Event raised when a waypoint has moved from one index to another.

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -28,6 +28,11 @@ namespace trview
         Event<Colour> on_colour_changed;
 
         /// <summary>
+        /// Event raised when the route stick colour has been changed.
+        /// </summary>
+        Event<Colour> on_stick_colour_changed;
+
+        /// <summary>
         /// Event raised when a waypoint has moved from one index to another.
         /// </summary>
         Event<int32_t, int32_t> on_waypoint_reordered;

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -18,6 +18,9 @@ namespace trview
         /// Event raised when a route is exported.
         Event<std::string, bool> on_route_export;
 
+        /// <summary>
+        /// Event raised when the route stick colour has changed.
+        /// </summary>
         Event<Colour> on_stick_colour_changed;
 
         /// Event raised when a waypoint is selected.

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -21,7 +21,7 @@ namespace trview
         /// <summary>
         /// Event raised when the route stick colour has changed.
         /// </summary>
-        Event<Colour> on_stick_colour_changed;
+        Event<Colour> on_waypoint_colour_changed;
 
         /// Event raised when a waypoint is selected.
         Event<uint32_t> on_waypoint_selected;

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -18,6 +18,8 @@ namespace trview
         /// Event raised when a route is exported.
         Event<std::string, bool> on_route_export;
 
+        Event<Colour> on_stick_colour_changed;
+
         /// Event raised when a waypoint is selected.
         Event<uint32_t> on_waypoint_selected;
 

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -41,12 +41,12 @@ namespace trview
             if (_show_settings && ImGui::BeginPopup("SettingsPopup"))
             {
                 auto colour = _route ? _route->colour() : Colour::Green;
-                if (ImGui::ColorEdit3("Blob##colour", &colour.r, ImGuiColorEditFlags_NoInputs))
+                if (ImGui::ColorEdit3("Route##colour", &colour.r, ImGuiColorEditFlags_NoInputs))
                 {
                     on_colour_changed(colour);
                 }
                 auto stick_colour = _route ? _route->stick_colour() : Colour::White;
-                if (ImGui::ColorEdit3("Stick##colour", &stick_colour.r, ImGuiColorEditFlags_NoInputs))
+                if (ImGui::ColorEdit3("Waypoint##colour", &stick_colour.r, ImGuiColorEditFlags_NoInputs))
                 {
                     on_stick_colour_changed(stick_colour);
                 }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -29,11 +29,34 @@ namespace trview
 
         if (ImGui::BeginChild(Names::waypoint_list_panel.c_str(), ImVec2(150, 0), true))
         {
-            auto colour = _route ? _route->colour() : Colour::Green;
-            if (ImGui::ColorEdit3("##colour", &colour.r, ImGuiColorEditFlags_NoInputs))
+            if (ImGui::Button("Settings"))
             {
-                on_colour_changed(colour);
+                if (!_show_settings)
+                {
+                    ImGui::OpenPopup("SettingsPopup");
+                }
+                _show_settings = !_show_settings;
             }
+
+            if (_show_settings && ImGui::BeginPopup("SettingsPopup"))
+            {
+                auto colour = _route ? _route->colour() : Colour::Green;
+                if (ImGui::ColorEdit3("Blob##colour", &colour.r, ImGuiColorEditFlags_NoInputs))
+                {
+                    on_colour_changed(colour);
+                }
+                auto stick_colour = _route ? _route->stick_colour() : Colour::White;
+                if (ImGui::ColorEdit3("Stick##colour", &stick_colour.r, ImGuiColorEditFlags_NoInputs))
+                {
+                    on_stick_colour_changed(stick_colour);
+                }
+                ImGui::EndPopup();
+            }
+            else
+            {
+                _show_settings = false;
+            }
+
             ImGui::SameLine();
             if (ImGui::Button(Names::import_button.c_str()))
             {

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -45,10 +45,10 @@ namespace trview
                 {
                     on_colour_changed(colour);
                 }
-                auto stick_colour = _route ? _route->stick_colour() : Colour::White;
-                if (ImGui::ColorEdit3("Waypoint##colour", &stick_colour.r, ImGuiColorEditFlags_NoInputs))
+                auto waypoint_colour = _route ? _route->waypoint_colour() : Colour::White;
+                if (ImGui::ColorEdit3("Waypoint##colour", &waypoint_colour.r, ImGuiColorEditFlags_NoInputs))
                 {
-                    on_stick_colour_changed(stick_colour);
+                    on_waypoint_colour_changed(waypoint_colour);
                 }
                 ImGui::EndPopup();
             }

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -67,5 +67,6 @@ namespace trview
         bool _scroll_to_waypoint{ false };
         std::optional<float> _tooltip_timer;
         bool _need_focus{ false };
+        bool _show_settings{ false };
     };
 }

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -33,6 +33,7 @@ namespace trview
         _route_window->on_route_import += on_route_import;
         _route_window->on_route_export += on_route_export;
         _route_window->on_item_selected += on_item_selected;
+        _route_window->on_stick_colour_changed += on_stick_colour_changed;
         _route_window->on_trigger_selected += on_trigger_selected;
         _route_window->on_waypoint_selected += on_waypoint_selected;
         _route_window->on_waypoint_deleted += on_waypoint_deleted;

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -33,7 +33,7 @@ namespace trview
         _route_window->on_route_import += on_route_import;
         _route_window->on_route_export += on_route_export;
         _route_window->on_item_selected += on_item_selected;
-        _route_window->on_stick_colour_changed += on_stick_colour_changed;
+        _route_window->on_waypoint_colour_changed += on_waypoint_colour_changed;
         _route_window->on_trigger_selected += on_trigger_selected;
         _route_window->on_waypoint_selected += on_waypoint_selected;
         _route_window->on_waypoint_deleted += on_waypoint_deleted;


### PR DESCRIPTION
Let the user set a custom colour for the waypoint stick.
Also add an option to the settings window to allow the user to choose the default colours. These will be applied when the route is created when a level is opened.
Closes #962 