### PR TITLE
Clear the log before loading levels

### DIFF
--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -347,6 +347,9 @@ namespace trlevel
     Level::Level(const std::string& filename, const std::shared_ptr<trview::IFiles>& files, const std::shared_ptr<IDecrypter>& decrypter, const std::shared_ptr<trview::ILog>& log)
         : _log(log)
     {
+        // Clear the log before loading the level so we don't keep accumulating memory.
+        _log->clear();
+
         // Load the level from the file.
         auto last_index = std::min(filename.find_last_of('\\'), filename.find_last_of('/'));
         _name = last_index == filename.npos ? filename : filename.substr(std::min(last_index + 1, filename.size()));

--- a/trview.common.tests/Logs/LogTests.cpp
+++ b/trview.common.tests/Logs/LogTests.cpp
@@ -44,3 +44,12 @@ TEST(Log, AllMessages)
     auto messages = log.messages();
     ASSERT_EQ(messages.size(), 3);
 }
+
+TEST(Log, Clear)
+{
+    Log log;
+    log.log(Message::Status::Information, "topic", "activity", "text");
+    ASSERT_EQ(log.messages().size(), 1);
+    log.clear();
+    ASSERT_EQ(log.messages().size(), 0);
+}

--- a/trview.common/Logs/ILog.h
+++ b/trview.common/Logs/ILog.h
@@ -13,5 +13,6 @@ namespace trview
         virtual std::vector<Message> messages(const std::string& topic, const std::string& activity) const = 0;
         virtual std::vector<std::string> topics() const = 0;
         virtual std::vector<std::string> activities(const std::string& topic) const = 0;
+        virtual void clear() = 0;
     };
 }

--- a/trview.common/Logs/Log.cpp
+++ b/trview.common/Logs/Log.cpp
@@ -60,4 +60,9 @@ namespace trview
         }
         return { all_activities.begin(), all_activities.end() };
     }
+
+    void Log::clear()
+    {
+        _messages.clear();
+    }
 }

--- a/trview.common/Logs/Log.h
+++ b/trview.common/Logs/Log.h
@@ -15,6 +15,7 @@ namespace trview
         virtual std::vector<Message> messages(const std::string& topic, const std::string& activity) const override;
         virtual std::vector<std::string> topics() const override;
         virtual std::vector<std::string> activities(const std::string& topic) const override;
+        virtual void clear() override;
     private:
         std::vector<Message> _messages;
     };

--- a/trview.common/Mocks/Logs/ILog.h
+++ b/trview.common/Mocks/Logs/ILog.h
@@ -15,6 +15,7 @@ namespace trview
             MOCK_METHOD(std::vector<Message>, messages, (const std::string&, const std::string&), (const, override));
             MOCK_METHOD(std::vector<std::string>, topics, (), (const, override));
             MOCK_METHOD(std::vector<std::string>, activities, (const std::string&), (const, override));
+            MOCK_METHOD(void, clear, (), (override));
         };
     }
 }


### PR DESCRIPTION
Since the level loading is currently the only thing that writes to the log, clear it before loading a level. Without this we just amass more and more log messages which takes a lot of memory after a while. Will fix log system to not do to this in the future. 
Closes #1043