### PR TITLE
Fix invalid sectors, break sector loops and change wall detection

### DIFF
--- a/trview.app/Elements/ISector.h
+++ b/trview.app/Elements/ISector.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <set>
+#include <unordered_set>
 #include <vector>
 #include <SimpleMath.h>
 #include "Types.h"
@@ -121,7 +122,7 @@ namespace trview
 
         // New triangle generation to include TRLE mode.
         virtual void generate_triangles() = 0;
-        virtual void add_triangle(const ISector::Portal& portal, const Triangle& triangle) = 0;
+        virtual void add_triangle(const ISector::Portal& portal, const Triangle& triangle, std::unordered_set<uint32_t> visited_rooms) = 0;
         virtual void add_flag(SectorFlag flag) = 0;
     };
 }

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -904,9 +904,13 @@ namespace trview
             const auto other_room = _level.room(sector->room_above()).lock();
             const auto diff = (position() - other_room->position()) + Vector3(static_cast<float>(x1), 0, static_cast<float>(z1));
             const int other_id = static_cast<int>(diff.x * other_room->num_z_sectors() + diff.z);
-            portal.sector_above = other_room->sectors()[other_id];
-            portal.above_offset = Vector3(static_cast<float>(x1), 0, static_cast<float>(z1)) - diff;
-            portal.room_above = other_room;
+            const auto sectors = other_room->sectors();
+            if (other_id >= 0 && other_id < std::ssize(sectors))
+            {
+                portal.sector_above = other_room->sectors()[other_id];
+                portal.above_offset = Vector3(static_cast<float>(x1), 0, static_cast<float>(z1)) - diff;
+                portal.room_above = other_room;
+            }
         }
 
         const auto id = get_sector_id(x2, z2);
@@ -923,7 +927,7 @@ namespace trview
             const auto diff = (position() - other_room->position()) + Vector3(static_cast<float>(x2), 0, static_cast<float>(z2));
             const int other_id = static_cast<int>(diff.x * other_room->num_z_sectors() + diff.z);
             const auto sectors = other_room->sectors();
-            if (other_id < std::ssize(sectors))
+            if (other_id >= 0 && other_id < std::ssize(sectors))
             {
                 portal.target = sectors[other_id];
                 portal.offset = Vector3(static_cast<float>(x2), 0, static_cast<float>(z2)) - diff;

--- a/trview.app/Elements/Sector.h
+++ b/trview.app/Elements/Sector.h
@@ -51,7 +51,7 @@ namespace trview
         virtual bool is_portal() const override;
         virtual bool is_ceiling() const override;
         virtual void generate_triangles() override;
-        virtual void add_triangle(const ISector::Portal& portal, const Triangle& triangle) override;
+        virtual void add_triangle(const ISector::Portal& portal, const Triangle& triangle, std::unordered_set<uint32_t> visited_rooms) override;
         virtual void add_flag(SectorFlag flag) override;
     private:
         bool parse(const trlevel::ILevel& level);

--- a/trview.app/Mocks/Elements/ISector.h
+++ b/trview.app/Mocks/Elements/ISector.h
@@ -32,7 +32,7 @@ namespace trview
             MOCK_METHOD(bool, is_ceiling, (), (const, override));
 
             MOCK_METHOD(void, generate_triangles, (), (override));
-            MOCK_METHOD(void, add_triangle, (const ISector::Portal&, const Triangle&), (override));
+            MOCK_METHOD(void, add_triangle, (const ISector::Portal&, const Triangle&, std::unordered_set<uint32_t>), (override));
             MOCK_METHOD(void, add_flag, (SectorFlag), (override));
         };
     }


### PR DESCRIPTION
A few more fixes for some old customs:
- If a sector link is invalid in TRLE geometry generation don't do anything.
- If there's a cycle in TREL geometry generation don't follow it for a second time.
- Detect walls by checking for equal floor and ceiling 

Closes #1050