### PR TITLE
Add 'open route on startup' and remember last route for level

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -720,3 +720,31 @@ TEST(Application, RouteSetToDefaultColoursOnReset)
         .build();
     application->open("test.tr2", ILevel::OpenMode::Full);
 }
+
+TEST(Application, RouteWindowCreatedOnStartup)
+{
+    UserSettings settings;
+    settings.route_startup = true;
+    auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
+    ON_CALL(settings_loader, load_user_settings).WillByDefault(Return(settings));
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    EXPECT_CALL(route_window_manager, create_window).Times(1);
+    auto application = register_test_module()
+        .with_settings_loader(std::move(settings_loader_ptr))
+        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .build();
+}
+
+TEST(Application, RouteWindowNotCreatedOnStartup)
+{
+    UserSettings settings;
+    settings.route_startup = false;
+    auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
+    ON_CALL(settings_loader, load_user_settings).WillByDefault(Return(settings));
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    EXPECT_CALL(route_window_manager, create_window).Times(0);
+    auto application = register_test_module()
+        .with_settings_loader(std::move(settings_loader_ptr))
+        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .build();
+}

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -169,7 +169,7 @@ namespace
                 return *this;
             }
 
-            test_module& with_level_source(ILevel::Source& level_source)
+            test_module& with_level_source(ILevel::Source level_source)
             {
                 this->level_source = level_source;
                 return *this;
@@ -747,4 +747,30 @@ TEST(Application, RouteWindowNotCreatedOnStartup)
         .with_settings_loader(std::move(settings_loader_ptr))
         .with_route_window_manager(std::move(route_window_manager_ptr))
         .build();
+}
+
+TEST(Application, RecentRouteLoaded)
+{
+    UserSettings settings;
+    settings.recent_routes["test.tr2"] = { "test.tvr", false };
+    auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
+    ON_CALL(settings_loader, load_user_settings).WillByDefault(Return(settings));
+    auto dialogs = mock_shared<MockDialogs>();
+    EXPECT_CALL(*dialogs, message_box(std::wstring(L"Reopen last used route for this level?"), std::wstring(L"Reopen route"), IDialogs::Buttons::Yes_No)).Times(1).WillOnce(Return(true));
+    auto route = mock_shared<MockRoute>();
+    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
+    EXPECT_CALL(viewer, set_route(std::shared_ptr<IRoute>(route))).Times(1);
+    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
+    ON_CALL(level, filename).WillByDefault(Return("test.tr2"));
+
+    auto application = register_test_module()
+        .with_settings_loader(std::move(settings_loader_ptr))
+        .with_dialogs(dialogs)
+        .with_viewer(std::move(viewer_ptr))
+        .with_route_source([&](auto&&...) {return route; })
+        .with_level_source([&](auto&&...) { return std::move(level_ptr); })
+        .build();
+    
+    application->open("test.tr2", ILevel::OpenMode::Full);
+
 }

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -764,6 +764,8 @@ TEST(Application, RecentRouteLoaded)
     EXPECT_CALL(viewer, set_settings).Times(AtLeast(1)).WillRepeatedly(SaveArg<0>(&called_settings));
     auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
     ON_CALL(level, filename).WillByDefault(Return("test.tr2"));
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    ON_CALL(route_window_manager, is_window_open).WillByDefault(Return(true));
 
     auto application = register_test_module()
         .with_settings_loader(std::move(settings_loader_ptr))
@@ -771,6 +773,7 @@ TEST(Application, RecentRouteLoaded)
         .with_viewer(std::move(viewer_ptr))
         .with_route_source([&](auto&&...) {return route; })
         .with_level_source([&](auto&&...) { return std::move(level_ptr); })
+        .with_route_window_manager(std::move(route_window_manager_ptr))
         .build();
     
     application->open("test.tr2", ILevel::OpenMode::Full);
@@ -791,15 +794,52 @@ TEST(Application, RecentRouteNotLoaded)
     EXPECT_CALL(viewer, set_settings).Times(AtLeast(1)).WillRepeatedly(SaveArg<0>(&called_settings));
     auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
     ON_CALL(level, filename).WillByDefault(Return("test.tr2"));
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    ON_CALL(route_window_manager, is_window_open).WillByDefault(Return(true));
 
     auto application = register_test_module()
         .with_settings_loader(std::move(settings_loader_ptr))
         .with_dialogs(dialogs)
         .with_viewer(std::move(viewer_ptr))
         .with_level_source([&](auto&&...) { return std::move(level_ptr); })
+        .with_route_window_manager(std::move(route_window_manager_ptr))
         .build();
 
     application->open("test.tr2", ILevel::OpenMode::Full);
 
     ASSERT_TRUE(called_settings.recent_routes.empty());
+}
+
+TEST(Application, RecentRouteLoadedOnWindowOpened)
+{
+    UserSettings settings;
+    settings.recent_routes["test.tr2"] = { "test.tvr", false };
+    auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
+    ON_CALL(settings_loader, load_user_settings).WillByDefault(Return(settings));
+    auto dialogs = mock_shared<MockDialogs>();
+    EXPECT_CALL(*dialogs, message_box(std::wstring(L"Reopen last used route for this level?"), std::wstring(L"Reopen route"), IDialogs::Buttons::Yes_No)).Times(1).WillOnce(Return(true));
+    auto route = mock_shared<MockRoute>();
+    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
+    EXPECT_CALL(viewer, set_route(std::shared_ptr<IRoute>(route))).Times(1);
+    UserSettings called_settings{};
+    EXPECT_CALL(viewer, set_settings).Times(AtLeast(1)).WillRepeatedly(SaveArg<0>(&called_settings));
+    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
+    ON_CALL(level, filename).WillByDefault(Return("test.tr2"));
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+
+    auto application = register_test_module()
+        .with_settings_loader(std::move(settings_loader_ptr))
+        .with_dialogs(dialogs)
+        .with_viewer(std::move(viewer_ptr))
+        .with_route_source([&](auto&&...) {return route; })
+        .with_level_source([&](auto&&...) { return std::move(level_ptr); })
+        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .build();
+
+    application->open("test.tr2", ILevel::OpenMode::Full);
+
+    ON_CALL(route_window_manager, is_window_open).WillByDefault(Return(true));
+    route_window_manager.on_window_created();
+
+    ASSERT_EQ(called_settings.recent_routes["test.tr2"].route_path, "test.tvr");
 }

--- a/trview.app.tests/Settings/SettingsLoaderTests.cpp
+++ b/trview.app.tests/Settings/SettingsLoaderTests.cpp
@@ -548,3 +548,28 @@ TEST(SettingsLoader, WaypointColourLoaded)
     auto settings_yellow = loader_yellow->load_user_settings();
     ASSERT_EQ(settings_yellow.waypoint_colour, Colour::Yellow);
 }
+
+TEST(SettingsLoader, RouteStartupLoaded)
+{
+    auto loader = setup_setting("{\"routestartup\":false}");
+    auto settings = loader->load_user_settings();
+    ASSERT_EQ(settings.route_startup, false);
+
+    auto loader_true = setup_setting("{\"routestartup\":true}");
+    auto settings_true = loader_true->load_user_settings();
+    ASSERT_EQ(settings_true.route_startup, true);
+}
+
+TEST(SettingsLoader, RouteStartupSaved)
+{
+    std::string output;
+    auto loader = setup_save_setting(output);
+    UserSettings settings;
+    settings.route_startup = false;
+    loader->save_user_settings(settings);
+    EXPECT_THAT(output, HasSubstr("\"routestartup\":false"));
+
+    settings.route_startup = true;
+    loader->save_user_settings(settings);
+    EXPECT_THAT(output, HasSubstr("\"routestartup\":true"));
+}

--- a/trview.app.tests/Settings/SettingsLoaderTests.cpp
+++ b/trview.app.tests/Settings/SettingsLoaderTests.cpp
@@ -573,3 +573,21 @@ TEST(SettingsLoader, RouteStartupSaved)
     loader->save_user_settings(settings);
     EXPECT_THAT(output, HasSubstr("\"routestartup\":true"));
 }
+
+TEST(SettingsLoader, RecentRoutesLoaded)
+{
+    auto loader = setup_setting("{\"recentroutes\":{\"path.tr2\":{\"is_rando\":true,\"route_path\":\"route.tvr\"}}}");
+    auto settings = loader->load_user_settings();
+    ASSERT_EQ(settings.recent_routes["path.tr2"].route_path, "route.tvr");
+    ASSERT_EQ(settings.recent_routes["path.tr2"].is_rando, true);
+}
+
+TEST(SettingsLoader, RecentRoutesSaved)
+{
+    std::string output;
+    auto loader = setup_save_setting(output);
+    UserSettings settings;
+    settings.recent_routes["path.tr2"] = { "route.tvr", true };
+    loader->save_user_settings(settings);
+    EXPECT_THAT(output, HasSubstr("\"recentroutes\":{\"path.tr2\":{\"is_rando\":true,\"route_path\":\"route.tvr\"}}"));
+}

--- a/trview.app.tests/SettingsWindowTests.cpp
+++ b/trview.app.tests/SettingsWindowTests.cpp
@@ -665,3 +665,35 @@ TEST(SettingsWindow, SetDefaultWaypointColourUpdatesColours)
     ASSERT_THAT(imgui.item_text(imgui.id("Settings").push("TabBar").push("Route").push(SettingsWindow::Names::default_waypoint_colour).id("##Y")), HasSubstr("191"));
     ASSERT_THAT(imgui.item_text(imgui.id("Settings").push("TabBar").push("Route").push(SettingsWindow::Names::default_waypoint_colour).id("##Z")), HasSubstr("255"));
 }
+
+TEST(SettingsWindow, SetRouteWindowOnStartupUpdatesCheckbox)
+{
+    SettingsWindow window;
+    window.toggle_visibility();
+
+    TestImgui imgui([&]() { window.render(); });
+    ASSERT_FALSE(imgui.status_flags(imgui.id("Settings").push("TabBar").push("General").id(SettingsWindow::Names::route_startup)) & ImGuiItemStatusFlags_Checked);
+
+    window.set_route_startup(true);
+    imgui.render();
+    ASSERT_TRUE(imgui.status_flags(imgui.id("Settings").push("TabBar").push("General").id(SettingsWindow::Names::route_startup)) & ImGuiItemStatusFlags_Checked);
+}
+
+TEST(SettingsWindow, ClickingRouteWindowOnStartupRaisesEvent)
+{
+    SettingsWindow window;
+    window.toggle_visibility();
+
+    std::optional<bool> received_value;
+    auto token = window.on_route_startup += [&](bool value)
+    {
+        received_value = value;
+    };
+
+    TestImgui imgui([&]() { window.render(); });
+    ASSERT_FALSE(imgui.status_flags(imgui.id("Settings").push("TabBar").push("General").id(SettingsWindow::Names::route_startup)) & ImGuiItemStatusFlags_Checked);
+    imgui.click_element(imgui.id("Settings").push("TabBar").push("General").id(SettingsWindow::Names::route_startup));
+    ASSERT_TRUE(imgui.status_flags(imgui.id("Settings").push("TabBar").push("General").id(SettingsWindow::Names::route_startup)) & ImGuiItemStatusFlags_Checked);
+    ASSERT_EQ(received_value.has_value(), true);
+    ASSERT_TRUE(received_value.value());
+}

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -325,3 +325,32 @@ TEST(ViewerUI, OnCopyEventForwarded)
     ASSERT_TRUE(raised);
     ASSERT_EQ(raised, trview::IContextMenu::CopyType::Position);
 }
+
+TEST(ViewerUI, OnRouteStartupEventRaised)
+{
+    auto [settings_window_ptr, settings_window] = create_mock<MockSettingsWindow>();
+    auto ui = register_test_module().with_settings_window(std::move(settings_window_ptr)).build();
+
+    std::optional<UserSettings> settings;
+    auto token = ui->on_settings += [&](auto raised)
+    {
+        settings = raised;
+    };
+
+    settings_window.on_route_startup(true);
+
+    ASSERT_TRUE(settings);
+    ASSERT_TRUE(settings.value().route_startup);
+}
+
+TEST(ViewerUI, SetRouteStartupUpdatesSettingsWindow)
+{
+    auto [settings_window_ptr, settings_window] = create_mock<MockSettingsWindow>();
+    EXPECT_CALL(settings_window, set_route_startup(true)).Times(1);
+
+    auto ui = register_test_module().with_settings_window(std::move(settings_window_ptr)).build();
+
+    UserSettings settings{};
+    settings.route_startup = true;
+    ui->set_settings(settings);
+}

--- a/trview.app.tests/Windows/RouteWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/RouteWindowManagerTests.cpp
@@ -145,3 +145,27 @@ TEST(RouteWindowManager, OnWaypointColourChangedEventRaised)
     ASSERT_TRUE(raised.has_value());
     ASSERT_EQ(raised.value(), Colour::Yellow);
 }
+
+TEST(RouteWindowManager, OnWindowCreatedEventRaised)
+{
+    auto manager = register_test_module().build();
+
+    bool raised = false;
+    auto token = manager->on_window_created += [&]() { raised = true; };
+
+    manager->create_window();
+
+    ASSERT_TRUE(raised);
+}
+
+TEST(RouteWindowManager, IsWindowOpen)
+{
+    auto mock_window = mock_shared<MockRouteWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    ASSERT_FALSE(manager->is_window_open());
+    manager->create_window();
+    ASSERT_TRUE(manager->is_window_open());
+    mock_window->on_window_closed();
+    manager->render();
+    ASSERT_FALSE(manager->is_window_open());
+}

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -425,6 +425,11 @@ namespace trview
 
     void Application::setup_route_window()
     {
+        if (_settings.route_startup)
+        {
+            _route_window->create_window();
+        }
+
         _token_store += _route_window->on_waypoint_selected += [&](auto index) { select_waypoint(index); };
         _token_store += _route_window->on_item_selected += [&](const auto& item) { select_item(item); };
         _token_store += _route_window->on_trigger_selected += [&](const auto& trigger) { select_trigger(trigger); };

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -222,6 +222,20 @@ namespace trview
             _settings.auto_orbit = old_auto_orbit;
             _viewer->set_settings(_settings);
         }
+        else
+        {
+            const auto recent_route = _settings.recent_routes.find(_level->filename());
+            if (recent_route != _settings.recent_routes.end() &&
+                _dialogs->message_box(L"Reopen last used route for this level?", L"Reopen route", IDialogs::Buttons::Yes_No))
+            {
+                this->import_route(recent_route->second.route_path, recent_route->second.is_rando);
+            }
+            else
+            {
+                _settings.recent_routes.erase(_level->filename());
+                _viewer->set_settings(_settings);
+            }
+        }
     }
 
     std::optional<int> Application::process_message(UINT message, WPARAM wParam, LPARAM)
@@ -433,21 +447,16 @@ namespace trview
         _token_store += _route_window->on_waypoint_selected += [&](auto index) { select_waypoint(index); };
         _token_store += _route_window->on_item_selected += [&](const auto& item) { select_item(item); };
         _token_store += _route_window->on_trigger_selected += [&](const auto& trigger) { select_trigger(trigger); };
-        _token_store += _route_window->on_route_import += [&](const std::string& path, bool is_rando)
-        {
-            auto route = import_route(_route_source, _files, path, _level.get(), _settings.randomizer, is_rando);
-            if (route)
-            {
-                _route = route;
-                _route_window->set_route(_route.get());
-                _route->set_randomizer_enabled(_settings.randomizer_tools);
-                _viewer->set_route(_route);
-            }
-        };
+        _token_store += _route_window->on_route_import += [&](const std::string& path, bool is_rando) { this->import_route(path, is_rando); };
         _token_store += _route_window->on_route_export += [&](const std::string& path, bool is_rando)
         {
             export_route(*_route, _files, path, _level ? _level->filename() : "", _settings.randomizer, is_rando);
             _route->set_unsaved(false);
+            if (_level)
+            {
+                _settings.recent_routes[_level->filename()] = { path, is_rando };
+                _viewer->set_settings(_settings);
+            }
         };
         _token_store += _route_window->on_waypoint_deleted += [&](auto index) { remove_waypoint(index); };
         _token_store += _route_window->on_colour_changed += [&](const Colour& colour)
@@ -753,6 +762,23 @@ namespace trview
             return;
         }
         open(_level->filename(), ILevel::OpenMode::Reload);
+    }
+
+    void Application::import_route(const std::string& path, bool is_rando)
+    {
+        auto route = trview::import_route(_route_source, _files, path, _level.get(), _settings.randomizer, is_rando);
+        if (route)
+        {
+            _route = route;
+            _route_window->set_route(_route.get());
+            _route->set_randomizer_enabled(_settings.randomizer_tools);
+            _viewer->set_route(_route);
+            if (_level)
+            {
+                _settings.recent_routes[_level->filename()] = { path, is_rando };
+                _viewer->set_settings(_settings);
+            }
+        }
     }
 
     Window create_window(HINSTANCE hInstance, int nCmdShow)

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -98,6 +98,7 @@ namespace trview
         bool should_discard_changes();
         void reload();
         void import_route(const std::string& path, bool is_rando);
+        void open_recent_route();
 
         TokenStore _token_store;
 
@@ -136,6 +137,7 @@ namespace trview
         std::unique_ptr<IImGuiBackend> _imgui_backend;
         std::string _imgui_ini_filename;
         std::unique_ptr<ILogWindowManager> _log_windows;
+        bool _recent_route_prompted{ false };
     };
 
     Window create_window(HINSTANCE hInstance, int command_show);

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -97,6 +97,7 @@ namespace trview
         void register_lua();
         bool should_discard_changes();
         void reload();
+        void import_route(const std::string& path, bool is_rando);
 
         TokenStore _token_store;
 

--- a/trview.app/Mocks/UI/ISettingsWindow.h
+++ b/trview.app/Mocks/UI/ISettingsWindow.h
@@ -30,6 +30,7 @@ namespace trview
             MOCK_METHOD(void, set_background_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_map_colours, (const MapColours&), (override));
             MOCK_METHOD(void, toggle_visibility, (), (override));
+            MOCK_METHOD(void, set_route_startup, (bool), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRouteWindowManager.h
+++ b/trview.app/Mocks/Windows/IRouteWindowManager.h
@@ -19,6 +19,7 @@ namespace trview
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, set_randomizer_enabled, (bool), (override));
             MOCK_METHOD(void, set_randomizer_settings, (const RandomizerSettings&), (override));
+            MOCK_METHOD(bool, is_window_open, (), (const, override));
         };
     }
 }

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -43,6 +43,7 @@ namespace trview
             read_attribute(json, settings.map_colours, "mapcolours");
             read_attribute(json, settings.route_colour, "routecolour");
             read_attribute(json, settings.waypoint_colour, "waypointcolour");
+            read_attribute(json, settings.route_startup, "routestartup");
 
             settings.recent_files.resize(std::min<std::size_t>(settings.recent_files.size(), settings.max_recent_files));
         }
@@ -99,6 +100,7 @@ namespace trview
             json["mapcolours"] = settings.map_colours;
             json["routecolour"] = settings.route_colour;
             json["waypointcolour"] = settings.waypoint_colour;
+            json["routestartup"] = settings.route_startup;
             _files->save_file(file_path, json.dump());
         }
         catch (...)

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -5,6 +5,18 @@
 
 namespace trview
 {
+    void to_json(nlohmann::json& json, const UserSettings::RecentRoute& item)
+    {
+        json["route_path"] = item.route_path;
+        json["is_rando"] = item.is_rando;
+    }
+
+    void from_json(const nlohmann::json& json, UserSettings::RecentRoute& item)
+    {
+        item.route_path = read_attribute<std::string>(json, "route_path");
+        item.is_rando = read_attribute<bool>(json, "is_rando");
+    }
+
     SettingsLoader::SettingsLoader(const std::shared_ptr<IFiles>& files)
         : _files(files)
     {
@@ -44,6 +56,7 @@ namespace trview
             read_attribute(json, settings.route_colour, "routecolour");
             read_attribute(json, settings.waypoint_colour, "waypointcolour");
             read_attribute(json, settings.route_startup, "routestartup");
+            read_attribute(json, settings.recent_routes, "recentroutes");
 
             settings.recent_files.resize(std::min<std::size_t>(settings.recent_files.size(), settings.max_recent_files));
         }
@@ -101,6 +114,7 @@ namespace trview
             json["routecolour"] = settings.route_colour;
             json["waypointcolour"] = settings.waypoint_colour;
             json["routestartup"] = settings.route_startup;
+            json["recentroutes"] = settings.recent_routes;
             _files->save_file(file_path, json.dump());
         }
         catch (...)

--- a/trview.app/Settings/UserSettings.cpp
+++ b/trview.app/Settings/UserSettings.cpp
@@ -38,6 +38,7 @@ namespace trview
             recent_files == other.recent_files &&
             max_recent_files == other.max_recent_files &&
             route_colour == other.route_colour &&
-            waypoint_colour == other.waypoint_colour;
+            waypoint_colour == other.waypoint_colour &&
+            route_startup == other.route_startup;
     }
 }

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -11,6 +11,12 @@ namespace trview
     {
         void add_recent_file(const std::string& file);
 
+        struct RecentRoute
+        {
+            std::string route_path;
+            bool is_rando;
+        };
+
         std::list<std::string>  recent_files;
         float camera_sensitivity{ 0 };
         float camera_movement_speed{ 0.5f };
@@ -33,6 +39,7 @@ namespace trview
         Colour route_colour{ Colour::Green };
         Colour waypoint_colour{ Colour::White };
         bool route_startup{ false };
+        std::unordered_map<std::string, RecentRoute> recent_routes;
 
         bool operator==(const UserSettings& other) const;
     };

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -32,6 +32,7 @@ namespace trview
         MapColours map_colours;
         Colour route_colour{ Colour::Green };
         Colour waypoint_colour{ Colour::White };
+        bool route_startup{ false };
 
         bool operator==(const UserSettings& other) const;
     };

--- a/trview.app/UI/ISettingsWindow.h
+++ b/trview.app/UI/ISettingsWindow.h
@@ -75,6 +75,7 @@ namespace trview
 
         Event<Colour> on_default_route_colour;
         Event<Colour> on_default_waypoint_colour;
+        Event<bool> on_route_startup;
 
         virtual void render() = 0;
         /// <summary>
@@ -169,6 +170,7 @@ namespace trview
         virtual void set_max_recent_files(uint32_t value) = 0;
         virtual void set_background_colour(const Colour& colour) = 0;
         virtual void set_map_colours(const MapColours& colours) = 0;
+        virtual void set_route_startup(bool value) = 0;
         /// <summary>
         /// Toggle the visibility of the settings window.
         /// </summary>

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -30,6 +30,7 @@ namespace trview
                     checkbox(Names::items_startup, _items_startup, on_items_startup);
                     checkbox(Names::triggers_startup, _triggers_startup, on_triggers_startup);
                     checkbox(Names::rooms_startup, _rooms_startup, on_rooms_startup);
+                    checkbox(Names::route_startup, _route_startup, on_route_startup);
                     checkbox(Names::randomizer_tools, _randomizer_tools, on_randomizer_tools);
                     if (ImGui::InputInt(Names::max_recent_files.c_str(), &_max_recent_files))
                     {
@@ -241,5 +242,10 @@ namespace trview
     void SettingsWindow::set_default_waypoint_colour(const Colour& colour)
     {
         _default_waypoint_colour = colour;
+    }
+
+    void SettingsWindow::set_route_startup(bool value)
+    {
+        _route_startup = value;
     }
 }

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -31,6 +31,7 @@ namespace trview
             static inline const std::string background_colour = "Background Colour";
             static inline const std::string default_route_colour = "Default Route Colour";
             static inline const std::string default_waypoint_colour = "Default Waypoint Colour";
+            static inline const std::string route_startup = "Open Route Window at startup";
         };
 
         virtual ~SettingsWindow() = default;
@@ -55,6 +56,7 @@ namespace trview
         virtual void toggle_visibility() override;
         virtual void set_default_route_colour(const Colour& colour) override;
         virtual void set_default_waypoint_colour(const Colour& colour) override;
+        virtual void set_route_startup(bool value) override;
     private:
         bool _visible{ false };
         bool _vsync{ false };
@@ -76,5 +78,6 @@ namespace trview
         Colour _default_route_colour{ Colour::Green };
         Colour _default_waypoint_colour{ Colour::White };
         MapColours _colours;
+        bool _route_startup{ false };
     };
 }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -88,101 +88,35 @@ namespace trview
         _level_info = std::make_unique<LevelInfo>(*texture_storage);
         _token_store += _level_info->on_toggle_settings += [&]() { _settings_window->toggle_visibility(); };
 
-        _token_store += _settings_window->on_vsync += [&](bool value)
+        const auto forward_setting = [&]<typename T>(auto& event, T& target)
         {
-            _settings.vsync = value;
-            on_settings(_settings);
+            _token_store += event += [&](T value)
+            {
+                target = value;
+                on_settings(_settings);
+            };
         };
-        _token_store += _settings_window->on_go_to_lara += [&](bool value)
-        {
-            _settings.go_to_lara = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_invert_map_controls += [&](bool value)
-        {
-            _settings.invert_map_controls = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_items_startup += [&](bool value)
-        {
-            _settings.items_startup = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_triggers_startup += [&](bool value)
-        {
-            _settings.triggers_startup = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_rooms_startup += [&](bool value)
-        {
-            _settings.rooms_startup = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_auto_orbit += [&](bool value)
-        {
-            _settings.auto_orbit = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_invert_vertical_pan += [&](bool value)
-        {
-            _settings.invert_vertical_pan = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_sensitivity_changed += [&](float value)
-        {
-            _settings.camera_sensitivity = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_movement_speed_changed += [&](float value)
-        {
-            _settings.camera_movement_speed = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_camera_acceleration += [&](bool value)
-        {
-            _settings.camera_acceleration = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_camera_acceleration_rate += [&](float value)
-        {
-            _settings.camera_acceleration_rate = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_camera_display_degrees += [&](bool value)
-        {
-            _settings.camera_display_degrees = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_randomizer_tools += [&](bool value)
-        {
-            _settings.randomizer_tools = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_max_recent_files += [&](uint32_t value)
-        {
-            _settings.max_recent_files = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_background_colour += [&](Colour value)
-        {
-            _settings.background_colour = value;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_minimap_colours += [&](MapColours colours)
-        {
-            _settings.map_colours = colours;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_default_route_colour += [&](const Colour& colour)
-        {
-            _settings.route_colour = colour;
-            on_settings(_settings);
-        };
-        _token_store += _settings_window->on_default_waypoint_colour += [&](const Colour& colour)
-        {
-            _settings.waypoint_colour = colour;
-            on_settings(_settings);
-        };
+
+        forward_setting(_settings_window->on_vsync, _settings.vsync);
+        forward_setting(_settings_window->on_go_to_lara, _settings.go_to_lara);
+        forward_setting(_settings_window->on_invert_map_controls, _settings.invert_map_controls);
+        forward_setting(_settings_window->on_items_startup, _settings.items_startup);
+        forward_setting(_settings_window->on_triggers_startup, _settings.triggers_startup);
+        forward_setting(_settings_window->on_rooms_startup, _settings.rooms_startup);
+        forward_setting(_settings_window->on_auto_orbit, _settings.auto_orbit);
+        forward_setting(_settings_window->on_invert_vertical_pan, _settings.invert_vertical_pan);
+        forward_setting(_settings_window->on_sensitivity_changed, _settings.camera_sensitivity);
+        forward_setting(_settings_window->on_movement_speed_changed, _settings.camera_movement_speed);
+        forward_setting(_settings_window->on_camera_acceleration, _settings.camera_acceleration);
+        forward_setting(_settings_window->on_camera_acceleration_rate, _settings.camera_acceleration_rate);
+        forward_setting(_settings_window->on_camera_display_degrees, _settings.camera_display_degrees);
+        forward_setting(_settings_window->on_randomizer_tools, _settings.randomizer_tools);
+        forward_setting(_settings_window->on_max_recent_files, _settings.max_recent_files);
+        forward_setting(_settings_window->on_background_colour, _settings.background_colour);
+        forward_setting(_settings_window->on_minimap_colours, _settings.map_colours);
+        forward_setting(_settings_window->on_default_route_colour, _settings.route_colour);
+        forward_setting(_settings_window->on_default_waypoint_colour, _settings.waypoint_colour);
+        forward_setting(_settings_window->on_route_startup, _settings.route_startup);
 
         _camera_position = std::make_unique<CameraPosition>();
         _camera_position->on_position_changed += on_camera_position;
@@ -396,6 +330,7 @@ namespace trview
         _settings_window->set_map_colours(settings.map_colours);
         _settings_window->set_default_route_colour(settings.route_colour);
         _settings_window->set_default_waypoint_colour(settings.waypoint_colour);
+        _settings_window->set_route_startup(settings.route_startup);
         _camera_position->set_display_degrees(settings.camera_display_degrees);
         _map_renderer->set_colours(settings.map_colours);
     }

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -40,6 +40,8 @@ namespace trview
         /// </summary>
         Event<int32_t, int32_t> on_waypoint_reordered;
 
+        Event<> on_window_created;
+
         /// Render all of the route windows.
         virtual void render() = 0;
 
@@ -76,5 +78,7 @@ namespace trview
         /// </summary>
         /// <param name="settings">The settings.</param>
         virtual void set_randomizer_settings(const RandomizerSettings& settings) = 0;
+
+        virtual bool is_window_open() const = 0;
     };
 }

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -50,6 +50,7 @@ namespace trview
             _route_window->set_route(_route);
         }
         _route_window->select_waypoint(_selected_waypoint);
+        on_window_created();
     }
 
     void RouteWindowManager::render()
@@ -137,5 +138,10 @@ namespace trview
         {
             _route_window->set_randomizer_settings(settings);
         }
+    }
+
+    bool RouteWindowManager::is_window_open() const
+    {
+        return _route_window.get();
     }
 }

--- a/trview.app/Windows/RouteWindowManager.h
+++ b/trview.app/Windows/RouteWindowManager.h
@@ -24,6 +24,7 @@ namespace trview
         virtual void update(float delta) override;
         virtual void set_randomizer_enabled(bool value) override;
         virtual void set_randomizer_settings(const RandomizerSettings& settings) override;
+        virtual bool is_window_open() const override;
     private:
         TokenStore _token_store;
         std::shared_ptr<IRouteWindow> _route_window;


### PR DESCRIPTION
Add an option to open the route window on startup.
Remember the last route that was exported/imported for a level and ask the user if they want to reopen it when they open the level. If they say yes the route is loaded - if they say no then the association is removed.
Closes #1004 