### PR TITLE
Recreate the Textures window

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -14,6 +14,7 @@
 #include <trview.app/Mocks/Windows/IRoomsWindowManager.h>
 #include <trview.app/Mocks/Windows/ILightsWindowManager.h>
 #include <trview.app/Mocks/Windows/ILogWindowManager.h>
+#include <trview.app/Mocks/Windows/ITexturesWindowManager.h>
 #include <trview.common/Mocks/Windows/IShortcuts.h>
 #include <trview.common/Mocks/Windows/IDialogs.h>
 #include <trview.common/Mocks/IFiles.h>
@@ -69,6 +70,7 @@ namespace
             std::unique_ptr<IImGuiBackend> imgui_backend{ std::make_unique<NullImGuiBackend>() };
             std::unique_ptr<ILightsWindowManager> lights_window_manager{ mock_unique<MockLightsWindowManager>() };
             std::unique_ptr<ILogWindowManager> log_window_manager{ mock_unique<MockLogWindowManager>() };
+            std::unique_ptr<ITexturesWindowManager> textures_window_manager{ mock_unique<MockTexturesWindowManager>() };
 
             std::unique_ptr<Application> build()
             {
@@ -76,7 +78,8 @@ namespace
                 return std::make_unique<Application>(window, std::move(update_checker), std::move(settings_loader),
                     trlevel_source, std::move(file_menu), std::move(viewer), route_source, shortcuts,
                     std::move(items_window_manager), std::move(triggers_window_manager), std::move(route_window_manager), std::move(rooms_window_manager),
-                    level_source, startup_options, dialogs, files, std::move(imgui_backend), std::move(lights_window_manager), std::move(log_window_manager));
+                    level_source, startup_options, dialogs, files, std::move(imgui_backend), std::move(lights_window_manager), std::move(log_window_manager),
+                    std::move(textures_window_manager));
             }
 
             test_module& with_dialogs(std::shared_ptr<IDialogs> dialogs)

--- a/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
+++ b/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
@@ -15,7 +15,6 @@ using testing::AtLeast;
 using testing::Exactly;
 using testing::NiceMock;
 using testing::SaveArg;
-using testing::SaveArgPointee;
 using namespace trview::graphics::mocks;
 
 TEST(LevelTextureStorage, PaletteLoadedTomb1)

--- a/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
+++ b/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
@@ -2,6 +2,7 @@
 #include <trview.app/Graphics/LevelTextureStorage.h>
 #include <trview.graphics/mocks/IDevice.h>
 #include <trview.app/Mocks/Graphics/ITextureStorage.h>
+#include <ranges>
 
 using namespace trview;
 using namespace trlevel;
@@ -13,6 +14,8 @@ using testing::_;
 using testing::AtLeast;
 using testing::Exactly;
 using testing::NiceMock;
+using testing::SaveArg;
+using testing::SaveArgPointee;
 using namespace trview::graphics::mocks;
 
 TEST(LevelTextureStorage, PaletteLoadedTomb1)
@@ -53,4 +56,35 @@ TEST(LevelTextureStorage, PaletteNotLoadedTomb5)
     EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb5));
     EXPECT_CALL(level, get_palette_entry(_)).Times(Exactly(0));
     LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
+}
+
+TEST(LevelTextureStorage, TexturesGenerated)
+{
+    std::vector<uint32_t> data;
+    data.resize(256 * 256, 0x000080ff);
+
+    NiceMock<trlevel::mocks::MockLevel> level;
+    ON_CALL(level, num_textiles).WillByDefault(Return(1));
+    EXPECT_CALL(level, get_textile(0)).Times(1).WillRepeatedly(Return(data));
+    auto device = mock_shared<MockDevice>();
+
+    std::vector<std::vector<uint32_t>> saved_data;
+    EXPECT_CALL(*device, create_texture_2D).Times(3).WillRepeatedly(testing::Invoke(
+        [&](auto&& desc, auto&& data)
+        {
+            const uint32_t* ptr = reinterpret_cast<const uint32_t*>(data.pSysMem);
+            saved_data.push_back({ ptr, ptr + 256 * 256 });
+            return nullptr;
+        }));
+    EXPECT_CALL(*device, create_shader_resource_view).Times(3);
+
+    LevelTextureStorage subject(device, mock_unique<MockTextureStorage>(), level);
+
+    // 0: Tile, 1: Opaque tile, 2: TRLE
+    ASSERT_EQ(saved_data.size(), 3u);
+    ASSERT_EQ(saved_data[0].size(), 65536u);
+    ASSERT_THAT(saved_data[0], testing::Each(testing::Eq(0x000080ff)));
+    ASSERT_EQ(saved_data[1].size(), 65536u);
+    ASSERT_THAT(saved_data[1], testing::Each(testing::Eq(0xff0080ff)));
+    ASSERT_EQ(saved_data[2].size(), 65536u);
 }

--- a/trview.app.tests/TexturesWindowManagerTests.cpp
+++ b/trview.app.tests/TexturesWindowManagerTests.cpp
@@ -46,7 +46,7 @@ TEST(TexturesWindowManager, SetTextureStoragePassesToWindows)
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
     manager->create_window();
 
-    EXPECT_CALL(*mock_window, set_texture_storage).Times(2);
+    EXPECT_CALL(*mock_window, set_texture_storage).Times(1);
     manager->set_texture_storage(mock_shared<MockLevelTextureStorage>());
 }
 

--- a/trview.app.tests/TexturesWindowManagerTests.cpp
+++ b/trview.app.tests/TexturesWindowManagerTests.cpp
@@ -1,0 +1,70 @@
+#include <trview.app/Windows/Textures/TexturesWindowManager.h>
+#include <trview.app/Mocks/Windows/ITexturesWindow.h>
+#include <trview.app/Resources/resource.h>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace trview::tests;
+
+namespace
+{
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            Window window{ create_test_window(L"TexturesWindowManagerTests") };
+            ITexturesWindow::Source window_source{ [](auto&&...) { return mock_shared<MockTexturesWindow>(); } };
+
+            test_module& with_window_source(const ITexturesWindow::Source& source)
+            {
+                this->window_source = source;
+                return *this;
+            }
+
+            std::unique_ptr<TexturesWindowManager> build()
+            {
+                return std::make_unique<TexturesWindowManager>(window, window_source);
+            }
+        };
+
+        return test_module{};
+    }
+}
+
+TEST(TexturesWindowManager, CreateWindowPassesLevelTextureStorage)
+{
+    auto mock_window = mock_shared<MockTexturesWindow>();
+    EXPECT_CALL(*mock_window, set_texture_storage).Times(1);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->set_texture_storage(mock_shared<MockLevelTextureStorage>());
+    manager->create_window();
+}
+
+TEST(TexturesWindowManager, SetTextureStoragePassesToWindows)
+{
+    auto mock_window = mock_shared<MockTexturesWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+
+    EXPECT_CALL(*mock_window, set_texture_storage).Times(2);
+    manager->set_texture_storage(mock_shared<MockLevelTextureStorage>());
+}
+
+TEST(TexturesWindowManager, WindowsRendered)
+{
+    auto mock_window = mock_shared<MockTexturesWindow>();
+    EXPECT_CALL(*mock_window, render).Times(1);
+
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+    manager->render();
+}
+
+TEST(TexturesWindowManager, WindowCreatedOnMenuItem)
+{
+    auto mock_window = mock_shared<MockTexturesWindow>();
+    EXPECT_CALL(*mock_window, set_number).Times(1);
+
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->process_message(WM_COMMAND, MAKEWPARAM(ID_WINDOWS_TEXTURES, 0), 0);
+}

--- a/trview.app.tests/TexturesWindowTests.cpp
+++ b/trview.app.tests/TexturesWindowTests.cpp
@@ -1,0 +1,75 @@
+#include <trview.app/Windows/Textures/TexturesWindow.h>
+#include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
+#include "TestImgui.h"
+
+using namespace trview;
+using namespace trview::tests;
+using namespace trview::mocks;
+using testing::Return;
+
+namespace
+{
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            std::unique_ptr<TexturesWindow> build()
+            {
+                return std::make_unique<TexturesWindow>();
+            }
+        };
+
+        return test_module{};
+    }
+}
+
+TEST(TexturesWindow, RegularTileUsed)
+{
+    auto window = register_test_module().build();
+    auto storage = mock_shared<MockLevelTextureStorage>();
+    ON_CALL(*storage, num_tiles).WillByDefault(Return(1));
+    EXPECT_CALL(*storage, texture).Times(0);
+    EXPECT_CALL(*storage, opaque_texture).Times(0);
+    EXPECT_CALL(*storage, texture(0)).Times(1);
+
+    window->set_texture_storage(storage);
+
+    TestImgui imgui([&]() { window->render(); });
+}
+
+TEST(TexturesWindow, OpaqueTileUsed)
+{
+    auto window = register_test_module().build();
+
+    TestImgui imgui([&]() { window->render(); });
+    imgui.click_element(imgui.id("Textures 0")
+        .id(TexturesWindow::Names::transparency_checkbox));
+
+    auto storage = mock_shared<MockLevelTextureStorage>();
+    ON_CALL(*storage, num_tiles).WillByDefault(Return(1));
+    EXPECT_CALL(*storage, texture).Times(0);
+    EXPECT_CALL(*storage, opaque_texture).Times(0);
+    EXPECT_CALL(*storage, opaque_texture(0)).Times(1);
+    window->set_texture_storage(storage);
+
+    imgui.render();
+}
+
+TEST(TexturesWindow, ChangeTile)
+{
+    auto window = register_test_module().build();
+
+    auto storage = mock_shared<MockLevelTextureStorage>();
+    ON_CALL(*storage, num_tiles).WillByDefault(Return(2));
+    EXPECT_CALL(*storage, texture).Times(0);
+    EXPECT_CALL(*storage, texture(0)).Times(2);
+    EXPECT_CALL(*storage, texture(1)).Times(2);
+    EXPECT_CALL(*storage, opaque_texture).Times(0);
+    window->set_texture_storage(storage);
+
+    TestImgui imgui([&]() { window->render(); });
+    imgui.click_element(imgui.id("Textures 0")
+        .id(TexturesWindow::Names::tile));
+    imgui.enter_text("1");
+    imgui.press_key(ImGuiKey_Enter);
+}

--- a/trview.app.tests/TexturesWindowTests.cpp
+++ b/trview.app.tests/TexturesWindowTests.cpp
@@ -73,3 +73,25 @@ TEST(TexturesWindow, ChangeTile)
     imgui.enter_text("1");
     imgui.press_key(ImGuiKey_Enter);
 }
+
+TEST(TexturesWindow, IndexClampedOnSet)
+{
+    auto window = register_test_module().build();
+
+    auto storage = mock_shared<MockLevelTextureStorage>();
+    ON_CALL(*storage, num_tiles).WillByDefault(Return(2));
+    window->set_texture_storage(storage);
+
+    TestImgui imgui([&]() { window->render(); });
+    imgui.click_element(imgui.id("Textures 0")
+        .id(TexturesWindow::Names::tile));
+    imgui.enter_text("1");
+    imgui.press_key(ImGuiKey_Enter);
+
+    ON_CALL(*storage, num_tiles).WillByDefault(Return(1));
+    window->set_texture_storage(storage);
+
+    imgui.render();
+
+    ASSERT_EQ("0", imgui.item_text(imgui.id("Textures 0").id(TexturesWindow::Names::tile)));
+}

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -682,9 +682,9 @@ TEST(Viewer, SelectionRendered)
 
     auto viewer = register_test_module().with_device(device).build();
 
-    NiceMock<MockLevelTextureStorage> texture_storage;
+    auto texture_storage = mock_shared<MockLevelTextureStorage>();
     NiceMock<MockLevel> level;
-    ON_CALL(level, texture_storage).WillByDefault(testing::ReturnRef(texture_storage));
+    ON_CALL(level, texture_storage).WillByDefault(testing::Return(texture_storage));
     EXPECT_CALL(level, render(A<const ICamera&>(), true)).Times(1);
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, render(A<const ICamera&>(), A<const ILevelTextureStorage&>(), true)).Times(1);
@@ -702,9 +702,9 @@ TEST(Viewer, SelectionNotRendered)
 
     auto viewer = register_test_module().with_device(device).build();
 
-    NiceMock<MockLevelTextureStorage> texture_storage;
+    auto texture_storage = mock_shared<MockLevelTextureStorage>();
     NiceMock<MockLevel> level;
-    ON_CALL(level, texture_storage).WillByDefault(testing::ReturnRef(texture_storage));
+    ON_CALL(level, texture_storage).WillByDefault(testing::Return(texture_storage));
     EXPECT_CALL(level, render(A<const ICamera&>(), false)).Times(1);
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, render(A<const ICamera&>(), A<const ILevelTextureStorage&>(), false)).Times(1);

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -63,6 +63,8 @@
     </ClCompile>
     <ClCompile Include="TestImgui.cpp" />
     <ClCompile Include="TestImGuiId.cpp" />
+    <ClCompile Include="TexturesWindowManagerTests.cpp" />
+    <ClCompile Include="TexturesWindowTests.cpp" />
     <ClCompile Include="TriggersWindowManagerTests.cpp" />
     <ClCompile Include="TriggersWindowTests.cpp" />
     <ClCompile Include="UI\CameraControlsTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -161,6 +161,12 @@
     <ClCompile Include="Elements\SectorTests.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
+    <ClCompile Include="TexturesWindowTests.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
+    <ClCompile Include="TexturesWindowManagerTests.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -50,12 +50,14 @@ namespace trview
         std::shared_ptr<IFiles> files,
         std::unique_ptr<IImGuiBackend> imgui_backend,
         std::unique_ptr<ILightsWindowManager> lights_window_manager,
-        std::unique_ptr<ILogWindowManager> log_window_manager)
+        std::unique_ptr<ILogWindowManager> log_window_manager,
+        std::unique_ptr<ITexturesWindowManager> textures_window_manager)
         : MessageHandler(application_window), _instance(GetModuleHandle(nullptr)),
         _file_menu(std::move(file_menu)), _update_checker(std::move(update_checker)), _view_menu(window()), _settings_loader(settings_loader), _trlevel_source(trlevel_source),
         _viewer(std::move(viewer)), _route_source(route_source), _route(route_source()), _shortcuts(shortcuts), _items_windows(std::move(items_window_manager)),
         _triggers_windows(std::move(triggers_window_manager)), _route_window(std::move(route_window_manager)), _rooms_windows(std::move(rooms_window_manager)), _level_source(level_source),
-        _dialogs(dialogs), _files(files), _timer(default_time_source()), _imgui_backend(std::move(imgui_backend)), _lights_windows(std::move(lights_window_manager)), _log_windows(std::move(log_window_manager))
+        _dialogs(dialogs), _files(files), _timer(default_time_source()), _imgui_backend(std::move(imgui_backend)), _lights_windows(std::move(lights_window_manager)), _log_windows(std::move(log_window_manager)),
+        _textures_windows(std::move(textures_window_manager))
     {
         SetWindowLongPtr(window(), GWLP_USERDATA, reinterpret_cast<LONG_PTR>(_imgui_backend.get()));
 
@@ -148,6 +150,7 @@ namespace trview
             _route->set_unsaved(false);
             _route_window->set_route(_route.get());
         }
+        _textures_windows->set_texture_storage(_level->texture_storage());
 
         _viewer->open(_level.get(), open_mode);
         _viewer->set_route(_route);
@@ -688,6 +691,7 @@ namespace trview
         _route_window->render();
         _lights_windows->render();
         _log_windows->render();
+        _textures_windows->render();
 
         ImGui::PopFont();
         ImGui::Render();

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -22,6 +22,7 @@
 #include <trview.common/Windows/IDialogs.h>
 #include <trview.common/Windows/IShortcuts.h>
 #include "Windows/Log/ILogWindowManager.h"
+#include "Windows/Textures/ITexturesWindowManager.h"
 #include "UI/IImGuiBackend.h"
 
 struct ImFont;
@@ -57,7 +58,8 @@ namespace trview
             std::shared_ptr<IFiles> files,
             std::unique_ptr<IImGuiBackend> imgui_backend,
             std::unique_ptr<ILightsWindowManager> lights_window_manager,
-            std::unique_ptr<ILogWindowManager> log_window_manager);
+            std::unique_ptr<ILogWindowManager> log_window_manager,
+            std::unique_ptr<ITexturesWindowManager> textures_window_manager);
         virtual ~Application();
         /// Attempt to open the specified level file.
         /// @param filename The level file to open.
@@ -139,6 +141,8 @@ namespace trview
         std::string _imgui_ini_filename;
         std::unique_ptr<ILogWindowManager> _log_windows;
         bool _recent_route_prompted{ false };
+
+        std::unique_ptr<ITexturesWindowManager> _textures_windows;
     };
 
     std::unique_ptr<IApplication> create_application(HINSTANCE hInstance, int command_show, const std::wstring& command_line);

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -53,6 +53,8 @@
 #include "Windows/Log/LogWindow.h"
 #include "Windows/Log/LogWindowManager.h"
 #include "UI/DX11ImGuiBackend.h"
+#include "Windows/Textures/TexturesWindowManager.h"
+#include "Windows/Textures/TexturesWindow.h"
 
 namespace trview
 {
@@ -255,6 +257,7 @@ namespace trview
         auto decrypter = std::make_shared<trlevel::Decrypter>();
 
         auto trlevel_source = [=](auto&& filename) { return std::make_unique<trlevel::Level>(filename, files, decrypter, log); };
+        auto textures_window_source = [=]() { return std::make_shared<TexturesWindow>(); };
 
         return std::make_unique<Application>(
             window,
@@ -275,6 +278,7 @@ namespace trview
             files,
             std::make_unique<DX11ImGuiBackend>(window, device),
             std::make_unique<LightsWindowManager>(window, shortcuts, lights_window_source),
-            std::make_unique<LogWindowManager>(window, log_window_source));
+            std::make_unique<LogWindowManager>(window, log_window_source),
+            std::make_unique<TexturesWindowManager>(window, textures_window_source));
     }
 }

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -110,7 +110,7 @@ namespace trview
         virtual bool show_lights() const = 0;
         virtual bool show_triggers() const = 0;
         virtual bool show_items() const = 0;
-        virtual const ILevelTextureStorage& texture_storage() const = 0;
+        virtual std::shared_ptr<ILevelTextureStorage> texture_storage() const = 0;
         /// <summary>
         /// Get the trigger at the specific index.
         /// </summary>

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -337,6 +337,7 @@ namespace trview
         {
             context->RSSetState(_wireframe_rasterizer.Get());
         }
+
         // Render the triangles that the transparency buffer has produced.
         _transparency->render(camera, *_texture_storage.get());
     }
@@ -835,9 +836,9 @@ namespace trview
         on_level_changed();
     }
 
-    const ILevelTextureStorage& Level::texture_storage() const
+    std::shared_ptr<ILevelTextureStorage> Level::texture_storage() const
     {
-        return *_texture_storage;
+        return _texture_storage;
     }
 
     std::set<uint32_t> Level::alternate_groups() const

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -87,7 +87,7 @@ namespace trview
         virtual bool show_items() const override;
         virtual void set_selected_trigger(uint32_t number) override;
         virtual void set_selected_light(uint32_t number) override;
-        virtual const ILevelTextureStorage& texture_storage() const override;
+        virtual std::shared_ptr<ILevelTextureStorage> texture_storage() const override;
         virtual std::set<uint32_t> alternate_groups() const override;
         virtual trlevel::LevelVersion version() const override;
         virtual std::string filename() const override;

--- a/trview.app/Graphics/ILevelTextureStorage.h
+++ b/trview.app/Graphics/ILevelTextureStorage.h
@@ -16,6 +16,8 @@ namespace trview
 
         virtual graphics::Texture texture(uint32_t texture_index) const = 0;
 
+        virtual graphics::Texture opaque_texture(uint32_t texture_index) const = 0;
+
         virtual graphics::Texture untextured() const = 0;
 
         virtual DirectX::SimpleMath::Vector2 uv(uint32_t texture_index, uint32_t uv_index) const = 0;
@@ -29,6 +31,8 @@ namespace trview
         virtual DirectX::SimpleMath::Color palette_from_texture(uint32_t texture) const = 0;
 
         virtual graphics::Texture geometry_texture() const = 0;
+
+        virtual uint32_t num_object_textures() const = 0;
     };
 }
 

--- a/trview.app/Graphics/LevelTextureStorage.cpp
+++ b/trview.app/Graphics/LevelTextureStorage.cpp
@@ -14,6 +14,11 @@ namespace trview
         {
             std::vector<uint32_t> data = level.get_textile(i);
             _tiles.emplace_back(*device, 256, 256, data);
+            for (auto& d : data)
+            {
+                d |= 0xff000000;
+            }
+            _opaque_tiles.emplace_back(*device, 256, 256, data);
         }
 
         // Copy object textures locally from the level.
@@ -68,6 +73,11 @@ namespace trview
     graphics::Texture LevelTextureStorage::texture(uint32_t tile_index) const
     {
         return _tiles[tile_index];
+    }
+
+    graphics::Texture LevelTextureStorage::opaque_texture(uint32_t tile_index) const
+    {
+        return _opaque_tiles[tile_index];
     }
 
     graphics::Texture LevelTextureStorage::coloured(uint32_t colour) const
@@ -135,5 +145,10 @@ namespace trview
     graphics::Texture LevelTextureStorage::geometry_texture() const
     {
         return _geometry_texture;
+    }
+
+    uint32_t LevelTextureStorage::num_object_textures() const
+    {
+        return static_cast<uint32_t>(_object_textures.size());
     }
 }

--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -17,6 +17,7 @@ namespace trview
         explicit LevelTextureStorage(const std::shared_ptr<graphics::IDevice>& device, std::unique_ptr<ITextureStorage> texture_storage, const trlevel::ILevel& level);
         virtual ~LevelTextureStorage() = default;
         virtual graphics::Texture texture(uint32_t tile_index) const override;
+        virtual graphics::Texture opaque_texture(uint32_t texture_index) const override;
         virtual graphics::Texture coloured(uint32_t colour) const override;
         virtual graphics::Texture lookup(const std::string& key) const override;
         virtual void              store(const std::string& key, const graphics::Texture& texture) override;
@@ -27,10 +28,12 @@ namespace trview
         virtual uint16_t attribute(uint32_t texture_index) const override;
         virtual DirectX::SimpleMath::Color palette_from_texture(uint32_t texture) const override;
         virtual graphics::Texture geometry_texture() const override;
+        virtual uint32_t num_object_textures() const override;
     private:
         void determine_texture_mode();
 
         std::vector<graphics::Texture> _tiles;
+        std::vector<graphics::Texture> _opaque_tiles;
         std::vector<trlevel::tr_object_texture> _object_textures;
         std::unique_ptr<ITextureStorage> _texture_storage;
         mutable graphics::Texture _untextured_texture;

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -61,7 +61,7 @@ namespace trview
             MOCK_METHOD(bool, show_lights, (), (const, override));
             MOCK_METHOD(bool, show_triggers, (), (const, override));
             MOCK_METHOD(bool, show_items, (), (const, override));
-            MOCK_METHOD(const ILevelTextureStorage&, texture_storage, (), (const, override));
+            MOCK_METHOD(std::shared_ptr<ILevelTextureStorage>, texture_storage, (), (const, override));
             MOCK_METHOD(std::weak_ptr<ITrigger>, trigger, (uint32_t), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<ITrigger>>, triggers, (), (const, override));
             MOCK_METHOD(trlevel::LevelVersion, version, (), (const, override));

--- a/trview.app/Mocks/Graphics/ILevelTextureStorage.h
+++ b/trview.app/Mocks/Graphics/ILevelTextureStorage.h
@@ -13,7 +13,8 @@ namespace trview
             MOCK_METHOD(graphics::Texture, coloured, (uint32_t), (const, override));
             MOCK_METHOD(graphics::Texture, lookup, (const std::string&), (const, override));
             MOCK_METHOD(void, store, (const std::string&, const graphics::Texture&), (override));
-            MOCK_METHOD(graphics::Texture, texture, (uint32_t texture_index), (const, override));
+            MOCK_METHOD(graphics::Texture, texture, (uint32_t), (const, override));
+            MOCK_METHOD(graphics::Texture, opaque_texture, (uint32_t), (const, override));
             MOCK_METHOD(graphics::Texture, untextured, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector2, uv, (uint32_t, uint32_t), (const, override));
             MOCK_METHOD(uint32_t, tile, (uint32_t), (const, override));
@@ -21,6 +22,7 @@ namespace trview
             MOCK_METHOD(uint16_t, attribute, (uint32_t), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Color, palette_from_texture, (uint32_t), (const, override));
             MOCK_METHOD(graphics::Texture, geometry_texture, (), (const, override));
+            MOCK_METHOD(uint32_t, num_object_textures, (), (const, override));
         };
     }
 }

--- a/trview.app/Mocks/Mocks.cpp
+++ b/trview.app/Mocks/Mocks.cpp
@@ -46,6 +46,7 @@
 #include "Windows/ITriggersWindow.h"
 #include "Windows/ITriggersWindowManager.h"
 #include "Windows/IViewer.h"
+#include "Windows/ITexturesWindowManager.h"
 
 namespace trview
 {
@@ -185,5 +186,8 @@ namespace trview
 
         MockViewer::MockViewer() {}
         MockViewer::~MockViewer() {}
+
+        MockTexturesWindowManager::MockTexturesWindowManager() {}
+        MockTexturesWindowManager::~MockTexturesWindowManager() {}
     }
 }

--- a/trview.app/Mocks/Mocks.cpp
+++ b/trview.app/Mocks/Mocks.cpp
@@ -47,6 +47,7 @@
 #include "Windows/ITriggersWindowManager.h"
 #include "Windows/IViewer.h"
 #include "Windows/ITexturesWindowManager.h"
+#include "Windows/ITexturesWindow.h"
 
 namespace trview
 {
@@ -189,5 +190,8 @@ namespace trview
 
         MockTexturesWindowManager::MockTexturesWindowManager() {}
         MockTexturesWindowManager::~MockTexturesWindowManager() {}
+
+        MockTexturesWindow::MockTexturesWindow() {}
+        MockTexturesWindow::~MockTexturesWindow() {}
     }
 }

--- a/trview.app/Mocks/Windows/ITexturesWindow.h
+++ b/trview.app/Mocks/Windows/ITexturesWindow.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "../../Windows/Textures/ITexturesWindow.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockTexturesWindow : public ITexturesWindow
+        {
+            MockTexturesWindow();
+            virtual ~MockTexturesWindow();
+            MOCK_METHOD(void, render, (), (override));
+            MOCK_METHOD(void, set_number, (int32_t), (override));
+            MOCK_METHOD(void, set_texture_storage, (const std::shared_ptr<ILevelTextureStorage>&), (override));
+        };
+    }
+}

--- a/trview.app/Mocks/Windows/ITexturesWindowManager.h
+++ b/trview.app/Mocks/Windows/ITexturesWindowManager.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "../../Windows/Textures/ITexturesWindowManager.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockTexturesWindowManager : public ITexturesWindowManager
+        {
+            MockTexturesWindowManager();
+            virtual ~MockTexturesWindowManager();
+            MOCK_METHOD(std::weak_ptr<ITexturesWindow>, create_window, (), (override));
+            MOCK_METHOD(void, render, (), (override));
+            MOCK_METHOD(void, set_texture_storage, (const std::shared_ptr<ILevelTextureStorage>&), (override));
+        };
+    }
+}

--- a/trview.app/Resources/resource.h
+++ b/trview.app/Resources/resource.h
@@ -43,6 +43,7 @@
 #define ID_WINDOWS_RESET_LAYOUT         33019
 #define ID_WINDOWS_LOG                  33020
 #define ID_FILE_RELOAD                  33021
+#define ID_WINDOWS_TEXTURES             33022
 
 // Next default values for new objects
 // 

--- a/trview.app/Resources/trview.app.rc
+++ b/trview.app/Resources/trview.app.rc
@@ -71,6 +71,7 @@ BEGIN
         MENUITEM "&Route\tCtrl+R",              ID_WINDOWS_ROUTE
         MENUITEM "&Lights\tCtrl+L"              ID_WINDOWS_LIGHTS
         MENUITEM "Log"                          ID_WINDOWS_LOG
+        MENUITEM "Textures"                     ID_WINDOWS_TEXTURES
         MENUITEM SEPARATOR
         MENUITEM "Reset Layout"                 ID_WINDOWS_RESET_LAYOUT
     END

--- a/trview.app/Windows/Textures/ITexturesWindow.h
+++ b/trview.app/Windows/Textures/ITexturesWindow.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace trview
+{
+    struct ILevelTextureStorage;
+    struct ITexturesWindow
+    {
+        using Source = std::function<std::shared_ptr<ITexturesWindow>()>;
+
+        virtual ~ITexturesWindow() = 0;
+        virtual void render() = 0;
+        virtual void set_number(int32_t number) = 0;
+        virtual void set_texture_storage(const std::shared_ptr<ILevelTextureStorage>& texture_storage) = 0;
+
+        /// <summary>
+        /// Event raised when the window is closed.
+        /// </summary>
+        Event<> on_window_closed;
+    };
+}

--- a/trview.app/Windows/Textures/ITexturesWindowManager.h
+++ b/trview.app/Windows/Textures/ITexturesWindowManager.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "ITexturesWindow.h"
+
+namespace trview
+{
+    struct ITexturesWindowManager
+    {
+        virtual ~ITexturesWindowManager() = 0;
+        virtual std::weak_ptr<ITexturesWindow> create_window() = 0;
+        virtual void render() = 0;
+        virtual void set_texture_storage(const std::shared_ptr<ILevelTextureStorage>& texture_storage) = 0;
+    };
+}

--- a/trview.app/Windows/Textures/TexturesWindow.cpp
+++ b/trview.app/Windows/Textures/TexturesWindow.cpp
@@ -1,0 +1,54 @@
+#include "TexturesWindow.h"
+#include "../../Graphics/ILevelTextureStorage.h"
+#include <format>
+
+namespace trview
+{
+    ITexturesWindow::~ITexturesWindow()
+    {
+    }
+
+    void TexturesWindow::render()
+    {
+        if (!render_textures_window())
+        {
+            on_window_closed();
+            return;
+        }
+    }
+
+    bool TexturesWindow::render_textures_window()
+    {
+        bool stay_open = true;
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(270, 335));
+        if (ImGui::Begin(_id.c_str(), &stay_open, ImGuiWindowFlags_NoResize))
+        {
+            ImGui::Checkbox("Transparency", &_transparency);
+
+            const int32_t max_textures = std::max(0, (_texture_storage ? static_cast<int32_t>(_texture_storage->num_tiles()) : 0) - 1);
+            if (ImGui::InputInt("Tile", &_index))
+            {
+                _index = std::clamp(_index, 0, max_textures);
+            }
+
+            if (_texture_storage && _index < static_cast<int32_t>(_texture_storage->num_tiles()))
+            {
+                auto texture = _transparency ? _texture_storage->texture(_index) : _texture_storage->opaque_texture(_index);
+                ImGui::Image(texture.view().Get(), ImVec2(256, 256));
+            }
+        }
+        ImGui::End();
+        ImGui::PopStyleVar();
+        return stay_open;
+    }
+
+    void TexturesWindow::set_number(int32_t number)
+    {
+        _id = std::format("Textures {}", number);
+    }
+
+    void TexturesWindow::set_texture_storage(const std::shared_ptr<ILevelTextureStorage>& texture_storage)
+    {
+        _texture_storage = texture_storage;
+    }
+}

--- a/trview.app/Windows/Textures/TexturesWindow.cpp
+++ b/trview.app/Windows/Textures/TexturesWindow.cpp
@@ -23,10 +23,10 @@ namespace trview
         ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(270, 335));
         if (ImGui::Begin(_id.c_str(), &stay_open, ImGuiWindowFlags_NoResize))
         {
-            ImGui::Checkbox("Transparency", &_transparency);
+            ImGui::Checkbox(Names::transparency_checkbox.c_str(), &_transparency);
 
             const int32_t max_textures = std::max(0, (_texture_storage ? static_cast<int32_t>(_texture_storage->num_tiles()) : 0) - 1);
-            if (ImGui::InputInt("Tile", &_index))
+            if (ImGui::InputInt(Names::tile.c_str(), &_index))
             {
                 _index = std::clamp(_index, 0, max_textures);
             }

--- a/trview.app/Windows/Textures/TexturesWindow.cpp
+++ b/trview.app/Windows/Textures/TexturesWindow.cpp
@@ -25,10 +25,9 @@ namespace trview
         {
             ImGui::Checkbox(Names::transparency_checkbox.c_str(), &_transparency);
 
-            const int32_t max_textures = std::max(0, (_texture_storage ? static_cast<int32_t>(_texture_storage->num_tiles()) : 0) - 1);
             if (ImGui::InputInt(Names::tile.c_str(), &_index))
             {
-                _index = std::clamp(_index, 0, max_textures);
+                clamp_index();
             }
 
             if (_texture_storage && _index < static_cast<int32_t>(_texture_storage->num_tiles()))
@@ -50,5 +49,12 @@ namespace trview
     void TexturesWindow::set_texture_storage(const std::shared_ptr<ILevelTextureStorage>& texture_storage)
     {
         _texture_storage = texture_storage;
+        clamp_index();
+    }
+
+    void TexturesWindow::clamp_index()
+    {
+        const int32_t max_textures = std::max(0, (_texture_storage ? static_cast<int32_t>(_texture_storage->num_tiles()) : 0) - 1);
+        _index = std::clamp(_index, 0, max_textures);
     }
 }

--- a/trview.app/Windows/Textures/TexturesWindow.h
+++ b/trview.app/Windows/Textures/TexturesWindow.h
@@ -19,6 +19,7 @@ namespace trview
         virtual void set_texture_storage(const std::shared_ptr<ILevelTextureStorage>& texture_storage) override;
     private:
         bool render_textures_window();
+        void clamp_index();
 
         std::shared_ptr<ILevelTextureStorage> _texture_storage;
         std::string _id{ "Textures 0" };

--- a/trview.app/Windows/Textures/TexturesWindow.h
+++ b/trview.app/Windows/Textures/TexturesWindow.h
@@ -7,6 +7,12 @@ namespace trview
     class TexturesWindow final : public ITexturesWindow
     {
     public:
+        struct Names
+        {
+            static inline const std::string transparency_checkbox = "Transparency";
+            static inline const std::string tile = "Tile";
+        };
+
         virtual ~TexturesWindow() = default;
         virtual void render() override;
         virtual void set_number(int32_t number) override;

--- a/trview.app/Windows/Textures/TexturesWindow.h
+++ b/trview.app/Windows/Textures/TexturesWindow.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ITexturesWindow.h"
+
+namespace trview
+{
+    class TexturesWindow final : public ITexturesWindow
+    {
+    public:
+        virtual ~TexturesWindow() = default;
+        virtual void render() override;
+        virtual void set_number(int32_t number) override;
+        virtual void set_texture_storage(const std::shared_ptr<ILevelTextureStorage>& texture_storage) override;
+    private:
+        bool render_textures_window();
+
+        std::shared_ptr<ILevelTextureStorage> _texture_storage;
+        std::string _id{ "Textures 0" };
+        int32_t _index{ 0u };
+        bool _transparency{ true };
+    };
+}

--- a/trview.app/Windows/Textures/TexturesWindowManager.cpp
+++ b/trview.app/Windows/Textures/TexturesWindowManager.cpp
@@ -1,0 +1,44 @@
+#include "TexturesWindowManager.h"
+#include "../../Resources/resource.h"
+
+namespace trview
+{
+    ITexturesWindowManager::~ITexturesWindowManager()
+    {
+    }
+
+    TexturesWindowManager::TexturesWindowManager(const Window& window, const ITexturesWindow::Source& textures_window_source)
+        : MessageHandler(window), _textures_window_source(textures_window_source)
+    {
+    }
+
+    std::weak_ptr<ITexturesWindow> TexturesWindowManager::create_window()
+    {
+        auto window = _textures_window_source();
+        window->set_texture_storage(_texture_storage);
+        return add_window(window);
+    }
+
+    std::optional<int> TexturesWindowManager::process_message(UINT message, WPARAM wParam, LPARAM)
+    {
+        if (message == WM_COMMAND && LOWORD(wParam) == ID_WINDOWS_TEXTURES)
+        {
+            create_window();
+        }
+        return {};
+    }
+
+    void TexturesWindowManager::render()
+    {
+        WindowManager::render();
+    }
+
+    void TexturesWindowManager::set_texture_storage(const std::shared_ptr<ILevelTextureStorage>& texture_storage)
+    {
+        _texture_storage = texture_storage;
+        for (auto& window : _windows)
+        {
+            window.second->set_texture_storage(_texture_storage);
+        }
+    }
+}

--- a/trview.app/Windows/Textures/TexturesWindowManager.h
+++ b/trview.app/Windows/Textures/TexturesWindowManager.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <trview.common/MessageHandler.h>
+
+#include "../WindowManager.h"
+#include "ITexturesWindowManager.h"
+#include "ITexturesWindow.h"
+
+namespace trview
+{
+    class TexturesWindowManager final : public ITexturesWindowManager, public WindowManager<ITexturesWindow>, public MessageHandler
+    {
+    public:
+        explicit TexturesWindowManager(const Window& window, const ITexturesWindow::Source& textures_window);
+        virtual ~TexturesWindowManager() = default;
+        virtual std::weak_ptr<ITexturesWindow> create_window() override;
+        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        virtual void render() override;
+        virtual void set_texture_storage(const std::shared_ptr<ILevelTextureStorage>& texture_storage) override;
+    private:
+        ITexturesWindow::Source _textures_window_source;
+        std::shared_ptr<ILevelTextureStorage> _texture_storage;
+    };
+}

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -700,17 +700,18 @@ namespace trview
             const auto& camera = current_camera();
 
             _level->render(camera, _show_selection);
-            _sector_highlight->render(camera, _level->texture_storage());
+            auto texture_storage = _level->texture_storage();
 
-            _measure->render(camera, _level->texture_storage());
+            _sector_highlight->render(camera, *texture_storage);
+            _measure->render(camera, *texture_storage);
 
             if (_show_route)
             {
-                _route->render(camera, _level->texture_storage(), _show_selection);
+                _route->render(camera, *texture_storage, _show_selection);
             }
 
             _level->render_transparency(camera);
-            _compass->render(camera, _level->texture_storage());
+            _compass->render(camera, *texture_storage);
         }
     }
 

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -119,6 +119,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Windows\RoomsWindowManager.cpp" />
     <ClCompile Include="Windows\RouteWindow.cpp" />
     <ClCompile Include="Windows\RouteWindowManager.cpp" />
+    <ClCompile Include="Windows\Textures\TexturesWindow.cpp" />
+    <ClCompile Include="Windows\Textures\TexturesWindowManager.cpp" />
     <ClCompile Include="Windows\TriggersWindow.cpp" />
     <ClCompile Include="Windows\TriggersWindowManager.cpp" />
     <ClCompile Include="Windows\Viewer.cpp" />
@@ -230,6 +232,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\Windows\IRoomsWindowManager.h" />
     <ClInclude Include="Mocks\Windows\IRouteWindow.h" />
     <ClInclude Include="Mocks\Windows\IRouteWindowManager.h" />
+    <ClInclude Include="Mocks\Windows\ITexturesWindowManager.h" />
     <ClInclude Include="Mocks\Windows\ITriggersWindow.h" />
     <ClInclude Include="Mocks\Windows\ITriggersWindowManager.h" />
     <ClInclude Include="Mocks\Windows\IViewer.h" />
@@ -303,6 +306,10 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Windows\RoomsWindowManager.h" />
     <ClInclude Include="Windows\RouteWindow.h" />
     <ClInclude Include="Windows\RouteWindowManager.h" />
+    <ClInclude Include="Windows\Textures\ITexturesWindow.h" />
+    <ClInclude Include="Windows\Textures\ITexturesWindowManager.h" />
+    <ClInclude Include="Windows\Textures\TexturesWindow.h" />
+    <ClInclude Include="Windows\Textures\TexturesWindowManager.h" />
     <ClInclude Include="Windows\TriggersWindow.h" />
     <ClInclude Include="Windows\TriggersWindowManager.h" />
     <ClInclude Include="Windows\Viewer.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -232,6 +232,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\Windows\IRoomsWindowManager.h" />
     <ClInclude Include="Mocks\Windows\IRouteWindow.h" />
     <ClInclude Include="Mocks\Windows\IRouteWindowManager.h" />
+    <ClInclude Include="Mocks\Windows\ITexturesWindow.h" />
     <ClInclude Include="Mocks\Windows\ITexturesWindowManager.h" />
     <ClInclude Include="Mocks\Windows\ITriggersWindow.h" />
     <ClInclude Include="Mocks\Windows\ITriggersWindowManager.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -813,6 +813,9 @@
     <ClInclude Include="Mocks\Windows\ITexturesWindowManager.h">
       <Filter>Mocks\Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Mocks\Windows\ITexturesWindow.h">
+      <Filter>Mocks\Windows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -249,6 +249,12 @@
     <ClCompile Include="Mocks\Mocks.cpp">
       <Filter>Mocks</Filter>
     </ClCompile>
+    <ClCompile Include="Windows\Textures\TexturesWindow.cpp">
+      <Filter>Windows\Textures</Filter>
+    </ClCompile>
+    <ClCompile Include="Windows\Textures\TexturesWindowManager.cpp">
+      <Filter>Windows\Textures</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -792,6 +798,21 @@
     <ClInclude Include="Elements\RenderFilter.h">
       <Filter>Elements</Filter>
     </ClInclude>
+    <ClInclude Include="Windows\Textures\ITexturesWindow.h">
+      <Filter>Windows\Textures</Filter>
+    </ClInclude>
+    <ClInclude Include="Windows\Textures\ITexturesWindowManager.h">
+      <Filter>Windows\Textures</Filter>
+    </ClInclude>
+    <ClInclude Include="Windows\Textures\TexturesWindow.h">
+      <Filter>Windows\Textures</Filter>
+    </ClInclude>
+    <ClInclude Include="Windows\Textures\TexturesWindowManager.h">
+      <Filter>Windows\Textures</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\Windows\ITexturesWindowManager.h">
+      <Filter>Mocks\Windows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">
@@ -907,6 +928,9 @@
     </Filter>
     <Filter Include="Windows\Log">
       <UniqueIdentifier>{d617ca7e-d7f1-4ea4-b6d6-ea63e358ff24}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Windows\Textures">
+      <UniqueIdentifier>{36446548-876c-425f-ad6c-ea61b062a959}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Recreate the Textures window. Shows the texture tiles in the level.
Also has a checkbox to control whether transparency is used or if the generated opaque texture is used.
#1050 