### PR TITLE
Add copy option to context menu

### DIFF
--- a/trview.app.tests/ContextMenuTests.cpp
+++ b/trview.app.tests/ContextMenuTests.cpp
@@ -207,3 +207,13 @@ TEST(ContextMenu, AddMidWaypointNotRaisedWhenDisabled)
     ASSERT_FALSE(raised);
     ASSERT_TRUE(menu.visible());
 }
+
+TEST(ContextMenu, CopyPosition)
+{
+    FAIL();
+}
+
+TEST(ContextMenu, CopyRoom)
+{
+    FAIL();
+}

--- a/trview.app.tests/ContextMenuTests.cpp
+++ b/trview.app.tests/ContextMenuTests.cpp
@@ -210,10 +210,38 @@ TEST(ContextMenu, AddMidWaypointNotRaisedWhenDisabled)
 
 TEST(ContextMenu, CopyPosition)
 {
-    FAIL();
+    ContextMenu menu;
+    menu.set_visible(true);
+
+    TestImgui imgui([&]() { menu.render(); });
+
+    std::optional<trview::IContextMenu::CopyType> raised;
+    auto token = menu.on_copy += [&raised](auto type) { raised = type; };
+
+    imgui.show_context_menu("Debug##Default");
+    imgui.hover_element(imgui.popup_id("void_context").id(ContextMenu::Names::copy));
+    imgui.click_element(imgui.id("##Menu_00").id(ContextMenu::Names::copy_position), true);
+    imgui.render();
+
+    ASSERT_TRUE(raised);
+    ASSERT_FALSE(menu.visible());
 }
 
-TEST(ContextMenu, CopyRoom)
+TEST(ContextMenu, CopyNumber)
 {
-    FAIL();
+    ContextMenu menu;
+    menu.set_visible(true);
+
+    TestImgui imgui([&]() { menu.render(); });
+
+    std::optional<trview::IContextMenu::CopyType> raised;
+    auto token = menu.on_copy += [&raised](auto type) { raised = type; };
+
+    imgui.show_context_menu("Debug##Default");
+    imgui.hover_element(imgui.popup_id("void_context").id(ContextMenu::Names::copy));
+    imgui.click_element(imgui.id("##Menu_00").id(ContextMenu::Names::copy_number), true);
+    imgui.render();
+
+    ASSERT_TRUE(raised);
+    ASSERT_FALSE(menu.visible());
 }

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -308,3 +308,8 @@ TEST(ViewerUI, SetDefaultWaypointColourCalled)
     settings.waypoint_colour = Colour::Yellow;
     window->set_settings(settings);
 }
+
+TEST(ViewerUI, OnCopyEventForwarded)
+{
+    FAIL();
+}

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -311,5 +311,17 @@ TEST(ViewerUI, SetDefaultWaypointColourCalled)
 
 TEST(ViewerUI, OnCopyEventForwarded)
 {
-    FAIL();
+    auto [context_menu_ptr, context_menu] = create_mock<MockContextMenu>();
+    auto ui = register_test_module().with_context_menu(std::move(context_menu_ptr)).build();
+
+    std::optional<trview::IContextMenu::CopyType> raised;
+    auto token = ui->on_copy += [&](auto&& value)
+    {
+        raised = value;
+    };
+
+    context_menu.on_copy(trview::IContextMenu::CopyType::Position);
+
+    ASSERT_TRUE(raised);
+    ASSERT_EQ(raised, trview::IContextMenu::CopyType::Position);
 }

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -19,6 +19,7 @@
 #include <trlevel/Mocks/ILevel.h>
 #include <trview.app/Mocks/Routing/IWaypoint.h>
 #include <trview.app/Mocks/Elements/ILight.h>
+#include <trview.common/Mocks/Windows/IClipboard.h>
 #include "TestImgui.h"
 
 using testing::A;
@@ -67,12 +68,13 @@ namespace
             IRenderTarget::SizeSource render_target_source{ [](auto&&...) { return mock_unique<MockRenderTarget>(); } };
             IDeviceWindow::Source device_window_source{ [](auto&&...) { return mock_unique<MockDeviceWindow>(); } };
             std::unique_ptr<ISectorHighlight> sector_highlight{ mock_unique<MockSectorHighlight>() };
+            std::shared_ptr<IClipboard> clipboard{ mock_shared<MockClipboard>() };
 
             std::unique_ptr<Viewer> build()
             {
                 EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
                 return std::make_unique<Viewer>(window, device, std::move(ui), std::move(picking), std::move(mouse), shortcuts, route, sprite_source,
-                    std::move(compass), std::move(measure), render_target_source, device_window_source, std::move(sector_highlight));
+                    std::move(compass), std::move(measure), render_target_source, device_window_source, std::move(sector_highlight), clipboard);
             }
 
             test_module& with_device(const std::shared_ptr<IDevice>& device)
@@ -803,4 +805,14 @@ TEST(Viewer, ReloadLevelSyncProperties)
 
     viewer->open(&original, ILevel::OpenMode::Full);
     viewer->open(&reloaded, ILevel::OpenMode::Reload);
+}
+
+TEST(Viewer, CopyPosition)
+{
+    FAIL();
+}
+
+TEST(Viewer, CopyRoom)
+{
+    FAIL();
 }

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -100,6 +100,12 @@ namespace
                 this->mouse = std::move(mouse);
                 return *this;
             }
+
+            test_module& with_clipboard(std::shared_ptr<IClipboard> clipboard)
+            {
+                this->clipboard = clipboard;
+                return *this;
+            }
         };
         return test_module{};
     }
@@ -809,10 +815,32 @@ TEST(Viewer, ReloadLevelSyncProperties)
 
 TEST(Viewer, CopyPosition)
 {
-    FAIL();
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    auto [picking_ptr, picking] = create_mock<MockPicking>();
+    auto [mouse_ptr, mouse] = create_mock<MockMouse>();
+    auto clipboard = mock_shared<MockClipboard>();
+
+    EXPECT_CALL(*clipboard, write(std::wstring(L"1024, 2048, 3072"))).Times(1);
+
+    auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_clipboard(clipboard).with_mouse(std::move(mouse_ptr)).build();
+
+    activate_context_menu(picking, mouse, PickResult::Type::Room, 0, { 1, 2, 3 });
+
+    ui.on_copy(trview::IContextMenu::CopyType::Position);
 }
 
 TEST(Viewer, CopyRoom)
 {
-    FAIL();
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    auto [picking_ptr, picking] = create_mock<MockPicking>();
+    auto [mouse_ptr, mouse] = create_mock<MockMouse>();
+    auto clipboard = mock_shared<MockClipboard>();
+
+    EXPECT_CALL(*clipboard, write(std::wstring(L"14"))).Times(1);
+
+    auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_clipboard(clipboard).with_mouse(std::move(mouse_ptr)).build();
+
+    activate_context_menu(picking, mouse, PickResult::Type::Room, 14);
+
+    ui.on_copy(trview::IContextMenu::CopyType::Number);
 }

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -161,6 +161,8 @@ namespace trview
             std::make_unique<ContextMenu>(),
             std::make_unique<CameraControls>());
 
+        auto clipboard = std::make_shared<Clipboard>(window);
+
         auto viewer = std::make_unique<Viewer>(
             window,
             device,
@@ -174,10 +176,10 @@ namespace trview
             std::make_unique<Measure>(device, mesh_source),
             render_target_source,
             device_window_source,
-            std::make_unique<SectorHighlight>(mesh_source));
+            std::make_unique<SectorHighlight>(mesh_source),
+            clipboard);
 
         auto dialogs = std::make_shared<Dialogs>(window);
-        auto clipboard = std::make_shared<Clipboard>(window);
 
         auto items_window_source = [=]() { return std::make_shared<ItemsWindow>(clipboard); };
         auto triggers_window_source = [=]() { return std::make_shared<TriggersWindow>(clipboard); };

--- a/trview.app/UI/ContextMenu.cpp
+++ b/trview.app/UI/ContextMenu.cpp
@@ -28,6 +28,19 @@ namespace trview
                 on_hide();
             }
 
+            if (ImGui::BeginMenu(Names::copy.c_str()))
+            {
+                if (ImGui::MenuItem(Names::copy_position.c_str()))
+                {
+                    on_copy(CopyType::Position);
+                }
+                if (ImGui::MenuItem(Names::copy_number.c_str()))
+                {
+                    on_copy(CopyType::Number);
+                }
+                ImGui::EndMenu();
+            }
+
             ImGui::EndPopup();
         }
         else

--- a/trview.app/UI/ContextMenu.h
+++ b/trview.app/UI/ContextMenu.h
@@ -15,6 +15,9 @@ namespace trview
             static inline const std::string hide = "Hide";
             static inline const std::string orbit = "Orbit Here";
             static inline const std::string remove_waypoint = "Remove Waypoint";
+            static inline const std::string copy = "Copy";
+            static inline const std::string copy_position = "Position";
+            static inline const std::string copy_number = "Room/Object Number";
         };
 
         virtual ~ContextMenu() = default;

--- a/trview.app/UI/IContextMenu.h
+++ b/trview.app/UI/IContextMenu.h
@@ -4,6 +4,12 @@ namespace trview
 {
     struct IContextMenu
     {
+        enum class CopyType
+        {
+            Position,
+            Number
+        };
+
         virtual ~IContextMenu() = 0;
         /// <summary>
         /// Event raised when the user has clicked the button to create a new waypoint for the current route.
@@ -25,6 +31,10 @@ namespace trview
         /// Event raised when the user has clicked the hide button.
         /// </summary>
         Event<> on_hide;
+        /// <summary>
+        /// Event raised when the user has clicked a copy button.
+        /// </summary>
+        Event<CopyType> on_copy;
         virtual void render() = 0;
         /// <summary>
         /// Set the context menu to visible.

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -7,8 +7,10 @@
 #include <trview.app/Elements/IRoom.h>
 #include <trview.app/Geometry/PickInfo.h>
 #include <trview.app/Settings/UserSettings.h>
+#include "IContextMenu.h"
 
 #include <trview.common/Event.h>
+
 
 namespace trview
 {
@@ -97,6 +99,11 @@ namespace trview
         /// Event raised when the user changes a toggle.
         /// </summary>
         Event<std::string, bool> on_toggle_changed;
+
+        /// <summary>
+        /// Event raised when the user has clicked a copy button.
+        /// </summary>
+        Event<IContextMenu::CopyType> on_copy;
 
         /// Render the UI.
         virtual void render() = 0;

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -81,6 +81,7 @@ namespace trview
         _context_menu->on_remove_waypoint += on_remove_waypoint;
         _context_menu->on_orbit_here += on_orbit;
         _context_menu->on_hide += on_hide;
+        _context_menu->on_copy += on_copy;
         _context_menu->set_remove_enabled(false);
         _context_menu->set_hide_enabled(false);
 

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -37,6 +37,7 @@
 #include <trview.common/Windows/Shortcuts.h>
 #include <trview.graphics/IDeviceWindow.h>
 #include <trview.app/Windows/IViewer.h>
+#include <trview.common/Windows/IClipboard.h>
 
 namespace trview
 {
@@ -64,7 +65,8 @@ namespace trview
             std::unique_ptr<IMeasure> measure,
             const graphics::IRenderTarget::SizeSource& render_target_source,
             const graphics::IDeviceWindow::Source& device_window_source,
-            std::unique_ptr<ISectorHighlight> sector_highlight);
+            std::unique_ptr<ISectorHighlight> sector_highlight,
+            const std::shared_ptr<IClipboard>& clipboard);
         virtual ~Viewer() = default;
         virtual CameraMode camera_mode() const override;
         virtual void render() override;
@@ -172,6 +174,8 @@ namespace trview
 
         std::vector<PickResult> _recent_orbits;
         std::size_t _recent_orbit_index{ 0u };
+
+        std::shared_ptr<IClipboard> _clipboard;
     };
 }
 


### PR DESCRIPTION
Add a sub-menu to the context menu to allow user to copy the coordinates of the pick or the room/object number clicked on.
Closes #1003