### PR TITLE
Correctly read portal number as uint16_t

### DIFF
--- a/trview.app.tests/Elements/SectorTests.cpp
+++ b/trview.app.tests/Elements/SectorTests.cpp
@@ -1,0 +1,28 @@
+#include <trview.app/Elements/Sector.h>
+#include <trlevel/Mocks/ILevel.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace trlevel;
+using namespace trlevel::mocks;
+using testing::NiceMock;
+using testing::Return;
+
+TEST(Sector, HighNumberedPortal)
+{
+    NiceMock<trlevel::mocks::MockLevel> level;
+    ON_CALL(level, num_floor_data).WillByDefault(Return(3));
+    EXPECT_CALL(level, get_floor_data(1)).WillRepeatedly(Return(0x8001));
+    EXPECT_CALL(level, get_floor_data(2)).WillRepeatedly(Return(378));
+
+    tr3_room tr_room{};
+    tr_room.num_x_sectors = 1;
+    tr_room.num_z_sectors = 1;
+    tr_room_sector sector { 1, 0xffff, 255, 0, 255, 0 };
+    NiceMock<MockRoom> room;
+
+    Sector s(level, tr_room, sector, 0, 0, room);
+
+    ASSERT_EQ(s.portal(), 378);
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="Elements\LevelTests.cpp" />
     <ClCompile Include="Elements\LightTests.cpp" />
     <ClCompile Include="Elements\RoomTests.cpp" />
+    <ClCompile Include="Elements\SectorTests.cpp" />
     <ClCompile Include="Elements\StaticMeshTests.cpp" />
     <ClCompile Include="Elements\TriggerTests.cpp" />
     <ClCompile Include="Elements\TypeNameLookupTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -158,6 +158,9 @@
     <ClCompile Include="Elements\ItemTests.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\SectorTests.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Elements/ISector.cpp
+++ b/trview.app/Elements/ISector.cpp
@@ -11,7 +11,7 @@ namespace trview
 
     Vector3 ISector::Portal::corner(ISector::Corner corner) const
     {
-        if (has_flag(direct->flags(), SectorFlag::Portal))
+        if (has_flag(direct->flags(), SectorFlag::Portal) && target)
         {
             return target->corner(corner) + offset;
         }

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -919,7 +919,7 @@ namespace trview
             const auto sectors = other_room->sectors();
             if (other_id < sectors.size())
             {
-                portal.target = other_room->sectors()[other_id];
+                portal.target = sectors[other_id];
                 portal.offset = Vector3(x2, 0, z2) - diff;
             }
         }

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -916,8 +916,12 @@ namespace trview
             const auto other_room = _level.room(portal.direct->portal()).lock();
             const auto diff = (position() - other_room->position()) + Vector3(x2, 0, z2);
             const int other_id = diff.x * other_room->num_z_sectors() + diff.z;
-            portal.target = other_room->sectors()[other_id];
-            portal.offset = Vector3(x2, 0, z2) - diff;
+            const auto sectors = other_room->sectors();
+            if (other_id < sectors.size())
+            {
+                portal.target = other_room->sectors()[other_id];
+                portal.offset = Vector3(x2, 0, z2) - diff;
+            }
         }
 
         return portal;

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -65,10 +65,11 @@ namespace trview
             switch (floor & 0x1f)
             {
             case 0x1:
-                _portal = level.get_floor_data(++cur_index) & 0xFF;
+            {
+                _portal = level.get_floor_data(++cur_index);
                 _flags |= SectorFlag::Portal;
-                break; 
-
+                break;
+            }
             case 0x2: 
             {
                 _floor_slant = level.get_floor_data(++cur_index);

--- a/trview.app/Elements/Sector.h
+++ b/trview.app/Elements/Sector.h
@@ -65,7 +65,9 @@ namespace trview
         SectorFlag _flags{ SectorFlag::None };
 
         // Holds the "wall portal" that this sector points to - this is the id of the room 
-        std::uint8_t _portal, _room_above, _room_below;
+        std::uint16_t _portal;
+        std::uint8_t _room_above;
+        std::uint8_t _room_below;
 
         // Holds slope data 
         std::uint16_t _floor_slant{ 0 }, _ceiling_slant{ 0 };


### PR DESCRIPTION
Portal in floordata was being read as a `uint8_t`. This meant if the level had more than 256 rooms bad portal information would be generated, leading to a crash.

Just store the `uint16_t` instead of making it `uint8_t`.

Also add a few checks if a portal ever does link to a non-adjacent room somehow to stop geometry generator from crashing.

Closes #1039 