### PR TITLE
Use 0x7fff for texture mask for all versions

### DIFF
--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -70,7 +70,7 @@ namespace trview
         _inverted_room_offset = _room_offset.Invert();
 
         generate_sectors(level, room, sector_source);
-        generate_geometry(level.get_version(), mesh_source, room);
+        generate_geometry(mesh_source, room);
         generate_adjacency();
         generate_static_meshes(mesh_source, level, room, mesh_storage, static_mesh_mesh_source, static_mesh_position_source, activity);
 
@@ -336,7 +336,7 @@ namespace trview
         }
     }
 
-    void Room::generate_geometry(trlevel::LevelVersion level_version, const IMesh::Source& mesh_source, const trlevel::tr3_room& room)
+    void Room::generate_geometry(const IMesh::Source& mesh_source, const trlevel::tr3_room& room)
     {
         std::vector<trlevel::tr_vertex> room_vertices;
         std::transform(room.data.vertices.begin(), room.data.vertices.end(), std::back_inserter(room_vertices),
@@ -350,8 +350,8 @@ namespace trview
         
         std::vector<Triangle> collision_triangles;
 
-        process_textured_rectangles(level_version, room.data.rectangles, room_vertices, *_texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
-        process_textured_triangles(level_version, room.data.triangles, room_vertices, *_texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
+        process_textured_rectangles(room.data.rectangles, room_vertices, *_texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
+        process_textured_triangles(room.data.triangles, room_vertices, *_texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
         process_collision_transparency(transparent_triangles, collision_triangles);
 
         _mesh = mesh_source(vertices, indices, std::vector<uint32_t>{}, transparent_triangles, collision_triangles);
@@ -915,7 +915,7 @@ namespace trview
 
         portal.direct = _sectors[id];
         portal.direct_room = std::const_pointer_cast<IRoom>(shared_from_this());
-        if (has_flag(portal.direct->flags(), SectorFlag::Portal))
+        if (has_flag(portal.direct->flags(), SectorFlag::Portal) && portal.direct->portal() != 0xff)
         {
             const auto other_room = _level.room(portal.direct->portal()).lock();
             const auto diff = (position() - other_room->position()) + Vector3(static_cast<float>(x2), 0, static_cast<float>(z2));

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -78,7 +78,7 @@ namespace trview
         virtual bool visible() const override;
         virtual void set_visible(bool visible) override;
     private:
-        void generate_geometry(trlevel::LevelVersion level_version, const IMesh::Source& mesh_source, const trlevel::tr3_room& room);
+        void generate_geometry(const IMesh::Source& mesh_source, const trlevel::tr3_room& room);
         void generate_adjacency();
         void generate_static_meshes(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr3_room& room, const IMeshStorage& mesh_storage,
             const IStaticMesh::MeshSource& static_mesh_mesh_source, const IStaticMesh::PositionSource& static_mesh_position_source, const Activity& activity);

--- a/trview.app/Geometry/IMesh.cpp
+++ b/trview.app/Geometry/IMesh.cpp
@@ -7,13 +7,7 @@ namespace trview
 {
     namespace
     {
-        const uint16_t Texture_Mask_TR4 = 0x7fff;
-        const uint16_t Texture_Mask = 0x0fff;
-
-        uint16_t texture_mask(trlevel::LevelVersion level_version)
-        {
-            return level_version == trlevel::LevelVersion::Tomb4 ? Texture_Mask_TR4 : Texture_Mask;
-        }
+        const uint16_t Texture_Mask = 0x7fff;
 
         Vector3 calculate_normal(const Vector3* const vertices)
         {
@@ -29,7 +23,7 @@ namespace trview
     {
     }
 
-    std::shared_ptr<IMesh> create_mesh(trlevel::LevelVersion level_version, const trlevel::tr_mesh& mesh, const IMesh::Source& source, const ILevelTextureStorage& texture_storage, bool transparent_collision)
+    std::shared_ptr<IMesh> create_mesh(const trlevel::tr_mesh& mesh, const IMesh::Source& source, const ILevelTextureStorage& texture_storage, bool transparent_collision)
     {
         std::vector<std::vector<uint32_t>> indices(texture_storage.num_tiles());
         std::vector<MeshVertex> vertices;
@@ -37,8 +31,8 @@ namespace trview
         std::vector<TransparentTriangle> transparent_triangles;
         std::vector<Triangle> collision_triangles;
 
-        process_textured_rectangles(level_version, mesh.textured_rectangles, mesh.vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles, transparent_collision);
-        process_textured_triangles(level_version, mesh.textured_triangles, mesh.vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles, transparent_collision);
+        process_textured_rectangles(mesh.textured_rectangles, mesh.vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles, transparent_collision);
+        process_textured_triangles(mesh.textured_triangles, mesh.vertices, texture_storage, vertices, indices, transparent_triangles, collision_triangles, transparent_collision);
         process_coloured_rectangles(mesh.coloured_rectangles, mesh.vertices, texture_storage, vertices, untextured_indices, collision_triangles);
         process_coloured_triangles(mesh.coloured_triangles, mesh.vertices, texture_storage, vertices, untextured_indices, collision_triangles);
 
@@ -204,7 +198,6 @@ namespace trview
     }
 
     void process_textured_rectangles(
-        trlevel::LevelVersion level_version,
         const std::vector<trlevel::tr4_mesh_face4>& rectangles,
         const std::vector<trlevel::tr_vertex>& input_vertices,
         const ILevelTextureStorage& texture_storage,
@@ -224,7 +217,7 @@ namespace trview
                 verts[i] = convert_vertex(input_vertices[rect.vertices[i]]);
             }
 
-            const uint16_t texture = rect.texture & texture_mask(level_version);
+            const uint16_t texture = rect.texture & Texture_Mask;
 
             std::array<Vector2, 4> uvs;
             for (auto i = 0u; i < uvs.size(); ++i)
@@ -295,7 +288,6 @@ namespace trview
     }
 
     void process_textured_triangles(
-        trlevel::LevelVersion level_version,
         const std::vector<trlevel::tr4_mesh_face3>& triangles,
         const std::vector<trlevel::tr_vertex>& input_vertices,
         const ILevelTextureStorage& texture_storage,
@@ -314,7 +306,7 @@ namespace trview
             }
 
             // Select UVs - otherwise they will be 0.
-            const uint16_t texture = tri.texture & texture_mask(level_version);
+            const uint16_t texture = tri.texture & Texture_Mask;
             std::array<Vector2, 3> uvs;
             for (auto i = 0u; i < uvs.size(); ++i)
             {

--- a/trview.app/Geometry/IMesh.h
+++ b/trview.app/Geometry/IMesh.h
@@ -33,13 +33,12 @@ namespace trview
     };
 
     /// Create a new mesh based on the contents of the mesh specified.
-    /// @param level_version The level version - affects texture index
     /// @param mesh The level mesh to generate.
     /// @param source The mesh source function.
     /// @param texture_storage The textures for the level.
     /// @param transparent_collision Whether to include transparent triangles in collision triangles.
     /// @returns The new mesh.
-    std::shared_ptr<IMesh> create_mesh(trlevel::LevelVersion level_version, const trlevel::tr_mesh& mesh, const IMesh::Source& source, const ILevelTextureStorage& texture_storage, bool transparent_collision = true);
+    std::shared_ptr<IMesh> create_mesh(const trlevel::tr_mesh& mesh, const IMesh::Source& source, const ILevelTextureStorage& texture_storage, bool transparent_collision = true);
 
     /// Create a new cube mesh.
     std::shared_ptr<IMesh> create_cube_mesh(const IMesh::Source& source);
@@ -76,7 +75,6 @@ namespace trview
         SpriteOffsetMode offset_mode);
 
     /// Convert the textured rectangles into collections required to create a mesh.
-    /// @param level_version The level version - affects texture index.
     /// @param rectangles The rectangles from the mesh or room geometry.
     /// @param input_vertices The vertices that the rectangle indices refer to.
     /// @param texture_storage The texture storage for the level.
@@ -86,7 +84,6 @@ namespace trview
     /// @param collision_triangles The collection to add collision triangles to.
     /// @param transparent_collision Whether to add transparent rectangles as collision triangles.
     void process_textured_rectangles(
-        trlevel::LevelVersion level_version,
         const std::vector<trlevel::tr4_mesh_face4>& rectangles,
         const std::vector<trlevel::tr_vertex>& input_vertices,
         const ILevelTextureStorage& texture_storage,
@@ -106,7 +103,6 @@ namespace trview
     /// @param collision_triangles The collection to add collision triangles to.
     /// @param transparent_collision Whether to add transparent rectangles as collision triangles.
     void process_textured_triangles(
-        trlevel::LevelVersion level_version,
         const std::vector<trlevel::tr4_mesh_face3>& triangles,
         const std::vector<trlevel::tr_vertex>& input_vertices,
         const ILevelTextureStorage& texture_storage,

--- a/trview.app/Graphics/MeshStorage.cpp
+++ b/trview.app/Graphics/MeshStorage.cpp
@@ -11,7 +11,7 @@ namespace trview
         const uint32_t pointers = level.num_mesh_pointers();
         for (uint32_t i = 0; i < pointers; ++i)
         {
-            _meshes.insert({ i, create_mesh(level.get_version(), level.get_mesh_by_pointer(i), mesh_source, texture_storage) });
+            _meshes.insert({ i, create_mesh(level.get_mesh_by_pointer(i), mesh_source, texture_storage) });
         }
     }
 


### PR DESCRIPTION
Previously trview was using 0xfff for versions before TR4 - this is apparently wrong and may have come from an old version of the format docs.
Remove the 0xfff version and just use 0x7fff. This means we don't have to pass the level version around.
#1050