### PR TITLE
Add FOV option to Camera settings

### DIFF
--- a/trview.app.tests/Settings/SettingsLoaderTests.cpp
+++ b/trview.app.tests/Settings/SettingsLoaderTests.cpp
@@ -591,3 +591,20 @@ TEST(SettingsLoader, RecentRoutesSaved)
     loader->save_user_settings(settings);
     EXPECT_THAT(output, HasSubstr("\"recentroutes\":{\"path.tr2\":{\"is_rando\":true,\"route_path\":\"route.tvr\"}}"));
 }
+
+TEST(SettingsLoader, FovLoaded)
+{
+    auto loader = setup_setting("{\"fov\":10.0}");
+    auto settings = loader->load_user_settings();
+    ASSERT_EQ(settings.fov, 10.0f);
+}
+
+TEST(SettingsLoader, FovSaved)
+{
+    std::string output;
+    auto loader = setup_save_setting(output);
+    UserSettings settings;
+    settings.fov = 10.0f;
+    loader->save_user_settings(settings);
+    EXPECT_THAT(output, HasSubstr("\"fov\":10.0"));
+}

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -385,3 +385,34 @@ TEST(ViewerUI, SetTriggeredByUpdatesContextMenu)
 
     ui->set_triggered_by({ mock_shared<MockTrigger>() });
 }
+
+
+TEST(ViewerUI, FovEventRaised)
+{
+    auto [settings_window_ptr, settings_window] = create_mock<MockSettingsWindow>();
+    auto ui = register_test_module().with_settings_window(std::move(settings_window_ptr)).build();
+
+    std::optional<UserSettings> settings;
+    auto token = ui->on_settings += [&](auto raised)
+    {
+        settings = raised;
+    };
+
+    settings_window.on_camera_fov(1.0f);
+
+    ASSERT_TRUE(settings);
+    ASSERT_EQ(settings.value().fov, 1.0f);
+}
+
+TEST(ViewerUI, SetFovUpdatesSettingsWindow)
+{
+    auto [settings_window_ptr, settings_window] = create_mock<MockSettingsWindow>();
+    EXPECT_CALL(settings_window, set_fov(1.0f)).Times(1);
+
+    auto ui = register_test_module().with_settings_window(std::move(settings_window_ptr)).build();
+
+    UserSettings settings{};
+    settings.fov = 1.0f;
+    ui->set_settings(settings);
+}
+

--- a/trview.app/Camera/Camera.cpp
+++ b/trview.app/Camera/Camera.cpp
@@ -211,8 +211,9 @@ namespace trview
         if (_projection_mode == ProjectionMode::Perspective)
         {
             float aspect_ratio = _view_size.width / _view_size.height;
-            _projection = XMMatrixPerspectiveFovRH(_fov, aspect_ratio, 0.1f, 10000.0f);
-            _projection_lh = XMMatrixPerspectiveFovLH(_fov, aspect_ratio, 0.1f, 10000.0f);
+            const float fov_rad = DirectX::XMConvertToRadians(_fov);
+            _projection = XMMatrixPerspectiveFovRH(fov_rad, aspect_ratio, 0.1f, 10000.0f);
+            _projection_lh = XMMatrixPerspectiveFovLH(fov_rad, aspect_ratio, 0.1f, 10000.0f);
         }
         else if (_projection_mode == ProjectionMode::Orthographic)
         {

--- a/trview.app/Camera/Camera.cpp
+++ b/trview.app/Camera/Camera.cpp
@@ -211,8 +211,8 @@ namespace trview
         if (_projection_mode == ProjectionMode::Perspective)
         {
             float aspect_ratio = _view_size.width / _view_size.height;
-            _projection = XMMatrixPerspectiveFovRH(XM_PIDIV4, aspect_ratio, 0.1f, 10000.0f);
-            _projection_lh = XMMatrixPerspectiveFovLH(XM_PIDIV4, aspect_ratio, 0.1f, 10000.0f);
+            _projection = XMMatrixPerspectiveFovRH(_fov, aspect_ratio, 0.1f, 10000.0f);
+            _projection_lh = XMMatrixPerspectiveFovLH(_fov, aspect_ratio, 0.1f, 10000.0f);
         }
         else if (_projection_mode == ProjectionMode::Orthographic)
         {
@@ -247,5 +247,11 @@ namespace trview
     bool Camera::idle_rotation() const
     {
         return !_last_rotation.has_value() || _last_rotation.value() > 0.3f;
+    }
+
+    void Camera::set_fov(float value)
+    {
+        _fov = value;
+        calculate_projection_matrix();
     }
 }

--- a/trview.app/Camera/Camera.h
+++ b/trview.app/Camera/Camera.h
@@ -39,6 +39,7 @@ namespace trview
         virtual const Size view_size() const override;
         virtual float zoom() const override;
         virtual bool idle_rotation() const override;
+        virtual void set_fov(float value) override;
 
         /// Event raised when the view of the camera has changed.
         Event<> on_view_changed;
@@ -59,6 +60,7 @@ namespace trview
         const float default_pitch = -0.78539f;
         const float default_yaw = 0.0f;
         const float default_zoom = 8.0f;
+        static constexpr float default_fov = 0.785398163f;
 
         DirectX::SimpleMath::Vector3 _position;
         DirectX::SimpleMath::Vector3 _forward;
@@ -79,5 +81,6 @@ namespace trview
         std::optional<float> _target_rotation_yaw;
         std::optional<float> _target_rotation_pitch;
         float _ortho_size{ 10.0f };
+        float _fov{ default_fov };
     };
 }

--- a/trview.app/Camera/Camera.h
+++ b/trview.app/Camera/Camera.h
@@ -60,7 +60,7 @@ namespace trview
         const float default_pitch = -0.78539f;
         const float default_yaw = 0.0f;
         const float default_zoom = 8.0f;
-        static constexpr float default_fov = 0.785398163f;
+        static constexpr float default_fov = 45;
 
         DirectX::SimpleMath::Vector3 _position;
         DirectX::SimpleMath::Vector3 _forward;

--- a/trview.app/Camera/ICamera.h
+++ b/trview.app/Camera/ICamera.h
@@ -99,5 +99,7 @@ namespace trview
         virtual float zoom() const = 0;
 
         virtual bool idle_rotation() const = 0;
+
+        virtual void set_fov(float value) = 0;
     };
 }

--- a/trview.app/Mocks/Camera/ICamera.h
+++ b/trview.app/Mocks/Camera/ICamera.h
@@ -31,6 +31,7 @@ namespace trview
             MOCK_METHOD(const Size, view_size, (), (const, override));
             MOCK_METHOD(float, zoom, (), (const, override));
             MOCK_METHOD(bool, idle_rotation, (), (const, override));
+            MOCK_METHOD(void, set_fov, (float), (override));
         };
     }
 }

--- a/trview.app/Mocks/UI/ISettingsWindow.h
+++ b/trview.app/Mocks/UI/ISettingsWindow.h
@@ -31,6 +31,7 @@ namespace trview
             MOCK_METHOD(void, set_map_colours, (const MapColours&), (override));
             MOCK_METHOD(void, toggle_visibility, (), (override));
             MOCK_METHOD(void, set_route_startup, (bool), (override));
+            MOCK_METHOD(void, set_fov, (float), (override));
         };
     }
 }

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -57,6 +57,7 @@ namespace trview
             read_attribute(json, settings.waypoint_colour, "waypointcolour");
             read_attribute(json, settings.route_startup, "routestartup");
             read_attribute(json, settings.recent_routes, "recentroutes");
+            read_attribute(json, settings.fov, "fov");
 
             settings.recent_files.resize(std::min<std::size_t>(settings.recent_files.size(), settings.max_recent_files));
         }
@@ -115,6 +116,7 @@ namespace trview
             json["waypointcolour"] = settings.waypoint_colour;
             json["routestartup"] = settings.route_startup;
             json["recentroutes"] = settings.recent_routes;
+            json["fov"] = settings.fov;
             _files->save_file(file_path, json.dump());
         }
         catch (...)

--- a/trview.app/Settings/UserSettings.cpp
+++ b/trview.app/Settings/UserSettings.cpp
@@ -39,6 +39,7 @@ namespace trview
             max_recent_files == other.max_recent_files &&
             route_colour == other.route_colour &&
             waypoint_colour == other.waypoint_colour &&
-            route_startup == other.route_startup;
+            route_startup == other.route_startup &&
+            fov == other.fov;
     }
 }

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -40,6 +40,7 @@ namespace trview
         Colour waypoint_colour{ Colour::White };
         bool route_startup{ false };
         std::unordered_map<std::string, RecentRoute> recent_routes;
+        float fov{ 0.785398163f };
 
         bool operator==(const UserSettings& other) const;
     };

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -40,7 +40,7 @@ namespace trview
         Colour waypoint_colour{ Colour::White };
         bool route_startup{ false };
         std::unordered_map<std::string, RecentRoute> recent_routes;
-        float fov{ 0.785398163f };
+        float fov{ 45 };
 
         bool operator==(const UserSettings& other) const;
     };

--- a/trview.app/UI/ISettingsWindow.h
+++ b/trview.app/UI/ISettingsWindow.h
@@ -76,6 +76,7 @@ namespace trview
         Event<Colour> on_default_route_colour;
         Event<Colour> on_default_waypoint_colour;
         Event<bool> on_route_startup;
+        Event<float> on_camera_fov;
 
         virtual void render() = 0;
         /// <summary>
@@ -171,6 +172,7 @@ namespace trview
         virtual void set_background_colour(const Colour& colour) = 0;
         virtual void set_map_colours(const MapColours& colours) = 0;
         virtual void set_route_startup(bool value) = 0;
+        virtual void set_fov(float value) = 0;
         /// <summary>
         /// Toggle the visibility of the settings window.
         /// </summary>

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -68,7 +68,7 @@ namespace trview
                         on_camera_fov(_fov);
                     }
                     ImGui::SameLine();
-                    if (ImGui::SliderFloat(Names::fov.c_str(), &_fov, 1, 179))
+                    if (ImGui::SliderFloat(Names::fov.c_str(), &_fov, 10, 145))
                     {
                         on_camera_fov(_fov);
                     }

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -62,7 +62,7 @@ namespace trview
                     {
                         on_camera_acceleration_rate(_acceleration_rate);
                     }
-                    if (ImGui::Button("Reset##Fov"))
+                    if (ImGui::Button(Names::reset_fov.c_str()))
                     {
                         _fov = 45;
                         on_camera_fov(_fov);

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -64,11 +64,11 @@ namespace trview
                     }
                     if (ImGui::Button("Reset##Fov"))
                     {
-                        _fov = 0.785398163f;
+                        _fov = 45;
                         on_camera_fov(_fov);
                     }
                     ImGui::SameLine();
-                    if (ImGui::SliderFloat(Names::fov.c_str(), &_fov, 0.1f, 3.141592654f))
+                    if (ImGui::SliderFloat(Names::fov.c_str(), &_fov, 1, 179))
                     {
                         on_camera_fov(_fov);
                     }

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -62,6 +62,16 @@ namespace trview
                     {
                         on_camera_acceleration_rate(_acceleration_rate);
                     }
+                    if (ImGui::Button("Reset##Fov"))
+                    {
+                        _fov = 0.785398163f;
+                        on_camera_fov(_fov);
+                    }
+                    ImGui::SameLine();
+                    if (ImGui::SliderFloat(Names::fov.c_str(), &_fov, 0.1f, 3.141592654f))
+                    {
+                        on_camera_fov(_fov);
+                    }
                     ImGui::EndTabItem();
                 }
 
@@ -247,5 +257,10 @@ namespace trview
     void SettingsWindow::set_route_startup(bool value)
     {
         _route_startup = value;
+    }
+
+    void SettingsWindow::set_fov(float value)
+    {
+        _fov = value;
     }
 }

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -32,6 +32,7 @@ namespace trview
             static inline const std::string default_route_colour = "Default Route Colour";
             static inline const std::string default_waypoint_colour = "Default Waypoint Colour";
             static inline const std::string route_startup = "Open Route Window at startup";
+            static inline const std::string fov = "Camera FOV";
         };
 
         virtual ~SettingsWindow() = default;
@@ -57,6 +58,7 @@ namespace trview
         virtual void set_default_route_colour(const Colour& colour) override;
         virtual void set_default_waypoint_colour(const Colour& colour) override;
         virtual void set_route_startup(bool value) override;
+        virtual void set_fov(float value) override;
     private:
         bool _visible{ false };
         bool _vsync{ false };
@@ -79,5 +81,6 @@ namespace trview
         Colour _default_waypoint_colour{ Colour::White };
         MapColours _colours;
         bool _route_startup{ false };
+        float _fov{ 0.785398163f };
     };
 }

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -81,6 +81,6 @@ namespace trview
         Colour _default_waypoint_colour{ Colour::White };
         MapColours _colours;
         bool _route_startup{ false };
-        float _fov{ 0.785398163f };
+        float _fov{ 45 };
     };
 }

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -33,6 +33,7 @@ namespace trview
             static inline const std::string default_waypoint_colour = "Default Waypoint Colour";
             static inline const std::string route_startup = "Open Route Window at startup";
             static inline const std::string fov = "Camera FOV";
+            static inline const std::string reset_fov = "Reset##Fov";
         };
 
         virtual ~SettingsWindow() = default;

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -118,6 +118,7 @@ namespace trview
         forward_setting(_settings_window->on_default_route_colour, _settings.route_colour);
         forward_setting(_settings_window->on_default_waypoint_colour, _settings.waypoint_colour);
         forward_setting(_settings_window->on_route_startup, _settings.route_startup);
+        forward_setting(_settings_window->on_camera_fov, _settings.fov);
 
         _camera_position = std::make_unique<CameraPosition>();
         _camera_position->on_position_changed += on_camera_position;
@@ -332,6 +333,7 @@ namespace trview
         _settings_window->set_default_route_colour(settings.route_colour);
         _settings_window->set_default_waypoint_colour(settings.waypoint_colour);
         _settings_window->set_route_startup(settings.route_startup);
+        _settings_window->set_fov(settings.fov);
         _camera_position->set_display_degrees(settings.camera_display_degrees);
         _map_renderer->set_colours(settings.map_colours);
     }

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -22,7 +22,7 @@ namespace trview
         _menu_detector(window), _device(device), _route(route), _ui(std::move(ui)), _picking(std::move(picking)), _compass(std::move(compass)), _measure(std::move(measure)),
         _render_target_source(render_target_source), _sector_highlight(std::move(sector_highlight)), _clipboard(clipboard)
     {
-        apply_acceleration_settings();
+        apply_camera_settings();
 
         _scene_target = _render_target_source(static_cast<uint32_t>(window.size().width), static_cast<uint32_t>(window.size().height), graphics::IRenderTarget::DepthStencilMode::Enabled);
         _scene_sprite = sprite_source(window.size());
@@ -1232,16 +1232,18 @@ namespace trview
         }
     }
 
-    void Viewer::apply_acceleration_settings()
+    void Viewer::apply_camera_settings()
     {
         _free_camera.set_acceleration_settings(_settings.camera_acceleration, _settings.camera_acceleration_rate);
+        _free_camera.set_fov(_settings.fov);
+        _camera.set_fov(_settings.fov);
     }
 
     void Viewer::set_settings(const UserSettings& settings)
     {
         _settings = settings;
         _ui->set_settings(_settings);
-        apply_acceleration_settings();
+        apply_camera_settings();
         _scene_changed = true;
     }
 

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -127,7 +127,7 @@ namespace trview
         void select_pick(const PickResult& pick);
 
         void register_lua();
-        void apply_acceleration_settings();
+        void apply_camera_settings();
 
         const std::shared_ptr<graphics::IDevice> _device;
         const std::shared_ptr<IShortcuts>& _shortcuts;


### PR DESCRIPTION
Add an option to change the FOV of the camera in the settings window. Default is 45 - can be set in the range of 10 to 145.
Closes #1014 