### PR TITLE
Make Go To Lara select the last Lara

### DIFF
--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -877,3 +877,27 @@ TEST(Viewer, SetShowRooms)
     viewer->open(&level, ILevel::OpenMode::Full);
     ui.on_toggle_changed(IViewer::Options::rooms, true);
 }
+
+TEST(Viewer, GoToLaraSelectsLast)
+{
+    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto viewer = register_test_module().build();
+
+    const std::vector<Item> items
+    {
+        Item { 0, 0, 0, "Lara", 0, 0, {}, {} },
+        Item { 1, 0, 0, "Lara", 0, 0, {}, {} }
+    };
+    ON_CALL(level, items).WillByDefault(Return(items));
+
+    std::optional<Item> selected;
+    auto token = viewer->on_item_selected += [&](const auto& item)
+    {
+        selected = item;
+    };
+
+    viewer->open(&level, ILevel::OpenMode::Full);
+
+    ASSERT_TRUE(selected);
+    ASSERT_EQ(selected.value().number(), 1u);
+}

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1050,4 +1050,16 @@ namespace trview
         output_item = *found_item;
         return true;
     }
+
+    bool find_last_item_by_type_id(const ILevel& level, uint32_t type_id, Item& output_item)
+    {
+        const auto& items = level.items();
+        auto found_item = std::find_if(items.rbegin(), items.rend(), [=](const auto& item) { return item.type_id() == type_id; });
+        if (found_item == items.rend())
+        {
+            return false;
+        }
+        output_item = *found_item;
+        return true;
+    }
 }

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -193,4 +193,13 @@ namespace trview
     /// @param output_item The item to output the result into.
     /// @returns True if the item was found.
     bool find_item_by_type_id(const ILevel& level, uint32_t type_id, Item& output_item);
+
+    /// <summary>
+    /// Find the last item with the type id specified.
+    /// </summary>
+    /// <param name="level">The level to search.</param>
+    /// <param name="type_id">The type id to search for.</param>
+    /// <param name="output_item">The item to output the result into.</param>
+    /// <returns>True if the item was found.</returns>
+    bool find_last_item_by_type_id(const ILevel& level, uint32_t type_id, Item& output_item);
 }

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -596,7 +596,7 @@ namespace trview
             _recent_orbit_index = 0u;
 
             Item lara;
-            if (_settings.go_to_lara && find_item_by_type_id(*_level, 0u, lara))
+            if (_settings.go_to_lara && find_last_item_by_type_id(*_level, 0u, lara))
             {
                 on_item_selected(lara);
             }


### PR DESCRIPTION
When there are multiple `Lara` objects in the level select the last one, not the first. This occurred in some 20 year old customs, but could be in any level if the builder didn't pay attention.
#1050