### PR TITLE
Stop reading sound samples

### DIFF
--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -869,14 +869,7 @@ namespace trlevel
             load_level_data(activity, file);
         }
 
-        activity.log("Reading sound sample count");
-        uint32_t num_sound_samples = read<uint32_t>(file);
-        std::vector<tr4_sample> sound_samples(num_sound_samples);
-        activity.log(std::format("Reading {} sound samples", num_sound_samples));
-        for (uint32_t i = 0; i < num_sound_samples; ++i)
-        {
-            sound_samples[i].sound_data = read_compressed(file);
-        }
+        activity.log("Skipping sound samples");
 
         activity.log("Generating meshes");
         generate_meshes(_mesh_data);


### PR DESCRIPTION
It seems like some levels have sound samples in one format and some in another. Since we never use the sound samples, just don't try to read them. Closes #1057