### PR TITLE
Sort window lists on initialisation

### DIFF
--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -21,6 +21,7 @@ namespace trview
         _all_items = items;
         _triggered_by.clear();
         setup_filters();
+        _force_sort = true;
     }
 
     void ItemsWindow::update_item(const Item& item)
@@ -120,7 +121,7 @@ namespace trview
                         [](auto&& l, auto&& r) { return std::tuple(l.type_id(), l.number()) < std::tuple(r.type_id(), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.visible(), l.number()) < std::tuple(r.visible(), r.number()); }
-                    });
+                    }, _force_sort);
 
                 for (const auto& item : _all_items)
                 {
@@ -259,7 +260,7 @@ namespace trview
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
                         [](auto&& l, auto&& r) { return std::tuple(l.room(), l.number()) < std::tuple(r.room(), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
-                    });
+                    }, _force_sort);
 
                 for (auto& trigger : _triggered_by)
                 {
@@ -299,6 +300,7 @@ namespace trview
             render_items_list();
             ImGui::SameLine();
             render_item_details();
+            _force_sort = false;
 
             if (_tooltip_timer.has_value())
             {
@@ -342,6 +344,7 @@ namespace trview
     {
         _selected_item = item;
         _triggered_by = item.triggers();
+        _force_sort = true;
     }
 
     void ItemsWindow::setup_filters()

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -259,7 +259,7 @@ namespace trview
                     {
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
                         [](auto&& l, auto&& r) { return std::tuple(l.room(), l.number()) < std::tuple(r.room(), r.number()); },
-                        [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(trigger_type_name(l.type()), l.number()) < std::tuple(trigger_type_name(r.type()), r.number()); },
                     }, _force_sort);
 
                 for (auto& trigger : _triggered_by)

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -68,5 +68,6 @@ namespace trview
         Filters<Item> _filters;
         trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Unknown };
         std::function<bool(uint32_t)> _model_checker;
+        bool _force_sort{ false };
     };
 }

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -109,7 +109,7 @@ namespace trview
                     {
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
                         [](auto&& l, auto&& r) { return std::tuple(l.room(), l.number()) < std::tuple(r.room(), r.number()); },
-                        [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(light_type_name(l.type()), l.number()) < std::tuple(light_type_name(r.type()), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.visible(), l.number()) < std::tuple(r.visible(), r.number()); }
                     }, _force_sort);
 

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -41,6 +41,7 @@ namespace trview
     {
         _all_lights = lights;
         setup_filters();
+        _force_sort = true;
     }
 
     void LightsWindow::set_selected_light(const std::weak_ptr<ILight>& light)
@@ -110,7 +111,7 @@ namespace trview
                         [](auto&& l, auto&& r) { return std::tuple(l.room(), l.number()) < std::tuple(r.room(), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.visible(), l.number()) < std::tuple(r.visible(), r.number()); }
-                    });
+                    }, _force_sort);
 
                 for (const auto& light_ptr : _all_lights)
                 {
@@ -261,6 +262,7 @@ namespace trview
             render_lights_list();
             ImGui::SameLine();
             render_light_details();
+            _force_sort = false;
 
             if (_tooltip_timer.has_value())
             {

--- a/trview.app/Windows/LightsWindow.h
+++ b/trview.app/Windows/LightsWindow.h
@@ -52,5 +52,6 @@ namespace trview
         uint32_t _current_room{ 0u };
         std::unordered_map<std::string, std::string> _tips;
         Filters<ILight> _filters;
+        bool _force_sort{ false };
     };
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -575,7 +575,7 @@ namespace trview
                             imgui_sort_weak(_all_triggers,
                                 {
                                     [](auto&& l, auto&& r) { return l.number() < r.number(); },
-                                    [&](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); }
+                                    [&](auto&& l, auto&& r) { return std::tuple(trigger_type_name(l.type()), l.number()) < std::tuple(trigger_type_name(r.type()), r.number()); }
                                 }, _force_sort);
 
                             for (const auto& trigger : _all_triggers)

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -138,6 +138,7 @@ namespace trview
         _all_rooms = rooms;
         _current_room = 0xffffffff;
         generate_filters();
+        _force_sort = true;
     }
 
     void RoomsWindow::set_selected_item(const Item& item)
@@ -230,6 +231,7 @@ namespace trview
             render_rooms_list();
             ImGui::SameLine();
             render_room_details();
+            _force_sort = false;
 
             if (_tooltip_timer.has_value())
             {
@@ -304,7 +306,7 @@ namespace trview
                         [&](auto&& l, auto&& r) { return item_count(l) < item_count(r); },
                         [&](auto&& l, auto&& r) { return trigger_count(l) < trigger_count(r); },
                         [&](auto&& l, auto&& r) { return l.visible() < r.visible(); }
-                    });
+                    }, _force_sort);
 
                 for (const auto& room : _all_rooms)
                 {
@@ -392,7 +394,7 @@ namespace trview
                         float remainder = (341 - _map_texture.size().height) * 0.5f;
                         ImGui::SetCursorPosX(std::round((ImGui::GetWindowSize().x - _map_texture.size().width) * 0.5f));
                         ImGui::SetCursorPosY(ImGui::GetCursorPosY() + std::floor(remainder));
-                        
+
                         const auto io = ImGui::GetIO();
                         if (io.WantCaptureMouse)
                         {
@@ -502,7 +504,7 @@ namespace trview
                                 {
                                     [](auto&& l, auto&& r) { return l.number() < r.number(); },
                                     [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
-                                });
+                                }, _force_sort);
                             
                             for (const auto& item : _all_items)
                             {
@@ -574,7 +576,7 @@ namespace trview
                                 {
                                     [](auto&& l, auto&& r) { return l.number() < r.number(); },
                                     [&](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); }
-                                });
+                                }, _force_sort);
 
                             for (const auto& trigger : _all_triggers)
                             {

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -84,5 +84,6 @@ namespace trview
         graphics::Texture _map_texture;
 
         Filters<IRoom> _filters;
+        bool _force_sort{ false };
     };
 }

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -15,7 +15,8 @@ namespace trview
     {
         _all_triggers = triggers;
 
-        _selected_commands.clear();
+        const std::string existing_command = _selected_command < _all_commands.size() ? _all_commands[_selected_command] : "All";
+
         std::set<TriggerCommandType> command_set;
         for (const auto& trigger : triggers)
         {
@@ -28,6 +29,12 @@ namespace trview
         std::vector<std::string> all_commands{ "All", "Flipmaps" };
         std::transform(command_set.begin(), command_set.end(), std::back_inserter(all_commands), command_type_name);
         _all_commands = all_commands;
+
+        auto reselected_command = std::find(_all_commands.begin(), _all_commands.end(), existing_command);
+        if (reselected_command != _all_commands.end())
+        {
+            _selected_command = reselected_command - _all_commands.begin();
+        }
 
         setup_filters();
         _need_filtering = true;
@@ -191,7 +198,7 @@ namespace trview
                         [](auto&& l, auto&& r) { return std::tuple(l.room(), l.number()) < std::tuple(r.room(), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.visible(), l.number()) < std::tuple(r.visible(), r.number()); }
-                    });
+                    }, _force_sort);
 
                 ImGuiListClipper clipper;
                 clipper.Begin(_filtered_triggers.size());
@@ -330,7 +337,7 @@ namespace trview
                         [](auto&& l, auto&& r) { return std::tuple(l.type(), l.index()) < std::tuple(r.type(), r.index()); },
                         [](auto&& l, auto&& r) { return l.index() < r.index(); },
                         [&](auto&& l, auto&& r) { return std::tuple(get_command_display(l), l.index()) < std::tuple(get_command_display(r), r.index()); },
-                    });
+                    }, _force_sort);
 
                 for (auto& command : _local_selected_trigger_commands)
                 {
@@ -366,6 +373,7 @@ namespace trview
             render_triggers_list();
             ImGui::SameLine();
             render_trigger_details();
+            _force_sort = false;
 
             if (_tooltip_timer.has_value())
             {
@@ -479,11 +487,7 @@ namespace trview
                          (!_selected_commands.empty() && !has_any_command(*trigger_ptr, _selected_commands)));
             });
         _need_filtering = false;
-
-        if (auto specs = ImGui::TableGetSortSpecs())
-        {
-            specs->SpecsDirty = true;
-        }
+        _force_sort = true;
     }
 
     void TriggersWindow::calculate_column_widths()

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -196,7 +196,7 @@ namespace trview
                     {
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
                         [](auto&& l, auto&& r) { return std::tuple(l.room(), l.number()) < std::tuple(r.room(), r.number()); },
-                        [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(trigger_type_name(l.type()), l.number()) < std::tuple(trigger_type_name(r.type()), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.visible(), l.number()) < std::tuple(r.visible(), r.number()); }
                     }, _force_sort);
 
@@ -334,7 +334,7 @@ namespace trview
 
                 imgui_sort(_local_selected_trigger_commands,
                     {
-                        [](auto&& l, auto&& r) { return std::tuple(l.type(), l.index()) < std::tuple(r.type(), r.index()); },
+                        [](auto&& l, auto&& r) { return std::tuple(command_type_name(l.type()), l.index()) < std::tuple(command_type_name(r.type()), r.index()); },
                         [](auto&& l, auto&& r) { return l.index() < r.index(); },
                         [&](auto&& l, auto&& r) { return std::tuple(get_command_display(l), l.index()) < std::tuple(get_command_display(r), r.index()); },
                     }, _force_sort);

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -76,5 +76,6 @@ namespace trview
         bool _need_filtering{ true };
         float _required_number_width{ 0.0f };
         float _required_type_width{ 0.0f };
+        bool _force_sort{ false };
     };
 }

--- a/trview.app/trview_imgui.h
+++ b/trview.app/trview_imgui.h
@@ -3,10 +3,10 @@
 namespace trview
 {
     template < typename T >
-    void imgui_sort(std::vector<T>& container, std::vector<std::function<bool(const T&, const T&)>> callbacks);
+    void imgui_sort(std::vector<T>& container, std::vector<std::function<bool(const T&, const T&)>> callbacks, bool force_sort = false);
 
     template < typename T >
-    void imgui_sort_weak(std::vector<std::weak_ptr<T>>& container, std::vector<std::function<bool(const T&, const T&)>> callbacks);
+    void imgui_sort_weak(std::vector<std::weak_ptr<T>>& container, std::vector<std::function<bool(const T&, const T&)>> callbacks, bool force_sort = false);
 
     struct ImGuiScroller
     {

--- a/trview.app/trview_imgui.hpp
+++ b/trview.app/trview_imgui.hpp
@@ -3,10 +3,10 @@
 namespace trview
 {
     template < typename T >
-    void imgui_sort(std::vector<T>& container, std::vector<std::function<bool(const T&, const T&)>> callbacks)
+    void imgui_sort(std::vector<T>& container, std::vector<std::function<bool(const T&, const T&)>> callbacks, bool force_sort)
     {
         auto specs = ImGui::TableGetSortSpecs();
-        if (specs && specs->SpecsDirty)
+        if (specs && (specs->SpecsDirty || force_sort))
         {
             std::sort(container.begin(), container.end(),
                 [&](const auto& l, const auto& r) -> int
@@ -20,10 +20,10 @@ namespace trview
     }
 
     template < typename T >
-    void imgui_sort_weak(std::vector<std::weak_ptr<T>>& container, std::vector<std::function<bool(const T&, const T&)>> callbacks)
+    void imgui_sort_weak(std::vector<std::weak_ptr<T>>& container, std::vector<std::function<bool(const T&, const T&)>> callbacks, bool force_sort)
     {
         auto specs = ImGui::TableGetSortSpecs();
-        if (specs && specs->SpecsDirty)
+        if (specs && (specs->SpecsDirty || force_sort))
         {
             std::sort(container.begin(), container.end(),
                 [&](const auto& l, const auto& r) -> bool


### PR DESCRIPTION
When a window gets new contents given to it by the outside force a sort of the contents. This means that windows will keep their filters and sorts through level switching. Sorts will also survive closing and reopening the program. Also preserve command trigger filter in the triggers window.
Closes #1048