### PR TITLE
Add mutant type to mutant eggs

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -252,6 +252,8 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
 
     EXPECT_CALL(items_window_manager, set_items(A<const std::vector<Item>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_items"); });
     EXPECT_CALL(items_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_triggers"); });
+    EXPECT_CALL(items_window_manager, set_level_version(A<trlevel::LevelVersion>())).Times(1).WillOnce([&](auto) { events.push_back("items_version"); });
+    EXPECT_CALL(items_window_manager, set_model_checker(A<const std::function<bool (uint32_t)>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_model_checker"); });
     EXPECT_CALL(triggers_window_manager, set_items(A<const std::vector<Item>&>())).Times(1).WillOnce([&](auto) { events.push_back("triggers_items"); });
     EXPECT_CALL(triggers_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("triggers_triggers"); });
     EXPECT_CALL(rooms_window_manager, set_level_version(A<trlevel::LevelVersion>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_version"); });
@@ -282,7 +284,7 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
     ASSERT_TRUE(called.has_value());
     ASSERT_EQ(called.value(), "test_path.tr2");
 
-    ASSERT_EQ(events.size(), 15);
+    ASSERT_EQ(events.size(), 17);
     ASSERT_EQ(events.back(), "viewer");
 }
 

--- a/trview.app.tests/Elements/ItemTests.cpp
+++ b/trview.app.tests/Elements/ItemTests.cpp
@@ -1,0 +1,38 @@
+#include <trview.app/Elements/Item.h>
+
+using namespace trview;
+
+TEST(Item, IsMutantEgg)
+{
+    ASSERT_TRUE(is_mutant_egg(Item(0, 0, 163, "", 0, 0, {}, {})));
+    ASSERT_TRUE(is_mutant_egg(Item(0, 0, 181, "", 0, 0, {}, {})));
+    ASSERT_FALSE(is_mutant_egg(Item(0, 0, 0, "", 0, 0, {}, {})));
+}
+
+TEST(Item, IsMutantEggId)
+{
+    ASSERT_TRUE(is_mutant_egg(163));
+    ASSERT_TRUE(is_mutant_egg(181));
+    ASSERT_FALSE(is_mutant_egg(0));
+}
+
+TEST(Item, MutantEggContents)
+{
+    ASSERT_EQ(20, mutant_egg_contents(Item(0, 0, 163, "", 0, 0 << 9, {}, {})));
+    ASSERT_EQ(21, mutant_egg_contents(Item(0, 0, 163, "", 0, 1 << 9, {}, {})));
+    ASSERT_EQ(23, mutant_egg_contents(Item(0, 0, 163, "", 0, 2 << 9, {}, {})));
+    ASSERT_EQ(34, mutant_egg_contents(Item(0, 0, 163, "", 0, 4 << 9, {}, {})));
+    ASSERT_EQ(22, mutant_egg_contents(Item(0, 0, 163, "", 0, 8 << 9, {}, {})));
+
+    ASSERT_EQ(20, mutant_egg_contents(Item(0, 0, 163, "", 0, 1851, {}, {})));
+}
+
+TEST(Item, MutantEggContentsFlags)
+{
+    ASSERT_EQ(20, mutant_egg_contents(0));
+    ASSERT_EQ(21, mutant_egg_contents(1));
+    ASSERT_EQ(23, mutant_egg_contents(2));
+    ASSERT_EQ(34, mutant_egg_contents(4));
+    ASSERT_EQ(22, mutant_egg_contents(8));
+    ASSERT_EQ(20, mutant_egg_contents(1851));
+}

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -710,3 +710,15 @@ TEST(Level, LightNotFound)
     auto light = level->light(0).lock();
     ASSERT_EQ(light, nullptr);
 }
+
+TEST(Level, MeshSetBuilt)
+{
+    auto [mock_level_ptr, mock_level] = create_mock<trlevel::mocks::MockLevel>();
+    ON_CALL(mock_level, num_models()).WillByDefault(Return(1));
+    ON_CALL(mock_level, get_model(0)).WillByDefault(Return(trlevel::tr_model{ 100 }));
+
+    auto level = register_test_module().with_level(std::move(mock_level_ptr)).build();
+
+    ASSERT_TRUE(level->has_model(100));
+    ASSERT_FALSE(level->has_model(123));
+}

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -121,6 +121,7 @@ TEST(Level, LoadTypeNames)
     tr2_entity entity;
     entity.Room = 0;
     entity.TypeID = 123;
+    entity.Flags = 100;
 
     auto [mock_level_ptr, mock_level] = create_mock<trlevel::mocks::MockLevel>();
     EXPECT_CALL(mock_level, get_version).WillRepeatedly(Return(LevelVersion::Tomb2));
@@ -129,7 +130,7 @@ TEST(Level, LoadTypeNames)
     EXPECT_CALL(mock_level, get_entity(0)).WillRepeatedly(Return(entity));
 
     auto mock_type_name_lookup = mock_shared<MockTypeNameLookup>();
-    EXPECT_CALL(*mock_type_name_lookup, lookup_type_name(LevelVersion::Tomb2, 123));
+    EXPECT_CALL(*mock_type_name_lookup, lookup_type_name(LevelVersion::Tomb2, 123, 100));
     auto level = register_test_module().with_level(std::move(mock_level_ptr)).with_type_name_lookup(mock_type_name_lookup).build();
 }
 

--- a/trview.app.tests/Elements/TypeNameLookupTests.cpp
+++ b/trview.app.tests/Elements/TypeNameLookupTests.cpp
@@ -34,7 +34,52 @@ TEST(TypeNameLookup, LookupMissingItem)
     ASSERT_EQ("123", lookup.lookup_type_name(LevelVersion::Tomb3, 123, 0));
 }
 
-TEST(TypeNameLookup, LookupMutantEggs)
+TEST(TypeNameLookup, LookupNormalMutantEggs)
 {
-    FAIL();
+    std::string json = "{\"games\":{\"tr1\":[{\"id\":163,\"name\":\"Test Name 1\"}]}}";
+    TypeNameLookup lookup(json);
+
+    auto winged = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 0);
+    auto shooter = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 1 << 9);
+    auto centaur = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 2 << 9);
+    auto torso = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 4 << 9);
+    auto grounded = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 8 << 9);
+    auto def = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 3 << 9);
+
+    ASSERT_EQ(winged, "Mutant Egg (Winged)");
+    ASSERT_EQ(shooter, "Mutant Egg (Shooter)");
+    ASSERT_EQ(centaur, "Mutant Egg (Centaur)");
+    ASSERT_EQ(torso, "Mutant Egg (Torso)");
+    ASSERT_EQ(grounded, "Mutant Egg (Grounded)");
+    ASSERT_EQ(def, "Mutant Egg (Winged)");
+}
+
+TEST(TypeNameLookup, LookupBigMutantEggs)
+{
+    std::string json = "{\"games\":{\"tr1\":[{\"id\":181,\"name\":\"Test Name 2\"}]}}";
+    TypeNameLookup lookup(json);
+
+    auto winged = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 0);
+    auto shooter = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 1 << 9);
+    auto centaur = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 2 << 9);
+    auto torso = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 4 << 9);
+    auto grounded = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 8 << 9);
+    auto def = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 3 << 9);
+
+    ASSERT_EQ(winged, "Mutant Egg (Winged)");
+    ASSERT_EQ(shooter, "Mutant Egg (Shooter)");
+    ASSERT_EQ(centaur, "Mutant Egg (Centaur)");
+    ASSERT_EQ(torso, "Mutant Egg (Torso)");
+    ASSERT_EQ(grounded, "Mutant Egg (Grounded)");
+    ASSERT_EQ(def, "Mutant Egg (Winged)");
+}
+
+TEST(TypeNameLookup, LookupNormalMutantEggsTR2)
+{
+    std::string json = "{\"games\":{\"tr1\":[{\"id\":163,\"name\":\"Test Name 1\"}],\"tr2\":[{\"id\":163,\"name\":\"Test Name 2\"}]}}";
+    TypeNameLookup lookup(json);
+
+    auto winged = lookup.lookup_type_name(trlevel::LevelVersion::Tomb2, 163, 0);
+
+    ASSERT_EQ(winged, "Test Name 2");
 }

--- a/trview.app.tests/Elements/TypeNameLookupTests.cpp
+++ b/trview.app.tests/Elements/TypeNameLookupTests.cpp
@@ -10,7 +10,7 @@ TEST(TypeNameLookup, LookupTR1)
 
     TypeNameLookup lookup(json);
 
-    ASSERT_EQ("Test Name", lookup.lookup_type_name(LevelVersion::Tomb1, 123));
+    ASSERT_EQ("Test Name", lookup.lookup_type_name(LevelVersion::Tomb1, 123, 0));
 }
 
 // Tests that if there are identical entries for different games, the correct result is returned.
@@ -20,8 +20,8 @@ TEST(TypeNameLookup, LookupMultipleGames)
 
     TypeNameLookup lookup(json);
 
-    ASSERT_EQ("Test Name TR1", lookup.lookup_type_name(LevelVersion::Tomb1, 123));
-    ASSERT_EQ("Test Name TR2", lookup.lookup_type_name(LevelVersion::Tomb2, 123));
+    ASSERT_EQ("Test Name TR1", lookup.lookup_type_name(LevelVersion::Tomb1, 123, 0));
+    ASSERT_EQ("Test Name TR2", lookup.lookup_type_name(LevelVersion::Tomb2, 123, 0));
 }
 
 // Tests that if the name is missing, it still returns the number.
@@ -31,5 +31,10 @@ TEST(TypeNameLookup, LookupMissingItem)
 
     TypeNameLookup lookup(json);
 
-    ASSERT_EQ("123", lookup.lookup_type_name(LevelVersion::Tomb3, 123));
+    ASSERT_EQ("123", lookup.lookup_type_name(LevelVersion::Tomb3, 123, 0));
+}
+
+TEST(TypeNameLookup, LookupMutantEggs)
+{
+    FAIL();
 }

--- a/trview.app.tests/ItemsWindowManagerTests.cpp
+++ b/trview.app.tests/ItemsWindowManagerTests.cpp
@@ -7,6 +7,7 @@
 using namespace trview;
 using namespace trview::tests;
 using namespace trview::mocks;
+using testing::A;
 
 namespace
 {
@@ -231,4 +232,41 @@ TEST(ItemsWindowManager, WindowsUpdated)
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
     manager->create_window();
     manager->update(1.0f);
+}
+
+TEST(ItemsWindowManager, CreateWindowPassesLevelVersion)
+{
+    auto mock_window = mock_shared<MockItemsWindow>();
+    EXPECT_CALL(*mock_window, set_level_version(trlevel::LevelVersion::Tomb4)).Times(1);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->set_level_version(trlevel::LevelVersion::Tomb4);
+    manager->create_window();
+}
+
+TEST(ItemsWindowManager, SetLevelVersionUpdatesWindows)
+{
+    auto mock_window = mock_shared<MockItemsWindow>();
+    EXPECT_CALL(*mock_window, set_level_version(trlevel::LevelVersion::Unknown)).Times(1);
+    EXPECT_CALL(*mock_window, set_level_version(trlevel::LevelVersion::Tomb4)).Times(1);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+    manager->set_level_version(trlevel::LevelVersion::Tomb4);
+}
+
+TEST(ItemsWindowManager, CreateWindowPassesModelChecker)
+{
+    auto mock_window = mock_shared<MockItemsWindow>();
+    EXPECT_CALL(*mock_window, set_model_checker(A<const std::function<bool (uint32_t)>&>())).Times(1);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->set_model_checker([](auto) {return true; });
+    manager->create_window();
+}
+
+TEST(ItemsWindowManager, SetModelCheckerUpdatesWindows)
+{
+    auto mock_window = mock_shared<MockItemsWindow>();
+    EXPECT_CALL(*mock_window, set_model_checker(A<const std::function<bool(uint32_t)>&>())).Times(2);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+    manager->set_model_checker([](auto) {return true; });
 }

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="Camera\CameraInputTests.cpp" />
     <ClCompile Include="ContextMenuTests.cpp" />
     <ClCompile Include="Elements\EntityTests.cpp" />
+    <ClCompile Include="Elements\ItemTests.cpp" />
     <ClCompile Include="Elements\LevelTests.cpp" />
     <ClCompile Include="Elements\LightTests.cpp" />
     <ClCompile Include="Elements\RoomTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -155,6 +155,9 @@
     <ClCompile Include="Windows\LogWindowTests.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\ItemTests.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -162,6 +162,8 @@ namespace trview
 
         _items_windows->set_items(_level->items());
         _items_windows->set_triggers(_level->triggers());
+        _items_windows->set_level_version(_level->version());
+        _items_windows->set_model_checker([&](uint32_t id) { return _level->has_model(id); });
         _triggers_windows->set_items(_level->items());
         _triggers_windows->set_triggers(_level->triggers());
         _rooms_windows->set_level_version(_level->version());

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -42,6 +42,7 @@ namespace trview
         /// @returns True if there are flipmaps.
         virtual bool any_alternates() const = 0;
         virtual std::string filename() const = 0;
+        virtual bool has_model(uint32_t type_id) const = 0;
         virtual bool highlight_mode_enabled(RoomHighlightMode mode) const = 0;
         virtual std::optional<Item> item(uint32_t index) const = 0;
         /// Get the items in this level.

--- a/trview.app/Elements/ITypeNameLookup.h
+++ b/trview.app/Elements/ITypeNameLookup.h
@@ -10,7 +10,7 @@ namespace trview
     {
     public:
         virtual ~ITypeNameLookup() = 0;
-        virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id) const = 0;
+        virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint32_t flags) const = 0;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const = 0;
     };
 }

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -66,4 +66,35 @@ namespace trview
     {
         _visible = value;
     }
+
+    bool is_mutant_egg(const Item& item)
+    {
+        return is_mutant_egg(item.type_id());
+    }
+
+    bool is_mutant_egg(uint32_t type_id)
+    {
+        return equals_any(type_id, 163, 181);
+    }
+
+    uint16_t mutant_egg_contents(const Item& item)
+    {
+        return mutant_egg_contents(item.activation_flags());
+    }
+
+    uint16_t mutant_egg_contents(uint16_t flags)
+    {
+        switch (flags)
+        {
+        case 1:
+            return 21; // Shooter
+        case 2:
+            return 23; // Centaur
+        case 4:
+            return 34; // Torso
+        case 8:
+            return 22; // Mutant
+        }
+        return 20; // Winged
+    }
 }

--- a/trview.app/Elements/Item.h
+++ b/trview.app/Elements/Item.h
@@ -81,4 +81,9 @@ namespace trview
         uint16_t _flags{ 0u };
         bool _visible{ true };
     };
+
+    bool is_mutant_egg(const Item& item);
+    bool is_mutant_egg(uint32_t type_id);
+    uint16_t mutant_egg_contents(const Item& item);
+    uint16_t mutant_egg_contents(uint16_t flags);
 }

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -529,7 +529,7 @@ namespace trview
                 }
             }
 
-            _items.push_back(Item(i, level_entity.Room, level_entity.TypeID, type_names.lookup_type_name(_version, level_entity.TypeID), 
+            _items.push_back(Item(i, level_entity.Room, level_entity.TypeID, type_names.lookup_type_name(_version, level_entity.TypeID, level_entity.Flags), 
                 version() >= trlevel::LevelVersion::Tomb4 ? level_entity.Intensity2 : 0, level_entity.Flags, relevant_triggers, level_entity.position()));
         }
 
@@ -541,7 +541,7 @@ namespace trview
             _rooms[entity->room()]->add_entity(entity);
             _entities.push_back(entity);
 
-            _items.push_back(Item(num_entities + i, ai_object.room, ai_object.type_id, type_names.lookup_type_name(_version, ai_object.type_id), ai_object.ocb,
+            _items.push_back(Item(num_entities + i, ai_object.room, ai_object.type_id, type_names.lookup_type_name(_version, ai_object.type_id, ai_object.flags), ai_object.ocb,
                 ai_object.flags, {}, ai_object.position()));
         }
     }

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -64,6 +64,7 @@ namespace trview
         // Create the texture sampler state.
         _sampler_state = device->create_sampler_state(sampler_desc);
 
+        record_models(*level);
         generate_rooms(*level, room_source, *mesh_storage);
         generate_triggers(trigger_source);
         generate_entities(*level, *type_names, entity_source, ai_source, *mesh_storage);
@@ -1012,6 +1013,19 @@ namespace trview
             return trigger->number();
         }
         return std::nullopt;
+    }
+
+    bool Level::has_model(uint32_t type_id) const
+    {
+        return _models.find(type_id) != _models.end();
+    }
+
+    void Level::record_models(const trlevel::ILevel& level)
+    {
+        for (uint32_t i = 0; i < level.num_models(); ++i)
+        {
+            _models.insert(level.get_model(i).ID);
+        }
     }
 
     bool find_item_by_type_id(const ILevel& level, uint32_t type_id, Item& output_item)

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -99,6 +99,7 @@ namespace trview
         virtual void set_map_colours(const MapColours& map_colours) override;
         virtual std::optional<uint32_t> selected_light() const override;
         virtual std::optional<uint32_t> selected_trigger() const override;
+        virtual bool has_model(uint32_t type_id) const override;
     private:
         void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage);
         void generate_triggers(const ITrigger::Source& trigger_source);
@@ -142,6 +143,7 @@ namespace trview
         bool is_alternate_group_set(uint16_t group) const;
         void apply_ocb_adjustment();
         void deduplicate_triangles();
+        void record_models(const trlevel::ILevel& level);
 
         std::shared_ptr<graphics::IDevice> _device;
         std::vector<std::shared_ptr<IRoom>>   _rooms;
@@ -185,6 +187,8 @@ namespace trview
         trlevel::LevelVersion _version;
         std::string _filename;
         std::shared_ptr<ILog> _log;
+
+        std::set<uint32_t> _models;
     };
 
     /// Find the first item with the type id specified.

--- a/trview.app/Elements/TypeNameLookup.cpp
+++ b/trview.app/Elements/TypeNameLookup.cpp
@@ -9,12 +9,18 @@ namespace trview
     {
         const std::unordered_map<int, std::string> mutant_names
         {
-            { 0, "Winged Shooter" },
-            { 1, "Grounded Shooter" },
+            { 0, "Winged" },
+            { 1, "Shooter" },
             { 2, "Centaur" },
             { 4, "Torso" },
-            { 8, "Grounded non-shooter" }
+            { 8, "Grounded" }
         };
+
+        std::string mutant_name(uint16_t flags)
+        {
+            auto mutant_name = mutant_names.find((flags & 0x3E00) >> 9);
+            return std::format("Mutant Egg ({})", mutant_name == mutant_names.end() ? "Winged" : mutant_name->second);
+        }
     }
 
     TypeNameLookup::TypeNameLookup(const std::string& type_name_json)
@@ -78,12 +84,9 @@ namespace trview
             return std::to_string(type_id);
         }
 
-        // Special overrides for TR1
         if (level_version == LevelVersion::Tomb1 && type_id == 163 || type_id == 181)
         {
-            int mutant_type = (flags & 0x3E00) >> 9;
-            auto mutant_name = mutant_names.find(mutant_type);
-            return std::format("Mutant Egg ({})", mutant_name == mutant_names.end() ? "Big" : mutant_name->second);
+            return mutant_name(flags);
         }
 
         return found_type->second.name;

--- a/trview.app/Elements/TypeNameLookup.cpp
+++ b/trview.app/Elements/TypeNameLookup.cpp
@@ -1,5 +1,6 @@
 #include "TypeNameLookup.h"
 #include <trview.common/Json.h>
+#include "Item.h"
 
 using namespace trlevel;
 
@@ -9,16 +10,16 @@ namespace trview
     {
         const std::unordered_map<int, std::string> mutant_names
         {
-            { 0, "Winged" },
-            { 1, "Shooter" },
-            { 2, "Centaur" },
-            { 4, "Torso" },
-            { 8, "Grounded" }
+            { 20, "Winged" },
+            { 21, "Shooter" },
+            { 22, "Grounded" },
+            { 23, "Centaur" },
+            { 34, "Torso" }
         };
 
         std::string mutant_name(uint16_t flags)
         {
-            auto mutant_name = mutant_names.find((flags & 0x3E00) >> 9);
+            auto mutant_name = mutant_names.find(mutant_egg_contents((flags & 0x3E00) >> 9));
             return std::format("Mutant Egg ({})", mutant_name == mutant_names.end() ? "Winged" : mutant_name->second);
         }
     }
@@ -84,7 +85,7 @@ namespace trview
             return std::to_string(type_id);
         }
 
-        if (level_version == LevelVersion::Tomb1 && type_id == 163 || type_id == 181)
+        if (level_version == LevelVersion::Tomb1 && is_mutant_egg(type_id))
         {
             return mutant_name(flags);
         }

--- a/trview.app/Elements/TypeNameLookup.cpp
+++ b/trview.app/Elements/TypeNameLookup.cpp
@@ -5,6 +5,18 @@ using namespace trlevel;
 
 namespace trview
 {
+    namespace
+    {
+        const std::unordered_map<int, std::string> mutant_names
+        {
+            { 0, "Winged Shooter" },
+            { 1, "Grounded Shooter" },
+            { 2, "Centaur" },
+            { 4, "Torso" },
+            { 8, "Grounded non-shooter" }
+        };
+    }
+
     TypeNameLookup::TypeNameLookup(const std::string& type_name_json)
     {
         auto json = nlohmann::json::parse(type_name_json.begin(), type_name_json.end());
@@ -52,7 +64,7 @@ namespace trview
         load_game_types(LevelVersion::Tomb5);
     }
 
-    std::string TypeNameLookup::lookup_type_name(LevelVersion level_version, uint32_t type_id) const
+    std::string TypeNameLookup::lookup_type_name(LevelVersion level_version, uint32_t type_id, uint32_t flags) const
     {
         const auto& game_types = _type_names.find(level_version);
         if (game_types == _type_names.end())
@@ -65,6 +77,15 @@ namespace trview
         {
             return std::to_string(type_id);
         }
+
+        // Special overrides for TR1
+        if (level_version == LevelVersion::Tomb1 && type_id == 163 || type_id == 181)
+        {
+            int mutant_type = (flags & 0x3E00) >> 9;
+            auto mutant_name = mutant_names.find(mutant_type);
+            return std::format("Mutant Egg ({})", mutant_name == mutant_names.end() ? "Big" : mutant_name->second);
+        }
+
         return found_type->second.name;
     }
 

--- a/trview.app/Elements/TypeNameLookup.h
+++ b/trview.app/Elements/TypeNameLookup.h
@@ -10,7 +10,7 @@ namespace trview
     public:
         explicit TypeNameLookup(const std::string& type_name_json);
         virtual ~TypeNameLookup() = default;
-        virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id) const override;
+        virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint32_t flags) const override;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const override;
     private:
         struct Type

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -14,6 +14,7 @@ namespace trview
             MOCK_METHOD(bool, alternate_mode, (), (const, override));
             MOCK_METHOD(bool, any_alternates, (), (const, override));
             MOCK_METHOD(std::string, filename, (), (const, override));
+            MOCK_METHOD(bool, has_model, (uint32_t), (const, override));
             MOCK_METHOD(bool, highlight_mode_enabled, (RoomHighlightMode), (const, override));
             MOCK_METHOD(std::optional<Item>, item, (uint32_t), (const, override));
             MOCK_METHOD(std::vector<Item>, items, (), (const, override));

--- a/trview.app/Mocks/Elements/ITypeNameLookup.h
+++ b/trview.app/Mocks/Elements/ITypeNameLookup.h
@@ -9,7 +9,7 @@ namespace trview
         struct MockTypeNameLookup : public ITypeNameLookup
         {
             virtual ~MockTypeNameLookup() = default;
-            MOCK_METHOD(std::string, lookup_type_name, (trlevel::LevelVersion, uint32_t), (const, override));
+            MOCK_METHOD(std::string, lookup_type_name, (trlevel::LevelVersion, uint32_t, uint32_t), (const, override));
             MOCK_METHOD(bool, is_pickup, (trlevel::LevelVersion, uint32_t), (const, override));
         };
     }

--- a/trview.app/Mocks/Windows/IItemsWindow.h
+++ b/trview.app/Mocks/Windows/IItemsWindow.h
@@ -19,6 +19,8 @@ namespace trview
             MOCK_METHOD(std::optional<Item>, selected_item, (), (const, override));
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));
+            MOCK_METHOD(void, set_level_version, (trlevel::LevelVersion), (override));
+            MOCK_METHOD(void, set_model_checker, (const std::function<bool(uint32_t)>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IItemsWindowManager.h
+++ b/trview.app/Mocks/Windows/IItemsWindowManager.h
@@ -12,6 +12,8 @@ namespace trview
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
             MOCK_METHOD(void, set_item_visible, (const Item&, bool), (override));
+            MOCK_METHOD(void, set_level_version, (trlevel::LevelVersion), (override));
+            MOCK_METHOD(void, set_model_checker, (const std::function<bool(uint32_t)>&), (override));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(void, set_room, (uint32_t), (override));
             MOCK_METHOD(void, set_selected_item, (const Item&), (override));

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -62,13 +62,13 @@
 				"name": "Raptor"
 			}, {
 				"id": 20,
-				"name": "Mutant"
+				"name": "Mutant (Winged)"
 			}, {
 				"id": 21,
-				"name": "Mutant Spawn"
+				"name": "Mutant (Shooter)"
 			}, {
 				"id": 22,
-				"name": "Mutant Spawn"
+				"name": "Mutant"
 			}, {
 				"id": 23,
 				"name": "Centaur"

--- a/trview.app/Windows/IItemsWindow.h
+++ b/trview.app/Windows/IItemsWindow.h
@@ -64,6 +64,10 @@ namespace trview
         virtual void update(float delta) = 0;
 
         virtual void set_number(int32_t number) = 0;
+
+        virtual void set_level_version(trlevel::LevelVersion version) = 0;
+
+        virtual void set_model_checker(const std::function<bool(uint32_t)>& checker) = 0;
     };
 }
 

--- a/trview.app/Windows/IItemsWindowManager.h
+++ b/trview.app/Windows/IItemsWindowManager.h
@@ -32,6 +32,10 @@ namespace trview
         /// @param visible Whether the item is visible.
         virtual void set_item_visible(const Item& item, bool visible) = 0;
 
+        virtual void set_level_version(trlevel::LevelVersion version) = 0;
+
+        virtual void set_model_checker(const std::function<bool (uint32_t)>& checker) = 0;
+
         /// Set the triggers to use in the windows.
         /// @param triggers The triggers in the level.
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -11,6 +11,7 @@ namespace trview
         _tips["OCB"] = "Changes entity behaviour";
         _tips["Clear Body"] = "If true, removed when Bodybag is triggered";
         _tips["Trigger triggerer"] = "Disables the trigger on the same sector until this item is triggered";
+        _tips["Type*"] = "Mutant Egg spawn target is missing; egg will be empty";
 
         setup_filters();
     }
@@ -220,7 +221,14 @@ namespace trview
                         return std::format("{:.0f}, {:.0f}, {:.0f}", pos.x, pos.y, pos.z);
                     };
 
-                    add_stat("Type", item.type());
+                    auto is_bad_mutant_egg = [&]() 
+                    { 
+                        return _level_version == trlevel::LevelVersion::Tomb1 &&
+                            is_mutant_egg(item) &&
+                            !_model_checker(mutant_egg_contents(item));
+                    };
+
+                    add_stat(std::format("Type{}", is_bad_mutant_egg() ? "*" : ""), item.type());
                     add_stat("#", item.number());
                     add_stat("Position", position_text());
                     add_stat("Type ID", item.type_id());
@@ -367,5 +375,15 @@ namespace trview
                 }
                 return results;
             });
+    }
+
+    void ItemsWindow::set_level_version(trlevel::LevelVersion version)
+    {
+        _level_version = version;
+    }
+
+    void ItemsWindow::set_model_checker(const std::function<bool(uint32_t)>& checker)
+    {
+        _model_checker = checker;
     }
 }

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -85,7 +85,7 @@ namespace trview
 
     void ItemsWindow::render_items_list()
     {
-        if (ImGui::BeginChild(Names::item_list_panel.c_str(), ImVec2(280, 0), true))
+        if (ImGui::BeginChild(Names::item_list_panel.c_str(), ImVec2(290, 0), true))
         {
             _filters.render();
             ImGui::SameLine();
@@ -285,7 +285,7 @@ namespace trview
     bool ItemsWindow::render_items_window()
     {
         bool stay_open = true;
-        ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(530, 500));
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(540, 500));
         if (ImGui::Begin(_id.c_str(), &stay_open))
         {
             render_items_list();

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -39,6 +39,8 @@ namespace trview
         virtual std::optional<Item> selected_item() const override;
         virtual void update(float delta) override;
         virtual void set_number(int32_t number) override;
+        virtual void set_level_version(trlevel::LevelVersion version) override;
+        virtual void set_model_checker(const std::function<bool(uint32_t)>& checker) override;
     private:
         void set_track_room(bool value);
         void set_sync_item(bool value);
@@ -64,5 +66,7 @@ namespace trview
         bool _scroll_to_item{ false };
 
         Filters<Item> _filters;
+        trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Unknown };
+        std::function<bool(uint32_t)> _model_checker;
     };
 }

--- a/trview.app/Windows/ItemsWindowManager.cpp
+++ b/trview.app/Windows/ItemsWindowManager.cpp
@@ -33,6 +33,8 @@ namespace trview
         items_window->set_items(_items);
         items_window->set_triggers(_triggers);
         items_window->set_current_room(_current_room);
+        items_window->set_level_version(_level_version);
+        items_window->set_model_checker(_model_checker);
         if (_selected_item.has_value())
         {
             items_window->set_selected_item(_selected_item.value());
@@ -62,6 +64,24 @@ namespace trview
         for (auto& window : _windows)
         {
             window.second->update_item(*found);
+        }
+    }
+
+    void ItemsWindowManager::set_level_version(trlevel::LevelVersion version)
+    {
+        _level_version = version;
+        for (auto& window : _windows)
+        {
+            window.second->set_level_version(version);
+        }
+    }
+
+    void ItemsWindowManager::set_model_checker(const std::function<bool(uint32_t)>& checker)
+    {
+        _model_checker = checker;
+        for (auto& window : _windows)
+        {
+            window.second->set_model_checker(checker);
         }
     }
 

--- a/trview.app/Windows/ItemsWindowManager.h
+++ b/trview.app/Windows/ItemsWindowManager.h
@@ -28,6 +28,8 @@ namespace trview
         virtual void render() override;
         virtual void set_items(const std::vector<Item>& items) override;
         virtual void set_item_visible(const Item& item, bool visible) override;
+        virtual void set_level_version(trlevel::LevelVersion version) override;
+        virtual void set_model_checker(const std::function<bool(uint32_t)>& checker) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void set_room(uint32_t room) override;
         virtual void set_selected_item(const Item& item) override;
@@ -39,5 +41,7 @@ namespace trview
         uint32_t _current_room{ 0u };
         std::optional<Item> _selected_item;
         IItemsWindow::Source _items_window_source;
+        trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Unknown };
+        std::function<bool(uint32_t)> _model_checker;
     };
 }

--- a/trview.common/Strings.cpp
+++ b/trview.common/Strings.cpp
@@ -26,7 +26,8 @@ namespace trview
 
     std::string format_binary(uint16_t value)
     {
-        return std::bitset<5>(value).to_string();
+        std::string result = std::bitset<5>(value).to_string();
+        return std::string(result.rbegin(), result.rend());
     }
 
     bool is_link(const std::wstring& text)


### PR DESCRIPTION
Use the flags field of the item for the mutant eggs in TR1 to show which type of mutant will spawn.
Also fix the flags fields being reversed in display.
Closes #1001 