### PR TITLE
Allow user to move waypoints from the route window

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -874,3 +874,18 @@ TEST(Application, SectorHoverForwarded)
 
     rooms_window_manager.on_sector_hover(mock_shared<MockSector>());
 }
+
+TEST(Application, WaypointChangedUpdatesViewer)
+{
+    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
+    EXPECT_CALL(viewer, set_scene_changed).Times(1);
+
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+
+    auto application = register_test_module()
+        .with_viewer(std::move(viewer_ptr))
+        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .build();
+
+    route_window_manager.on_waypoint_changed();
+}

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -85,31 +85,6 @@ TEST(RouteWindow, WaypointRoomPositionCalculatedCorrectly)
     ASSERT_THAT(rendered, Contains("30720, 51200, 25600"));
 }
 
-TEST(RouteWindow, PositionValuesCopiedToClipboard)
-{
-    auto clipboard = mock_shared<MockClipboard>();
-    EXPECT_CALL(*clipboard, write(std::wstring(L"133120, 256000, 332800"))).Times(1);
-
-    auto window = register_test_module().with_clipboard(clipboard).build();
-
-    const Vector3 waypoint_pos{ 130, 250, 325 };
-    NiceMock<MockWaypoint> waypoint;
-    EXPECT_CALL(waypoint, position).WillRepeatedly(Return(waypoint_pos));
-
-    NiceMock<MockRoute> route;
-    EXPECT_CALL(route, waypoints).WillRepeatedly(Return(1));
-    EXPECT_CALL(route, waypoint(An<uint32_t>())).WillRepeatedly(ReturnRef(waypoint));
-
-    window->set_route(&route);
-    window->select_waypoint(0);
-
-    TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
-        .push_child(RouteWindow::Names::waypoint_details_panel)
-        .push(RouteWindow::Names::waypoint_stats)
-        .id("Position"));
-}
-
 TEST(RouteWindow, RoomPositionValuesCopiedToClipboard)
 {
     auto clipboard = mock_shared<MockClipboard>();

--- a/trview.app.tests/Windows/RouteWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/RouteWindowManagerTests.cpp
@@ -169,3 +169,19 @@ TEST(RouteWindowManager, IsWindowOpen)
     manager->render();
     ASSERT_FALSE(manager->is_window_open());
 }
+
+TEST(RouteWindowManager, WaypointChangedRaised)
+{
+    auto mock_window = mock_shared<MockRouteWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+
+    bool raised = false;
+    auto token = manager->on_waypoint_changed += [&]()
+    {
+        raised = true;
+    };
+
+    manager->create_window();
+    mock_window->on_waypoint_changed();
+    ASSERT_TRUE(raised);
+}

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -431,6 +431,10 @@ namespace trview
             _route->move(from, to);
             _viewer->set_route(_route);
         };
+        _token_store += _route_window->on_waypoint_changed += [&]()
+        {
+            _viewer->set_scene_changed();
+        };
         _route_window->set_randomizer_enabled(_settings.randomizer_tools);
         _route->set_randomizer_enabled(_settings.randomizer_tools);
         _route_window->set_randomizer_settings(_settings.randomizer);

--- a/trview.app/Mocks/Routing/IWaypoint.h
+++ b/trview.app/Mocks/Routing/IWaypoint.h
@@ -31,6 +31,7 @@ namespace trview
             MOCK_METHOD(DirectX::SimpleMath::Vector3, normal, (), (const, override));
             MOCK_METHOD(WaypointRandomizerSettings, randomizer_settings, (), (const, override));
             MOCK_METHOD(void, set_randomizer_settings, (const WaypointRandomizerSettings&), (override));
+            MOCK_METHOD(void, set_position, (const DirectX::SimpleMath::Vector3&), (override));
             /// <summary>
             /// Index used for testing ordering.
             /// </summary>

--- a/trview.app/Mocks/Windows/IViewer.h
+++ b/trview.app/Mocks/Windows/IViewer.h
@@ -34,6 +34,7 @@ namespace trview
             MOCK_METHOD(void, render_ui, (), (override));
             MOCK_METHOD(void, set_target, (const DirectX::SimpleMath::Vector3&), (override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, target, (), (const, override));
+            MOCK_METHOD(void, set_scene_changed, (), (override));
         };
     }
 }

--- a/trview.app/Routing/IWaypoint.h
+++ b/trview.app/Routing/IWaypoint.h
@@ -106,6 +106,8 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 normal() const = 0;
         virtual WaypointRandomizerSettings randomizer_settings() const = 0;
         virtual void set_randomizer_settings(const WaypointRandomizerSettings& settings) = 0;
+
+        virtual void set_position(const DirectX::SimpleMath::Vector3& position) = 0;
     };
 
     /// <summary>

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -166,5 +166,10 @@ namespace trview
     {
         _randomizer_settings = settings;
     }
+
+    void Waypoint::set_position(const DirectX::SimpleMath::Vector3& position)
+    {
+        _position = position;
+    }
 }
 

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -45,6 +45,7 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 normal() const override;
         virtual WaypointRandomizerSettings randomizer_settings() const override;
         virtual void set_randomizer_settings(const WaypointRandomizerSettings& settings) override;
+        virtual void set_position(const DirectX::SimpleMath::Vector3& position) override;
     private:
         DirectX::SimpleMath::Matrix calculate_waypoint_rotation() const;
 

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -32,6 +32,8 @@ namespace trview
         /// </summary>
         Event<Colour> on_waypoint_colour_changed;
 
+        Event<> on_waypoint_changed;
+
         /// <summary>
         /// Event raised when a waypoint has moved from one index to another.
         /// </summary>

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -35,6 +35,8 @@ namespace trview
         /// Event raised when a waypoint is deleted.
         Event<uint32_t> on_waypoint_deleted;
 
+        Event<> on_waypoint_changed;
+
         /// <summary>
         /// Event raised when a waypoint has moved from one index to another.
         /// </summary>

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -142,5 +142,6 @@ namespace trview
         virtual void set_target(const DirectX::SimpleMath::Vector3& target) = 0;
 
         virtual void select_sector(const std::weak_ptr<ISector>& sector) = 0;
+        virtual void set_scene_changed() = 0;
     };
 }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -235,7 +235,7 @@ namespace trview
                     on_waypoint_changed();
                 }
 
-                if (ImGui::BeginPopupContextItem())
+                if (ImGui::BeginPopupContextItem("Position"))
                 {
                     if (ImGui::MenuItem("Copy"))
                     {
@@ -324,6 +324,8 @@ namespace trview
 
     bool RouteWindow::render_route_window()
     {
+        ImGui::ShowStackToolWindow();
+
         bool stay_open = true;
         ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(420, 500));
         if (ImGui::Begin("Route", &stay_open))

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -228,11 +228,20 @@ namespace trview
                 }
 
                 const auto pos = waypoint.position();
-                int pos_value[3] = { pos.x * trlevel::Scale, pos.y * trlevel::Scale, pos.z * trlevel::Scale };
+                int pos_value[3] = { static_cast<int>(pos.x * trlevel::Scale), static_cast<int>(pos.y * trlevel::Scale), static_cast<int>(pos.z * trlevel::Scale) };
                 if (ImGui::DragScalarN("Position", ImGuiDataType_S32, pos_value, 3))
                 {
-                    waypoint.set_position(Vector3(pos_value[0], pos_value[1], pos_value[2]) / trlevel::Scale);
+                    waypoint.set_position(Vector3(static_cast<float>(pos_value[0]), static_cast<float>(pos_value[1]), static_cast<float>(pos_value[2])) / trlevel::Scale);
                     on_waypoint_changed();
+                }
+
+                if (ImGui::BeginPopupContextItem())
+                {
+                    if (ImGui::MenuItem("Copy"))
+                    {
+                        _clipboard->write(to_utf16(std::format("{},{},{}", pos_value[0], pos_value[1], pos_value[2])));
+                    }
+                    ImGui::EndPopup();
                 }
 
                 const std::string save_text = waypoint.has_save() ? "SAVEGAME.0" : Names::attach_save.c_str();

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -324,8 +324,6 @@ namespace trview
 
     bool RouteWindow::render_route_window()
     {
-        ImGui::ShowStackToolWindow();
-
         bool stay_open = true;
         ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(420, 500));
         if (ImGui::Begin("Route", &stay_open))

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -221,10 +221,18 @@ namespace trview
                     };
 
                     add_stat("Type", waypoint_type_to_string(waypoint.type()));
-                    add_stat("Position", position_text(waypoint.position()));
                     add_stat("Room", waypoint.room());
+
                     add_stat("Room Position", position_text(get_room_pos()));
                     ImGui::EndTable();
+                }
+
+                const auto pos = waypoint.position();
+                int pos_value[3] = { pos.x * trlevel::Scale, pos.y * trlevel::Scale, pos.z * trlevel::Scale };
+                if (ImGui::DragScalarN("Position", ImGuiDataType_S32, pos_value, 3))
+                {
+                    waypoint.set_position(Vector3(pos_value[0], pos_value[1], pos_value[2]) / trlevel::Scale);
+                    on_waypoint_changed();
                 }
 
                 const std::string save_text = waypoint.has_save() ? "SAVEGAME.0" : Names::attach_save.c_str();

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -42,6 +42,7 @@ namespace trview
         _route_window->on_waypoint_selected += on_waypoint_selected;
         _route_window->on_waypoint_deleted += on_waypoint_deleted;
         _route_window->on_waypoint_reordered += on_waypoint_reordered;
+        _route_window->on_waypoint_changed += on_waypoint_changed;
         _token_store += _route_window->on_window_closed += [&]() { _closing = true; };
 
         _route_window->set_randomizer_settings(_randomizer_settings);

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1315,4 +1315,9 @@ namespace trview
             Matrix::CreateTranslation(room_info.x / trlevel::Scale_X, 0, room_info.z / trlevel::Scale_Z));
         _scene_changed = true;
     }
+
+    void Viewer::set_scene_changed()
+    {
+        _scene_changed = true;
+    }
 }

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -95,6 +95,7 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 target() const override;
         virtual void set_target(const DirectX::SimpleMath::Vector3& target) override;
         virtual void select_sector(const std::weak_ptr<ISector>& sector) override;
+        virtual void set_scene_changed() override;
     private:
         void initialise_input();
         void toggle_highlight();


### PR DESCRIPTION
User can move the waypoints by entering coordinates or clicking and dragging the values (shift to go faster).
Coordinates can be copied with context menu.
Closes #1037 