### PR TITLE
Add Alternate and Alternate Group filters to room window

### DIFF
--- a/trview.app/Filters/Filters.hpp
+++ b/trview.app/Filters/Filters.hpp
@@ -50,7 +50,7 @@ namespace trview
     template <typename value_type>
     void Filters<T>::add_getter(const std::string& key, const std::function<value_type(const T&)>& getter, const std::function<bool(const T&)>& predicate)
     {
-        add_getter(key, available_options<value_type>(), getter, {});
+        add_getter(key, available_options<value_type>(), getter, predicate);
     }
 
     template <typename T>
@@ -462,7 +462,13 @@ namespace trview
         const auto& getter = _getters.find(key);
         if (getter != _getters.end())
         {
-            return getter->second.ops;
+            auto ops = getter->second.ops;
+            if (getter->second.predicate)
+            {
+                ops.push_back(CompareOp::Exists);
+                ops.push_back(CompareOp::NotExists);
+            }
+            return ops;
         }
         else
         {

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -442,14 +442,21 @@ namespace trview
                         ImGui::Separator();
                     }
 
-                    auto add_stat = [&]<typename T>(const std::string& name, const T&& value)
+                    auto add_stat = [&]<typename T>(const std::string & name, const T && value, std::function<void()> click = {})
                     {
                         const auto string_value = get_string(value);
                         ImGui::TableNextColumn();
                         if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
                         {
-                            _clipboard->write(to_utf16(string_value));
-                            _tooltip_timer = 0.0f;
+                            if (click)
+                            {
+                                click();
+                            }
+                            else
+                            {
+                                _clipboard->write(to_utf16(string_value));
+                                _tooltip_timer = 0.0f;
+                            }
                         }
                         ImGui::TableNextColumn();
                         ImGui::Text(string_value.c_str());
@@ -472,7 +479,7 @@ namespace trview
                             add_stat("Z", room->info().z);
                             if (room->alternate_mode() != Room::AlternateMode::None)
                             {
-                                add_stat("Alternate", room->alternate_room());
+                                add_stat("Alternate", room->alternate_room(), [this, room]() { on_room_selected(room->alternate_room()); });
                                 if (room->alternate_group() != 0xff)
                                 {
                                     add_stat("Alternate Group", room->alternate_group());

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -727,5 +727,7 @@ namespace trview
         _filters.add_getter<bool>("Bit 13", [](auto&& room) { return room.flag(IRoom::Flag::Bit13); });
         _filters.add_getter<bool>("Bit 14", [](auto&& room) { return room.flag(IRoom::Flag::Bit14); });
         _filters.add_getter<bool>("Bit 15", [](auto&& room) { return room.flag(IRoom::Flag::Bit15); });
+        _filters.add_getter<float>("Alternate", [](auto&& room) { return room.alternate_room(); }, [](auto&& room) { return room.alternate_mode() != IRoom::AlternateMode::None; });
+        _filters.add_getter<float>("Alternate Group", [](auto&& room) { return room.alternate_group(); }, [](auto&& room) { return room.alternate_mode() != IRoom::AlternateMode::None; });
     }
 }


### PR DESCRIPTION
Add filters for Alternate and Alternate Group to the Room window.
Since these are optional attributes added the ability for a single getter filter to have the `is present` and `is not present` ops - as long as there's a predicate. There was also a bug where the predicate wasn't being used which I fixed.
The ability to click the `Alternate` field and go to that room was missing - might have been lost when moving to ImGui. I have added it back in.
Closes #1029 