### PR TITLE
Add floordata view to Rooms Window

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -269,6 +269,7 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
     EXPECT_CALL(rooms_window_manager, set_level_version(A<trlevel::LevelVersion>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_version"); });
     EXPECT_CALL(rooms_window_manager, set_items(A<const std::vector<Item>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_items"); });
     EXPECT_CALL(rooms_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_triggers"); });
+    EXPECT_CALL(rooms_window_manager, set_floordata(A<const std::vector<uint16_t>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_floordata"); });
     EXPECT_CALL(rooms_window_manager, set_rooms(A<const std::vector<std::weak_ptr<IRoom>>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_rooms"); });
     EXPECT_CALL(route_window_manager, set_items(A<const std::vector<Item>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_items"); });
     EXPECT_CALL(route_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_triggers"); });
@@ -296,7 +297,7 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
     ASSERT_TRUE(called.has_value());
     ASSERT_EQ(called.value(), "test_path.tr2");
 
-    ASSERT_EQ(events.size(), 18);
+    ASSERT_EQ(events.size(), 19);
     ASSERT_EQ(events.back(), "viewer");
 }
 
@@ -857,4 +858,19 @@ TEST(Application, RecentRouteLoadedOnWindowOpened)
     route_window_manager.on_window_created();
 
     ASSERT_EQ(called_settings.recent_routes["test.tr2"].route_path, "test.tvr");
+}
+
+TEST(Application, SectorHoverForwarded)
+{
+    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
+    EXPECT_CALL(viewer, select_sector).Times(1);
+
+    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
+
+    auto application = register_test_module()
+        .with_viewer(std::move(viewer_ptr))
+        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
+        .build();
+
+    rooms_window_manager.on_sector_hover(mock_shared<MockSector>());
 }

--- a/trview.app.tests/Elements/SectorTests.cpp
+++ b/trview.app.tests/Elements/SectorTests.cpp
@@ -13,8 +13,8 @@ TEST(Sector, HighNumberedPortal)
 {
     NiceMock<trlevel::mocks::MockLevel> level;
     ON_CALL(level, num_floor_data).WillByDefault(Return(3));
-    EXPECT_CALL(level, get_floor_data(1)).WillRepeatedly(Return(0x8001));
-    EXPECT_CALL(level, get_floor_data(2)).WillRepeatedly(Return(378));
+    std::vector<uint16_t> floor_data{ 0x0000, 0x8001, 378 };
+    EXPECT_CALL(level, get_floor_data_all).WillRepeatedly(Return(floor_data));
 
     tr3_room tr_room{};
     tr_room.num_x_sectors = 1;

--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -133,3 +133,38 @@ TEST(RoomsWindowManager, OnRoomVisibilityRaised)
     ASSERT_EQ(std::get<0>(raised.value()).lock(), room);
     ASSERT_TRUE(std::get<1>(raised.value()));
 }
+
+TEST(RoomsWindowManager, SetFloordataPassedToWindows)
+{
+    auto mock_window = mock_shared<MockRoomsWindow>();
+    EXPECT_CALL(*mock_window, set_floordata).Times(2);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+    manager->set_floordata({});
+}
+
+TEST(RoomsWindowManager, FloordataPassedToNewWindows)
+{
+    auto mock_window = mock_shared<MockRoomsWindow>();
+    EXPECT_CALL(*mock_window, set_floordata).Times(1);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+}
+
+TEST(RoomsWindowManager, OnSectorHoverRaised)
+{
+    auto manager = register_test_module().build();
+    auto sector = mock_shared<MockSector>();
+
+    std::weak_ptr<ISector> raised;
+    auto token = manager->on_sector_hover += [&](auto&& value)
+    {
+        raised = value;
+    };
+
+    auto window = manager->create_window().lock();
+    ASSERT_NE(window, nullptr);
+
+    window->on_sector_hover(sector);
+    ASSERT_EQ(raised.lock(), sector);
+}

--- a/trview.app.tests/RoomsWindowTests.cpp
+++ b/trview.app.tests/RoomsWindowTests.cpp
@@ -40,31 +40,6 @@ namespace
     }
 }
 
-TEST(RoomsWindow, ClickStatShowsBubbleAndCopies)
-{
-    auto clipboard = mock_shared<MockClipboard>();
-    EXPECT_CALL(*clipboard, write).Times(1);
-    auto window = register_test_module().with_clipboard(clipboard).build();
-
-    auto room = mock_shared<MockRoom>();
-    window->set_rooms({ room });
-    window->set_current_room(0);
-
-    TestImgui imgui([&]() { window->render(); });
-
-    ASSERT_EQ(imgui.find_window("##Tooltip_00"), nullptr);
-
-    const auto id = imgui.id("Rooms 0")
-        .push_child(RoomsWindow::Names::details_panel)
-        .push_override(RoomsWindow::Names::bottom)
-        .push(RoomsWindow::Names::properties)
-        .id("X");
-    imgui.click_element_with_hover(id);
-
-    ASSERT_NE(imgui.find_window("##Tooltip_00"), nullptr);
-}
-
-
 TEST(RoomsWindow, LevelVersionChangesFlags)
 {
     auto room = mock_shared<MockRoom>();
@@ -80,13 +55,15 @@ TEST(RoomsWindow, LevelVersionChangesFlags)
     ASSERT_TRUE(imgui.element_present(
             imgui.id("Rooms 0")
             .push_child(RoomsWindow::Names::details_panel)
-            .push_override(RoomsWindow::Names::bottom)
+            .push("TabBar")
+            .push(RoomsWindow::Names::properties_tab)
             .push(RoomsWindow::Names::properties)
             .id("Bit 7")));
     ASSERT_FALSE(imgui.element_present(
         imgui.id("Rooms 0")
         .push_child(RoomsWindow::Names::details_panel)
-        .push_override(RoomsWindow::Names::bottom)
+        .push("TabBar")
+        .push(RoomsWindow::Names::properties_tab)
         .push(RoomsWindow::Names::properties)
         .id("Quicksand / 7")));
 
@@ -100,13 +77,15 @@ TEST(RoomsWindow, LevelVersionChangesFlags)
     ASSERT_FALSE(imgui.element_present(
         imgui.id("Rooms 0")
         .push_child(RoomsWindow::Names::details_panel)
-        .push_override(RoomsWindow::Names::bottom)
+        .push("TabBar")
+        .push(RoomsWindow::Names::properties_tab)
         .push(RoomsWindow::Names::properties)
         .id("Bit 7")));
     ASSERT_TRUE(imgui.element_present(
         imgui.id("Rooms 0")
         .push_child(RoomsWindow::Names::details_panel)
-        .push_override(RoomsWindow::Names::bottom)
+        .push("TabBar")
+        .push(RoomsWindow::Names::properties_tab)
         .push(RoomsWindow::Names::properties)
         .id("Quicksand / 7")));
 }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -396,6 +396,7 @@ namespace trview
         _token_store += _rooms_windows->on_item_selected += [this](const auto& item) { select_item(item); };
         _token_store += _rooms_windows->on_trigger_selected += [this](const auto& trigger) { select_trigger(trigger); };
         _token_store += _rooms_windows->on_room_visibility += [this](const auto& room, bool value) { set_room_visibility(room, value); };
+        _token_store += _rooms_windows->on_sector_hover += [this](const auto& sector) { select_sector(sector); };
     }
 
     void Application::setup_route_window()
@@ -631,6 +632,11 @@ namespace trview
                 _level->set_room_visibility(room_ptr->number(), visible);
             }
         }
+    }
+
+    void Application::select_sector(const std::weak_ptr<ISector>& sector)
+    {
+        _viewer->select_sector(sector);
     }
 
     void Application::render()

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -136,6 +136,7 @@ namespace trview
         _rooms_windows->set_level_version(_level->version());
         _rooms_windows->set_items(_level->items());
         _rooms_windows->set_triggers(_level->triggers());
+        _rooms_windows->set_floordata(_level->floor_data());
         _rooms_windows->set_rooms(_level->rooms());
         _route_window->set_items(_level->items());
         _route_window->set_triggers(_level->triggers());

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -95,6 +95,7 @@ namespace trview
         void set_trigger_visibility(const std::weak_ptr<ITrigger>& trigger, bool visible);
         void set_light_visibility(const std::weak_ptr<ILight>& light, bool visible);
         void set_room_visibility(const std::weak_ptr<IRoom>& room, bool visible);
+        void select_sector(const std::weak_ptr<ISector>& sector);
         // Lua
         void register_lua();
         bool should_discard_changes();

--- a/trview.app/Elements/Floordata.cpp
+++ b/trview.app/Elements/Floordata.cpp
@@ -225,7 +225,7 @@ namespace trview
 
         if (index == 0)
         {
-            result.commands.push_back(Floordata::Command(Floordata::Command::Function::None, { floordata[index] }, FloordataMeanings::None, items));
+            result.commands.push_back(Floordata::Command(Floordata::Command::Function::None, { floordata[index] }, meanings, items));
             return result;
         }
         

--- a/trview.app/Elements/Floordata.cpp
+++ b/trview.app/Elements/Floordata.cpp
@@ -1,0 +1,327 @@
+#include "Floordata.h"
+#include "ITrigger.h"
+
+namespace trview
+{
+    Floordata::Command::Command(Function type, const std::vector<uint16_t>& data, FloordataMeanings meanings, const std::vector<Item>& items)
+        : type(type), data(data)
+    {
+        if (meanings == FloordataMeanings::Generate)
+        {
+            create_meanings(items);
+        }
+    }
+
+    void Floordata::Command::create_meanings(const std::vector<Item>& items)
+    {
+        // Parse the data to create the meanings.
+        const uint16_t subfunction = (data[0] & 0x7F00) >> 8;
+
+        switch (type)
+        {
+            case Function::None:
+            {
+                meanings.push_back("None");
+                break;
+            }
+            case Function::Portal:
+            {
+                meanings.push_back("Portal");
+                meanings.push_back("  Room " + std::to_string(data[1] & 0xff));
+                break;
+            }
+            case Function::FloorSlant:
+            {
+                meanings.push_back("Floor Slant");
+
+                uint16_t floor_slant = data[1];
+                const int8_t x_slope = floor_slant & 0x00ff;
+                const int8_t z_slope = floor_slant >> 8;
+                meanings.push_back("  X:" + std::to_string(x_slope) + ", Z:" + std::to_string(z_slope));
+                break;
+            }
+            case Function::CeilingSlant:
+            {
+                meanings.push_back("Ceiling Slant");
+
+                uint16_t ceiling_slant = data[1];
+                const int8_t x_slope = ceiling_slant & 0x00ff;
+                const int8_t z_slope = ceiling_slant >> 8;
+                meanings.push_back("  X:" + std::to_string(x_slope) + ", Z:" + std::to_string(z_slope));
+                break;
+            }
+            case Function::Trigger:
+            {
+                uint32_t i = 0;
+                std::uint16_t command = 0;
+                std::uint16_t setup = data[++i];
+
+                auto trigger_type = (TriggerType)subfunction;
+                meanings.push_back(trigger_type_name(trigger_type));
+                meanings.push_back("  Timer:" + std::to_string(setup & 0xff) + ", Only Once:" + std::to_string((setup & 0x100) >> 8) + ", Mask:" + format_binary((setup & 0x3e00) >> 9));
+
+                bool continue_processing = true;
+                if (trigger_type == TriggerType::Key || trigger_type == TriggerType::Switch)
+                {
+                    auto reference = data[++i];
+                    continue_processing = (reference & 0x8000) == 0;
+                    meanings.push_back("  Lock/Switch " + std::to_string(reference));
+                }
+
+                if (continue_processing)
+                {
+                    do
+                    {
+                        if (++i < data.size())
+                        {
+                            command = data[i];
+                            auto action = static_cast<TriggerCommandType>((command & 0x7C00) >> 10);
+                            auto index = static_cast<uint16_t>(command & 0x3FF);
+
+                            std::string meaning = "  " + command_type_name(action);
+                            if (command_has_index(action))
+                            {
+                                meaning += " " + std::to_string(index);
+                                if (command_is_item(action) && index < items.size())
+                                {
+                                    const auto item = items[index];
+                                    meaning += " - " + item.type();
+                                }
+                            }
+
+                            meanings.push_back(meaning);
+                            if (action == TriggerCommandType::Camera || action == TriggerCommandType::Flyby)
+                            {
+                                // Camera has another uint16_t - skip for now.
+                                command = data[++i];
+                                meanings.push_back("    " + std::to_string(command));
+                            }
+                        }
+
+                    } while (i < data.size() && !(command & 0x8000));
+                }
+
+                break;
+            }
+            case Function::Death:
+            {
+                meanings.push_back("Death");
+                break;
+            }
+            case Function::ClimbableWall:
+            {
+                meanings.push_back("Climbable wall");
+                break;
+            }
+            case Function::Triangulation_Floor_NWSE:
+            {
+                meanings.push_back("Floor triangulation");
+                meanings.push_back("");
+                break;
+            }
+            case Function::Triangulation_Floor_NESW:
+            {
+                meanings.push_back("Floor triangulation");
+                meanings.push_back("");
+                break;
+            }
+            case Function::Triangulation_Ceiling_NW:
+            {
+                meanings.push_back("Ceiling triangulation");
+                meanings.push_back("");
+                break;
+            }
+            case Function::Triangulation_Ceiling_NE:
+            {
+                meanings.push_back("Ceiling triangulation");
+                meanings.push_back("");
+                break;
+            }
+            case Function::Triangulation_Floor_Collision_SW:
+            {
+                meanings.push_back("Floor triangulation");
+                meanings.push_back("");
+                break;
+            }
+            case Function::Triangulation_Floor_Collision_NE:
+            {
+                meanings.push_back("Floor triangulation");
+                meanings.push_back("");
+                break;
+            }
+            case Function::Triangulation_Floor_Collision_SE:
+            {
+                meanings.push_back("Floor triangulation");
+                meanings.push_back("");
+                break;
+            }
+            case Function::Triangulation_Floor_Collision_NW:
+            {
+                meanings.push_back("Floor triangulation");
+                meanings.push_back("");
+                break;
+            }
+            case Function::Triangulation_Ceiling_Collision_SW:
+            {
+                meanings.push_back("Ceiling triangulation");
+                meanings.push_back("");
+                break;
+            }
+            case Function::Triangulation_Ceiling_Collision_NE:
+            {
+                meanings.push_back("Ceiling triangulation");
+                meanings.push_back("");
+                break;
+            }
+            case Function::Triangulation_Ceiling_Collision_NW:
+            {
+                meanings.push_back("Ceiling triangulation");
+                meanings.push_back("");
+                break;
+            }
+            case Function::Triangulation_Ceiling_Collision_SE:
+            {
+                meanings.push_back("Ceiling triangulation");
+                meanings.push_back("");
+                break;
+            }
+            case Function::MonkeySwing:
+            {
+                meanings.push_back("Monkey swing");
+                break;
+            }
+            case Function::MinecartLeft_DeferredTrigger:
+            {
+                meanings.push_back("Minecart left");
+                break;
+            }
+            case Function::MinecartRight_Mapper:
+            {
+                meanings.push_back("Minecart right");
+                break;
+            }
+        }
+    }
+
+    uint32_t Floordata::size() const
+    {
+        uint32_t sum = 0;
+        for (const auto& command : commands)
+        {
+            sum += static_cast<uint32_t>(command.data.size());
+        }
+        return sum;
+    }
+
+    Floordata parse_floordata(const std::vector<uint16_t>& floordata, uint32_t index, FloordataMeanings meanings)
+    {
+        return parse_floordata(floordata, index, meanings, std::vector<Item>{});
+    }
+
+
+    Floordata parse_floordata(const std::vector<uint16_t>& floordata, uint32_t index, FloordataMeanings meanings, const std::vector<Item>& items)
+    {
+        Floordata result;
+
+        if (index == 0)
+        {
+            result.commands.push_back(Floordata::Command(Floordata::Command::Function::None, { floordata[index] }, FloordataMeanings::None, items));
+            return result;
+        }
+        
+        while (true)
+        {
+            // Parse the floordata here.
+            const uint16_t floor = floordata[index];
+            Floordata::Command::Function function = static_cast<Floordata::Command::Function>(floor & 0x1f);
+            uint16_t subfunction = (floor & 0x7F00) >> 8;
+
+            using Function = Floordata::Command::Function;
+
+            std::vector<uint16_t> data;
+            data.push_back(floor);
+
+            switch (function)
+            {
+                case Function::Trigger:
+                {
+                    std::uint16_t trigger_command = 0;
+                    std::uint16_t setup = floordata[++index];
+                    data.push_back(setup);
+
+                    auto type = (TriggerType)subfunction;
+
+                    bool continue_processing = true;
+                    if (type == TriggerType::Key || type == TriggerType::Switch)
+                    {
+                        auto reference = floordata[++index];
+                        data.push_back(reference);
+                        continue_processing = (reference & 0x8000) == 0;
+                    }
+
+                    if (continue_processing)
+                    {
+                        do
+                        {
+                            if (++index < floordata.size())
+                            {
+                                trigger_command = floordata[index];
+                                data.push_back(trigger_command);
+                                auto action = static_cast<TriggerCommandType>((trigger_command & 0x7C00) >> 10);
+                                if (action == TriggerCommandType::Camera || action == TriggerCommandType::Flyby)
+                                {
+                                    // Camera has another uint16_t - skip for now.
+                                    trigger_command = floordata[++index];
+                                    data.push_back(trigger_command);
+                                }
+                            }
+
+                        } while (index < floordata.size() && !(trigger_command & 0x8000));
+                    }
+
+                    break;
+                }
+                case Function::Portal:
+                case Function::FloorSlant:
+                case Function::CeilingSlant:
+                case Function::Triangulation_Floor_NWSE:
+                case Function::Triangulation_Floor_NESW:
+                case Function::Triangulation_Floor_Collision_SW:
+                case Function::Triangulation_Floor_Collision_NE:
+                case Function::Triangulation_Floor_Collision_SE:
+                case Function::Triangulation_Floor_Collision_NW:
+                case Function::Triangulation_Ceiling_NW:
+                case Function::Triangulation_Ceiling_NE:
+                case Function::Triangulation_Ceiling_Collision_SW:
+                case Function::Triangulation_Ceiling_Collision_NE:
+                case Function::Triangulation_Ceiling_Collision_NW:
+                case Function::Triangulation_Ceiling_Collision_SE:
+                {
+                    data.push_back(floordata[++index]);
+                    break;
+                }
+                case Function::MonkeySwing:
+                case Function::MinecartLeft_DeferredTrigger:
+                case Function::MinecartRight_Mapper:
+                case Function::Death:
+                case Function::ClimbableWall:
+                {
+                    break;
+                }
+            }
+
+            result.commands.push_back(Floordata::Command(function, data, meanings, items));
+
+            if ((floor >> 15) || index == 0)
+            {
+                break;
+            }
+            else
+            {
+                ++index;
+            }
+        }
+
+        return result;
+    }
+}

--- a/trview.app/Elements/Floordata.h
+++ b/trview.app/Elements/Floordata.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "Types.h"
+#include "Item.h"
+
+namespace trview
+{
+    enum class FloordataMeanings
+    {
+        None,
+        Generate
+    };
+
+    struct Floordata
+    {
+        struct Command
+        {
+            enum class Function : uint16_t
+            {
+                None,
+                Portal,
+                FloorSlant,
+                CeilingSlant,
+                Trigger,
+                Death,
+                ClimbableWall,
+                Triangulation_Floor_NWSE,
+                Triangulation_Floor_NESW,
+                Triangulation_Ceiling_NW,
+                Triangulation_Ceiling_NE,
+                Triangulation_Floor_Collision_SW,
+                Triangulation_Floor_Collision_NE,
+                Triangulation_Floor_Collision_SE,
+                Triangulation_Floor_Collision_NW,
+                Triangulation_Ceiling_Collision_SW,
+                Triangulation_Ceiling_Collision_NE,
+                Triangulation_Ceiling_Collision_NW,
+                Triangulation_Ceiling_Collision_SE,
+                MonkeySwing,
+                MinecartLeft_DeferredTrigger,
+                MinecartRight_Mapper
+            };
+
+            explicit Command(Function type, const std::vector<uint16_t>& data, FloordataMeanings meanings, const std::vector<Item>& items);
+
+            Function type;
+            std::vector<uint16_t> data;
+            std::vector<std::string> meanings;
+        private:
+            void create_meanings(const std::vector<Item>& items);
+        };
+
+        std::vector<Command> commands;
+        uint32_t size() const;
+    };
+
+    /// <summary>
+    /// Parse the floordata at the specified index.
+    /// </summary>
+    /// <param name="floordata">The raw floor data.</param>
+    /// <param name="index">The index to start at.</param>
+    /// <returns>The parsed floor data.</returns>
+    Floordata parse_floordata(const std::vector<uint16_t>& floordata, uint32_t index, FloordataMeanings meanings);
+
+    Floordata parse_floordata(const std::vector<uint16_t>& floordata, uint32_t index, FloordataMeanings meanings, const std::vector<Item>& items);
+}

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -43,6 +43,7 @@ namespace trview
         virtual bool any_alternates() const = 0;
         virtual std::string filename() const = 0;
         virtual bool has_model(uint32_t type_id) const = 0;
+        virtual std::vector<uint16_t> floor_data() const = 0;
         virtual bool highlight_mode_enabled(RoomHighlightMode mode) const = 0;
         virtual std::optional<Item> item(uint32_t index) const = 0;
         /// Get the items in this level.

--- a/trview.app/Elements/ISector.h
+++ b/trview.app/Elements/ISector.h
@@ -117,6 +117,7 @@ namespace trview
         virtual std::vector<Triangle> triangles() const = 0;
         virtual bool is_floor() const = 0;
         virtual bool is_wall() const = 0;
+        virtual uint32_t floordata_index() const = 0;
         virtual bool is_portal() const = 0;
         virtual bool is_ceiling() const = 0;
 

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -47,7 +47,8 @@ namespace trview
         const std::shared_ptr<ILog>& log,
         const graphics::IBuffer::ConstantSource& buffer_source)
         : _device(device), _version(level->get_version()), _texture_storage(level_texture_storage),
-        _transparency(std::move(transparency_buffer)), _selection_renderer(std::move(selection_renderer)), _log(log)
+        _transparency(std::move(transparency_buffer)), _selection_renderer(std::move(selection_renderer)), _log(log),
+        _floor_data(level->get_floor_data_all())
     {
         _vertex_shader = shader_storage->get("level_vertex_shader");
         _pixel_shader = shader_storage->get("level_pixel_shader");
@@ -921,6 +922,11 @@ namespace trview
                 entity->adjust_y(new_height - entity_pos.y);
             }
         }
+    }
+
+    std::vector<uint16_t> Level::floor_data() const
+    {
+        return _floor_data;
     }
 
     void Level::generate_lights(const trlevel::ILevel& level, const ILight::Source& light_source)

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -94,6 +94,7 @@ namespace trview
         virtual trlevel::LevelVersion version() const override;
         virtual std::string filename() const override;
         virtual void set_filename(const std::string& filename) override;
+        virtual std::vector<uint16_t> floor_data() const override;
         virtual std::weak_ptr<ILight> light(uint32_t index) const override;
         virtual std::vector<std::weak_ptr<ILight>> lights() const override;
         virtual void set_light_visibility(uint32_t index, bool state) override;
@@ -186,7 +187,7 @@ namespace trview
         trlevel::LevelVersion _version;
         std::string _filename;
         std::shared_ptr<ILog> _log;
-
+        std::vector<uint16_t> _floor_data;
         std::set<uint32_t> _models;
     };
 

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -36,7 +36,7 @@ namespace trview
     Sector::parse(const trlevel::ILevel& level)
     {
         // Basic sector items 
-        if (_sector.floor == _sector.ceiling)
+        if (_sector.floor == -127 && _sector.ceiling == -127)
             _flags |= SectorFlag::Wall;
         if (_room_above != 0xFF)
             _flags |= SectorFlag::RoomAbove;

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -68,7 +68,7 @@ namespace trview
                 case Function::Portal:
                 {
                     _flags |= SectorFlag::Portal;
-                    _portal = command.data[1] & 0xFF;
+                    _portal = command.data[1];
                     break;
                 }
                 case Function::FloorSlant:

--- a/trview.app/Elements/Sector.h
+++ b/trview.app/Elements/Sector.h
@@ -45,6 +45,7 @@ namespace trview
         virtual uint32_t room() const override;
         virtual TriangulationDirection triangulation_function() const override;
         virtual std::vector<Triangle> triangles() const override;
+        virtual uint32_t floordata_index() const override;
         /// Determines whether this is a walkable floor.
         virtual bool is_floor() const override;
         virtual bool is_wall() const override;
@@ -100,6 +101,7 @@ namespace trview
 
         std::set<uint16_t> _neighbours;
 
+        uint32_t _floordata_index;
         trlevel::tr_room_info _info;
         std::vector<Triangle> _triangles;
         const IRoom& _room_ptr;
@@ -112,5 +114,5 @@ namespace trview
     /// <param name="floor">The current floordata value.</param>
     /// <param name="cur_index">The current floordata index - this will be updated.</param>
     /// <returns>Triangulation data.</returns>
-    Triangulation read_triangulation(const trlevel::ILevel& level, uint16_t floor, std::uint16_t& cur_index);
+    Triangulation parse_triangulation(uint16_t floor, uint16_t data);
 }

--- a/trview.app/Geometry/Picking.cpp
+++ b/trview.app/Geometry/Picking.cpp
@@ -25,7 +25,10 @@ namespace trview
         if (mouse_pos.x < 0 || mouse_pos.x > window_size.width ||
             mouse_pos.y < 0 || mouse_pos.y > window_size.height)
         {
-            on_pick({}, {});
+            PickResult empty;
+            empty.stop = true;
+            on_pick({}, empty);
+            return;
         }
 
         Vector3 position = camera.position();

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -16,6 +16,7 @@ namespace trview
             MOCK_METHOD(bool, any_alternates, (), (const, override));
             MOCK_METHOD(std::string, filename, (), (const, override));
             MOCK_METHOD(bool, has_model, (uint32_t), (const, override));
+            MOCK_METHOD(std::vector<uint16_t>, floor_data, (), (const, override));
             MOCK_METHOD(bool, highlight_mode_enabled, (RoomHighlightMode), (const, override));
             MOCK_METHOD(std::optional<Item>, item, (uint32_t), (const, override));
             MOCK_METHOD(std::vector<Item>, items, (), (const, override));

--- a/trview.app/Mocks/Elements/ISector.h
+++ b/trview.app/Mocks/Elements/ISector.h
@@ -16,6 +16,7 @@ namespace trview
             MOCK_METHOD(std::uint16_t, room_below, (), (const, override));
             MOCK_METHOD(std::uint16_t, room_above, (), (const, override));
             MOCK_METHOD(SectorFlag, flags, (), (const, override));
+            MOCK_METHOD(uint32_t, floordata_index, (), (const, override));
             MOCK_METHOD(TriggerInfo, trigger, (), (const, override));
             MOCK_METHOD(uint16_t, x, (), (const, override));
             MOCK_METHOD(uint16_t, z, (), (const, override));

--- a/trview.app/Mocks/UI/IMapRenderer.h
+++ b/trview.app/Mocks/UI/IMapRenderer.h
@@ -26,6 +26,7 @@ namespace trview
             MOCK_METHOD(Point, first, (), (const, override));
             MOCK_METHOD(void, set_render_mode, (RenderMode), (override));
             MOCK_METHOD(void, set_colours, (const MapColours&), (override));
+            MOCK_METHOD(void, set_selection, (const std::shared_ptr<ISector>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRoomsWindow.h
+++ b/trview.app/Mocks/Windows/IRoomsWindow.h
@@ -22,6 +22,7 @@ namespace trview
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));
+            MOCK_METHOD(void, set_floordata, (const std::vector<uint16_t>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRoomsWindowManager.h
+++ b/trview.app/Mocks/Windows/IRoomsWindowManager.h
@@ -22,6 +22,7 @@ namespace trview
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(std::weak_ptr<IRoomsWindow>, create_window, (), (override));
             MOCK_METHOD(void, update, (float), (override));
+            MOCK_METHOD(void, set_floordata, (const std::vector<uint16_t>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IViewer.h
+++ b/trview.app/Mocks/Windows/IViewer.h
@@ -17,6 +17,7 @@ namespace trview
             MOCK_METHOD(void, select_item, (const Item&), (override));
             MOCK_METHOD(void, select_room, (uint32_t), (override));
             MOCK_METHOD(void, select_light, (const std::weak_ptr<ILight>&), (override));
+            MOCK_METHOD(void, select_sector, (const std::weak_ptr<ISector>&), (override));
             MOCK_METHOD(void, select_trigger, (const std::weak_ptr<ITrigger>&), (override));
             MOCK_METHOD(void, select_waypoint, (const IWaypoint&), (override));
             MOCK_METHOD(void, set_camera_mode, (CameraMode), (override));

--- a/trview.app/UI/IMapRenderer.h
+++ b/trview.app/UI/IMapRenderer.h
@@ -62,5 +62,7 @@ namespace trview
         virtual void set_render_mode(RenderMode mode) = 0;
 
         virtual void set_colours(const MapColours& colours) = 0;
+
+        virtual void set_selection(const std::shared_ptr<ISector>& sector) = 0;
     };
 }

--- a/trview.app/UI/MapRenderer.cpp
+++ b/trview.app/UI/MapRenderer.cpp
@@ -75,9 +75,9 @@ namespace trview
             // If the cursor is over the tile, then negate colour 
             Point first = tile.position, last = Point(tile.size.width, tile.size.height) + tile.position;
             if (_cursor.is_between(first, last) ||
-                (_selected_sector.has_value() &&
-                    _selected_sector.value().first == tile.sector->x() &&
-                    _selected_sector.value().second == tile.sector->z()))
+                (_highlighted_sector.has_value() &&
+                    _highlighted_sector.value().first == tile.sector->x() &&
+                    _highlighted_sector.value().second == tile.sector->z()))
             {
                 draw_color.Negate();
                 text_color.Negate();
@@ -115,6 +115,14 @@ namespace trview
             if (has_flag(tile.sector->flags(), SectorFlag::Portal))
             {
                 _font->render(context, std::to_wstring(tile.sector->portal()), tile.position.x - 1, tile.position.y, tile.size.width, tile.size.height, text_color);
+            }
+
+            if (_selected_sector.lock() == tile.sector)
+            {
+                draw(tile.position, { tile.size.width, 1.0f }, Colour::Yellow);
+                draw(tile.position + Point(0, 1.0f), { 1.0f, tile.size.height - 2.0f }, Colour::Yellow);
+                draw(tile.position + Point(0, tile.size.height - 1.0f), { tile.size.width, 1.0f }, Colour::Yellow);
+                draw(tile.position + Point(tile.size.width - 1.0f, 1.0f), { 1.0f, tile.size.height - 2.0f }, Colour::Yellow);
             }
         });
     }
@@ -274,9 +282,9 @@ namespace trview
 
     void MapRenderer::clear_highlight()
     {
-        if (_selected_sector.has_value())
+        if (_highlighted_sector.has_value())
         {
-            _selected_sector.reset();
+            _highlighted_sector.reset();
             _force_redraw = true;
         }
     }
@@ -284,12 +292,12 @@ namespace trview
     void MapRenderer::set_highlight(uint16_t x, uint16_t z)
     {
         if (x > _columns || z > _rows ||
-            (_selected_sector.has_value() && x == _selected_sector.value().first && z == _selected_sector.value().second))
+            (_highlighted_sector.has_value() && x == _highlighted_sector.value().first && z == _highlighted_sector.value().second))
         {
             return;
         }
 
-        _selected_sector = { x, z };
+        _highlighted_sector = { x, z };
         _force_redraw = true;
     }
 
@@ -307,6 +315,12 @@ namespace trview
     void MapRenderer::set_colours(const MapColours& colours)
     {
         _colours = colours;
+        _force_redraw = true;
+    }
+
+    void MapRenderer::set_selection(const std::shared_ptr<ISector>& sector)
+    {
+        _selected_sector = sector;
         _force_redraw = true;
     }
 };

--- a/trview.app/UI/MapRenderer.h
+++ b/trview.app/UI/MapRenderer.h
@@ -88,6 +88,7 @@ namespace trview
 
         virtual void set_render_mode(RenderMode mode) override;
         virtual void set_colours(const MapColours& colours) override;
+        virtual void set_selection(const std::shared_ptr<ISector>& sector) override;
     private:
         // Determines the position (on screen) to draw a sector 
         Point get_position(const ISector& sector); 
@@ -131,11 +132,12 @@ namespace trview
         const float                         _DRAW_MARGIN = 30.0f; 
         const float                         _DRAW_SCALE = 17.0f; 
 
-        std::optional<std::pair<uint16_t, uint16_t>> _selected_sector;
+        std::optional<std::pair<uint16_t, uint16_t>> _highlighted_sector;
         std::unique_ptr<graphics::IFont> _font;
         std::shared_ptr<ISector> _previous_sector;
         Microsoft::WRL::ComPtr<ID3D11DepthStencilState> _depth_stencil_state;
         RenderMode _render_mode{ RenderMode::Screen };
         MapColours _colours;
+        std::weak_ptr<ISector> _selected_sector;
     };
 };

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -72,5 +72,7 @@ namespace trview
         virtual void update(float delta) = 0;
 
         virtual void set_number(int32_t number) = 0;
+
+        virtual void set_floordata(const std::vector<uint16_t>& data) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -29,6 +29,8 @@ namespace trview
 
         Event<std::weak_ptr<IRoom>, bool> on_room_visibility;
 
+        Event<std::weak_ptr<ISector>> on_sector_hover;
+
         /// Clear the selected trigger.
         virtual void clear_selected_trigger() = 0;
 

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -57,5 +57,7 @@ namespace trview
         /// </summary>
         /// <param name="delta">Elapsed time since previous update.</param>
         virtual void update(float delta) = 0;
+
+        virtual void set_floordata(const std::vector<uint16_t>& data) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -19,6 +19,8 @@ namespace trview
 
         Event<std::weak_ptr<IRoom>, bool> on_room_visibility;
 
+        Event<std::weak_ptr<ISector>> on_sector_hover;
+
         /// Render all of the rooms windows.
         virtual void render() = 0;
 

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -140,5 +140,7 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 target() const = 0;
 
         virtual void set_target(const DirectX::SimpleMath::Vector3& target) = 0;
+
+        virtual void select_sector(const std::weak_ptr<ISector>& sector) = 0;
     };
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -4,6 +4,7 @@
 #include <trview.app/Elements/ITrigger.h>
 #include <trview.common/Strings.h>
 #include "../trview_imgui.h"
+#include "../Elements/Floordata.h"
 
 namespace trview
 {
@@ -97,6 +98,7 @@ namespace trview
             return;
         }
 
+        _selected_sector.reset();
         _current_room = room;
         _scroll_to_room = true;
         if (_sync_room && _current_room < _all_rooms.size())
@@ -143,6 +145,7 @@ namespace trview
         _current_room = 0xffffffff;
         generate_filters();
         _force_sort = true;
+        _selected_sector.reset();
     }
 
     void RoomsWindow::set_selected_item(const Item& item)
@@ -412,24 +415,31 @@ namespace trview
                             {
                                 if (io.MouseClicked[0])
                                 {
-                                    if (has_flag(sector->flags(), SectorFlag::Portal))
+                                    if (_in_floordata_mode)
                                     {
-                                        on_room_selected(sector->portal());
-                                    }
-                                    else if (sector->room_below() != 0xff)
-                                    {
-                                        on_room_selected(sector->room_below());
+                                        _selected_sector = sector;
                                     }
                                     else
                                     {
-                                        // Select triggers
-                                        for (const auto& trigger : _all_triggers)
+                                        if (has_flag(sector->flags(), SectorFlag::Portal))
                                         {
-                                            auto trigger_ptr = trigger.lock();
-                                            if (trigger_ptr && trigger_ptr->room() == _current_room && trigger_ptr->sector_id() == sector->id())
+                                            on_room_selected(sector->portal());
+                                        }
+                                        else if (sector->room_below() != 0xff)
+                                        {
+                                            on_room_selected(sector->room_below());
+                                        }
+                                        else
+                                        {
+                                            // Select triggers
+                                            for (const auto& trigger : _all_triggers)
                                             {
-                                                on_trigger_selected(trigger);
-                                                break;
+                                                auto trigger_ptr = trigger.lock();
+                                                if (trigger_ptr && trigger_ptr->room() == _current_room && trigger_ptr->sector_id() == sector->id())
+                                                {
+                                                    on_trigger_selected(trigger);
+                                                    break;
+                                                }
                                             }
                                         }
                                     }
@@ -448,174 +458,45 @@ namespace trview
                         ImGui::Separator();
                     }
 
-                    auto add_stat = [&]<typename T>(const std::string & name, const T && value, std::function<void()> click = {})
+                    if (ImGui::BeginTabBar("TabBar"))
                     {
-                        const auto string_value = get_string(value);
-                        ImGui::TableNextColumn();
-                        if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
+                        if (ImGui::BeginTabItem("Properties"))
                         {
-                            if (click)
-                            {
-                                click();
-                            }
-                            else
-                            {
-                                _clipboard->write(to_utf16(string_value));
-                                _tooltip_timer = 0.0f;
-                            }
-                        }
-                        ImGui::TableNextColumn();
-                        ImGui::Text(string_value.c_str());
-                    };
-
-                    if (ImGui::BeginTable(Names::bottom.c_str(), 2))
-                    {
-                        ImGui::TableNextRow();
-                        ImGui::TableNextColumn();
-
-                        ImGui::Text("Properties");
-                        if (ImGui::BeginTable(Names::properties.c_str(), 2, ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(0, 150)))
-                        {
-                            ImGui::TableSetupColumn("Name");
-                            ImGui::TableSetupColumn("Value");
-                            ImGui::TableNextRow();
-
-                            add_stat("X", room->info().x);
-                            add_stat("Y", room->info().yBottom);
-                            add_stat("Z", room->info().z);
-                            if (room->alternate_mode() != Room::AlternateMode::None)
-                            {
-                                add_stat("Alternate", room->alternate_room(), [this, room]() { on_room_selected(room->alternate_room()); });
-                                if (room->alternate_group() != 0xff)
-                                {
-                                    add_stat("Alternate Group", room->alternate_group());
-                                }
-                            }
-                            add_room_flags(*_clipboard, _level_version, *room);
-                            ImGui::EndTable();
+                            render_properties_tab(room);
+                            ImGui::EndTabItem();
                         }
 
-                        ImGui::TableNextColumn();
-                        ImGui::Text("Items");
-                        if (ImGui::BeginTable("Items", 2, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(0, 150)))
+                        if (ImGui::BeginTabItem("Neigbours"))
                         {
-                            ImGui::TableSetupColumn("#");
-                            ImGui::TableSetupColumn("Type");
-                            ImGui::TableSetupScrollFreeze(1, 1);
-                            ImGui::TableHeadersRow();
-
-                            imgui_sort(_all_items,
-                                {
-                                    [](auto&& l, auto&& r) { return l.number() < r.number(); },
-                                    [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
-                                }, _force_sort);
-                            
-                            for (const auto& item : _all_items)
-                            {
-                                if (item.room() == room->number())
-                                {
-                                    ImGui::TableNextRow();
-                                    ImGui::TableNextColumn();
-                                    bool selected = _local_selected_item.has_value() && _local_selected_item.value().number() == item.number();
-                                    
-                                    ImGuiScroller scroller;
-                                    if (selected && _scroll_to_item)
-                                    {
-                                        scroller.scroll_to_item();
-                                        _scroll_to_item = false;
-                                    }
-
-                                    if (ImGui::Selectable(std::to_string(item.number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
-                                    {
-                                        scroller.fix_scroll();
-                                        _local_selected_item = item;
-                                        on_item_selected(item);
-                                        _scroll_to_item = false;
-                                    }
-
-                                    ImGui::TableNextColumn();
-                                    ImGui::Text(item.type().c_str());
-                                }
-                            }
-
-                            ImGui::EndTable();
+                            render_neighbours_tab(room);
+                            ImGui::EndTabItem();
                         }
 
-                        ImGui::TableNextColumn();
-                        ImGui::Text("Neighbours");
-                        if (ImGui::BeginTable("Neighbours", 1, ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(0, 150)))
+                        if (ImGui::BeginTabItem("Items"))
                         {
-                            ImGui::TableSetupColumn("#");
-                            ImGui::TableSetupScrollFreeze(1, 1);
-                            ImGui::TableHeadersRow();
-
-                            for (auto& neighbour : room->neighbours())
-                            {
-                                ImGui::TableNextRow();
-                                ImGui::TableNextColumn();
-                                bool selected = false;
-                                if (ImGui::Selectable(std::to_string(neighbour).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
-                                {
-                                    _selected_room = neighbour;
-                                    if (_sync_room)
-                                    {
-                                        on_room_selected(neighbour);
-                                    }
-                                }
-                            }
-
-                            ImGui::EndTable();
+                            render_items_tab(room);
+                            ImGui::EndTabItem();
                         }
 
-                        ImGui::TableNextColumn();
-                        ImGui::Text("Triggers");
-                        if (ImGui::BeginTable("Triggers", 2, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(0, 150)))
+                        if (ImGui::BeginTabItem("Triggers"))
                         {
-                            ImGui::TableSetupColumn("#");
-                            ImGui::TableSetupColumn("Type");
-                            ImGui::TableSetupScrollFreeze(1, 1);
-                            ImGui::TableHeadersRow();
-
-                            imgui_sort_weak(_all_triggers,
-                                {
-                                    [](auto&& l, auto&& r) { return l.number() < r.number(); },
-                                    [&](auto&& l, auto&& r) { return std::tuple(trigger_type_name(l.type()), l.number()) < std::tuple(trigger_type_name(r.type()), r.number()); }
-                                }, _force_sort);
-
-                            for (const auto& trigger : _all_triggers)
-                            {
-                                const auto trigger_ptr = trigger.lock();
-                                if (trigger_ptr->room() == room->number())
-                                {
-                                    ImGui::TableNextRow();
-                                    ImGui::TableNextColumn();
-                                    const auto local_selection = _local_selected_trigger.lock();
-                                    bool selected = local_selection && local_selection->number() == trigger_ptr->number();
-                                    
-                                    ImGuiScroller scroller;
-                                    if (selected && _scroll_to_trigger)
-                                    {
-                                        scroller.scroll_to_item();
-                                        _scroll_to_trigger = false;
-                                    }
-
-                                    if (ImGui::Selectable(std::format("{0}##{0}", trigger_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
-                                    {
-                                        scroller.fix_scroll();
-                                        _local_selected_trigger = trigger_ptr;
-                                        on_trigger_selected(trigger);
-                                        _scroll_to_trigger = false;
-                                    }
-
-                                    ImGui::TableNextColumn();
-                                    ImGui::Text(trigger_type_name(trigger_ptr->type()).c_str());
-                                }
-                            }
-
-                            ImGui::EndTable();
+                            render_triggers_tab(room);
+                            ImGui::EndTabItem();
                         }
 
-                        ImGui::EndTable();
+                        if (ImGui::BeginTabItem("Floordata"))
+                        {
+                            _in_floordata_mode = true;
+                            render_floordata_tab(room);
+                            ImGui::EndTabItem();
+                        }
+                        else
+                        {
+                            _in_floordata_mode = false;
+                        }
+
+
+                        ImGui::EndTabBar();
                     }
                 }
             }
@@ -742,5 +623,222 @@ namespace trview
         _filters.add_getter<bool>("Bit 15", [](auto&& room) { return room.flag(IRoom::Flag::Bit15); });
         _filters.add_getter<float>("Alternate", [](auto&& room) { return room.alternate_room(); }, [](auto&& room) { return room.alternate_mode() != IRoom::AlternateMode::None; });
         _filters.add_getter<float>("Alternate Group", [](auto&& room) { return room.alternate_group(); }, [](auto&& room) { return room.alternate_mode() != IRoom::AlternateMode::None; });
+    }
+
+    void RoomsWindow::render_properties_tab(const std::shared_ptr<IRoom>& room)
+    {
+        const auto add_stat = [&]<typename T>(const std::string & name, const T && value, std::function<void()> click = {})
+        {
+            const auto string_value = get_string(value);
+            ImGui::TableNextColumn();
+            if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
+            {
+                if (click)
+                {
+                    click();
+                }
+                else
+                {
+                    _clipboard->write(to_utf16(string_value));
+                    _tooltip_timer = 0.0f;
+                }
+            }
+            ImGui::TableNextColumn();
+            ImGui::Text(string_value.c_str());
+        };
+
+        if (ImGui::BeginTable(Names::properties.c_str(), 2, ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingStretchSame))
+        {
+            ImGui::TableSetupColumn("Name");
+            ImGui::TableSetupColumn("Value");
+            ImGui::TableNextRow();
+
+            add_stat("X", room->info().x);
+            add_stat("Y", room->info().yBottom);
+            add_stat("Z", room->info().z);
+            if (room->alternate_mode() != Room::AlternateMode::None)
+            {
+                add_stat("Alternate", room->alternate_room(), [this, room]() { on_room_selected(room->alternate_room()); });
+                if (room->alternate_group() != 0xff)
+                {
+                    add_stat("Alternate Group", room->alternate_group());
+                }
+            }
+            add_room_flags(*_clipboard, _level_version, *room);
+            ImGui::EndTable();
+        }
+    }
+
+    void RoomsWindow::render_neighbours_tab(const std::shared_ptr<IRoom>& room)
+    {
+        if (ImGui::BeginTable("Neighbours", 1, ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingStretchProp))
+        {
+            ImGui::TableSetupColumn("#");
+            ImGui::TableSetupScrollFreeze(1, 1);
+            ImGui::TableHeadersRow();
+
+            for (auto& neighbour : room->neighbours())
+            {
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                bool selected = false;
+                if (ImGui::Selectable(std::to_string(neighbour).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
+                {
+                    _selected_room = neighbour;
+                    if (_sync_room)
+                    {
+                        on_room_selected(neighbour);
+                    }
+                }
+            }
+
+            ImGui::EndTable();
+        }
+    }
+
+    void RoomsWindow::render_items_tab(const std::shared_ptr<IRoom>& room)
+    {
+        if (ImGui::BeginTable("Items", 2, ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_ScrollY))
+        {
+            ImGui::TableSetupColumn("#");
+            ImGui::TableSetupColumn("Type");
+            ImGui::TableSetupScrollFreeze(1, 1);
+            ImGui::TableHeadersRow();
+
+            imgui_sort(_all_items,
+                {
+                    [](auto&& l, auto&& r) { return l.number() < r.number(); },
+                    [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
+                }, _force_sort);
+
+            for (const auto& item : _all_items)
+            {
+                if (item.room() == room->number())
+                {
+                    ImGui::TableNextRow();
+                    ImGui::TableNextColumn();
+                    bool selected = _local_selected_item.has_value() && _local_selected_item.value().number() == item.number();
+
+                    ImGuiScroller scroller;
+                    if (selected && _scroll_to_item)
+                    {
+                        scroller.scroll_to_item();
+                        _scroll_to_item = false;
+                    }
+
+                    if (ImGui::Selectable(std::to_string(item.number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
+                    {
+                        scroller.fix_scroll();
+                        _local_selected_item = item;
+                        on_item_selected(item);
+                        _scroll_to_item = false;
+                    }
+
+                    ImGui::TableNextColumn();
+                    ImGui::Text(item.type().c_str());
+                }
+            }
+
+            ImGui::EndTable();
+        }
+    }
+
+    void RoomsWindow::render_triggers_tab(const std::shared_ptr<IRoom>& room)
+    {
+        if (ImGui::BeginTable("Triggers", 2, ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_ScrollY))
+        {
+            ImGui::TableSetupColumn("#");
+            ImGui::TableSetupColumn("Type");
+            ImGui::TableSetupScrollFreeze(1, 1);
+            ImGui::TableHeadersRow();
+
+            imgui_sort_weak(_all_triggers,
+                {
+                    [](auto&& l, auto&& r) { return l.number() < r.number(); },
+                    [&](auto&& l, auto&& r) { return std::tuple(trigger_type_name(l.type()), l.number()) < std::tuple(trigger_type_name(r.type()), r.number()); }
+                }, _force_sort);
+
+            for (const auto& trigger : _all_triggers)
+            {
+                const auto trigger_ptr = trigger.lock();
+                if (trigger_ptr->room() == room->number())
+                {
+                    ImGui::TableNextRow();
+                    ImGui::TableNextColumn();
+                    const auto local_selection = _local_selected_trigger.lock();
+                    bool selected = local_selection && local_selection->number() == trigger_ptr->number();
+
+                    ImGuiScroller scroller;
+                    if (selected && _scroll_to_trigger)
+                    {
+                        scroller.scroll_to_item();
+                        _scroll_to_trigger = false;
+                    }
+
+                    if (ImGui::Selectable(std::format("{0}##{0}", trigger_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
+                    {
+                        scroller.fix_scroll();
+                        _local_selected_trigger = trigger_ptr;
+                        on_trigger_selected(trigger);
+                        _scroll_to_trigger = false;
+                    }
+
+                    ImGui::TableNextColumn();
+                    ImGui::Text(trigger_type_name(trigger_ptr->type()).c_str());
+                }
+            }
+
+            ImGui::EndTable();
+        }
+    }
+
+    void RoomsWindow::render_floordata_tab(const std::shared_ptr<IRoom>&)
+    {
+        ImGui::Checkbox(Names::simple_mode.c_str(), &_simple_mode);
+        render_simple();
+    }
+
+    void RoomsWindow::set_floordata(const std::vector<uint16_t>& data)
+    {
+        _floordata = data;
+    }
+
+    void RoomsWindow::render_simple()
+    {
+        if (ImGui::BeginTable("##floordata", _simple_mode ? 2 : 3, ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingStretchProp))
+        {
+            ImGui::TableSetupColumn("#");
+            ImGui::TableSetupColumn("Value");
+            if (!_simple_mode)
+            {
+                ImGui::TableSetupColumn("Meaning");
+            }
+            ImGui::TableSetupScrollFreeze(1, 1);
+            ImGui::TableHeadersRow();
+
+            if (_selected_sector)
+            {
+                const Floordata floordata = parse_floordata(_floordata, _selected_sector->floordata_index(), FloordataMeanings::Generate, _all_items);
+
+                uint32_t index = _selected_sector->floordata_index();
+                for (const auto& command : floordata.commands)
+                {
+                    for (std::size_t i = 0; i < command.data.size(); ++i)
+                    {
+                        ImGui::TableNextRow();
+                        ImGui::TableNextColumn();
+                        ImGui::Text(std::format("{}", index++).c_str());
+                        ImGui::TableNextColumn();
+                        ImGui::Text("%04X", command.data[i]);
+                        if (!_simple_mode)
+                        {
+                            ImGui::TableNextColumn();
+                            ImGui::Text(command.meanings[i].c_str());
+                        }
+                    }
+                }
+            }
+            ImGui::EndTable();
+        }
     }
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -460,7 +460,7 @@ namespace trview
 
                     if (ImGui::BeginTabBar("TabBar"))
                     {
-                        if (ImGui::BeginTabItem("Properties"))
+                        if (ImGui::BeginTabItem(Names::properties_tab.c_str()))
                         {
                             render_properties_tab(room);
                             ImGui::EndTabItem();

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -411,6 +411,7 @@ namespace trview
                             _map_renderer->set_cursor_position(Point(adjusted.x, adjusted.y));
 
                             auto sector = _map_renderer->sector_at_cursor();
+                            on_sector_hover(sector);
                             if (sector)
                             {
                                 if (io.MouseClicked[0])

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -58,8 +58,7 @@ namespace trview
         void render_items_tab(const std::shared_ptr<IRoom>& room);
         void render_triggers_tab(const std::shared_ptr<IRoom>& room);
         void render_floordata_tab(const std::shared_ptr<IRoom>& room);
-
-        void render_simple();
+        void set_selected_sector(const std::shared_ptr<ISector>& sector);
 
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<Item> _all_items;
@@ -97,6 +96,6 @@ namespace trview
         std::vector<uint16_t> _floordata;
         bool _simple_mode{ true };
         bool _in_floordata_mode{ false };
-        std::shared_ptr<ISector> _selected_sector;
+        std::weak_ptr<ISector> _selected_sector;
     };
 }

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -97,5 +97,6 @@ namespace trview
         bool _simple_mode{ true };
         bool _in_floordata_mode{ false };
         std::weak_ptr<ISector> _selected_sector;
+        uint32_t _selected_floordata{ 0 };
     };
 }

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -23,6 +23,7 @@ namespace trview
             static inline const std::string bottom = "##bottom";
             static inline const std::string rooms_panel = "Rooms List";
             static inline const std::string rooms_list = "##roomslist";
+            static inline const std::string simple_mode = "Simple";
         };
 
         /// Create a rooms window as a child of the specified window.
@@ -42,6 +43,7 @@ namespace trview
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void update(float delta) override;
         virtual void set_number(int32_t number) override;
+        virtual void set_floordata(const std::vector<uint16_t>& data) override;
     private:
         void set_sync_room(bool value);
         void set_track_item(bool value);
@@ -51,6 +53,13 @@ namespace trview
         bool render_rooms_window();
         void load_room_details(uint32_t room_number);
         void generate_filters();
+        void render_properties_tab(const std::shared_ptr<IRoom>& room);
+        void render_neighbours_tab(const std::shared_ptr<IRoom>& room);
+        void render_items_tab(const std::shared_ptr<IRoom>& room);
+        void render_triggers_tab(const std::shared_ptr<IRoom>& room);
+        void render_floordata_tab(const std::shared_ptr<IRoom>& room);
+
+        void render_simple();
 
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<Item> _all_items;
@@ -85,5 +94,9 @@ namespace trview
 
         Filters<IRoom> _filters;
         bool _force_sort{ false };
+        std::vector<uint16_t> _floordata;
+        bool _simple_mode{ true };
+        bool _in_floordata_mode{ false };
+        std::shared_ptr<ISector> _selected_sector;
     };
 }

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -23,7 +23,7 @@ namespace trview
             static inline const std::string properties_tab = "Properties##Properties Tab";
             static inline const std::string rooms_panel = "Rooms List";
             static inline const std::string rooms_list = "##roomslist";
-            static inline const std::string simple_mode = "Simple";
+            static inline const std::string simple_mode = "Raw";
         };
 
         /// Create a rooms window as a child of the specified window.

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -20,7 +20,7 @@ namespace trview
         {
             static inline const std::string details_panel = "Room Details";
             static inline const std::string properties = "Properties";
-            static inline const std::string bottom = "##bottom";
+            static inline const std::string properties_tab = "Properties##Properties Tab";
             static inline const std::string rooms_panel = "Rooms List";
             static inline const std::string rooms_list = "##roomslist";
             static inline const std::string simple_mode = "Simple";

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -120,11 +120,21 @@ namespace trview
         rooms_window->set_rooms(_all_rooms);
         rooms_window->set_current_room(_current_room);
         rooms_window->set_map_colours(_map_colours);
+        rooms_window->set_floordata(_floordata);
         return add_window(rooms_window);
     }
 
     void RoomsWindowManager::update(float delta)
     {
         WindowManager::update(delta);
+    }
+
+    void RoomsWindowManager::set_floordata(const std::vector<uint16_t>& data)
+    {
+        _floordata = data;
+        for (auto& window : _windows)
+        {
+            window.second->set_floordata(data);
+        }
     }
 }

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -114,6 +114,7 @@ namespace trview
         rooms_window->on_item_selected += on_item_selected;
         rooms_window->on_trigger_selected += on_trigger_selected;
         rooms_window->on_room_visibility += on_room_visibility;
+        rooms_window->on_sector_hover += on_sector_hover;
         rooms_window->set_level_version(_level_version);
         rooms_window->set_items(_all_items);
         rooms_window->set_triggers(_all_triggers);

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -41,6 +41,7 @@ namespace trview
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual std::weak_ptr<IRoomsWindow> create_window() override;
         virtual void update(float delta) override;
+        virtual void set_floordata(const std::vector<uint16_t>& data) override;
     private:
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
@@ -51,6 +52,7 @@ namespace trview
         IRoomsWindow::Source _rooms_window_source;
         trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Unknown };
         MapColours _map_colours;
+        std::vector<uint16_t> _floordata;
     };
 }
 

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -94,6 +94,7 @@ namespace trview
         ICamera& current_camera();
         virtual DirectX::SimpleMath::Vector3 target() const override;
         virtual void set_target(const DirectX::SimpleMath::Vector3& target) override;
+        virtual void select_sector(const std::weak_ptr<ISector>& sector) override;
     private:
         void initialise_input();
         void toggle_highlight();
@@ -126,9 +127,9 @@ namespace trview
         void select_next_orbit();
         void select_pick(const PickResult& pick);
         void set_show_rooms(bool show);
-
         void register_lua();
         void apply_camera_settings();
+        void set_sector_highlight(const std::shared_ptr<ISector>& sector);
 
         const std::shared_ptr<graphics::IDevice> _device;
         const std::shared_ptr<IShortcuts>& _shortcuts;

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -37,6 +37,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Camera\FreeCamera.cpp" />
     <ClCompile Include="Camera\OrbitCamera.cpp" />
     <ClCompile Include="Elements\Entity.cpp" />
+    <ClCompile Include="Elements\Floordata.cpp" />
     <ClCompile Include="Elements\ILight.cpp" />
     <ClCompile Include="Elements\ISector.cpp" />
     <ClCompile Include="Elements\Item.cpp" />
@@ -137,6 +138,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Camera\OrbitCamera.h" />
     <ClInclude Include="Camera\ProjectionMode.h" />
     <ClInclude Include="Elements\Entity.h" />
+    <ClInclude Include="Elements\Floordata.h" />
     <ClInclude Include="Elements\IEntity.h" />
     <ClInclude Include="Elements\ILevel.h" />
     <ClInclude Include="Elements\ILight.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -230,6 +230,9 @@
     <ClCompile Include="UI\SettingsWindow.cpp">
       <Filter>UI\Settings</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\Floordata.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
     <ClCompile Include="ApplicationCreate.cpp" />
     <ClCompile Include="Elements\Room.cpp">
       <Filter>Elements\Room</Filter>
@@ -740,6 +743,9 @@
     </ClInclude>
     <ClInclude Include="UI\SettingsWindow.h">
       <Filter>UI\Settings</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\Floordata.h">
+      <Filter>Elements</Filter>
     </ClInclude>
     <ClInclude Include="Filters\Filters.h">
       <Filter>Filters</Filter>


### PR DESCRIPTION
Add the floordata view to the Rooms window.
Reorganise the Rooms window to have tabs for the different sections - this gives everything a bit more space as there wasn't much left with the previous grid.
There is a toggle for raw - if disabled the meaning behind floordata will be shown (if available).
Not many tests for the UI of this - I need to see if there are updates to ImGui to make this easier. Had to delete a test for bubble copying because I couldn't fix it with the new layout.
Filters to be added in a separate issue.
Closes #128 