### PR TITLE
Add missing include files for latest VS

### DIFF
--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 #include <optional>
+#include <memory>
+
 #include "trtypes.h"
 #include "tr_rooms.h"
 #include "LevelVersion.h"

--- a/trview.input/IMouse.h
+++ b/trview.input/IMouse.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <cstdint>
+#include <memory>
+
 #include <trview.common/Event.h>
 #include <trview.common/Window.h>
 

--- a/trview.input/IWindowTester.h
+++ b/trview.input/IWindowTester.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include <trview.common/Window.h>
 
 namespace trview


### PR DESCRIPTION
Latest update to VS meant that the <memory> header wasn't included in another header that was already being included. Add an explicit include in files that need it.
#1042