### PR TITLE
Fix all warnings, turn on warnings as errors

### DIFF
--- a/external/DirectXTK/DirectXTK_Desktop.vcxproj
+++ b/external/DirectXTK/DirectXTK_Desktop.vcxproj
@@ -151,6 +151,7 @@
       <ExternalWarningLevel>Level4</ExternalWarningLevel>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <DisableSpecificWarnings>5262</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -176,6 +177,7 @@
       <ExternalWarningLevel>Level4</ExternalWarningLevel>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <DisableSpecificWarnings>5262</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -199,6 +201,7 @@
       <GuardEHContMetadata>true</GuardEHContMetadata>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <DisableSpecificWarnings>5262</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -224,6 +227,7 @@
       <ExternalWarningLevel>Level4</ExternalWarningLevel>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <DisableSpecificWarnings>5262</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/external/imgui/imgui_widgets.cpp
+++ b/external/imgui/imgui_widgets.cpp
@@ -2420,7 +2420,7 @@ bool ImGui::DragScalar(const char* label, ImGuiDataType data_type, void* p_data,
         LogSetNextTextDecoration("{", "}");
     RenderTextClipped(frame_bb.Min, frame_bb.Max, value_buf, value_buf_end, NULL, ImVec2(0.5f, 0.5f));
 
-    IMGUI_TRVIEW_TEST_ENGINE_ITEM_TEXT(id, value_buf, g.LastItemData.StatusFlags);
+    IMGUI_TRVIEW_TEST_ENGINE_ITEM_TEXT(id, value_buf);
 
     if (label_size.x > 0.0f)
         RenderText(ImVec2(frame_bb.Max.x + style.ItemInnerSpacing.x, frame_bb.Min.y + style.FramePadding.y), label);

--- a/trlevel.tests/trlevel.tests.vcxproj
+++ b/trlevel.tests/trlevel.tests.vcxproj
@@ -82,6 +82,7 @@
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -102,6 +103,7 @@
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -122,6 +124,7 @@
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -142,6 +145,7 @@
       <ForcedIncludeFiles>pch.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpplatest</LanguageStandard>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/trlevel/Mocks/ILevel.h
+++ b/trlevel/Mocks/ILevel.h
@@ -9,6 +9,8 @@ namespace trlevel
         class MockLevel : public trlevel::ILevel
         {
         public:
+            MockLevel();
+            virtual ~MockLevel();
             MOCK_METHOD(tr_colour, get_palette_entry8, (uint32_t), (const, override));
             MOCK_METHOD(tr_colour4, get_palette_entry_16, (uint32_t), (const, override));
             MOCK_METHOD(tr_colour4, get_palette_entry, (uint32_t), (const, override));

--- a/trlevel/Mocks/MockLevel.cpp
+++ b/trlevel/Mocks/MockLevel.cpp
@@ -1,0 +1,12 @@
+#include "../stdafx.h"
+#include <gmock/gmock.h>
+#include "ILevel.h"
+
+namespace trlevel
+{
+    namespace mocks
+    {
+        MockLevel::MockLevel() {}
+        MockLevel::~MockLevel() {}
+    }
+}

--- a/trlevel/tr_lights.cpp
+++ b/trlevel/tr_lights.cpp
@@ -10,13 +10,13 @@ namespace trlevel
         switch (level_version)
         {
         case LevelVersion::Tomb1:
-            return Vector3(tr1.x, tr1.y, tr1.z) / Scale_X;
+            return Vector3(static_cast<float>(tr1.x), static_cast<float>(tr1.y), static_cast<float>(tr1.z)) / Scale_X;
         case LevelVersion::Tomb2:
-            return Vector3(tr2.x, tr2.y, tr2.z) / Scale_X;
+            return Vector3(static_cast<float>(tr2.x), static_cast<float>(tr2.y), static_cast<float>(tr2.z)) / Scale_X;
         case LevelVersion::Tomb3:
             return tr3.position();
         case LevelVersion::Tomb4:
-            return Vector3(tr4.x, tr4.y, tr4.z) / Scale_X;
+            return Vector3(static_cast<float>(tr4.x), static_cast<float>(tr4.y), static_cast<float>(tr4.z)) / Scale_X;
         case LevelVersion::Tomb5:
             return type() == LightType::FogBulb ? 
                 Vector3(tr5_fog.position.x, tr5_fog.position.y, tr5_fog.position.z) / Scale_X :

--- a/trlevel/tr_lights.cpp
+++ b/trlevel/tr_lights.cpp
@@ -41,7 +41,7 @@ namespace trlevel
                 Colour(tr5_fog.colour.r, tr5_fog.colour.g, tr5_fog.colour.b) :
                 Colour(tr5.colour.r, tr5.colour.g, tr5.colour.b);
         }
-        Colour::Transparent;
+        return Colour::Transparent;
     }
 
     LightType tr_x_room_light::type() const

--- a/trlevel/trlevel.vcxproj
+++ b/trlevel/trlevel.vcxproj
@@ -178,7 +178,12 @@
     <ClInclude Include="tr_rooms.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="Decrypter.cpp" />
+    <ClCompile Include="Decrypter.cpp">
+      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">4302</DisableSpecificWarnings>
+      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4302</DisableSpecificWarnings>
+      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4302</DisableSpecificWarnings>
+      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4302</DisableSpecificWarnings>
+    </ClCompile>
     <ClCompile Include="Level.cpp" />
     <ClCompile Include="LevelVersion.cpp" />
     <ClCompile Include="stdafx.cpp">

--- a/trlevel/trlevel.vcxproj
+++ b/trlevel/trlevel.vcxproj
@@ -89,7 +89,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib;$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib;$(SolutionDir)external\DirectXTK\Inc;$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -108,7 +108,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib;$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib;$(SolutionDir)external\DirectXTK\Inc;$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -129,7 +129,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib;$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib;$(SolutionDir)external\DirectXTK\Inc;$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -152,7 +152,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib;$(SolutionDir)external\DirectXTK\Inc</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\zlib;$(SolutionDir)external\DirectXTK\Inc;$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -190,6 +190,7 @@
     </ClCompile>
     <ClCompile Include="Level.cpp" />
     <ClCompile Include="LevelVersion.cpp" />
+    <ClCompile Include="Mocks\MockLevel.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/trlevel/trlevel.vcxproj
+++ b/trlevel/trlevel.vcxproj
@@ -94,6 +94,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/utf-8</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -112,6 +113,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/utf-8</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -132,6 +134,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalOptions>/utf-8</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -154,6 +157,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalOptions>/utf-8</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trlevel/trlevel.vcxproj.filters
+++ b/trlevel/trlevel.vcxproj.filters
@@ -24,6 +24,9 @@
     <ClCompile Include="stdafx.cpp" />
     <ClCompile Include="tr_lights.cpp" />
     <ClCompile Include="Decrypter.cpp" />
+    <ClCompile Include="Mocks\MockLevel.cpp">
+      <Filter>Mocks</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">

--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -199,7 +199,7 @@ TEST(ItemsWindow, ItemsListPopulatedOnSet)
 
     TestImgui imgui([&]() { window->render(); });
 
-    for (auto i = 0; i < items.size(); ++i)
+    for (std::size_t i = 0; i < items.size(); ++i)
     {
         const auto& item = items[i];
         ASSERT_TRUE(imgui.element_present(imgui.id("Items 0")

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -59,9 +59,9 @@ TEST(RouteWindow, WaypointRoomPositionCalculatedCorrectly)
     auto window = register_test_module().build();
 
     RoomInfo info {};
-    info.x = room_pos.x;
-    info.yBottom = room_pos.y;
-    info.z = room_pos.z;
+    info.x = static_cast<int32_t>(room_pos.x);
+    info.yBottom = static_cast<int32_t>(room_pos.y);
+    info.z = static_cast<int32_t>(room_pos.z);
 
     auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, info).WillRepeatedly(Return(info));

--- a/trview.app.tests/UI/CameraPositionTests.cpp
+++ b/trview.app.tests/UI/CameraPositionTests.cpp
@@ -181,7 +181,7 @@ TEST(CameraPosition, RotationsCorrectlyConverted)
 TEST(CameraPosition, YawRemovesNegatives)
 {
     CameraPosition subject;
-    subject.set_rotation(-1.5707963267948966192313216916398, 1);
+    subject.set_rotation(-1.5707963267f, 1);
 
     TestImgui imgui([&]() { subject.render(); });
 

--- a/trview.app.tests/UI/CameraPositionTests.cpp
+++ b/trview.app.tests/UI/CameraPositionTests.cpp
@@ -79,8 +79,8 @@ TEST(CameraPosition, RotationEventRaised)
     imgui.press_key(ImGuiKey_Enter);
 
     ASSERT_EQ(times_called, 2);
-    ASSERT_FLOAT_EQ(new_yaw, 1.5707964);
-    ASSERT_FLOAT_EQ(new_pitch, 3.1415927);
+    ASSERT_FLOAT_EQ(new_yaw, 1.5707964f);
+    ASSERT_FLOAT_EQ(new_pitch, 3.1415927f);
 }
 
 TEST(CameraPosition, RotationUpdated)
@@ -174,8 +174,8 @@ TEST(CameraPosition, RotationsCorrectlyConverted)
     imgui.press_key(ImGuiKey_Enter);
 
     ASSERT_TRUE(value.has_value());
-    ASSERT_FLOAT_EQ(std::get<0>(value.value()), 1.5707963267948966192313216916398);
-    ASSERT_FLOAT_EQ(std::get<1>(value.value()), 2);
+    ASSERT_FLOAT_EQ(std::get<0>(value.value()), 1.570796326f);
+    ASSERT_FLOAT_EQ(std::get<1>(value.value()), 2.0f);
 }
 
 TEST(CameraPosition, YawRemovesNegatives)
@@ -196,7 +196,7 @@ TEST(CameraPosition, YawRemovesNegatives)
     imgui.press_key(ImGuiKey_Enter);
 
     ASSERT_TRUE(value);
-    ASSERT_FLOAT_EQ(std::get<0>(value.value()), 4.7123889803846898576939650749193);
+    ASSERT_FLOAT_EQ(std::get<0>(value.value()), 4.71238898f);
     ASSERT_FLOAT_EQ(std::get<1>(value.value()), 0);
 }
 

--- a/trview.app.tests/Windows/LogWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/LogWindowManagerTests.cpp
@@ -8,14 +8,11 @@ using namespace trview::mocks;
 
 namespace
 {
-    Event<> shortcut_handler;
-
     auto register_test_module()
     {
         struct test_module
         {
             Window window{ create_test_window(L"LogWindowManagerTests") };
-            std::shared_ptr<MockShortcuts> shortcuts{ mock_shared<MockShortcuts>() };
             ILogWindow::Source window_source{ [](auto&&...) { return mock_shared<MockLogWindow>(); } };
 
             test_module& with_window_source(const ILogWindow::Source& source)
@@ -24,20 +21,9 @@ namespace
                 return *this;
             }
 
-            test_module& with_shortcuts(const std::shared_ptr<MockShortcuts>& shortcuts)
-            {
-                this->shortcuts = shortcuts;
-                return *this;
-            }
-
-            test_module()
-            {
-                EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-            }
-
             std::unique_ptr<LogWindowManager> build()
             {
-                return std::make_unique<LogWindowManager>(window, shortcuts, window_source);
+                return std::make_unique<LogWindowManager>(window, window_source);
             }
         };
 

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -188,7 +188,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>d3d11.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Crypt32.lib;winhttp.lib;version.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -208,7 +208,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>d3d11.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Crypt32.lib;winhttp.lib;version.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -228,7 +228,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>d3d11.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Crypt32.lib;winhttp.lib;version.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -252,7 +252,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>d3d11.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;Crypt32.lib;winhttp.lib;version.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -182,6 +182,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -204,6 +205,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -224,6 +226,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -246,6 +249,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -275,6 +275,6 @@ namespace trview
             files,
             std::make_unique<DX11ImGuiBackend>(window, device),
             std::make_unique<LightsWindowManager>(window, shortcuts, lights_window_source),
-            std::make_unique<LogWindowManager>(window, shortcuts, log_window_source));
+            std::make_unique<LogWindowManager>(window, log_window_source));
     }
 }

--- a/trview.app/Elements/Entity.cpp
+++ b/trview.app/Elements/Entity.cpp
@@ -73,7 +73,7 @@ namespace trview
     {
     }
 
-    Entity::Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint32_t room, uint32_t index, uint32_t type_id,
+    Entity::Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint16_t room, uint32_t index, uint16_t type_id,
         const Vector3& position, int32_t angle, int32_t ocb, bool is_pickup)
         : _room(room), _index(index)
     {

--- a/trview.app/Elements/Entity.h
+++ b/trview.app/Elements/Entity.h
@@ -45,7 +45,7 @@ namespace trview
         virtual void adjust_y(float amount) override;
         virtual bool needs_ocb_adjustment() const override;
     private:
-        Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint32_t room, uint32_t index, uint32_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, bool is_pickup);
+        Entity(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint16_t room, uint32_t index, uint16_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, bool is_pickup);
 
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);

--- a/trview.app/Elements/ILight.cpp
+++ b/trview.app/Elements/ILight.cpp
@@ -85,12 +85,12 @@ namespace trview
 
     float fade(const ILight& light)
     {
-        return light.fade();
+        return static_cast<float>(light.fade());
     }
 
     float intensity(const ILight& light)
     {
-        return light.intensity();
+        return static_cast<float>(light.intensity());
     }
 
     float hotspot(const ILight& light)

--- a/trview.app/Elements/ITypeNameLookup.h
+++ b/trview.app/Elements/ITypeNameLookup.h
@@ -10,7 +10,7 @@ namespace trview
     {
     public:
         virtual ~ITypeNameLookup() = 0;
-        virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint32_t flags) const = 0;
+        virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint16_t flags) const = 0;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const = 0;
     };
 }

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -74,7 +74,7 @@ namespace trview
 
     bool is_mutant_egg(uint32_t type_id)
     {
-        return equals_any(type_id, 163, 181);
+        return equals_any(type_id, 163u, 181u);
     }
 
     uint16_t mutant_egg_contents(const Item& item)

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -973,13 +973,13 @@ namespace trview
             all_data.push_back(data);
         }
 
-        for (auto r = 0; r < _rooms.size(); ++r)
+        for (auto r = 0u; r < _rooms.size(); ++r)
         {
             for (const auto& neighbour : _rooms[r]->neighbours())
             {
-                for (auto t = 0; t < all_data[r].room_triangles.size(); ++t)
+                for (auto t = 0u; t < all_data[r].room_triangles.size(); ++t)
                 {
-                    for (auto t2 = 0; t2 < all_data[neighbour].room_triangles.size(); ++t2)
+                    for (auto t2 = 0u; t2 < all_data[neighbour].room_triangles.size(); ++t2)
                     {
                         if (all_data[r].room_triangles[t] == all_data[neighbour].room_triangles[t2])
                         {

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -459,7 +459,7 @@ namespace trview
             {
                 if (has_flag(sector->flags(), SectorFlag::Trigger))
                 {
-                    _triggers.push_back(trigger_source(_triggers.size(), i, sector->x(), sector->z(), sector->trigger(), _version));
+                    _triggers.push_back(trigger_source(static_cast<uint32_t>(_triggers.size()), i, sector->x(), sector->z(), sector->trigger(), _version));
                     room->add_trigger(_triggers.back());
                 }
             }
@@ -906,7 +906,7 @@ namespace trview
             auto room = level.get_room(i);
             for (const auto& light : room.lights)
             {
-                _lights.push_back(light_source(_lights.size(), i, light));
+                _lights.push_back(light_source(static_cast<uint32_t>(_lights.size()), i, light));
                 _rooms[i]->add_light(_lights.back());
             }
         }
@@ -967,7 +967,7 @@ namespace trview
                         t2.room = room->number();
                         return t2; 
                     });
-                data.sector_tri_counts.push_back(tris.size());
+                data.sector_tri_counts.push_back(static_cast<uint32_t>(tris.size()));
             }
             data.triangle_rooms.resize(data.room_triangles.size(), room->number());
             all_data.push_back(data);

--- a/trview.app/Elements/Light.cpp
+++ b/trview.app/Elements/Light.cpp
@@ -74,7 +74,7 @@ namespace trview
             {
                 _mesh->render(
                     Matrix::CreateScale(0.05f) * 
-                    Matrix::CreateTranslation(_position + step * i) *
+                    Matrix::CreateTranslation(_position + step * static_cast<float>(i)) *
                     camera.view_projection(), texture_storage, _colour, 1.0f, light_direction);
             }
         }

--- a/trview.app/Elements/Light.cpp
+++ b/trview.app/Elements/Light.cpp
@@ -55,7 +55,6 @@ namespace trview
         }
 
         auto world = Matrix::CreateScale(0.25f) * Matrix::CreateTranslation(_position);
-        auto wvp = world * camera.view_projection();
         auto light_direction = Vector3::TransformNormal(camera.position() - _position, world.Invert());
         light_direction.Normalize();
 
@@ -70,12 +69,13 @@ namespace trview
             d.Normalize();
 
             const int steps = 4;
-            const auto step = d * (1.0f / static_cast<float>(steps));
+            const Vector3 step = d * (1.0f / static_cast<float>(steps));
             for (int i = 1; i <= steps; ++i)
             {
-                auto world = Matrix::CreateScale(0.05f) * Matrix::CreateTranslation(_position + step * i);
-                auto wvp = world * camera.view_projection();
-                _mesh->render(wvp, texture_storage, _colour, 1.0f, light_direction);
+                _mesh->render(
+                    Matrix::CreateScale(0.05f) * 
+                    Matrix::CreateTranslation(_position + step * i) *
+                    camera.view_projection(), texture_storage, _colour, 1.0f, light_direction);
             }
         }
     }

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -900,10 +900,10 @@ namespace trview
         if (sector->room_above() != 0xff)
         {
             const auto other_room = _level.room(sector->room_above()).lock();
-            const auto diff = (position() - other_room->position()) + Vector3(x1, 0, z1);
+            const auto diff = (position() - other_room->position()) + Vector3(static_cast<float>(x1), 0, static_cast<float>(z1));
             const int other_id = diff.x * other_room->num_z_sectors() + diff.z;
             portal.sector_above = other_room->sectors()[other_id];
-            portal.above_offset = Vector3(x1, 0, z1) - diff;
+            portal.above_offset = Vector3(static_cast<float>(x1), 0, static_cast<float>(z1)) - diff;
             portal.room_above = other_room;
         }
 

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -869,11 +869,11 @@ namespace trview
         };
 
         std::unordered_map<uint32_t, MeshPart> mesh_parts;
-        uint32_t base = 0u;
+        std::size_t base = 0u;
         for (const auto& sector : _sectors)
         {
             const auto tris = sector->triangles();
-            for (uint32_t i = 0; i < tris.size(); ++i)
+            for (std::size_t i = 0; i < tris.size(); ++i)
             {
                 const auto& tri = tris[i];
                 auto& part = mesh_parts[_all_geometry_sector_rooms[base + i]];
@@ -901,7 +901,7 @@ namespace trview
         {
             const auto other_room = _level.room(sector->room_above()).lock();
             const auto diff = (position() - other_room->position()) + Vector3(static_cast<float>(x1), 0, static_cast<float>(z1));
-            const int other_id = diff.x * other_room->num_z_sectors() + diff.z;
+            const int other_id = static_cast<int>(diff.x * other_room->num_z_sectors() + diff.z);
             portal.sector_above = other_room->sectors()[other_id];
             portal.above_offset = Vector3(static_cast<float>(x1), 0, static_cast<float>(z1)) - diff;
             portal.room_above = other_room;
@@ -918,13 +918,13 @@ namespace trview
         if (has_flag(portal.direct->flags(), SectorFlag::Portal))
         {
             const auto other_room = _level.room(portal.direct->portal()).lock();
-            const auto diff = (position() - other_room->position()) + Vector3(x2, 0, z2);
-            const int other_id = diff.x * other_room->num_z_sectors() + diff.z;
+            const auto diff = (position() - other_room->position()) + Vector3(static_cast<float>(x2), 0, static_cast<float>(z2));
+            const int other_id = static_cast<int>(diff.x * other_room->num_z_sectors() + diff.z);
             const auto sectors = other_room->sectors();
             if (other_id < sectors.size())
             {
                 portal.target = sectors[other_id];
-                portal.offset = Vector3(x2, 0, z2) - diff;
+                portal.offset = Vector3(static_cast<float>(x2), 0, static_cast<float>(z2)) - diff;
             }
         }
 

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -921,7 +921,7 @@ namespace trview
             const auto diff = (position() - other_room->position()) + Vector3(static_cast<float>(x2), 0, static_cast<float>(z2));
             const int other_id = static_cast<int>(diff.x * other_room->num_z_sectors() + diff.z);
             const auto sectors = other_room->sectors();
-            if (other_id < sectors.size())
+            if (other_id < std::ssize(sectors))
             {
                 portal.target = sectors[other_id];
                 portal.offset = Vector3(static_cast<float>(x2), 0, static_cast<float>(z2)) - diff;

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -638,8 +638,8 @@ namespace trview
     Triangulation read_triangulation(const trlevel::ILevel& level, uint16_t floor, std::uint16_t& cur_index)
     {
         // Not sure what to do with h1 and h2 values yet.
-        const int16_t h2 = (floor & 0x7C00) >> 10;
-        const int16_t h1 = (floor & 0x03E0) >> 5;
+        // const int16_t h2 = (floor & 0x7C00) >> 10;
+        // const int16_t h1 = (floor & 0x03E0) >> 5;
         const int16_t function = (floor & 0x001F);
 
         ISector::TriangulationDirection direction{ ISector::TriangulationDirection::None };

--- a/trview.app/Elements/TypeNameLookup.cpp
+++ b/trview.app/Elements/TypeNameLookup.cpp
@@ -75,7 +75,7 @@ namespace trview
         load_game_types(LevelVersion::Tomb5);
     }
 
-    std::string TypeNameLookup::lookup_type_name(LevelVersion level_version, uint32_t type_id, uint32_t flags) const
+    std::string TypeNameLookup::lookup_type_name(LevelVersion level_version, uint32_t type_id, uint16_t flags) const
     {
         const auto& game_types = _type_names.find(level_version);
         if (game_types == _type_names.end())

--- a/trview.app/Elements/TypeNameLookup.h
+++ b/trview.app/Elements/TypeNameLookup.h
@@ -10,7 +10,7 @@ namespace trview
     public:
         explicit TypeNameLookup(const std::string& type_name_json);
         virtual ~TypeNameLookup() = default;
-        virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint32_t flags) const override;
+        virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint16_t flags) const override;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const override;
     private:
         struct Type

--- a/trview.app/Menus/FileMenu.cpp
+++ b/trview.app/Menus/FileMenu.cpp
@@ -85,7 +85,7 @@ namespace trview
         _token_store += shortcuts->add_shortcut(false, VK_F7) += [&]() { next_directory_file();  };
     }
 
-    std::optional<int> FileMenu::process_message(UINT message, WPARAM wParam, LPARAM lParam)
+    std::optional<int> FileMenu::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         if (message == WM_COMMAND)
         {

--- a/trview.app/Mocks/Camera/ICamera.h
+++ b/trview.app/Mocks/Camera/ICamera.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockCamera : public ICamera
         {
-            virtual ~MockCamera() = default;
+            MockCamera();
+            virtual ~MockCamera();
             MOCK_METHOD(DirectX::SimpleMath::Vector3, forward, (), (const, override));
             MOCK_METHOD(const DirectX::BoundingFrustum, frustum, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));

--- a/trview.app/Mocks/Elements/IEntity.h
+++ b/trview.app/Mocks/Elements/IEntity.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockEntity : public IEntity
         {
-            virtual ~MockEntity() = default;
+            MockEntity();
+            virtual ~MockEntity();
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(bool, visible, (), (const, override));

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockLevel : public ILevel
         {
-            virtual ~MockLevel() = default;
+            MockLevel();
+            virtual ~MockLevel();
             MOCK_METHOD(bool, alternate_group, (uint32_t), (const, override));
             MOCK_METHOD(std::set<uint32_t>, alternate_groups, (), (const, override));
             MOCK_METHOD(bool, alternate_mode, (), (const, override));

--- a/trview.app/Mocks/Elements/ILight.h
+++ b/trview.app/Mocks/Elements/ILight.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockLight : public ILight, public std::enable_shared_from_this<MockLight>
         {
-            virtual ~MockLight() = default;
+            MockLight();
+            virtual ~MockLight();
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(bool, visible, (), (const, override));

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockRoom : public IRoom, public std::enable_shared_from_this<MockRoom>
         {
-            virtual ~MockRoom() = default;
+            MockRoom();
+            virtual ~MockRoom();
             MOCK_METHOD(void, add_entity, (const std::weak_ptr<IEntity>&), (override));
             MOCK_METHOD(void, add_light, (const std::weak_ptr<ILight>&), (override));
             MOCK_METHOD(void, add_trigger, (const std::weak_ptr<ITrigger>&), (override));

--- a/trview.app/Mocks/Elements/ISector.h
+++ b/trview.app/Mocks/Elements/ISector.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockSector : public ISector
         {
-            virtual ~MockSector() = default;
+            MockSector();
+            virtual ~MockSector();
             MOCK_METHOD(std::uint16_t, portal, (), (const, override));
             MOCK_METHOD(int, id, (), (const, override));
             MOCK_METHOD(std::set<std::uint16_t>, neighbours, (), (const, override));

--- a/trview.app/Mocks/Elements/IStaticMesh.h
+++ b/trview.app/Mocks/Elements/IStaticMesh.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockStaticMesh : public IStaticMesh
         {
-            virtual ~MockStaticMesh() = default;
+            MockStaticMesh();
+            virtual ~MockStaticMesh();
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, render_bounding_box, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));

--- a/trview.app/Mocks/Elements/ITrigger.h
+++ b/trview.app/Mocks/Elements/ITrigger.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockTrigger : public ITrigger, public std::enable_shared_from_this<MockTrigger>
         {
-            virtual ~MockTrigger() = default;
+            MockTrigger();
+            virtual ~MockTrigger();
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(bool, visible, (), (const, override));

--- a/trview.app/Mocks/Elements/ITypeNameLookup.h
+++ b/trview.app/Mocks/Elements/ITypeNameLookup.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockTypeNameLookup : public ITypeNameLookup
         {
-            virtual ~MockTypeNameLookup() = default;
+            MockTypeNameLookup();
+            virtual ~MockTypeNameLookup();
             MOCK_METHOD(std::string, lookup_type_name, (trlevel::LevelVersion, uint32_t, uint16_t), (const, override));
             MOCK_METHOD(bool, is_pickup, (trlevel::LevelVersion, uint32_t), (const, override));
         };

--- a/trview.app/Mocks/Elements/ITypeNameLookup.h
+++ b/trview.app/Mocks/Elements/ITypeNameLookup.h
@@ -9,7 +9,7 @@ namespace trview
         struct MockTypeNameLookup : public ITypeNameLookup
         {
             virtual ~MockTypeNameLookup() = default;
-            MOCK_METHOD(std::string, lookup_type_name, (trlevel::LevelVersion, uint32_t, uint32_t), (const, override));
+            MOCK_METHOD(std::string, lookup_type_name, (trlevel::LevelVersion, uint32_t, uint16_t), (const, override));
             MOCK_METHOD(bool, is_pickup, (trlevel::LevelVersion, uint32_t), (const, override));
         };
     }

--- a/trview.app/Mocks/Geometry/IMesh.h
+++ b/trview.app/Mocks/Geometry/IMesh.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockMesh : public IMesh
         {
-            virtual ~MockMesh() = default;
+            MockMesh();
+            virtual ~MockMesh();
             MOCK_METHOD(void, render, (const DirectX::SimpleMath::Matrix&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&, float, DirectX::SimpleMath::Vector3, bool), (override));
             MOCK_METHOD(std::vector<TransparentTriangle>, transparent_triangles, (), (const, override));
             MOCK_METHOD(const DirectX::BoundingBox&, bounding_box, (), (const, override));

--- a/trview.app/Mocks/Geometry/IPicking.h
+++ b/trview.app/Mocks/Geometry/IPicking.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockPicking : public IPicking
         {
-            virtual ~MockPicking() = default;
+            MockPicking();
+            virtual ~MockPicking();
             MOCK_METHOD(void, pick, (const ICamera&), (override));
         };
     }

--- a/trview.app/Mocks/Geometry/ITransparencyBuffer.h
+++ b/trview.app/Mocks/Geometry/ITransparencyBuffer.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockTransparencyBuffer : public ITransparencyBuffer
         {
-            virtual ~MockTransparencyBuffer() = default;
+            MockTransparencyBuffer();
+            virtual ~MockTransparencyBuffer();
             MOCK_METHOD(void, add, (const TransparentTriangle&), (override));
             MOCK_METHOD(void, sort, (const DirectX::SimpleMath::Vector3&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));

--- a/trview.app/Mocks/Graphics/ILevelTextureStorage.h
+++ b/trview.app/Mocks/Graphics/ILevelTextureStorage.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockLevelTextureStorage : public ILevelTextureStorage
         {
-            virtual ~MockLevelTextureStorage() = default;
+            MockLevelTextureStorage();
+            virtual ~MockLevelTextureStorage();
             MOCK_METHOD(graphics::Texture, coloured, (uint32_t), (const, override));
             MOCK_METHOD(graphics::Texture, lookup, (const std::string&), (const, override));
             MOCK_METHOD(void, store, (const std::string&, const graphics::Texture&), (override));

--- a/trview.app/Mocks/Graphics/IMeshStorage.h
+++ b/trview.app/Mocks/Graphics/IMeshStorage.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockMeshStorage : public IMeshStorage
         {
-            virtual ~MockMeshStorage() = default;
+            MockMeshStorage();
+            virtual ~MockMeshStorage();
             MOCK_METHOD(std::shared_ptr<IMesh>, mesh, (uint32_t), (const, override));
         };
     }

--- a/trview.app/Mocks/Graphics/ISectorHighlight.h
+++ b/trview.app/Mocks/Graphics/ISectorHighlight.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockSectorHighlight : public ISectorHighlight
         {
-            virtual ~MockSectorHighlight() = default;
+            MockSectorHighlight();
+            virtual ~MockSectorHighlight();
             MOCK_METHOD(void, set_sector, (const std::shared_ptr<ISector>&, const DirectX::SimpleMath::Matrix&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&), (override));
         };

--- a/trview.app/Mocks/Graphics/ISelectionRenderer.h
+++ b/trview.app/Mocks/Graphics/ISelectionRenderer.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockSelectionRenderer : public ISelectionRenderer
         {
-            virtual ~MockSelectionRenderer() = default;
+            MockSelectionRenderer();
+            virtual ~MockSelectionRenderer();
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, IRenderable&, const DirectX::SimpleMath::Color&), (override));
         };
     }

--- a/trview.app/Mocks/Graphics/ITextureStorage.h
+++ b/trview.app/Mocks/Graphics/ITextureStorage.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockTextureStorage : public ITextureStorage
         {
-            virtual ~MockTextureStorage() = default;
+            MockTextureStorage();
+            virtual ~MockTextureStorage();
             MOCK_METHOD(graphics::Texture, coloured, (uint32_t), (const, override));
             MOCK_METHOD(graphics::Texture, lookup, (const std::string&), (const, override));
             MOCK_METHOD(void, store, (const std::string&, const graphics::Texture&), (override));

--- a/trview.app/Mocks/Menus/IFileMenu.h
+++ b/trview.app/Mocks/Menus/IFileMenu.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockFileMenu : public IFileMenu
         {
-            virtual ~MockFileMenu() = default;
+            MockFileMenu();
+            virtual ~MockFileMenu();
             MOCK_METHOD(void, open_file, (const std::string&), (override));
             MOCK_METHOD(void, set_recent_files, (const std::list<std::string>&), (override));
         };

--- a/trview.app/Mocks/Menus/IUpdateChecker.h
+++ b/trview.app/Mocks/Menus/IUpdateChecker.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockUpdateChecker : public IUpdateChecker
         {
-            virtual ~MockUpdateChecker() = default;
+            MockUpdateChecker();
+            virtual ~MockUpdateChecker();
             MOCK_METHOD(void, check_for_updates, (), (override));
         };
     }

--- a/trview.app/Mocks/Mocks.cpp
+++ b/trview.app/Mocks/Mocks.cpp
@@ -1,0 +1,189 @@
+#include "pch.h"
+#include <gmock/gmock.h>
+
+#include "Camera/ICamera.h"
+#include "Elements/IEntity.h"
+#include "Elements/ILevel.h"
+#include "Elements/ILight.h"
+#include "Elements/IRoom.h"
+#include "Elements/ISector.h"
+#include "Elements/IStaticMesh.h"
+#include "Elements/ITrigger.h"
+#include "Elements/ITypeNameLookup.h"
+#include "Geometry/IMesh.h"
+#include "Geometry/IPicking.h"
+#include "Geometry/ITransparencyBuffer.h"
+#include "Graphics/ILevelTextureStorage.h"
+#include "Graphics/IMeshStorage.h"
+#include "Graphics/ISectorHighlight.h"
+#include "Graphics/ISelectionRenderer.h"
+#include "Graphics/ITextureStorage.h"
+#include "Menus/IFileMenu.h"
+#include "Menus/IUpdateChecker.h"
+#include "Routing/IRoute.h"
+#include "Routing/IWaypoint.h"
+#include "Settings/ISettingsLoader.h"
+#include "Settings/IStartupOptions.h"
+#include "Tools/ICompass.h"
+#include "Tools/IMeasure.h"
+#include "UI/ICameraControls.h"
+#include "UI/IContextMenu.h"
+#include "UI/IImGuiBackend.h"
+#include "UI/IMapRenderer.h"
+#include "UI/ISettingsWindow.h"
+#include "UI/IViewerUI.h"
+#include "UI/IViewOptions.h"
+#include "Windows/IItemsWindow.h"
+#include "Windows/IItemsWindowManager.h"
+#include "Windows/ILightsWindow.h"
+#include "Windows/ILightsWindowManager.h"
+#include "Windows/ILogWindow.h"
+#include "Windows/ILogWindowManager.h"
+#include "Windows/IRoomsWindow.h"
+#include "Windows/IRoomsWindowManager.h"
+#include "Windows/IRouteWindow.h"
+#include "Windows/IRouteWindowManager.h"
+#include "Windows/ITriggersWindow.h"
+#include "Windows/ITriggersWindowManager.h"
+#include "Windows/IViewer.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        MockCamera::MockCamera() {}
+        MockCamera::~MockCamera() {}
+
+        MockEntity::MockEntity() {}
+        MockEntity::~MockEntity() {}
+
+        MockLevel::MockLevel() {}
+        MockLevel::~MockLevel() {}
+
+        MockLight::MockLight() {}
+        MockLight::~MockLight() {}
+
+        MockRoom::MockRoom() {}
+        MockRoom::~MockRoom() {}
+
+        MockSector::MockSector() {}
+        MockSector::~MockSector() {}
+
+        MockStaticMesh::MockStaticMesh() {}
+        MockStaticMesh::~MockStaticMesh() {}
+
+        MockTrigger::MockTrigger() {}
+        MockTrigger::~MockTrigger() {}
+
+        MockTypeNameLookup::MockTypeNameLookup() {}
+        MockTypeNameLookup::~MockTypeNameLookup() {}
+
+        MockMesh::MockMesh() {}
+        MockMesh::~MockMesh() {}
+
+        MockPicking::MockPicking() {}
+        MockPicking::~MockPicking() {}
+
+        MockTransparencyBuffer::MockTransparencyBuffer() {}
+        MockTransparencyBuffer::~MockTransparencyBuffer() {}
+
+        MockLevelTextureStorage::MockLevelTextureStorage() {}
+        MockLevelTextureStorage::~MockLevelTextureStorage() {}
+
+        MockMeshStorage::MockMeshStorage() {}
+        MockMeshStorage::~MockMeshStorage() {}
+
+        MockSectorHighlight::MockSectorHighlight() {}
+        MockSectorHighlight::~MockSectorHighlight() {}
+
+        MockSelectionRenderer::MockSelectionRenderer() {}
+        MockSelectionRenderer::~MockSelectionRenderer() {}
+
+        MockTextureStorage::MockTextureStorage() {}
+        MockTextureStorage::~MockTextureStorage() {}
+
+        MockFileMenu::MockFileMenu() {}
+        MockFileMenu::~MockFileMenu() {}
+
+        MockUpdateChecker::MockUpdateChecker() {}
+        MockUpdateChecker::~MockUpdateChecker() {}
+
+        MockRoute::MockRoute() {}
+        MockRoute::~MockRoute() {}
+
+        MockWaypoint::MockWaypoint() {}
+        MockWaypoint::~MockWaypoint() {}
+
+        MockSettingsLoader::MockSettingsLoader() {}
+        MockSettingsLoader::~MockSettingsLoader() {}
+
+        MockStartupOptions::MockStartupOptions() {}
+        MockStartupOptions::~MockStartupOptions() {}
+
+        MockCompass::MockCompass() {}
+        MockCompass::~MockCompass() {}
+
+        MockMeasure::MockMeasure() {}
+        MockMeasure::~MockMeasure() {}
+
+        MockCameraControls::MockCameraControls() {}
+        MockCameraControls::~MockCameraControls() {}
+
+        MockContextMenu::MockContextMenu() {}
+        MockContextMenu::~MockContextMenu() {}
+
+        MockImGuiBackend::MockImGuiBackend() {}
+        MockImGuiBackend::~MockImGuiBackend() {}
+
+        MockMapRenderer::MockMapRenderer() {}
+        MockMapRenderer::~MockMapRenderer() {}
+
+        MockSettingsWindow::MockSettingsWindow() {}
+        MockSettingsWindow::~MockSettingsWindow() {}
+
+        MockViewerUI::MockViewerUI() {}
+        MockViewerUI::~MockViewerUI() {}
+
+        MockViewOptions::MockViewOptions() {}
+        MockViewOptions::~MockViewOptions() {}
+
+        MockItemsWindow::MockItemsWindow() {}
+        MockItemsWindow::~MockItemsWindow() {}
+
+        MockItemsWindowManager::MockItemsWindowManager() {}
+        MockItemsWindowManager::~MockItemsWindowManager() {}
+
+        MockLightsWindow::MockLightsWindow() {}
+        MockLightsWindow::~MockLightsWindow() {}
+
+        MockLightsWindowManager::MockLightsWindowManager() {}
+        MockLightsWindowManager::~MockLightsWindowManager() {}
+
+        MockLogWindow::MockLogWindow() {}
+        MockLogWindow::~MockLogWindow() {}
+
+        MockLogWindowManager::MockLogWindowManager() {}
+        MockLogWindowManager::~MockLogWindowManager() {}
+
+        MockRoomsWindow::MockRoomsWindow() {}
+        MockRoomsWindow::~MockRoomsWindow() {}
+
+        MockRoomsWindowManager::MockRoomsWindowManager() {}
+        MockRoomsWindowManager::~MockRoomsWindowManager() {}
+
+        MockRouteWindow::MockRouteWindow() {}
+        MockRouteWindow::~MockRouteWindow() {}
+
+        MockRouteWindowManager::MockRouteWindowManager() {}
+        MockRouteWindowManager::~MockRouteWindowManager() {}
+
+        MockTriggersWindow::MockTriggersWindow() {}
+        MockTriggersWindow::~MockTriggersWindow() {}
+
+        MockTriggersWindowManager::MockTriggersWindowManager() {}
+        MockTriggersWindowManager::~MockTriggersWindowManager() {}
+
+        MockViewer::MockViewer() {}
+        MockViewer::~MockViewer() {}
+    }
+}

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockRoute : public IRoute
         {
-            virtual ~MockRoute() = default;
+            MockRoute();
+            virtual ~MockRoute();
             MOCK_METHOD(void, add, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t), (override));
             MOCK_METHOD(void, add, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, IWaypoint::Type, uint32_t), (override));
             MOCK_METHOD(void, clear, (), (override));

--- a/trview.app/Mocks/Routing/IWaypoint.h
+++ b/trview.app/Mocks/Routing/IWaypoint.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockWaypoint : public IWaypoint
         {
-            virtual ~MockWaypoint() = default;
+            MockWaypoint();
+            virtual ~MockWaypoint();
             MOCK_METHOD(DirectX::BoundingBox, bounding_box, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(Type, type, (), (const, override));

--- a/trview.app/Mocks/Settings/ISettingsLoader.h
+++ b/trview.app/Mocks/Settings/ISettingsLoader.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockSettingsLoader : public ISettingsLoader
         {
-            virtual ~MockSettingsLoader() = default;
+            MockSettingsLoader();
+            virtual ~MockSettingsLoader();
             MOCK_METHOD(UserSettings, load_user_settings, (), (const, override));
             MOCK_METHOD(void, save_user_settings, (const UserSettings&), (override));
         };

--- a/trview.app/Mocks/Settings/IStartupOptions.h
+++ b/trview.app/Mocks/Settings/IStartupOptions.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockStartupOptions : public IStartupOptions
         {
-            virtual ~MockStartupOptions() = default;
+            MockStartupOptions();
+            virtual ~MockStartupOptions();
             MOCK_METHOD(std::string, filename, (), (const, override));
             MOCK_METHOD(bool, feature, (const std::string&), (const, override));
         };

--- a/trview.app/Mocks/Tools/ICompass.h
+++ b/trview.app/Mocks/Tools/ICompass.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockCompass : public ICompass
         {
-            virtual ~MockCompass() = default;
+            MockCompass();
+            virtual ~MockCompass();
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&), (override));
             MOCK_METHOD(bool, pick, (const Point&, const Size&, Axis&), (override));
             MOCK_METHOD(void, set_visible, (bool), (override));

--- a/trview.app/Mocks/Tools/IMeasure.h
+++ b/trview.app/Mocks/Tools/IMeasure.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockMeasure : public IMeasure
         {
-            virtual ~MockMeasure() = default;
+            MockMeasure();
+            virtual ~MockMeasure();
             MOCK_METHOD(void, reset, (), (override));
             MOCK_METHOD(bool, add, (const DirectX::SimpleMath::Vector3&), (override));
             MOCK_METHOD(void, set, (const DirectX::SimpleMath::Vector3&), (override));

--- a/trview.app/Mocks/UI/ICameraControls.h
+++ b/trview.app/Mocks/UI/ICameraControls.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockCameraControls : public ICameraControls
         {
-            virtual ~MockCameraControls() = default;
+            MockCameraControls();
+            virtual ~MockCameraControls();
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_mode, (CameraMode), (override));
             MOCK_METHOD(void, set_projection_mode, (ProjectionMode), (override));

--- a/trview.app/Mocks/UI/IContextMenu.h
+++ b/trview.app/Mocks/UI/IContextMenu.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockContextMenu : public IContextMenu
         {
-            virtual ~MockContextMenu() = default;
+            MockContextMenu();
+            virtual ~MockContextMenu();
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(void, set_remove_enabled, (bool), (override));
             MOCK_METHOD(void, set_hide_enabled, (bool), (override));

--- a/trview.app/Mocks/UI/IImGuiBackend.h
+++ b/trview.app/Mocks/UI/IImGuiBackend.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockImGuiBackend : public IImGuiBackend
         {
-            virtual ~MockImGuiBackend() = default;
+            MockImGuiBackend();
+            virtual ~MockImGuiBackend();
             MOCK_METHOD(void, initialise, (), (override));
             MOCK_METHOD(void, new_frame, (), (override));
             MOCK_METHOD(void, render, (), (override));

--- a/trview.app/Mocks/UI/IMapRenderer.h
+++ b/trview.app/Mocks/UI/IMapRenderer.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockMapRenderer : public IMapRenderer
         {
-            virtual ~MockMapRenderer() = default;
+            MockMapRenderer();
+            virtual ~MockMapRenderer();
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, load, (const std::shared_ptr<trview::IRoom>&), (override));
             MOCK_METHOD(std::uint16_t, area, (), (const, override));

--- a/trview.app/Mocks/UI/ISettingsWindow.h
+++ b/trview.app/Mocks/UI/ISettingsWindow.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockSettingsWindow : public ISettingsWindow
         {
-            virtual ~MockSettingsWindow() = default;
+            MockSettingsWindow();
+            virtual ~MockSettingsWindow();
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_vsync, (bool), (override));
             MOCK_METHOD(void, set_go_to_lara, (bool), (override));

--- a/trview.app/Mocks/UI/IViewOptions.h
+++ b/trview.app/Mocks/UI/IViewOptions.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockViewOptions : public IViewOptions
         {
-            virtual ~MockViewOptions() = default;
+            MockViewOptions();
+            virtual ~MockViewOptions();
             MOCK_METHOD(void, set_alternate_group, (uint32_t, bool), (override));
             MOCK_METHOD(void, set_alternate_groups, (const std::set<uint32_t>&), (override));
             MOCK_METHOD(void, set_scalar, (const std::string&, int32_t), (override));

--- a/trview.app/Mocks/UI/IViewerUI.h
+++ b/trview.app/Mocks/UI/IViewerUI.h
@@ -28,7 +28,7 @@ namespace trview
             MOCK_METHOD(void, set_measure_distance, (float), (override));
             MOCK_METHOD(void, set_measure_position, (const Point&), (override));
             MOCK_METHOD(void, set_minimap_highlight, (uint16_t, uint16_t), (override));
-            MOCK_METHOD(void, set_pick, (const PickInfo&, const PickResult&), (override));
+            MOCK_METHOD(void, set_pick, (const PickResult&), (override));
             MOCK_METHOD(void, set_remove_waypoint_enabled, (bool), (override));
             MOCK_METHOD(void, set_selected_item, (uint32_t), (override));
             MOCK_METHOD(void, set_selected_room, (const std::shared_ptr<IRoom>&), (override));

--- a/trview.app/Mocks/UI/IViewerUI.h
+++ b/trview.app/Mocks/UI/IViewerUI.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockViewerUI : public IViewerUI
         {
-            virtual ~MockViewerUI() = default;
+            MockViewerUI();
+            virtual ~MockViewerUI();
             MOCK_METHOD(void, clear_minimap_highlight, (), (override));
             MOCK_METHOD(std::shared_ptr<ISector>, current_minimap_sector, (), (const, override));
             MOCK_METHOD(bool, is_input_active, (), (const, override));

--- a/trview.app/Mocks/Windows/IItemsWindow.h
+++ b/trview.app/Mocks/Windows/IItemsWindow.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockItemsWindow : public IItemsWindow
         {
-            virtual ~MockItemsWindow() = default;
+            MockItemsWindow();
+            virtual ~MockItemsWindow();
             MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
             MOCK_METHOD(void, update_item, (const Item&), (override));
             MOCK_METHOD(void, render, (), (override));

--- a/trview.app/Mocks/Windows/IItemsWindowManager.h
+++ b/trview.app/Mocks/Windows/IItemsWindowManager.h
@@ -9,6 +9,8 @@ namespace trview
         struct MockItemsWindowManager : public IItemsWindowManager
         {
         public:
+            MockItemsWindowManager();
+            virtual ~MockItemsWindowManager();
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
             MOCK_METHOD(void, set_item_visible, (const Item&, bool), (override));

--- a/trview.app/Mocks/Windows/ILightsWindow.h
+++ b/trview.app/Mocks/Windows/ILightsWindow.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockLightsWindow : public ILightsWindow
         {
-            virtual ~MockLightsWindow() = default;
+            MockLightsWindow();
+            virtual ~MockLightsWindow();
             MOCK_METHOD(void, clear_selected_light, (), (override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, update, (float), (override));

--- a/trview.app/Mocks/Windows/ILightsWindowManager.h
+++ b/trview.app/Mocks/Windows/ILightsWindowManager.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockLightsWindowManager : public ILightsWindowManager
         {
-            virtual ~MockLightsWindowManager() = default;
+            MockLightsWindowManager();
+            virtual ~MockLightsWindowManager();
             MOCK_METHOD(void, set_lights, (const std::vector<std::weak_ptr<ILight>>&), (override));
             MOCK_METHOD(std::weak_ptr<ILightsWindow>, create_window, (), (override));
             MOCK_METHOD(void, render, (), (override));

--- a/trview.app/Mocks/Windows/ILogWindow.h
+++ b/trview.app/Mocks/Windows/ILogWindow.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockLogWindow : public ILogWindow
         {
-            virtual ~MockLogWindow() = default;
+            MockLogWindow();
+            virtual ~MockLogWindow();
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));
         };

--- a/trview.app/Mocks/Windows/ILogWindowManager.h
+++ b/trview.app/Mocks/Windows/ILogWindowManager.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockLogWindowManager : public ILogWindowManager
         {
-            virtual ~MockLogWindowManager() = default;
+            MockLogWindowManager();
+            virtual ~MockLogWindowManager();
             MOCK_METHOD(std::weak_ptr<ILogWindow>, create_window, (), (override));
             MOCK_METHOD(void, render, (), (override));
         };

--- a/trview.app/Mocks/Windows/IRoomsWindow.h
+++ b/trview.app/Mocks/Windows/IRoomsWindow.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockRoomsWindow : public IRoomsWindow
         {
-            virtual ~MockRoomsWindow() = default;
+            MockRoomsWindow();
+            virtual ~MockRoomsWindow();
             MOCK_METHOD(void, clear_selected_trigger, (), (override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_current_room, (uint32_t), (override));

--- a/trview.app/Mocks/Windows/IRoomsWindowManager.h
+++ b/trview.app/Mocks/Windows/IRoomsWindowManager.h
@@ -9,6 +9,8 @@ namespace trview
         struct MockRoomsWindowManager : public IRoomsWindowManager
         {
         public:
+            MockRoomsWindowManager();
+            virtual ~MockRoomsWindowManager();
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
             MOCK_METHOD(void, set_level_version, (trlevel::LevelVersion), (override));

--- a/trview.app/Mocks/Windows/IRouteWindow.h
+++ b/trview.app/Mocks/Windows/IRouteWindow.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockRouteWindow : public IRouteWindow
         {
-            virtual ~MockRouteWindow() = default;
+            MockRouteWindow();
+            virtual ~MockRouteWindow();
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_route, (IRoute*), (override));
             MOCK_METHOD(void, select_waypoint, (uint32_t), (override));

--- a/trview.app/Mocks/Windows/IRouteWindowManager.h
+++ b/trview.app/Mocks/Windows/IRouteWindowManager.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockRouteWindowManager : public IRouteWindowManager
         {
-            virtual ~MockRouteWindowManager() = default;
+            MockRouteWindowManager();
+            virtual ~MockRouteWindowManager();
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_route, (IRoute*), (override));
             MOCK_METHOD(void, create_window, (), (override));

--- a/trview.app/Mocks/Windows/ITriggersWindow.h
+++ b/trview.app/Mocks/Windows/ITriggersWindow.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockTriggersWindow : public ITriggersWindow
         {
-            virtual ~MockTriggersWindow() = default;
+            MockTriggersWindow();
+            virtual ~MockTriggersWindow();
             MOCK_METHOD(void, clear_selected_trigger, (), (override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(std::weak_ptr<ITrigger>, selected_trigger, (), (const, override));

--- a/trview.app/Mocks/Windows/ITriggersWindowManager.h
+++ b/trview.app/Mocks/Windows/ITriggersWindowManager.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockTriggersWindowManager : public ITriggersWindowManager
         {
-            virtual ~MockTriggersWindowManager() = default;
+            MockTriggersWindowManager();
+            virtual ~MockTriggersWindowManager();
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_items, (const std::vector<Item>&), (override));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));

--- a/trview.app/Mocks/Windows/IViewer.h
+++ b/trview.app/Mocks/Windows/IViewer.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockViewer : public IViewer
         {
-            virtual ~MockViewer() = default;
+            MockViewer();
+            virtual ~MockViewer();
             MOCK_METHOD(CameraMode, camera_mode, (), (const, override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, open, (ILevel*, ILevel::OpenMode), (override));

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -328,7 +328,7 @@ namespace trview
                     if (!setting.second.options.empty() && json.count(setting.first) && json[setting.first].is_number())
                     {
                         const auto index = json[setting.first].get<int>();
-                        result[setting.first] = setting.second.options[std::max(0, std::min<int>(index, setting.second.options.size() - 1))];
+                        result[setting.first] = setting.second.options[std::max(0, std::min<int>(index, static_cast<int>(setting.second.options.size() - 1)))];
                     }
                     else
                     {
@@ -563,7 +563,8 @@ namespace trview
         }
 
         auto trimmed = level_filename.substr(level_filename.find_last_of("/\\") + 1);
-        std::transform(trimmed.begin(), trimmed.end(), trimmed.begin(), ::toupper);
+        std::transform(trimmed.begin(), trimmed.end(), trimmed.begin(),
+            [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
         json[trimmed] = waypoints;
         files->save_file(route_filename, json.dump(2, ' '));
     }

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -367,7 +367,7 @@ namespace trview
             int x = location["X"];
             int y = location["Y"];
             int z = location["Z"];
-            int room_number = location["Room"];
+            uint32_t room_number = location["Room"];
 
             // If the room space attribute is true then the coordinate must be transformed.
             if (read_attribute<bool>(location, "IsInRoomSpace", false))
@@ -385,7 +385,7 @@ namespace trview
                 y = room->info().yBottom - y;
             }
 
-            route->add(Vector3(x, y, z) / 1024.0f, Vector3::Down, room_number, IWaypoint::Type::Position, 0);
+            route->add(Vector3(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z)) / 1024.0f, Vector3::Down, room_number, IWaypoint::Type::Position, 0);
             auto& new_waypoint = route->waypoint(route->waypoints() - 1);
             new_waypoint.set_randomizer_settings(import_randomizer_settings(location, randomizer_settings));
         }

--- a/trview.app/Settings/RandomizerSettings.cpp
+++ b/trview.app/Settings/RandomizerSettings.cpp
@@ -142,7 +142,7 @@ namespace trview
 
     uint32_t RandomizerSettings::settings_of_type(Setting::Type type) const
     {
-        return std::count_if(settings.begin(), settings.end(),
-            [type](const auto& t) { return t.second.type == type; });
+        return static_cast<uint32_t>(std::count_if(settings.begin(), settings.end(),
+            [type](const auto& t) { return t.second.type == type; }));
     }
 }

--- a/trview.app/Tools/Toolbar.cpp
+++ b/trview.app/Tools/Toolbar.cpp
@@ -2,7 +2,7 @@
 
 namespace trview
 {
-    void Toolbar::add_tool(const std::string& name, const std::string& text)
+    void Toolbar::add_tool(const std::string& name)
     {
         _tools.push_back(name);
     }

--- a/trview.app/Tools/Toolbar.h
+++ b/trview.app/Tools/Toolbar.h
@@ -13,8 +13,7 @@ namespace trview
     public:
         /// Add a new tool to the toolbar.
         /// @param name The name of the tool
-        /// @param text The text to show in the button.
-        void add_tool(const std::string& name, const std::string& text);
+        void add_tool(const std::string& name);
 
         void render();
 

--- a/trview.app/UI/CameraControls.cpp
+++ b/trview.app/UI/CameraControls.cpp
@@ -28,7 +28,7 @@ namespace trview
             const std::array<std::string, 3> mode_items{ "Orbit", "Free", "Axis" };
             if (ImGui::BeginCombo(Names::mode.c_str(), mode_items[static_cast<uint32_t>(_mode)].c_str()))
             {
-                for (int n = 0; n < mode_items.size(); ++n)
+                for (std::size_t n = 0; n < mode_items.size(); ++n)
                 {
                     bool is_selected = _mode == static_cast<CameraMode>(n);
                     if (ImGui::Selectable(mode_items[n].c_str(), is_selected))
@@ -47,7 +47,7 @@ namespace trview
             const std::array<std::string, 2> projection_items{ "Perspective", "Orthographic" };
             if (ImGui::BeginCombo(Names::projection_mode.c_str(), projection_items[static_cast<uint32_t>(_projection_mode)].c_str()))
             {
-                for (int n = 0; n < projection_items.size(); ++n)
+                for (std::size_t n = 0; n < projection_items.size(); ++n)
                 {
                     bool is_selected = _projection_mode == static_cast<ProjectionMode>(n);
                     if (ImGui::Selectable(projection_items[n].c_str(), is_selected))

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -172,9 +172,8 @@ namespace trview
         virtual void set_minimap_highlight(uint16_t x, uint16_t z) = 0;
 
         /// Set the current pick result.
-        /// @param info The parameters for the pick.
         /// @param pick_result The pick result.
-        virtual void set_pick(const PickInfo& info, const PickResult& pick_result) = 0;
+        virtual void set_pick(const PickResult& pick_result) = 0;
 
         /// Set whether the user can click the remove waypoint button.
         /// "param value Whether the button is enabled.

--- a/trview.app/UI/RoomNavigator.cpp
+++ b/trview.app/UI/RoomNavigator.cpp
@@ -7,7 +7,7 @@ namespace trview
         ImGui::SetNextWindowPos(ImGui::GetMainViewport()->Pos + ImVec2(4, 4), ImGuiCond_FirstUseEver);
         if (ImGui::Begin("Room Navigator", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
         {
-            const uint32_t previous_selection = _selected_room;
+            const int32_t previous_selection = _selected_room;
             if (ImGui::InputInt(std::format("of {}##roomnumber", _max_rooms).c_str(), &_selected_room, 1, 10, ImGuiInputTextFlags_EnterReturnsTrue))
             {
                 _selected_room = std::clamp(_selected_room, 0, _max_rooms);

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -68,7 +68,7 @@ namespace trview
         };
 
         _toolbar = std::make_unique<Toolbar>();
-        _toolbar->add_tool("Measure", "|....|");
+        _toolbar->add_tool("Measure");
         _token_store += _toolbar->on_tool_clicked += [this](const std::string& tool)
         {
             if (tool == "Measure")

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -297,7 +297,7 @@ namespace trview
         _map_renderer->set_highlight(x, z);
     }
 
-    void ViewerUI::set_pick(const PickInfo& info, const PickResult& result)
+    void ViewerUI::set_pick(const PickResult& result)
     {
         // TODO: Context menu visible?
         _tooltip->set_visible(result.hit && _show_tooltip && !_context_menu->visible());

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -51,7 +51,7 @@ namespace trview
         virtual void set_measure_distance(float distance) override;
         virtual void set_measure_position(const Point& position) override;
         virtual void set_minimap_highlight(uint16_t x, uint16_t z) override;
-        virtual void set_pick(const PickInfo& info, const PickResult& pick_result) override;
+        virtual void set_pick(const PickResult& pick_result) override;
         virtual void set_remove_waypoint_enabled(bool value) override;
         virtual void set_selected_item(uint32_t index) override;
         virtual void set_selected_room(const std::shared_ptr<IRoom>& room) override;

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -145,7 +145,7 @@ namespace trview
                         _scroll_to_item = false;
                     }
 
-                    if (ImGui::Selectable(std::format("{0}##{0}", item.number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav | ImGuiTableFlags_SizingFixedFit))
+                    if (ImGui::Selectable(std::format("{0}##{0}", item.number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                     {
                         scroller.fix_scroll();
 
@@ -277,7 +277,7 @@ namespace trview
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
                     bool selected = _selected_trigger.lock() == trigger_ptr;
-                    if (ImGui::Selectable(std::to_string(trigger_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                    if (ImGui::Selectable(std::to_string(trigger_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                     {
                         _selected_trigger = trigger;
                         set_track_room(false);
@@ -377,7 +377,7 @@ namespace trview
                 {
                     if (auto trigger_ptr = trigger.lock())
                     {
-                        results.push_back(trigger_ptr->number());
+                        results.push_back(static_cast<float>(trigger_ptr->number()));
                     }
                 }
                 return results;

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -360,16 +360,16 @@ namespace trview
             available_types.insert(item.type());
         }
         _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& item) { return item.type(); });
-        _filters.add_getter<float>("#", [](auto&& item) { return item.number(); });
+        _filters.add_getter<float>("#", [](auto&& item) { return static_cast<float>(item.number()); });
         _filters.add_getter<float>("X", [](auto&& item) { return item.position().x * trlevel::Scale_X; });
         _filters.add_getter<float>("Y", [](auto&& item) { return item.position().y * trlevel::Scale_Y; });
         _filters.add_getter<float>("Z", [](auto&& item) { return item.position().z * trlevel::Scale_Z; });
-        _filters.add_getter<float>("Type ID", [](auto&& item) { return item.type_id(); });
-        _filters.add_getter<float>("Room", [](auto&& item) { return item.room(); });
+        _filters.add_getter<float>("Type ID", [](auto&& item) { return static_cast<float>(item.type_id()); });
+        _filters.add_getter<float>("Room", [](auto&& item) { return static_cast<float>(item.room()); });
         _filters.add_getter<bool>("Clear Body", [](auto&& item) { return item.clear_body_flag(); });
         _filters.add_getter<bool>("Invisible", [](auto&& item) { return item.invisible_flag(); });
         _filters.add_getter<std::string>("Flags", [](auto&& item) { return format_binary(item.activation_flags()); });
-        _filters.add_getter<float>("OCB", [](auto&& item) { return item.ocb(); });
+        _filters.add_getter<float>("OCB", [](auto&& item) { return static_cast<float>(item.ocb()); });
         _filters.add_multi_getter<float>("Triggered By", [](auto&& item)
             {
                 std::vector<float> results;

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -136,7 +136,7 @@ namespace trview
                         _scroll_to_light = false;
                     }
 
-                    if (ImGui::Selectable(std::format("{0}##{0}", light->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav | ImGuiTableFlags_SizingFixedFit))
+                    if (ImGui::Selectable(std::format("{0}##{0}", light->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                     {
                         scroller.fix_scroll();
 
@@ -187,7 +187,7 @@ namespace trview
                     {
                         const auto string_value = get_string(value);
                         ImGui::TableNextColumn();
-                        if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                        if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                         {
                             _clipboard->write(to_utf16(string_value));
                             _tooltip_timer = 0.0f;
@@ -307,19 +307,19 @@ namespace trview
             }
         }
         _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& light) { return light_type_name(light.type()); });
-        _filters.add_getter<float>("#", [](auto&& light) { return light.number(); });
-        _filters.add_getter<float>("Room", [](auto&& light) { return light.room(); });
+        _filters.add_getter<float>("#", [](auto&& light) { return static_cast<float>(light.number()); });
+        _filters.add_getter<float>("Room", [](auto&& light) { return static_cast<float>(light.room()); });
         _filters.add_getter<float>("X", [](auto&& light) { return light.position().x * trlevel::Scale_X; }, has_position);
         _filters.add_getter<float>("Y", [](auto&& light) { return light.position().y * trlevel::Scale_Y; }, has_position);
         _filters.add_getter<float>("Z", [](auto&& light) { return light.position().z * trlevel::Scale_Z; }, has_position);
-        _filters.add_getter<float>("Intensity", [](auto&& light) { return light.intensity(); }, has_intensity);
-        _filters.add_getter<float>("Fade", [](auto&& light) { return light.fade(); }, has_fade);
+        _filters.add_getter<float>("Intensity", [](auto&& light) { return static_cast<float>(light.intensity()); }, has_intensity);
+        _filters.add_getter<float>("Fade", [](auto&& light) { return static_cast<float>(light.fade()); }, has_fade);
 
         if (_level_version >= trlevel::LevelVersion::Tomb3)
         {
-            _filters.add_getter<float>("R", [](auto&& light) { return static_cast<int>(light.colour().r * 255.0f); }, has_colour);
-            _filters.add_getter<float>("G", [](auto&& light) { return static_cast<int>(light.colour().g * 255.0f); }, has_colour);
-            _filters.add_getter<float>("B", [](auto&& light) { return static_cast<int>(light.colour().b * 255.0f); }, has_colour);
+            _filters.add_getter<float>("R", [](auto&& light) { return std::floor(light.colour().r * 255.0f); }, has_colour);
+            _filters.add_getter<float>("G", [](auto&& light) { return std::floor(light.colour().g * 255.0f); }, has_colour);
+            _filters.add_getter<float>("B", [](auto&& light) { return std::floor(light.colour().b * 255.0f); }, has_colour);
             _filters.add_getter<float>("DX", [](auto&& light) { return light.direction().x * trlevel::Scale_X; }, has_direction);
             _filters.add_getter<float>("DY", [](auto&& light) { return light.direction().y * trlevel::Scale_Y; }, has_direction);
             _filters.add_getter<float>("DZ", [](auto&& light) { return light.direction().z * trlevel::Scale_Z; }, has_direction);

--- a/trview.app/Windows/Log/LogWindowManager.cpp
+++ b/trview.app/Windows/Log/LogWindowManager.cpp
@@ -23,7 +23,7 @@ namespace trview
         WindowManager::render();
     }
 
-    std::optional<int> LogWindowManager::process_message(UINT message, WPARAM wParam, LPARAM lParam)
+    std::optional<int> LogWindowManager::process_message(UINT message, WPARAM wParam, LPARAM)
     {
         if (message == WM_COMMAND && LOWORD(wParam) == ID_WINDOWS_LOG)
         {

--- a/trview.app/Windows/Log/LogWindowManager.cpp
+++ b/trview.app/Windows/Log/LogWindowManager.cpp
@@ -7,7 +7,7 @@ namespace trview
     {
     }
 
-    LogWindowManager::LogWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const ILogWindow::Source& log_window_source)
+    LogWindowManager::LogWindowManager(const Window& window, const ILogWindow::Source& log_window_source)
         : _log_window_source(log_window_source), MessageHandler(window)
     {
 

--- a/trview.app/Windows/Log/LogWindowManager.h
+++ b/trview.app/Windows/Log/LogWindowManager.h
@@ -10,7 +10,7 @@ namespace trview
     class LogWindowManager final : public ILogWindowManager, WindowManager<ILogWindow>, public MessageHandler
     {
     public:
-        LogWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const ILogWindow::Source& log_window_source);
+        LogWindowManager(const Window& window, const ILogWindow::Source& log_window_source);
         virtual ~LogWindowManager() = default;
         virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         virtual std::weak_ptr<ILogWindow> create_window() override;

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -332,7 +332,7 @@ namespace trview
                         _scroll_to_room = false;
                     }
 
-                    if (ImGui::Selectable(std::format("{0}##{0}", room_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                    if (ImGui::Selectable(std::format("{0}##{0}", room_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                     {
                         scroller.fix_scroll();
                         _selected_room = room_ptr->number();
@@ -525,7 +525,7 @@ namespace trview
                                         _scroll_to_item = false;
                                     }
 
-                                    if (ImGui::Selectable(std::to_string(item.number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                                    if (ImGui::Selectable(std::to_string(item.number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                                     {
                                         scroller.fix_scroll();
                                         _local_selected_item = item;
@@ -554,7 +554,7 @@ namespace trview
                                 ImGui::TableNextRow();
                                 ImGui::TableNextColumn();
                                 bool selected = false;
-                                if (ImGui::Selectable(std::to_string(neighbour).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                                if (ImGui::Selectable(std::to_string(neighbour).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                                 {
                                     _selected_room = neighbour;
                                     if (_sync_room)
@@ -599,7 +599,7 @@ namespace trview
                                         _scroll_to_trigger = false;
                                     }
 
-                                    if (ImGui::Selectable(std::format("{0}##{0}", trigger_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                                    if (ImGui::Selectable(std::format("{0}##{0}", trigger_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                                     {
                                         scroller.fix_scroll();
                                         _local_selected_trigger = trigger_ptr;
@@ -667,7 +667,7 @@ namespace trview
                     const auto trigger_ptr = trigger.lock();
                     if (trigger_ptr && trigger_ptr->room() == room.number())
                     {
-                        results.push_back(trigger_ptr->number());
+                        results.push_back(static_cast<float>(trigger_ptr->number()));
                     }
                 }
                 return results;
@@ -701,7 +701,7 @@ namespace trview
                 {
                     if (item.room() == room.number())
                     {
-                        results.push_back(item.number());
+                        results.push_back(static_cast<float>(item.number()));
                     }
                 }
                 return results;

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -649,9 +649,9 @@ namespace trview
     void RoomsWindow::generate_filters()
     {
         _filters.clear_all_getters();
-        _filters.add_getter<float>("X", [](auto&& room) { return room.info().x; });
-        _filters.add_getter<float>("Y", [](auto&& room) { return room.info().yBottom; });
-        _filters.add_getter<float>("Z", [](auto&& room) { return room.info().z; });
+        _filters.add_getter<float>("X", [](auto&& room) { return static_cast<float>(room.info().x); });
+        _filters.add_getter<float>("Y", [](auto&& room) { return static_cast<float>(room.info().yBottom); });
+        _filters.add_getter<float>("Z", [](auto&& room) { return static_cast<float>(room.info().z); });
         _filters.add_multi_getter<float>("Neighbours", [](auto&& room)
             {
                 std::vector<float> results;

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -94,8 +94,8 @@ namespace trview
                 }
             }
 
-            int32_t move_from = -1;
-            int32_t move_to = -1;
+            std::optional<uint32_t> move_from;
+            std::optional<uint32_t> move_to;
 
             if (ImGui::BeginTable("##waypointslist", 2, ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -1)))
             {
@@ -121,7 +121,7 @@ namespace trview
                             _scroll_to_waypoint = false;
                         }
 
-                        if (ImGui::Selectable(std::to_string(i).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                        if (ImGui::Selectable(std::to_string(i).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                         {
                             scroller.fix_scroll();
 
@@ -159,12 +159,12 @@ namespace trview
                 ImGui::EndTable();
             }
 
-            if (move_from != -1 && move_to != -1)
+            if (move_from && move_to)
             {
-                on_waypoint_reordered(move_from, move_to);
-                if (_selected_index == move_from)
+                on_waypoint_reordered(move_from.value(), move_to.value());
+                if (_selected_index == move_from.value())
                 {
-                    on_waypoint_selected(move_to);
+                    on_waypoint_selected(move_to.value());
                 }
             }
         }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -409,10 +409,8 @@ namespace trview
                             b.second.default_value : waypoint_settings[b.first]);
                     if (ImGui::Checkbox(b.second.display.c_str(), &value))
                     {
-                        auto& waypoint = _route->waypoint(_selected_index);
-                        auto settings = waypoint.randomizer_settings();
-                        settings[b.first] = value;
-                        waypoint.set_randomizer_settings(settings);
+                        waypoint_settings[b.first] = value;
+                        waypoint.set_randomizer_settings(waypoint_settings);
                         _route->set_unsaved(true);
                     }
                 }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -208,7 +208,7 @@ namespace trview
                                 return waypoint.position();
                             }
                             const auto info = room->info();
-                            const Vector3 bottom_left = Vector3(info.x, info.yBottom, info.z) / trlevel::Scale_X;
+                            const Vector3 bottom_left = Vector3(static_cast<float>(info.x), static_cast<float>(info.yBottom), static_cast<float>(info.z)) / trlevel::Scale_X;
                             return waypoint.position() - bottom_left;
                         }
                         return waypoint.position();

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -37,7 +37,7 @@ namespace trview
         auto reselected_command = std::find(_all_commands.begin(), _all_commands.end(), existing_command);
         if (reselected_command != _all_commands.end())
         {
-            _selected_command = reselected_command - _all_commands.begin();
+            _selected_command = static_cast<uint32_t>(reselected_command - _all_commands.begin());
         }
 
         setup_filters();
@@ -173,7 +173,7 @@ namespace trview
                         {
                             _selected_commands.push_back(command_from_name(_all_commands[n]));
                         }
-                        _selected_command = n;
+                        _selected_command = static_cast<uint32_t>(n);
                         _need_filtering = true;
                     }
 
@@ -205,7 +205,7 @@ namespace trview
                     }, _force_sort);
 
                 ImGuiListClipper clipper;
-                clipper.Begin(std::ssize(_filtered_triggers));
+                clipper.Begin(static_cast<int>(std::ssize(_filtered_triggers)));
 
                 while (clipper.Step())
                 {
@@ -529,7 +529,7 @@ namespace trview
                 });
             if (found != _filtered_triggers.end())
             {
-                return found - _filtered_triggers.begin();
+                return static_cast<int>(found - _filtered_triggers.begin());
             }
         }
         return std::nullopt;

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -205,7 +205,7 @@ namespace trview
                     }, _force_sort);
 
                 ImGuiListClipper clipper;
-                clipper.Begin(_filtered_triggers.size());
+                clipper.Begin(std::ssize(_filtered_triggers));
 
                 while (clipper.Step())
                 {

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -157,7 +157,7 @@ namespace trview
             std::string preview_command = _selected_command < _all_commands.size() ? _all_commands[_selected_command] : "";
             if (ImGui::BeginCombo(Names::command_filter.c_str(), preview_command.c_str()))
             {
-                for (int n = 0; n < _all_commands.size(); ++n)
+                for (std::size_t n = 0; n < _all_commands.size(); ++n)
                 {
                     bool is_selected = _selected_command == n;
                     if (ImGui::Selectable(_all_commands[n].c_str(), is_selected))
@@ -225,7 +225,7 @@ namespace trview
                         }
 
                         
-                        if (ImGui::Selectable(std::format("{0}##{0}", trigger_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                        if (ImGui::Selectable(std::format("{0}##{0}", trigger_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                         {
                             scroller.fix_scroll();
                             set_local_selected_trigger(trigger_ptr);
@@ -297,7 +297,7 @@ namespace trview
                     {
                         const auto string_value = get_string(value);
                         ImGui::TableNextColumn();
-                        if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                        if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                         {
                             _clipboard->write(to_utf16(string_value));
                             _tooltip_timer = 0.0f;
@@ -348,7 +348,7 @@ namespace trview
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
                     bool selected = false;
-                    if (ImGui::Selectable(std::format("{}##{}", command_type_name(command.type()), command.number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_SelectOnNav))
+                    if (ImGui::Selectable(std::format("{}##{}", command_type_name(command.type()), command.number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                     {
                         if (command.type() == TriggerCommandType::LookAtItem || command.type() == TriggerCommandType::Object && command.index() < _all_items.size())
                         {
@@ -414,11 +414,11 @@ namespace trview
             }
         }
         _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& trigger) { return trigger_type_name(trigger.type()); });
-        _filters.add_getter<float>("#", [](auto&& trigger) { return trigger.number(); });
-        _filters.add_getter<float>("Room", [](auto&& trigger) { return trigger.room(); });
+        _filters.add_getter<float>("#", [](auto&& trigger) { return static_cast<float>(trigger.number()); });
+        _filters.add_getter<float>("Room", [](auto&& trigger) { return static_cast<float>(trigger.room()); });
         _filters.add_getter<std::string>("Flags", [](auto&& trigger) { return format_binary(trigger.flags()); });
         _filters.add_getter<bool>("Only once", [](auto&& trigger) { return trigger.only_once(); });
-        _filters.add_getter<float>("Timer", [](auto&& trigger) { return trigger.timer(); });
+        _filters.add_getter<float>("Timer", [](auto&& trigger) { return static_cast<float>(trigger.timer()); });
 
         auto all_trigger_indices = [](TriggerCommandType type, const auto& trigger)
         {

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -322,7 +322,7 @@ namespace trview
             {
                 result.text = generate_pick_message(result, *_level, *_route);
             }
-            _ui->set_pick(pickInfo, result);
+            _ui->set_pick(result);
 
             // Highlight sectors in the minimap.
             if (_level)

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -314,7 +314,7 @@ namespace trview
             }
         };
 
-        _token_store += _picking->on_pick += [&](PickInfo pickInfo, PickResult result)
+        _token_store += _picking->on_pick += [&](PickInfo, PickResult result)
         {
             _current_pick = result;
 

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -430,6 +430,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DiagnosticsFormat>Column</DiagnosticsFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -456,6 +457,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DiagnosticsFormat>Column</DiagnosticsFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -480,6 +482,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DiagnosticsFormat>Column</DiagnosticsFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -506,6 +509,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DiagnosticsFormat>Column</DiagnosticsFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -62,6 +62,12 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Graphics\SelectionRenderer.cpp" />
     <ClCompile Include="Graphics\TextureStorage.cpp" />
     <ClCompile Include="Menus\FileMenu.cpp" />
+    <ClCompile Include="Mocks\Mocks.cpp">
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/bigobj %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
     <ClCompile Include="trview_imgui.cpp" />
     <ClCompile Include="Lua\Lua.cpp" />
     <ClCompile Include="Menus\AlternateGroupToggler.cpp" />
@@ -424,7 +430,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)external\imgui</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)external\imgui;$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
@@ -451,7 +457,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)external\imgui</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)external\imgui;$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
@@ -476,7 +482,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)external\imgui</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)external\imgui;$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
@@ -503,7 +509,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)external\imgui</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)external\imgui;$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -438,7 +438,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>Crypt32.lib;winhttp.lib;version.lib;</AdditionalDependencies>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -461,7 +462,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>Crypt32.lib;winhttp.lib;version.lib;</AdditionalDependencies>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -484,7 +486,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>Crypt32.lib;winhttp.lib;version.lib;</AdditionalDependencies>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -511,7 +514,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <Lib>
-      <AdditionalDependencies>Crypt32.lib;winhttp.lib;version.lib;</AdditionalDependencies>
+      <AdditionalDependencies>
+      </AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -246,6 +246,9 @@
     <ClCompile Include="Windows\Log\LogWindowManager.cpp">
       <Filter>Windows\Log</Filter>
     </ClCompile>
+    <ClCompile Include="Mocks\Mocks.cpp">
+      <Filter>Mocks</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">

--- a/trview.common.tests/Logs/LogTests.cpp
+++ b/trview.common.tests/Logs/LogTests.cpp
@@ -26,7 +26,7 @@ TEST(Log, TopicAndActivityFilter)
     log.log(Message::Status::Information, "topic", "activity 2", "text");
     log.log(Message::Status::Warning, "topic", "activity 2", "text 2");
     auto messages = log.messages("topic", "activity 2");
-    ASSERT_EQ(messages.size(), 2);
+    ASSERT_EQ(messages.size(), 2u);
     ASSERT_EQ(messages[0].text, "text");
     ASSERT_EQ(messages[0].status, Message::Status::Information);
     ASSERT_EQ(messages[0].topic, "topic");
@@ -42,14 +42,14 @@ TEST(Log, AllMessages)
     log.log(Message::Status::Information, "topic", "activity 2", "text");
     log.log(Message::Status::Warning, "topic", "activity 2", "text 2");
     auto messages = log.messages();
-    ASSERT_EQ(messages.size(), 3);
+    ASSERT_EQ(messages.size(), 3u);
 }
 
 TEST(Log, Clear)
 {
     Log log;
     log.log(Message::Status::Information, "topic", "activity", "text");
-    ASSERT_EQ(log.messages().size(), 1);
+    ASSERT_EQ(log.messages().size(), 1u);
     log.clear();
-    ASSERT_EQ(log.messages().size(), 0);
+    ASSERT_EQ(log.messages().size(), 0u);
 }

--- a/trview.common.tests/trview.common.tests.vcxproj
+++ b/trview.common.tests/trview.common.tests.vcxproj
@@ -125,6 +125,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -143,6 +144,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -163,6 +165,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -185,6 +188,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/trview.common/Colour.cpp
+++ b/trview.common/Colour.cpp
@@ -1,5 +1,6 @@
 #include "Colour.h"
 #include <trview.common/Json.h>
+#include <trview.common/Strings.h>
 
 namespace trview
 {
@@ -80,8 +81,7 @@ namespace trview
 
     Colour from_named_colour(const std::string& name)
     {
-        std::string lowercase_name;
-        std::transform(name.begin(), name.end(), std::back_inserter(lowercase_name), ::tolower);
+        std::string lowercase_name = to_lowercase(name);;
         if (lowercase_name == "black") { return Colour::Black; }
         if (lowercase_name == "grey") { return Colour::Grey; }
         if (lowercase_name == "lightgrey") { return Colour::LightGrey; }

--- a/trview.common/Mocks/IFiles.h
+++ b/trview.common/Mocks/IFiles.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockFiles : public IFiles
         {
-            virtual ~MockFiles() = default;
+            MockFiles();
+            virtual ~MockFiles();
             MOCK_METHOD(std::string, appdata_directory, (), (const, override));
             MOCK_METHOD(std::string, fonts_directory, (), (const, override));
             MOCK_METHOD(bool, create_directory, (const std::string&), (const, override));

--- a/trview.common/Mocks/Logs/ILog.h
+++ b/trview.common/Mocks/Logs/ILog.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockLog : public ILog
         {
-            virtual ~MockLog() = default;
+            MockLog();
+            virtual ~MockLog();
             MOCK_METHOD(void, log, (Message::Status, const std::string&, const std::string&, const std::string&), (override));
             MOCK_METHOD(void, log, (Message::Status, const std::string&, const std::vector<std::string>&, const std::string&), (override));
             MOCK_METHOD(std::vector<Message>, messages, (), (const, override));

--- a/trview.common/Mocks/Mocks.cpp
+++ b/trview.common/Mocks/Mocks.cpp
@@ -1,0 +1,34 @@
+#include "stdafx.h"
+
+#include <gmock/gmock.h>
+
+#include "Logs/ILog.h"
+#include "Windows/IClipboard.h"
+#include "Windows/IDialogs.h"
+#include "Windows/IShell.h"
+#include "Windows/IShortcuts.h"
+#include "IFiles.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        MockLog::MockLog() {}
+        MockLog::~MockLog() {}
+
+        MockClipboard::MockClipboard() {}
+        MockClipboard::~MockClipboard() {}
+
+        MockDialogs::MockDialogs() {}
+        MockDialogs::~MockDialogs() {}
+
+        MockShell::MockShell() {}
+        MockShell::~MockShell() {}
+
+        MockShortcuts::MockShortcuts() {}
+        MockShortcuts::~MockShortcuts() {}
+
+        MockFiles::MockFiles() {}
+        MockFiles::~MockFiles() {}
+    }
+}

--- a/trview.common/Mocks/Windows/IClipboard.h
+++ b/trview.common/Mocks/Windows/IClipboard.h
@@ -4,10 +4,14 @@
 
 namespace trview
 {
-    struct MockClipboard : public IClipboard
+    namespace mocks
     {
-        virtual ~MockClipboard() = default;
-        MOCK_METHOD(std::wstring, read, (), (const));
-        MOCK_METHOD(void, write, (const std::wstring&));
-    };
+        struct MockClipboard : public IClipboard
+        {
+            MockClipboard();
+            virtual ~MockClipboard();
+            MOCK_METHOD(std::wstring, read, (), (const));
+            MOCK_METHOD(void, write, (const std::wstring&));
+        };
+    }
 }

--- a/trview.common/Mocks/Windows/IDialogs.h
+++ b/trview.common/Mocks/Windows/IDialogs.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockDialogs : public IDialogs
         {
-            virtual ~MockDialogs() = default;
+            MockDialogs();
+            virtual ~MockDialogs();
             MOCK_METHOD(bool, message_box, (const std::wstring&, const std::wstring&, Buttons), (const, override));
             MOCK_METHOD(std::optional<FileResult>, open_file, (const std::wstring&, const std::vector<FileFilter>&, uint32_t), (const, override));
             MOCK_METHOD(std::optional<FileResult>, save_file, (const std::wstring&, const std::vector<FileFilter>&, uint32_t), (const, override));

--- a/trview.common/Mocks/Windows/IShell.h
+++ b/trview.common/Mocks/Windows/IShell.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockShell : public IShell
         {
-            virtual ~MockShell() = default;
+            MockShell();
+            virtual ~MockShell();
             MOCK_METHOD(void, open, (const std::wstring&), (override));
         };
     }

--- a/trview.common/Mocks/Windows/IShortcuts.h
+++ b/trview.common/Mocks/Windows/IShortcuts.h
@@ -8,7 +8,8 @@ namespace trview
     {
         struct MockShortcuts : public IShortcuts
         {
-            virtual ~MockShortcuts() = default;
+            MockShortcuts();
+            virtual ~MockShortcuts();
             MOCK_METHOD(Event<>&, add_shortcut, (bool, uint16_t));
             MOCK_METHOD(std::vector<Shortcut>, shortcuts, (), (const));
         };

--- a/trview.common/Strings.cpp
+++ b/trview.common/Strings.cpp
@@ -38,7 +38,8 @@ namespace trview
     std::string to_lowercase(const std::string& value)
     {
         std::string result;
-        std::transform(value.begin(), value.end(), std::back_inserter(result), ::tolower);
+        std::transform(value.begin(), value.end(), std::back_inserter(result),
+            [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
         return result;
     }
 }

--- a/trview.common/Windows/Dialogs.cpp
+++ b/trview.common/Windows/Dialogs.cpp
@@ -28,7 +28,7 @@ namespace trview
         std::wstring combine_filters(const std::wstring& filter, const std::vector<std::wstring>& file_types)
         {
             std::wstring final_filter = filter + L'\0';
-            for (auto i = 0; i < file_types.size(); ++i)
+            for (std::size_t i = 0u; i < file_types.size(); ++i)
             {
                 final_filter += file_types[i];
                 if (i < file_types.size() - 1)
@@ -46,7 +46,7 @@ namespace trview
             for (const auto& filter : filters)
             {
                 final_filter += filter.name + L'\0';
-                for (auto i = 0; i < filter.file_types.size(); ++i)
+                for (std::size_t i = 0; i < filter.file_types.size(); ++i)
                 {
                     final_filter += filter.file_types[i];
                     if (i < filter.file_types.size() - 1)

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -65,6 +65,7 @@
     <ClCompile Include="Logs\Activity.cpp" />
     <ClCompile Include="Logs\Log.cpp" />
     <ClCompile Include="MessageHandler.cpp" />
+    <ClCompile Include="Mocks\Mocks.cpp" />
     <ClCompile Include="Point.cpp" />
     <ClCompile Include="Resources.cpp" />
     <ClCompile Include="Size.cpp" />
@@ -160,7 +161,7 @@
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir);$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -183,7 +184,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir);$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -208,7 +209,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir);$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -235,7 +236,7 @@
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir);$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -164,6 +164,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -186,6 +187,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -210,6 +212,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -236,6 +239,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trview.common/trview.common.vcxproj.filters
+++ b/trview.common/trview.common.vcxproj.filters
@@ -119,6 +119,9 @@
     <ClCompile Include="Logs\Activity.cpp">
       <Filter>Logs</Filter>
     </ClCompile>
+    <ClCompile Include="Mocks\Mocks.cpp">
+      <Filter>Mocks</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.graphics.tests/trview.graphics.tests.vcxproj
+++ b/trview.graphics.tests/trview.graphics.tests.vcxproj
@@ -115,6 +115,7 @@
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -133,6 +134,7 @@
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -153,6 +155,7 @@
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -175,6 +178,7 @@
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/trview.graphics/mocks/D3D/ID3D11DeviceContext.h
+++ b/trview.graphics/mocks/D3D/ID3D11DeviceContext.h
@@ -10,7 +10,8 @@ namespace trview
         {
             struct MockD3D11DeviceContext : public ID3D11DeviceContext
             {
-                virtual ~MockD3D11DeviceContext() = default;
+                MockD3D11DeviceContext();
+                virtual ~MockD3D11DeviceContext();
 
                 // IUnknown
                 MOCK_METHOD(HRESULT, QueryInterface, (REFIID riid, void** ppvObject), (Calltype(STDMETHODCALLTYPE), override));

--- a/trview.graphics/mocks/IDevice.h
+++ b/trview.graphics/mocks/IDevice.h
@@ -11,7 +11,8 @@ namespace trview
         {
             struct MockDevice : public IDevice
             {
-                virtual ~MockDevice() = default;
+                MockDevice();
+                virtual ~MockDevice();
                 MOCK_METHOD(void, begin, (), (override));
                 MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11Device>, device, (), (const, override));
                 MOCK_METHOD(Microsoft::WRL::ComPtr<ID3D11DeviceContext>, context, (), (const, override));

--- a/trview.graphics/mocks/IDeviceWindow.h
+++ b/trview.graphics/mocks/IDeviceWindow.h
@@ -10,7 +10,8 @@ namespace trview
         {
             struct MockDeviceWindow : public IDeviceWindow
             {
-                virtual ~MockDeviceWindow() = default;
+                MockDeviceWindow();
+                virtual ~MockDeviceWindow();
                 MOCK_METHOD(void, begin, (), (override));
                 MOCK_METHOD(void, clear, (const DirectX::SimpleMath::Color&), (override));
                 MOCK_METHOD(void, present, (bool), (override));

--- a/trview.graphics/mocks/IFont.h
+++ b/trview.graphics/mocks/IFont.h
@@ -11,6 +11,8 @@ namespace trview
             class MockFont final : public graphics::IFont
             {
             public:
+                MockFont();
+                virtual ~MockFont();
                 MOCK_METHOD(void, render, (const Microsoft::WRL::ComPtr<ID3D11DeviceContext>&, const std::wstring&, float, float, const Colour&));
                 MOCK_METHOD(void, render, (const Microsoft::WRL::ComPtr<ID3D11DeviceContext>&, const std::wstring&, float, float, float, float, const Colour&));
                 MOCK_METHOD(Size, measure, (const std::wstring&), (const));

--- a/trview.graphics/mocks/IFontFactory.h
+++ b/trview.graphics/mocks/IFontFactory.h
@@ -12,6 +12,8 @@ namespace trview
             class MockFontFactory final : public IFontFactory
             {
             public:
+                MockFontFactory();
+                virtual ~MockFontFactory();
                 MOCK_METHOD(void, store, (const std::string&, const std::shared_ptr<DirectX::SpriteFont>&));
                 MOCK_METHOD(std::unique_ptr<graphics::IFont>, create_font, (const std::string&, int, graphics::TextAlignment, graphics::ParagraphAlignment), (const));
             };

--- a/trview.graphics/mocks/IRenderTarget.h
+++ b/trview.graphics/mocks/IRenderTarget.h
@@ -10,7 +10,8 @@ namespace trview
         {
             struct MockRenderTarget : public IRenderTarget
             {
-                virtual ~MockRenderTarget() = default;
+                MockRenderTarget();
+                virtual ~MockRenderTarget();
                 MOCK_METHOD(void, clear, (const DirectX::SimpleMath::Color& colour), (override));
                 MOCK_METHOD(void, apply, (), (override));
                 MOCK_METHOD(Texture, texture, (), (const, override));

--- a/trview.graphics/mocks/IShader.h
+++ b/trview.graphics/mocks/IShader.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "../IShader.h"
+
 namespace trview
 {
     namespace graphics
@@ -8,7 +10,8 @@ namespace trview
         {
             struct MockShader : public IShader
             {
-                virtual ~MockShader() = default;
+                MockShader();
+                virtual ~MockShader();
                 MOCK_METHOD(void, apply, (const Microsoft::WRL::ComPtr<ID3D11DeviceContext>&), (override));
             };
         }

--- a/trview.graphics/mocks/IShaderStorage.h
+++ b/trview.graphics/mocks/IShaderStorage.h
@@ -11,7 +11,8 @@ namespace trview
             class MockShaderStorage : public IShaderStorage
             {
             public:
-                virtual ~MockShaderStorage() = default;
+                MockShaderStorage();
+                virtual ~MockShaderStorage();
                 MOCK_METHOD(void, add, (const std::string&, std::unique_ptr<IShader>));
                 MOCK_METHOD(IShader*, get, (const std::string&), (const));
             };

--- a/trview.graphics/mocks/ISprite.h
+++ b/trview.graphics/mocks/ISprite.h
@@ -10,7 +10,8 @@ namespace trview
         {
             struct MockSprite : public ISprite
             {
-                virtual ~MockSprite() = default;
+                MockSprite();
+                virtual ~MockSprite();
                 MOCK_METHOD(void, render, (const Texture&, float, float, float, float, DirectX::SimpleMath::Color), (override));
                 MOCK_METHOD(Size, host_size, (), (const, override));
                 MOCK_METHOD(void, set_host_size, (const Size&), (override));

--- a/trview.graphics/mocks/Mocks.cpp
+++ b/trview.graphics/mocks/Mocks.cpp
@@ -1,0 +1,70 @@
+#include "stdafx.h"
+
+#include <gmock/gmock.h>
+
+// Fix for printing ComPtr - removes value printing:
+namespace testing
+{
+    namespace internal
+    {
+        template <typename T>
+        class UniversalPrinter<const Microsoft::WRL::ComPtr<T>&> {
+        public:
+            // MSVC warns about adding const to a function type, so we want to
+            // disable the warning.
+            GTEST_DISABLE_MSC_WARNINGS_PUSH_(4180)
+
+                static void Print(const Microsoft::WRL::ComPtr<T>& value, ::std::ostream* os) {
+                UniversalPrint(value, os);
+            }
+
+            GTEST_DISABLE_MSC_WARNINGS_POP_()
+        };
+    }
+}
+
+#include "D3D/ID3D11DeviceContext.h"
+#include "IDevice.h"
+#include "IDeviceWindow.h"
+#include "IFont.h"
+#include "IFontFactory.h"
+#include "IRenderTarget.h"
+#include "IShader.h"
+#include "IShaderStorage.h"
+#include "ISprite.h"
+
+namespace trview
+{
+    namespace graphics
+    {
+        namespace mocks
+        {
+            MockD3D11DeviceContext::MockD3D11DeviceContext() {}
+            MockD3D11DeviceContext::~MockD3D11DeviceContext() {}
+
+            MockDevice::MockDevice() {}
+            MockDevice::~MockDevice() {}
+
+            MockDeviceWindow::MockDeviceWindow() {}
+            MockDeviceWindow::~MockDeviceWindow() {}
+
+            MockFont::MockFont() {}
+            MockFont::~MockFont() {}
+
+            MockFontFactory::MockFontFactory() {}
+            MockFontFactory::~MockFontFactory() {}
+
+            MockRenderTarget::MockRenderTarget() {}
+            MockRenderTarget::~MockRenderTarget() {}
+
+            MockShader::MockShader() {}
+            MockShader::~MockShader() {}
+
+            MockShaderStorage::MockShaderStorage() {}
+            MockShaderStorage::~MockShaderStorage() {}
+
+            MockSprite::MockSprite() {}
+            MockSprite::~MockSprite() {}
+        }
+    }
+}

--- a/trview.graphics/trview.graphics.vcxproj
+++ b/trview.graphics/trview.graphics.vcxproj
@@ -170,6 +170,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -189,6 +190,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -210,6 +212,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -233,6 +236,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trview.graphics/trview.graphics.vcxproj
+++ b/trview.graphics/trview.graphics.vcxproj
@@ -65,6 +65,12 @@
     <ClCompile Include="Font.cpp" />
     <ClCompile Include="FontFactory.cpp" />
     <ClCompile Include="JsonSerializers.cpp" />
+    <ClCompile Include="Mocks\Mocks.cpp">
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/bigobj %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
     <ClCompile Include="PixelShader.cpp" />
     <ClCompile Include="PixelShaderStore.cpp" />
     <ClCompile Include="RasterizerStateStore.cpp" />
@@ -166,7 +172,7 @@
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -186,7 +192,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -208,7 +214,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -232,7 +238,7 @@
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\DirectXTK\Inc;$(ProjectDir);$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/trview.graphics/trview.graphics.vcxproj.filters
+++ b/trview.graphics/trview.graphics.vcxproj.filters
@@ -169,6 +169,9 @@
       <Filter>Rasterizer</Filter>
     </ClCompile>
     <ClCompile Include="JsonSerializers.cpp" />
+    <ClCompile Include="Mocks\Mocks.cpp">
+      <Filter>Mocks</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Shaders">

--- a/trview.input.tests/trview.input.tests.vcxproj
+++ b/trview.input.tests/trview.input.tests.vcxproj
@@ -76,6 +76,7 @@
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -93,6 +94,7 @@
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -112,6 +114,7 @@
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -133,6 +136,7 @@
       <PrecompiledHeaderFile />
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/trview.input/Mocks/IMouse.h
+++ b/trview.input/Mocks/IMouse.h
@@ -10,7 +10,8 @@ namespace trview
         {
             struct MockMouse : public IMouse
             {
-                virtual ~MockMouse() = default;
+                MockMouse();
+                virtual ~MockMouse();
                 MOCK_METHOD(long, x, (), (const, override));
                 MOCK_METHOD(long, y, (), (const, override));
             };

--- a/trview.input/Mocks/Mocks.cpp
+++ b/trview.input/Mocks/Mocks.cpp
@@ -1,0 +1,15 @@
+#include "../stdafx.h"
+#include <gmock/gmock.h>
+#include "IMouse.h"
+
+namespace trview
+{
+    namespace input
+    {
+        namespace mocks
+        {
+            MockMouse::MockMouse() {}
+            MockMouse::~MockMouse() {}
+        }
+    }
+}

--- a/trview.input/trview.input.vcxproj
+++ b/trview.input/trview.input.vcxproj
@@ -120,6 +120,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -143,6 +144,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -168,6 +170,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -195,6 +198,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trview.input/trview.input.vcxproj
+++ b/trview.input/trview.input.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Keyboard.cpp" />
+    <ClCompile Include="Mocks\Mocks.cpp" />
     <ClCompile Include="Mouse.cpp" />
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
@@ -116,7 +117,7 @@
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -140,7 +141,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -166,7 +167,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -194,7 +195,7 @@
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)external\googlemock\include;$(SolutionDir)external\googletest\include</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/trview.input/trview.input.vcxproj.filters
+++ b/trview.input/trview.input.vcxproj.filters
@@ -5,6 +5,9 @@
     <ClCompile Include="Keyboard.cpp" />
     <ClCompile Include="WindowTester.cpp" />
     <ClCompile Include="stdafx.cpp" />
+    <ClCompile Include="Mocks\Mocks.cpp">
+      <Filter>Mocks</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Mouse.h" />

--- a/trview.lau/trview.lau.vcxproj
+++ b/trview.lau/trview.lau.vcxproj
@@ -92,6 +92,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -110,6 +111,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -128,6 +130,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -146,6 +149,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/trview.tests.common/trview.tests.common.vcxproj
+++ b/trview.tests.common/trview.tests.common.vcxproj
@@ -104,6 +104,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -124,6 +125,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -142,6 +144,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -162,6 +165,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trview/trview.cpp
+++ b/trview/trview.cpp
@@ -1,28 +1,28 @@
 #include <trview.app/Application.h>
 #include <external/imgui/imgui_internal.h>
 
-void ImGuiTestEngineHook_ItemInfo(ImGuiContext* ctx, ImGuiID id, const char* label, ImGuiItemStatusFlags flags)
+void ImGuiTestEngineHook_ItemInfo(ImGuiContext*, ImGuiID, const char*, ImGuiItemStatusFlags)
 {
 }
 
-void ImGuiTestEngineHook_ItemAdd(ImGuiContext* ctx, const ImRect& bb, ImGuiID id)
+void ImGuiTestEngineHook_ItemAdd(ImGuiContext*, const ImRect&, ImGuiID)
 {
 }
 
-void ImGuiTestEngineHook_Log(ImGuiContext* ctx, const char* fmt, ...)
+void ImGuiTestEngineHook_Log(ImGuiContext*, const char*, ...)
 {
 }
 
-const char* ImGuiTestEngine_FindItemDebugLabel(ImGuiContext* ctx, ImGuiID id)
+const char* ImGuiTestEngine_FindItemDebugLabel(ImGuiContext*, ImGuiID)
 {
     return "";
 }
 
-void ImGuiTrviewTestEngineHook_ItemText(ImGuiContext* ctx, ImGuiID id, const char*)
+void ImGuiTrviewTestEngineHook_ItemText(ImGuiContext*, ImGuiID, const char*)
 {
 }
 
-void ImGuiTrviewTestEngineHook_RenderedText(ImGuiContext* ctx, ImGuiID id, const char*)
+void ImGuiTrviewTestEngineHook_RenderedText(ImGuiContext*, ImGuiID, const char*)
 {
 }
 

--- a/trview/trview.vcxproj
+++ b/trview/trview.vcxproj
@@ -97,7 +97,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;Crypt32.lib;winhttp.lib;version.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(SolutionDir);</AdditionalIncludeDirectories>
@@ -118,7 +118,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;Crypt32.lib;winhttp.lib;version.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(SolutionDir);</AdditionalIncludeDirectories>
@@ -143,7 +143,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;Crypt32.lib;winhttp.lib;version.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(SolutionDir);</AdditionalIncludeDirectories>
@@ -168,7 +168,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>d3d11.lib;Shlwapi.lib;Crypt32.lib;winhttp.lib;version.lib;$(OutDir)trview.app.res;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>$(SolutionDir);</AdditionalIncludeDirectories>

--- a/trview/trview.vcxproj
+++ b/trview/trview.vcxproj
@@ -93,6 +93,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -114,6 +115,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -137,6 +139,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -162,6 +165,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Fix all warnings and turn on warnings as errors so they stop accumulating.
Add Mock constructor and destructor implementations to a cpp to speed up the build. Saves one minute.
Closes #1042 