### PR TITLE
Fix triggers window losing sort on selection

### DIFF
--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -116,10 +116,10 @@ namespace trview
                 imgui_sort(_all_items,
                     {
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
-                        [](auto&& l, auto&& r) { return l.room() < r.room(); },
-                        [](auto&& l, auto&& r) { return l.type_id() < r.type_id(); },
-                        [](auto&& l, auto&& r) { return l.type() < r.type(); },
-                        [](auto&& l, auto&& r) { return l.visible() < r.visible(); }
+                        [](auto&& l, auto&& r) { return std::tuple(l.room(), l.number()) < std::tuple(r.room(), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(l.type_id(), l.number()) < std::tuple(r.type_id(), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(l.visible(), l.number()) < std::tuple(r.visible(), r.number()); }
                     });
 
                 for (const auto& item : _all_items)
@@ -257,8 +257,8 @@ namespace trview
                 imgui_sort_weak(_triggered_by,
                     {
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
-                        [](auto&& l, auto&& r) { return l.room() < r.room(); },
-                        [](auto&& l, auto&& r) { return l.type() < r.type(); },
+                        [](auto&& l, auto&& r) { return std::tuple(l.room(), l.number()) < std::tuple(r.room(), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
                     });
 
                 for (auto& trigger : _triggered_by)

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -107,9 +107,9 @@ namespace trview
                 imgui_sort_weak(_all_lights,
                     {
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
-                        [](auto&& l, auto&& r) { return l.room() < r.room(); },
-                        [](auto&& l, auto&& r) { return l.type() < r.type(); },
-                        [](auto&& l, auto&& r) { return l.visible() < r.visible(); }
+                        [](auto&& l, auto&& r) { return std::tuple(l.room(), l.number()) < std::tuple(r.room(), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(l.visible(), l.number()) < std::tuple(r.visible(), r.number()); }
                     });
 
                 for (const auto& light_ptr : _all_lights)

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -501,7 +501,7 @@ namespace trview
                             imgui_sort(_all_items,
                                 {
                                     [](auto&& l, auto&& r) { return l.number() < r.number(); },
-                                    [](auto&& l, auto&& r) { return l.type() < r.type(); },
+                                    [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
                                 });
                             
                             for (const auto& item : _all_items)
@@ -573,7 +573,7 @@ namespace trview
                             imgui_sort_weak(_all_triggers,
                                 {
                                     [](auto&& l, auto&& r) { return l.number() < r.number(); },
-                                    [&](auto&& l, auto&& r) { return l.type() < r.type(); }
+                                    [&](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); }
                                 });
 
                             for (const auto& trigger : _all_triggers)

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -480,8 +480,7 @@ namespace trview
             });
         _need_filtering = false;
 
-        auto specs = ImGui::TableGetSortSpecs();
-        if (specs)
+        if (auto specs = ImGui::TableGetSortSpecs())
         {
             specs->SpecsDirty = true;
         }

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -188,9 +188,9 @@ namespace trview
                 imgui_sort_weak(_filtered_triggers,
                     {
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
-                        [](auto&& l, auto&& r) { return l.room() < r.room(); },
-                        [](auto&& l, auto&& r) { return l.type() < r.type(); },
-                        [](auto&& l, auto&& r) { return l.visible() < r.visible(); }
+                        [](auto&& l, auto&& r) { return std::tuple(l.room(), l.number()) < std::tuple(r.room(), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(l.visible(), l.number()) < std::tuple(r.visible(), r.number()); }
                     });
 
                 ImGuiListClipper clipper;
@@ -327,9 +327,9 @@ namespace trview
 
                 imgui_sort(_local_selected_trigger_commands,
                     {
-                        [](auto&& l, auto&& r) { return l.type() < r.type(); },
+                        [](auto&& l, auto&& r) { return std::tuple(l.type(), l.index()) < std::tuple(r.type(), r.index()); },
                         [](auto&& l, auto&& r) { return l.index() < r.index(); },
-                        [&](auto&& l, auto&& r) { return get_command_display(l) < get_command_display(r); },
+                        [&](auto&& l, auto&& r) { return std::tuple(get_command_display(l), l.index()) < std::tuple(get_command_display(r), r.index()); },
                     });
 
                 for (auto& command : _local_selected_trigger_commands)

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -479,6 +479,12 @@ namespace trview
                          (!_selected_commands.empty() && !has_any_command(*trigger_ptr, _selected_commands)));
             });
         _need_filtering = false;
+
+        auto specs = ImGui::TableGetSortSpecs();
+        if (specs)
+        {
+            specs->SpecsDirty = true;
+        }
     }
 
     void TriggersWindow::calculate_column_widths()

--- a/trview.app/trview_imgui.hpp
+++ b/trview.app/trview_imgui.hpp
@@ -26,7 +26,7 @@ namespace trview
         if (specs && specs->SpecsDirty)
         {
             std::sort(container.begin(), container.end(),
-                [&](const auto& l, const auto& r) -> int
+                [&](const auto& l, const auto& r) -> bool
                 {
                     const auto& callback = callbacks[specs->Specs[0].ColumnIndex];
                     const auto result = callback(*l.lock(), *r.lock());


### PR DESCRIPTION
Stop the triggers window from losing the current column sort when a trigger is selected.
As part of this fix another issue where the sortable tables weren't satisfying the strong-weak sort. Fixed this so they no longer assert in debug mode.
Closes #1038