### PR TITLE
Add 'is not present' filter

### DIFF
--- a/trview.app.tests/Filters/FiltersTests.cpp
+++ b/trview.app.tests/Filters/FiltersTests.cpp
@@ -333,3 +333,28 @@ TEST(Filters, CheckboxShowsTooltip)
     ASSERT_NE(imgui.find_window("##Tooltip_00"), nullptr);
 }
 
+TEST(Filters, NotPresentFloat)
+{
+    Filters<Object> filters;
+    filters.add_multi_getter<float>("value", [](auto&& o) { return o.numbers; });
+
+    Filters<Object>::Filter present_float = make_filter().key("value").compare_op(CompareOp::NotExists);
+    filters.set_filters({ present_float });
+
+    ASSERT_FALSE(filters.match(Object().with_numbers({ 1, 3, 12, 15 })));
+    ASSERT_TRUE(filters.match(Object().with_numbers({ })));
+}
+
+TEST(Filters, NotPresentString)
+{
+    Filters<Object> filters;
+    filters.add_multi_getter<std::string>("value", [](auto&& o) { return o.texts; });
+
+    Filters<Object>::Filter present_string = make_filter().key("value").compare_op(CompareOp::NotExists);
+    filters.set_filters({ present_string });
+
+    ASSERT_FALSE(filters.match(Object().with_texts({ "test", "string" })));
+    ASSERT_TRUE(filters.match(Object().with_texts({ })));
+}
+
+

--- a/trview.app/Filters/Filters.h
+++ b/trview.app/Filters/Filters.h
@@ -17,7 +17,8 @@ namespace trview
         LessThanOrEqual,
         Between,
         BetweenInclusive,
-        Exists
+        Exists,
+        NotExists
     };
 
     enum class Op
@@ -52,6 +53,7 @@ namespace trview
             Op op{ Op::And };
 
             int value_count() const noexcept;
+            bool initial_state() const noexcept;
         };
 
         /// <summary>


### PR DESCRIPTION
Add an 'is not present' filter for multi-getters.
If there are no values present the filter will pass - it's a bit different to 'is present' though as it has to have an initial state of `true` and then just not fail (by having something present).
Closes #998