### PR TITLE
Add extra checks for invalid portals

### DIFF
--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -646,7 +646,9 @@ namespace trview
             return nullptr;
         }
 
-        auto room = _level.room(sector->portal()).lock();
+        auto room =
+            sector->portal() != 0xff ?
+            _level.room(sector->portal()).lock() : nullptr;
         if (!room)
         {
             return nullptr;

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -332,6 +332,11 @@ namespace trview
     {
         const auto add_neighbour = [&](std::uint16_t room)
         {
+            if (room == 0xff || room >= level.num_rooms())
+            {
+                return;
+            }
+
             const auto &r = level.get_room(room);
             if (r.alternate_room != -1)
             {


### PR DESCRIPTION
Some levels have portals to rooms that don't exist - in this case don't just carry on regardless.
#1050