### PR TITLE
Always use SW_SHOW when restoring window location

### DIFF
--- a/trview.app.tests/Settings/SettingsLoaderTests.cpp
+++ b/trview.app.tests/Settings/SettingsLoaderTests.cpp
@@ -624,7 +624,6 @@ TEST(SettingsLoader, WindowPlacementLoaded)
     ASSERT_EQ(placement.normal_left, 500);
     ASSERT_EQ(placement.normal_right, 2000);
     ASSERT_EQ(placement.normal_top, 200);
-    ASSERT_EQ(placement.show_cmd, 10);
 }
 
 TEST(SettingsLoader, WindowPlacementSaved)
@@ -634,11 +633,11 @@ TEST(SettingsLoader, WindowPlacementSaved)
     UserSettings settings;
     const UserSettings::WindowPlacement placement =
     {
-        10, -1, -1, -1, -1, 500, 200, 2000, 1000
+        -1, -1, -1, -1, 500, 200, 2000, 1000
     };
     settings.window_placement = placement;
     loader->save_user_settings(settings);
-    EXPECT_THAT(output, HasSubstr("\"window_placement\":{\"max_x\":-1,\"max_y\":-1,\"min_x\":-1,\"min_y\":-1,\"normal_bottom\":1000,\"normal_left\":500,\"normal_right\":2000,\"normal_top\":200,\"show_cmd\":10}"));
+    EXPECT_THAT(output, HasSubstr("\"window_placement\":{\"max_x\":-1,\"max_y\":-1,\"min_x\":-1,\"min_y\":-1,\"normal_bottom\":1000,\"normal_left\":500,\"normal_right\":2000,\"normal_top\":200}"));
 }
 
 TEST(SettingsLoader, WindowPlacementNotSavedIfMissing)

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -768,7 +768,6 @@ namespace trview
         {
             _settings.window_placement =
             {
-                placement.showCmd,
                 placement.ptMinPosition.x, placement.ptMinPosition.y,
                 placement.ptMaxPosition.x, placement.ptMaxPosition.y,
                 placement.rcNormalPosition.left, placement.rcNormalPosition.top, placement.rcNormalPosition.right, placement.rcNormalPosition.bottom

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -110,7 +110,7 @@ namespace trview
                 const auto p = settings.window_placement.value();
                 WINDOWPLACEMENT placement{};
                 placement.length = sizeof(placement);
-                placement.showCmd = p.show_cmd;
+                placement.showCmd = SW_SHOW;
                 placement.ptMinPosition = { p.min_x, p.min_y };
                 placement.ptMaxPosition = { p.max_x, p.max_y };
                 placement.rcNormalPosition = { p.normal_left, p.normal_top, p.normal_right, p.normal_bottom };

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -13,7 +13,6 @@ namespace trview
 
     void to_json(nlohmann::json& json, const UserSettings::WindowPlacement& placement)
     {
-        json["show_cmd"] = placement.show_cmd;
         json["min_x"] = placement.min_x;
         json["min_y"] = placement.min_y;
         json["max_x"] = placement.max_x;
@@ -32,7 +31,6 @@ namespace trview
 
     void from_json(const nlohmann::json& json, UserSettings::WindowPlacement& placement)
     {
-        placement.show_cmd = read_attribute<uint32_t>(json, "show_cmd");
         placement.min_x = read_attribute<int32_t>(json, "min_x");
         placement.min_y = read_attribute<int32_t>(json, "min_y");
         placement.max_x = read_attribute<int32_t>(json, "max_x");

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -19,7 +19,6 @@ namespace trview
 
         struct WindowPlacement
         {
-            uint32_t show_cmd;
             int32_t min_x;
             int32_t min_y;
             int32_t max_x;


### PR DESCRIPTION
When starting up always use SW_SHOW. Stop saving show_cmd. Closes #1051