### PR TITLE
Add special walls and walls on portals to minimap

### DIFF
--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -37,7 +37,14 @@ namespace trview
     {
         // Basic sector items 
         if (_sector.floor == -127 && _sector.ceiling == -127)
+        {
             _flags |= SectorFlag::Wall;
+            const auto info = level.get_room(_room);
+            if ((_x > 0 && _z > 0) && (_x < info.num_x_sectors - 1 && _z < info.num_z_sectors - 1))
+            {
+                _flags |= SectorFlag::SpecialWall;
+            }
+        }
         if (_room_above != 0xFF)
             _flags |= SectorFlag::RoomAbove;
         if (_room_below != 0xFF)

--- a/trview.app/Elements/Types.h
+++ b/trview.app/Elements/Types.h
@@ -9,20 +9,21 @@ namespace trview
     {
         None = 0x0,
         Portal = 0x1,
-        Wall = 0x2,
-        Trigger = 0x4,
-        Death = 0x8,
-        FloorSlant = 0x10,
-        CeilingSlant = 0x20,
-        ClimbableNorth = 0x40, // Top edge is climbable 
-        ClimbableEast = 0x80, // Right edge is climbable 
-        ClimbableSouth = 0x100, // Bottom edge is climbable 
-        ClimbableWest = 0x200, // Left edge is climbable
-        MonkeySwing = 0x400,
-        RoomAbove = 0x800, // There is a ceiling portal above
-        RoomBelow = 0x1000, // There is a floor portal 
-        MinecartLeft = 0x2000, // Minecart turns left, Trigger Triggerer in TR4+
-        MinecartRight = 0x4000, // Minecart turns right
+        SpecialWall = 0x2,
+        Wall = 0x4,
+        Trigger = 0x8,
+        Death = 0x10,
+        FloorSlant = 0x20,
+        CeilingSlant = 0x40,
+        ClimbableNorth = 0x80, // Top edge is climbable 
+        ClimbableEast = 0x100, // Right edge is climbable 
+        ClimbableSouth = 0x200, // Bottom edge is climbable 
+        ClimbableWest = 0x400, // Left edge is climbable
+        MonkeySwing = 0x800,
+        RoomAbove = 0x1000, // There is a ceiling portal above
+        RoomBelow = 0x2000, // There is a floor portal 
+        MinecartLeft = 0x4000, // Minecart turns left, Trigger Triggerer in TR4+
+        MinecartRight = 0x8000, // Minecart turns right,
         Climbable = ClimbableNorth | ClimbableEast | ClimbableSouth | ClimbableWest
     };
 

--- a/trview.app/Elements/Types.h
+++ b/trview.app/Elements/Types.h
@@ -9,21 +9,21 @@ namespace trview
     {
         None = 0x0,
         Portal = 0x1,
-        SpecialWall = 0x2,
-        Wall = 0x4,
-        Trigger = 0x8,
-        Death = 0x10,
-        FloorSlant = 0x20,
-        CeilingSlant = 0x40,
-        ClimbableNorth = 0x80, // Top edge is climbable 
-        ClimbableEast = 0x100, // Right edge is climbable 
-        ClimbableSouth = 0x200, // Bottom edge is climbable 
-        ClimbableWest = 0x400, // Left edge is climbable
-        MonkeySwing = 0x800,
-        RoomAbove = 0x1000, // There is a ceiling portal above
-        RoomBelow = 0x2000, // There is a floor portal 
-        MinecartLeft = 0x4000, // Minecart turns left, Trigger Triggerer in TR4+
-        MinecartRight = 0x8000, // Minecart turns right,
+        Wall = 0x2,
+        Trigger = 0x4,
+        Death = 0x8,
+        FloorSlant = 0x10,
+        CeilingSlant = 0x20,
+        ClimbableNorth = 0x40, // Top edge is climbable 
+        ClimbableEast = 0x80, // Right edge is climbable 
+        ClimbableSouth = 0x100, // Bottom edge is climbable 
+        ClimbableWest = 0x200, // Left edge is climbable
+        MonkeySwing = 0x400,
+        RoomAbove = 0x800, // There is a ceiling portal above
+        RoomBelow = 0x1000, // There is a floor portal 
+        MinecartLeft = 0x2000, // Minecart turns left, Trigger Triggerer in TR4+
+        MinecartRight = 0x4000, // Minecart turns right,
+        SpecialWall = 0x8000,
         Climbable = ClimbableNorth | ClimbableEast | ClimbableSouth | ClimbableWest
     };
 

--- a/trview.app/UI/MapColours.cpp
+++ b/trview.app/UI/MapColours.cpp
@@ -9,6 +9,7 @@ namespace trview
     {
         const std::map<SectorFlag, Colour> default_colours = {
             { SectorFlag::Portal, { 0.0f, 0.0f, 0.0f } },
+            { SectorFlag::SpecialWall, { 0.0f, 0.5f, 0.0f } },
             { SectorFlag::Wall, { 0.4f, 0.4f, 0.4f } },
             { SectorFlag::Trigger, { 1.0f, 0.3f, 0.7f } },
             { SectorFlag::Death, { 0.9f, 0.1f, 0.1f } },
@@ -18,7 +19,7 @@ namespace trview
             { SectorFlag::ClimbableNorth, { 0.6f, 0.0f, 0.9f, 0.0f } },
             { SectorFlag::ClimbableSouth, { 0.6f, 0.0f, 0.9f, 0.0f } },
             { SectorFlag::ClimbableEast, { 0.6f, 0.0f, 0.9f, 0.0f } },
-            { SectorFlag::ClimbableWest, { 0.6f, 0.0f, 0.9f, 0.0f } },
+            { SectorFlag::ClimbableWest, { 0.6f, 0.0f, 0.9f, 0.0f } }
         };
 
         const std::unordered_map<MapColours::Special, Colour> default_special_colours = {

--- a/trview.app/UI/MapRenderer.cpp
+++ b/trview.app/UI/MapRenderer.cpp
@@ -90,6 +90,12 @@ namespace trview
             // In the future I'd like to just draw a hollow square instead.
             const float thickness = _DRAW_SCALE / 4;
 
+            if (has_flag(tile.sector->flags(), SectorFlag::Wall) && has_flag(tile.sector->flags(), SectorFlag::Portal))
+            {
+                const auto colour = _colours.colour(has_flag(tile.sector->flags(), SectorFlag::SpecialWall) ? SectorFlag::SpecialWall : SectorFlag::Wall);
+                draw(tile.position, tile.size / 4.0f, colour);
+            }
+
             if (has_flag(tile.sector->flags(), SectorFlag::ClimbableNorth))
                 draw(tile.position, Size(tile.size.width, thickness), _colours.colour(SectorFlag::ClimbableNorth));
             if (has_flag(tile.sector->flags(), SectorFlag::ClimbableEast))

--- a/trview.app/UI/MapRenderer.cpp
+++ b/trview.app/UI/MapRenderer.cpp
@@ -72,6 +72,12 @@ namespace trview
             Color text_color = Colour::White;
             Color draw_color = _colours.colour_from_flags_field(tile.sector->flags());
 
+            // Special case for special walls.
+            if (has_flag(tile.sector->flags(), SectorFlag::Wall) && has_flag(tile.sector->flags(), SectorFlag::SpecialWall))
+            {
+                draw_color = _colours.colour(SectorFlag::SpecialWall);
+            }
+
             // If the cursor is over the tile, then negate colour 
             Point first = tile.position, last = Point(tile.size.width, tile.size.height) + tile.position;
             if (_cursor.is_between(first, last) ||

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -118,6 +118,7 @@ namespace trview
 
                     add_special("Default", MapColours::Special::Default);
                     add_colour("Portal", SectorFlag::Portal);
+                    add_colour("Special Wall", SectorFlag::SpecialWall);
                     add_colour("Wall", SectorFlag::Wall);
                     add_special("Geometry Wall", MapColours::Special::GeometryWall);
                     add_colour("Trigger", SectorFlag::Trigger);


### PR DESCRIPTION
Add 'special' walls to the minimap - these apparently suck you in and are when a wall isn't on the edge of a room. 
Also add a small square if a wall or special wall is on a portal. 
Closes #513