### PR TITLE
Show lights and camera/sinks in the rooms window

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -278,7 +278,6 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
     EXPECT_CALL(triggers_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("triggers_triggers"); });
     EXPECT_CALL(rooms_window_manager, set_level_version(A<trlevel::LevelVersion>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_version"); });
     EXPECT_CALL(rooms_window_manager, set_items(A<const std::vector<Item>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_items"); });
-    EXPECT_CALL(rooms_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_triggers"); });
     EXPECT_CALL(rooms_window_manager, set_floordata(A<const std::vector<uint16_t>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_floordata"); });
     EXPECT_CALL(rooms_window_manager, set_rooms(A<const std::vector<std::weak_ptr<IRoom>>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_rooms"); });
     EXPECT_CALL(route_window_manager, set_items(A<const std::vector<Item>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_items"); });
@@ -309,7 +308,7 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
     ASSERT_TRUE(called.has_value());
     ASSERT_EQ(called.value(), "test_path.tr2");
 
-    ASSERT_EQ(events.size(), 20);
+    ASSERT_EQ(events.size(), 19);
     ASSERT_EQ(events.back(), "viewer");
 }
 

--- a/trview.app.tests/CameraSinkWindowTests.cpp
+++ b/trview.app.tests/CameraSinkWindowTests.cpp
@@ -147,9 +147,8 @@ TEST(CameraSinkWindow, CameraSinkListFilteredWhenRoomSetAndTrackRoomEnabled)
     window->set_current_room(78);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Camera/Sink 0")
-        .push_child(CameraSinkWindow::Names::list_panel)
-        .id(CameraSinkWindow::Names::track_room));
+    imgui.click_element(imgui.id("Camera/Sink 0").push_child(CameraSinkWindow::Names::list_panel).id(Track<>::Names::Button));
+    imgui.click_element(imgui.popup_id(imgui.id("Camera/Sink 0").push_child(CameraSinkWindow::Names::list_panel), Track<>::Names::Popup).id("Room"));
 
     imgui.reset();
     imgui.render();

--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -174,9 +174,9 @@ TEST(ItemsWindow, ItemsListFilteredWhenRoomSetAndTrackRoomEnabled)
 
     TestImgui imgui([&]() { window->render(); });
 
-    imgui.click_element(imgui.id("Items 0")
-        .push_child(ItemsWindow::Names::item_list_panel)
-        .id(ItemsWindow::Names::track_room));
+    imgui.click_element(imgui.id("Items 0").push_child(ItemsWindow::Names::item_list_panel).id(Track<>::Names::Button));
+    imgui.click_element(imgui.popup_id(imgui.id("Items 0").push_child(ItemsWindow::Names::item_list_panel), Track<>::Names::Popup).id("Room"));
+    imgui.press_key(ImGuiKey_Escape);
 
     imgui.click_element_with_hover(imgui.id("Items 0")
         .push_child(ItemsWindow::Names::item_list_panel)
@@ -221,9 +221,8 @@ TEST(ItemsWindow, ItemsListUpdatedWhenFiltered)
     window->set_current_room(78);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Items 0")
-        .push_child(ItemsWindow::Names::item_list_panel)
-        .id(ItemsWindow::Names::track_room));
+    imgui.click_element(imgui.id("Items 0").push_child(ItemsWindow::Names::item_list_panel).id(Track<>::Names::Button));
+    imgui.click_element(imgui.popup_id(imgui.id("Items 0").push_child(ItemsWindow::Names::item_list_panel), Track<>::Names::Popup).id("Room"));
     imgui.reset();
     imgui.render();
 

--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -48,27 +48,6 @@ namespace
     }
 }
 
-TEST(RoomsWindowManager, SetTriggersClearsSelectedTrigger)
-{
-    auto mock_window = mock_shared<MockRoomsWindow>();
-    EXPECT_CALL(*mock_window, set_triggers).Times(3);
-    EXPECT_CALL(*mock_window, clear_selected_trigger).Times(2);
-    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
-
-    auto created_window = manager->create_window().lock();
-    ASSERT_NE(created_window, nullptr);
-    ASSERT_EQ(created_window, mock_window);
-
-    auto trigger = mock_shared<MockTrigger>();
-    manager->set_triggers({ trigger });
-
-    ASSERT_EQ(manager->selected_trigger().lock(), nullptr);
-    manager->set_selected_trigger(trigger);
-    ASSERT_EQ(manager->selected_trigger().lock(), trigger);
-    manager->set_triggers({});
-    ASSERT_EQ(manager->selected_trigger().lock(), nullptr);
-}
-
 TEST(RoomsWindowManager, WindowsUpdated)
 {
     auto mock_window = mock_shared<MockRoomsWindow>();

--- a/trview.app.tests/TestImgui.cpp
+++ b/trview.app.tests/TestImgui.cpp
@@ -358,10 +358,15 @@ namespace trview
             return TestImGuiId(window_name);
         }
 
+        TestImGuiId TestImgui::popup_id(const TestImGuiId& parent, const std::string& popup_name) const
+        {
+            auto id = parent.id(popup_name).id();
+            return TestImGuiId(std::format("##Popup_{:0>8x}", id));
+        }
+
         TestImGuiId TestImgui::popup_id(const std::string& popup_name) const
         {
-            auto id = TestImGuiId("Debug##Default").id(popup_name).id();
-            return TestImGuiId(std::format("##Popup_{:0>8x}", id));
+            return popup_id(TestImGuiId("Debug##Default"), popup_name);
         }
     }
 }

--- a/trview.app.tests/TestImgui.h
+++ b/trview.app.tests/TestImgui.h
@@ -53,6 +53,7 @@ namespace trview
             ImGuiWindow* find_window(const std::string& name) const;
             ImGuiWindow* find_window(ImGuiID id) const;
             TestImGuiId id(const std::string& window_name) const;
+            TestImGuiId popup_id(const TestImGuiId& parent, const std::string& popup_name) const;
             TestImGuiId popup_id(const std::string& popup_name) const;
         private:
             void click_element_internal(TestImGuiId test_id, bool show_context_menu, TestImGuiId active_override, bool hover);

--- a/trview.app.tests/TriggersWindowTests.cpp
+++ b/trview.app.tests/TriggersWindowTests.cpp
@@ -114,10 +114,11 @@ TEST(TriggersWindow, TriggersListFilteredWhenRoomSetAndTrackRoomEnabled)
         .push(TriggersWindow::Names::triggers_list)
         .id("1##1")));
 
+    imgui.click_element(imgui.id("Triggers 0").push_child(TriggersWindow::Names::trigger_list_panel).id(Track<>::Names::Button));
+    imgui.click_element(imgui.popup_id(imgui.id("Triggers 0").push_child(TriggersWindow::Names::trigger_list_panel), Track<>::Names::Popup).id("Room"));
+    imgui.press_key(ImGuiKey_Escape);
     imgui.reset();
-    imgui.click_element(imgui.id("Triggers 0")
-        .push_child(TriggersWindow::Names::trigger_list_panel)
-        .id(TriggersWindow::Names::track_room));
+    imgui.render();
 
     ASSERT_FALSE(imgui.element_present(imgui.id("Triggers 0")
         .push_child(TriggersWindow::Names::trigger_list_panel)

--- a/trview.app.tests/Windows/LightsWindowTests.cpp
+++ b/trview.app.tests/Windows/LightsWindowTests.cpp
@@ -98,9 +98,8 @@ TEST(LightsWindow, LightListFilteredWhenRoomSetAndTrackRoomEnabled)
     window->set_current_room(78);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Lights 0")
-        .push_child(LightsWindow ::Names::light_list_panel)
-        .id(LightsWindow::Names::track_room));
+    imgui.click_element(imgui.id("Lights 0").push_child(LightsWindow::Names::light_list_panel).id(Track<>::Names::Button));
+    imgui.click_element(imgui.popup_id(imgui.id("Lights 0").push_child(LightsWindow::Names::light_list_panel), Track<>::Names::Popup).id("Room"));
 
     imgui.reset();
     imgui.render();

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -141,7 +141,6 @@ namespace trview
         _rooms_windows->set_floordata(_level->floor_data());
         _rooms_windows->set_rooms(_level->rooms());
         _rooms_windows->set_camera_sinks(_level->camera_sinks());
-        _rooms_windows->set_lights(_level->lights());
         _route_window->set_items(_level->items());
         _route_window->set_triggers(_level->triggers());
         _route_window->set_rooms(_level->rooms());

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -140,6 +140,8 @@ namespace trview
         _rooms_windows->set_triggers(_level->triggers());
         _rooms_windows->set_floordata(_level->floor_data());
         _rooms_windows->set_rooms(_level->rooms());
+        _rooms_windows->set_camera_sinks(_level->camera_sinks());
+        _rooms_windows->set_lights(_level->lights());
         _route_window->set_items(_level->items());
         _route_window->set_triggers(_level->triggers());
         _route_window->set_rooms(_level->rooms());
@@ -422,6 +424,8 @@ namespace trview
         _token_store += _rooms_windows->on_trigger_selected += [this](const auto& trigger) { select_trigger(trigger); };
         _token_store += _rooms_windows->on_room_visibility += [this](const auto& room, bool value) { set_room_visibility(room, value); };
         _token_store += _rooms_windows->on_sector_hover += [this](const auto& sector) { select_sector(sector); };
+        _token_store += _rooms_windows->on_camera_sink_selected += [this](const auto& camera_sink) { select_camera_sink(camera_sink); };
+        _token_store += _rooms_windows->on_light_selected += [this](const auto& light) { select_light(light); };
     }
 
     void Application::setup_route_window()
@@ -603,6 +607,7 @@ namespace trview
         _level->set_selected_light(light_ptr->number());
         _viewer->select_light(light);
         _lights_windows->set_selected_light(light);
+        _rooms_windows->set_selected_light(light);
     }
 
     void Application::set_item_visibility(const Item& item, bool visible)
@@ -858,9 +863,10 @@ namespace trview
             return;
         }
 
-        select_room(camera_sink_ptr->room());
+        select_room(actual_room(*camera_sink_ptr));
         _level->set_selected_camera_sink(camera_sink_ptr->number());
         _viewer->select_camera_sink(camera_sink);
         _camera_sink_windows->set_selected_camera_sink(camera_sink);
+        _rooms_windows->set_selected_camera_sink(camera_sink);
     }
 }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -140,7 +140,6 @@ namespace trview
         _rooms_windows->set_triggers(_level->triggers());
         _rooms_windows->set_floordata(_level->floor_data());
         _rooms_windows->set_rooms(_level->rooms());
-        _rooms_windows->set_camera_sinks(_level->camera_sinks());
         _route_window->set_items(_level->items());
         _route_window->set_triggers(_level->triggers());
         _route_window->set_rooms(_level->rooms());

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -137,7 +137,6 @@ namespace trview
         _triggers_windows->set_triggers(_level->triggers());
         _rooms_windows->set_level_version(_level->version());
         _rooms_windows->set_items(_level->items());
-        _rooms_windows->set_triggers(_level->triggers());
         _rooms_windows->set_floordata(_level->floor_data());
         _rooms_windows->set_rooms(_level->rooms());
         _route_window->set_items(_level->items());

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -306,6 +306,7 @@ namespace trview
         virtual void set_visible(bool visible) = 0;
         virtual std::vector<std::weak_ptr<ILight>> lights() const = 0;
         virtual std::vector<std::weak_ptr<ICameraSink>> camera_sinks() const = 0;
+        virtual std::vector<std::weak_ptr<ITrigger>> triggers() const = 0;
     };
 
     /// <summary>

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -305,6 +305,7 @@ namespace trview
         /// </summary>
         virtual void set_visible(bool visible) = 0;
         virtual std::vector<std::weak_ptr<ILight>> lights() const = 0;
+        virtual std::vector<std::weak_ptr<ICameraSink>> camera_sinks() const = 0;
     };
 
     /// <summary>

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -304,6 +304,7 @@ namespace trview
         /// Sets whether the room is visible.
         /// </summary>
         virtual void set_visible(bool visible) = 0;
+        virtual std::vector<std::weak_ptr<ILight>> lights() const = 0;
     };
 
     /// <summary>

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -1009,6 +1009,16 @@ namespace trview
         return _camera_sinks;
     }
 
+    std::vector<std::weak_ptr<ITrigger>> Room::triggers() const 
+    {
+        std::vector<std::weak_ptr<ITrigger>> triggers;
+        for (const auto& t : _triggers)
+        {
+            triggers.push_back(t.second);
+        }
+        return triggers;
+    };
+
     std::shared_ptr<ISector> sector_from_point(const IRoom& room, const Vector3& point)
     {
         const auto info = room.info();

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -999,6 +999,11 @@ namespace trview
         _visible = visible;
     }
 
+    std::vector<std::weak_ptr<ILight>> Room::lights() const
+    {
+        return _lights;
+    }
+
     std::shared_ptr<ISector> sector_from_point(const IRoom& room, const Vector3& point)
     {
         const auto info = room.info();

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -1004,6 +1004,11 @@ namespace trview
         return _lights;
     }
 
+    std::vector<std::weak_ptr<ICameraSink>> Room::camera_sinks() const
+    {
+        return _camera_sinks;
+    }
+
     std::shared_ptr<ISector> sector_from_point(const IRoom& room, const Vector3& point)
     {
         const auto info = room.info();

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -80,6 +80,7 @@ namespace trview
         virtual bool visible() const override;
         virtual void set_visible(bool visible) override;
         virtual std::vector<std::weak_ptr<ILight>> lights() const override;
+        virtual std::vector<std::weak_ptr<ICameraSink>> camera_sinks() const override;
     private:
         void generate_geometry(const IMesh::Source& mesh_source, const trlevel::tr3_room& room);
         void generate_adjacency();

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -79,6 +79,7 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 position() const override;
         virtual bool visible() const override;
         virtual void set_visible(bool visible) override;
+        virtual std::vector<std::weak_ptr<ILight>> lights() const override;
     private:
         void generate_geometry(const IMesh::Source& mesh_source, const trlevel::tr3_room& room);
         void generate_adjacency();

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -81,6 +81,7 @@ namespace trview
         virtual void set_visible(bool visible) override;
         virtual std::vector<std::weak_ptr<ILight>> lights() const override;
         virtual std::vector<std::weak_ptr<ICameraSink>> camera_sinks() const override;
+        virtual std::vector<std::weak_ptr<ITrigger>> triggers() const override;
     private:
         void generate_geometry(const IMesh::Source& mesh_source, const trlevel::tr3_room& room);
         void generate_adjacency();

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -49,6 +49,7 @@ namespace trview
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(bool, visible, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool visible), (override));
+            MOCK_METHOD(std::vector<std::weak_ptr<ILight>>, lights, (), (const, override));
 
             std::shared_ptr<MockRoom> with_number(uint32_t number)
             {

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -50,6 +50,7 @@ namespace trview
             MOCK_METHOD(bool, visible, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool visible), (override));
             MOCK_METHOD(std::vector<std::weak_ptr<ILight>>, lights, (), (const, override));
+            MOCK_METHOD(std::vector<std::weak_ptr<ICameraSink>>, camera_sinks, (), (const, override));
 
             std::shared_ptr<MockRoom> with_number(uint32_t number)
             {

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -51,6 +51,8 @@ namespace trview
             MOCK_METHOD(void, set_visible, (bool visible), (override));
             MOCK_METHOD(std::vector<std::weak_ptr<ILight>>, lights, (), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<ICameraSink>>, camera_sinks, (), (const, override));
+            MOCK_METHOD(std::vector<std::weak_ptr<ITrigger>>, triggers, (), (const, override));
+
 
             std::shared_ptr<MockRoom> with_number(uint32_t number)
             {

--- a/trview.app/Mocks/Windows/IRoomsWindow.h
+++ b/trview.app/Mocks/Windows/IRoomsWindow.h
@@ -27,8 +27,6 @@ namespace trview
             MOCK_METHOD(void, set_selected_light, (const std::weak_ptr<ILight>&), (override));
             MOCK_METHOD(void, clear_selected_light, (), (override));
             MOCK_METHOD(void, clear_selected_camera_sink, (), (override));
-            MOCK_METHOD(void, set_lights, (const std::vector<std::weak_ptr<ILight>>&), (override));
-            MOCK_METHOD(void, set_camera_sinks, (const std::vector<std::weak_ptr<ICameraSink>>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRoomsWindow.h
+++ b/trview.app/Mocks/Windows/IRoomsWindow.h
@@ -19,7 +19,6 @@ namespace trview
             MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&), (override));
             MOCK_METHOD(void, set_selected_item, (const Item&), (override));
             MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&), (override));
-            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));
             MOCK_METHOD(void, set_floordata, (const std::vector<uint16_t>&), (override));

--- a/trview.app/Mocks/Windows/IRoomsWindow.h
+++ b/trview.app/Mocks/Windows/IRoomsWindow.h
@@ -25,6 +25,10 @@ namespace trview
             MOCK_METHOD(void, set_floordata, (const std::vector<uint16_t>&), (override));
             MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
             MOCK_METHOD(void, set_selected_light, (const std::weak_ptr<ILight>&), (override));
+            MOCK_METHOD(void, clear_selected_light, (), (override));
+            MOCK_METHOD(void, clear_selected_camera_sink, (), (override));
+            MOCK_METHOD(void, set_lights, (const std::vector<std::weak_ptr<ILight>>&), (override));
+            MOCK_METHOD(void, set_camera_sinks, (const std::vector<std::weak_ptr<ICameraSink>>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRoomsWindow.h
+++ b/trview.app/Mocks/Windows/IRoomsWindow.h
@@ -23,6 +23,8 @@ namespace trview
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));
             MOCK_METHOD(void, set_floordata, (const std::vector<uint16_t>&), (override));
+            MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
+            MOCK_METHOD(void, set_selected_light, (const std::weak_ptr<ILight>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRoomsWindowManager.h
+++ b/trview.app/Mocks/Windows/IRoomsWindowManager.h
@@ -19,7 +19,6 @@ namespace trview
             MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&), (override));
             MOCK_METHOD(void, set_selected_item, (const Item&), (override));
             MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>& ), (override));
-            MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(std::weak_ptr<IRoomsWindow>, create_window, (), (override));
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, set_floordata, (const std::vector<uint16_t>&), (override));

--- a/trview.app/Mocks/Windows/IRoomsWindowManager.h
+++ b/trview.app/Mocks/Windows/IRoomsWindowManager.h
@@ -26,7 +26,6 @@ namespace trview
             MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
             MOCK_METHOD(void, set_selected_light, (const std::weak_ptr<ILight>&), (override));
             MOCK_METHOD(void, set_camera_sinks, (const std::vector<std::weak_ptr<ICameraSink>>&), (override));
-            MOCK_METHOD(void, set_lights, (const std::vector<std::weak_ptr<ILight>>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRoomsWindowManager.h
+++ b/trview.app/Mocks/Windows/IRoomsWindowManager.h
@@ -23,6 +23,10 @@ namespace trview
             MOCK_METHOD(std::weak_ptr<IRoomsWindow>, create_window, (), (override));
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, set_floordata, (const std::vector<uint16_t>&), (override));
+            MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
+            MOCK_METHOD(void, set_selected_light, (const std::weak_ptr<ILight>&), (override));
+            MOCK_METHOD(void, set_camera_sinks, (const std::vector<std::weak_ptr<ICameraSink>>&), (override));
+            MOCK_METHOD(void, set_lights, (const std::vector<std::weak_ptr<ILight>>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRoomsWindowManager.h
+++ b/trview.app/Mocks/Windows/IRoomsWindowManager.h
@@ -25,7 +25,6 @@ namespace trview
             MOCK_METHOD(void, set_floordata, (const std::vector<uint16_t>&), (override));
             MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
             MOCK_METHOD(void, set_selected_light, (const std::weak_ptr<ILight>&), (override));
-            MOCK_METHOD(void, set_camera_sinks, (const std::vector<std::weak_ptr<ICameraSink>>&), (override));
         };
     }
 }

--- a/trview.app/Track/Track.h
+++ b/trview.app/Track/Track.h
@@ -8,6 +8,13 @@ namespace trview
     class Track
     {
     public:
+        struct Names
+        {
+            static const inline std::string Enable = "##TrackEnable";
+            static const inline std::string Button = "Track##track";
+            static const inline std::string Popup = "Track";
+        };
+
         void render();
         bool enabled() const;
         template <Type T>

--- a/trview.app/Track/Track.h
+++ b/trview.app/Track/Track.h
@@ -39,6 +39,8 @@ namespace trview
         bool enabled() const;
         template <Type T>
         Event<bool>& on_toggle();
+        template <Type T>
+        void set_enabled(bool value);
     private:
         void toggle_visible();
 

--- a/trview.app/Track/Track.h
+++ b/trview.app/Track/Track.h
@@ -35,7 +35,8 @@ namespace trview
     public:
         void render();
         bool enabled() const;
-        bool enabled(Type type) const;
+        template <Type T>
+        bool enabled() const;
         template <Type T>
         Event<bool>& on_toggle();
     private:

--- a/trview.app/Track/Track.h
+++ b/trview.app/Track/Track.h
@@ -1,34 +1,9 @@
 #pragma once
 
+#include "../Type.h"
+
 namespace trview
 {
-    enum class Type
-    {
-        CameraSink,
-        Item,
-        Light,
-        Room,
-        Trigger
-    };
-
-    inline constexpr std::string to_string(Type type) noexcept
-    {
-        switch (type)
-        {
-        case Type::CameraSink:
-            return "Camera/Sink";
-        case Type::Item:
-            return "Item";
-        case Type::Light:
-            return "Light";
-        case Type::Room:
-            return "Room";
-        case Type::Trigger:
-            return "Trigger";
-        }
-        return "Unknown";
-    }
-
     template <Type... Args>
     class Track
     {

--- a/trview.app/Track/Track.h
+++ b/trview.app/Track/Track.h
@@ -1,0 +1,55 @@
+#pragma once
+
+namespace trview
+{
+    enum class Type
+    {
+        CameraSink,
+        Item,
+        Light,
+        Room,
+        Trigger
+    };
+
+    inline constexpr std::string to_string(Type type) noexcept
+    {
+        switch (type)
+        {
+        case Type::CameraSink:
+            return "Camera/Sink";
+        case Type::Item:
+            return "Item";
+        case Type::Light:
+            return "Light";
+        case Type::Room:
+            return "Room";
+        case Type::Trigger:
+            return "Trigger";
+        }
+        return "Unknown";
+    }
+
+    template <Type... Args>
+    class Track
+    {
+    public:
+        void render();
+        bool enabled() const;
+        bool enabled(Type type) const;
+    private:
+        void toggle_visible();
+
+        struct Subject
+        {
+            Type type;
+            Event<bool> on_toggle;
+            bool value{ false };
+        };
+
+        std::array<Subject, sizeof...(Args)> state{ Subject{ Args, {}, false }... };
+        bool _show{ false };
+        bool _enabled{ true };
+    };
+}
+
+#include "Track.inl"

--- a/trview.app/Track/Track.h
+++ b/trview.app/Track/Track.h
@@ -36,6 +36,8 @@ namespace trview
         void render();
         bool enabled() const;
         bool enabled(Type type) const;
+        template <Type T>
+        Event<bool>& on_toggle();
     private:
         void toggle_visible();
 

--- a/trview.app/Track/Track.inl
+++ b/trview.app/Track/Track.inl
@@ -1,0 +1,65 @@
+#pragma once
+
+namespace trview
+{
+    template <Type... Args>
+    void Track<Args...>::render()
+    {
+        bool filter_enabled = true;
+        if (ImGui::Checkbox("##TrackEnable", &filter_enabled))
+        {
+            _enabled = filter_enabled;
+        }
+        ImGui::SameLine();
+
+        if (ImGui::Button("Track##track"))
+        {
+            toggle_visible();
+        }
+
+        if (_show && ImGui::BeginPopup("Track"))
+        {
+            for (Subject& v : state)
+            {
+                if (ImGui::Checkbox(to_string(v.type).c_str(), &v.value))
+                {
+                    v.on_toggle(v.value);
+                }
+            }
+            ImGui::EndPopup();
+        }
+        else
+        {
+            _show = false;
+        }
+    }
+
+    template <Type... Args>
+    void Track<Args...>::toggle_visible()
+    {
+        if (!_show)
+        {
+            ImGui::OpenPopup("Track");
+        }
+        _show = !_show;
+    }
+
+    template <Type... Args>
+    bool Track<Args...>::enabled() const
+    {
+        return _enabled;
+    }
+
+    template <Type... Args>
+    bool Track<Args...>::enabled(Type type) const
+    {
+        for (const auto& subject : state)
+        {
+            if (subject.type == type)
+            {
+                return subject.value;
+            }
+        }
+        return false;
+    }
+}

--- a/trview.app/Track/Track.inl
+++ b/trview.app/Track/Track.inl
@@ -86,4 +86,20 @@ namespace trview
 
         throw std::exception();
     }
+
+    template <Type... Args>
+    template <Type T>
+    void Track<Args...>::set_enabled(bool value)
+    {
+        static_assert(equals_any(T, Args...), "Type is not being tracked");
+
+        for (auto& subject : state)
+        {
+            if (subject.type == T && subject.value != value)
+            {
+                subject.value = value;
+                subject.on_toggle(subject.value);
+            }
+        }
+    }
 }

--- a/trview.app/Track/Track.inl
+++ b/trview.app/Track/Track.inl
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <trview.common/Algorithms.h>
+
 namespace trview
 {
     template <Type... Args>
@@ -21,8 +23,10 @@ namespace trview
         {
             for (Subject& v : state)
             {
-                if (ImGui::Checkbox(to_string(v.type).c_str(), &v.value))
+                bool value = v.value;
+                if (ImGui::Checkbox(to_string(v.type).c_str(), &value) && value != v.value)
                 {
+                    v.value = value;
                     v.on_toggle(v.value);
                 }
             }
@@ -61,5 +65,22 @@ namespace trview
             }
         }
         return false;
+    }
+
+    template <Type... Args>
+    template <Type T>
+    Event<bool>& Track<Args...>::on_toggle()
+    {
+        static_assert(equals_any(T, Args...), "Type is not being tracked");
+
+        for (auto& subject : state)
+        {
+            if (subject.type == T)
+            {
+                return subject.on_toggle;
+            }
+        }
+
+        throw std::exception();
     }
 }

--- a/trview.app/Track/Track.inl
+++ b/trview.app/Track/Track.inl
@@ -55,11 +55,14 @@ namespace trview
     }
 
     template <Type... Args>
-    bool Track<Args...>::enabled(Type type) const
+    template <Type T>
+    bool Track<Args...>::enabled() const
     {
+        static_assert(equals_any(T, Args...), "Type is not being tracked");
+
         for (const auto& subject : state)
         {
-            if (subject.type == type)
+            if (subject.type == T)
             {
                 return subject.value;
             }

--- a/trview.app/Track/Track.inl
+++ b/trview.app/Track/Track.inl
@@ -9,7 +9,7 @@ namespace trview
     template <Type... Args>
     void Track<Args...>::render()
     {
-        if (ImGui::Checkbox("##TrackEnable", &_enabled))
+        if (ImGui::Checkbox(Names::Enable.c_str(), &_enabled))
         {
             std::ranges::for_each(state, [=](auto& s) { s.on_toggle(s.value && _enabled); });
         }
@@ -21,12 +21,12 @@ namespace trview
         }
         ImGui::SameLine();
 
-        if (ImGui::Button("Track##track"))
+        if (ImGui::Button(Names::Button.c_str()))
         {
             toggle_visible();
         }
 
-        if (_show && ImGui::BeginPopup("Track"))
+        if (_show && ImGui::BeginPopup(Names::Popup.c_str()))
         {
             for (Subject& v : state)
             {

--- a/trview.app/Type.h
+++ b/trview.app/Type.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace trview
+{
+    enum class Type
+    {
+        CameraSink,
+        Item,
+        Light,
+        Room,
+        Trigger
+    };
+
+    constexpr std::string to_string(Type type) noexcept;
+}
+
+#include "Type.inl"

--- a/trview.app/Type.inl
+++ b/trview.app/Type.inl
@@ -1,0 +1,22 @@
+#include "Type.h"
+
+namespace trview
+{
+    constexpr std::string to_string(Type type) noexcept
+    {
+        switch (type)
+        {
+        case Type::CameraSink:
+            return "Camera/Sink";
+        case Type::Item:
+            return "Item";
+        case Type::Light:
+            return "Light";
+        case Type::Room:
+            return "Room";
+        case Type::Trigger:
+            return "Trigger";
+        }
+        return "Unknown";
+    }
+}

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -80,11 +80,6 @@ namespace trview
         return stay_open;
     }
 
-    void CameraSinkWindow::set_track_room(bool value)
-    {
-        _track_room = value;
-    }
-
     void CameraSinkWindow::set_sync(bool value)
     {
         if (_sync != value)
@@ -115,11 +110,7 @@ namespace trview
             _filters.render();
             ImGui::SameLine();
 
-            bool track_room = _track_room;
-            if (ImGui::Checkbox(Names::track_room.c_str(), &track_room))
-            {
-                set_track_room(track_room);
-            }
+            _track.render();
             ImGui::SameLine();
             bool sync = _sync;
             if (ImGui::Checkbox(Names::sync.c_str(), &sync))
@@ -148,7 +139,7 @@ namespace trview
                 {
                     const auto camera_sink = camera_sink_ptr.lock();
 
-                    if (_track_room && !matching_room(*camera_sink, _current_room) || !_filters.match(*camera_sink))
+                    if (_track.enabled<Type::Room>() && !matching_room(*camera_sink, _current_room) || !_filters.match(*camera_sink))
                     {
                         continue;
                     }
@@ -331,7 +322,7 @@ namespace trview
                         if (ImGui::Selectable(std::to_string(trigger_ptr->number()).c_str(), &trigger_selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                         {
                             _selected_trigger = trigger;
-                            set_track_room(false);
+                            _track.set_enabled<Type::Room>(false);
                             on_trigger_selected(trigger);
                         }
                         ImGui::TableNextColumn();

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -47,7 +47,6 @@ namespace trview
 
     void CameraSinkWindow::render()
     {
-        ImGui::ShowStackToolWindow();
         if (!render_camera_sink_window())
         {
             on_window_closed();

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -47,6 +47,7 @@ namespace trview
 
     void CameraSinkWindow::render()
     {
+        ImGui::ShowStackToolWindow();
         if (!render_camera_sink_window())
         {
             on_window_closed();

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -2,6 +2,7 @@
 
 #include <trview.common/Windows/IClipboard.h>
 #include "../../Filters/Filters.h"
+#include "../../Track/Track.h"
 #include "ICameraSinkWindow.h"
 
 namespace trview
@@ -30,7 +31,6 @@ namespace trview
         virtual void set_current_room(uint32_t room) override;
     private:
         bool render_camera_sink_window();
-        void set_track_room(bool value);
         void set_sync(bool value);
         void set_local_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink);
         void render_list();
@@ -45,11 +45,11 @@ namespace trview
         std::shared_ptr<IClipboard> _clipboard;
         Filters<ICameraSink> _filters;
         std::weak_ptr<ITrigger> _selected_trigger;
-        bool _track_room{ false };
         bool _sync{ true };
         bool _scroll_to{ false };
         uint32_t _current_room{ 0u };
         bool _force_sort{ false };
         std::vector<std::weak_ptr<ITrigger>> _triggered_by;
+        Track<Type::Room> _track;
     };
 }

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -13,7 +13,6 @@ namespace trview
         struct Names
         {
             static inline const std::string sync = "Sync";
-            static inline const std::string track_room = "Track Room";
             static inline const std::string camera_sink_list = "##camerasinklist";
             static inline const std::string list_panel = "Camera/Sink List";
             static inline const std::string details_panel = "Camera/Sink Details";

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -84,5 +84,11 @@ namespace trview
 
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) = 0;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
+
+        virtual void clear_selected_light() = 0;
+        virtual void clear_selected_camera_sink() = 0;
+
+        virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) = 0;
+        virtual void set_lights(const std::vector<std::weak_ptr<ILight>>& lights) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -87,8 +87,5 @@ namespace trview
 
         virtual void clear_selected_light() = 0;
         virtual void clear_selected_camera_sink() = 0;
-
-        virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) = 0;
-        virtual void set_lights(const std::vector<std::weak_ptr<ILight>>& lights) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -4,6 +4,8 @@
 #include <trview.common/Event.h>
 #include <trview.app/Elements/Item.h>
 #include <trview.app/Elements/ITrigger.h>
+#include "../Elements/CameraSink/ICameraSink.h"
+#include "../Elements/ILight.h"
 #include <trview.app/Elements/IRoom.h>
 #include "../UI/MapColours.h"
 
@@ -30,6 +32,9 @@ namespace trview
         Event<std::weak_ptr<IRoom>, bool> on_room_visibility;
 
         Event<std::weak_ptr<ISector>> on_sector_hover;
+
+        Event<std::weak_ptr<ILight>> on_light_selected;
+        Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
 
         /// Clear the selected trigger.
         virtual void clear_selected_trigger() = 0;
@@ -76,5 +81,8 @@ namespace trview
         virtual void set_number(int32_t number) = 0;
 
         virtual void set_floordata(const std::vector<uint16_t>& data) = 0;
+
+        virtual void set_selected_light(const std::weak_ptr<ILight>& light) = 0;
+        virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -69,9 +69,6 @@ namespace trview
         /// @param trigger The trigger currently selected.
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) = 0;
 
-        /// Set the triggers in the level.
-        /// @param triggers The triggers in the level.
-        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
         /// <summary>
         /// Update the window.
         /// </summary>

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -50,10 +50,6 @@ namespace trview
         /// @param trigger The trigger currently selected.
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) = 0;
 
-        /// Set the triggers in the level.
-        /// @param triggers The triggers in the level.
-        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
-
         /// Create a new rooms window.
         virtual std::weak_ptr<IRoomsWindow> create_window() = 0;
         /// <summary>

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -66,6 +66,5 @@ namespace trview
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) = 0;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
         virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) = 0;
-        virtual void set_lights(const std::vector<std::weak_ptr<ILight>>& lights) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -20,6 +20,8 @@ namespace trview
         Event<std::weak_ptr<IRoom>, bool> on_room_visibility;
 
         Event<std::weak_ptr<ISector>> on_sector_hover;
+        Event<std::weak_ptr<ILight>> on_light_selected;
+        Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
 
         /// Render all of the rooms windows.
         virtual void render() = 0;
@@ -61,5 +63,9 @@ namespace trview
         virtual void update(float delta) = 0;
 
         virtual void set_floordata(const std::vector<uint16_t>& data) = 0;
+        virtual void set_selected_light(const std::weak_ptr<ILight>& light) = 0;
+        virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
+        virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) = 0;
+        virtual void set_lights(const std::vector<std::weak_ptr<ILight>>& lights) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -65,6 +65,5 @@ namespace trview
         virtual void set_floordata(const std::vector<uint16_t>& data) = 0;
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) = 0;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
-        virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) = 0;
     };
 }

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -56,11 +56,6 @@ namespace trview
         _current_room = room;
     }
 
-    void ItemsWindow::set_track_room(bool value)
-    {
-        _track_room = value;
-    }
-
     void ItemsWindow::set_sync_item(bool value)
     {
         if (_sync_item != value)
@@ -94,13 +89,10 @@ namespace trview
         if (ImGui::BeginChild(Names::item_list_panel.c_str(), ImVec2(290, 0), true))
         {
             _filters.render();
-            ImGui::SameLine();
 
-            bool track_room = _track_room;
-            if (ImGui::Checkbox(Names::track_room.c_str(), &track_room))
-            {
-                set_track_room(track_room);
-            }
+            ImGui::SameLine();
+            _track.render();
+
             ImGui::SameLine();
             bool sync_item = _sync_item;
             if (ImGui::Checkbox(Names::sync_item.c_str(), &sync_item))
@@ -129,7 +121,7 @@ namespace trview
 
                 for (const auto& item : _all_items)
                 {
-                    if (_track_room && item.room() != _current_room || !_filters.match(item))
+                    if (_track.enabled<Type::Room>() && item.room() != _current_room || !_filters.match(item))
                     {
                         continue;
                     }
@@ -280,7 +272,7 @@ namespace trview
                     if (ImGui::Selectable(std::to_string(trigger_ptr->number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                     {
                         _selected_trigger = trigger;
-                        set_track_room(false);
+                        _track.set_enabled<Type::Room>(false);
                         on_trigger_selected(trigger);
                     }
                     ImGui::TableNextColumn();

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -20,7 +20,6 @@ namespace trview
         {
             static inline const std::string add_to_route_button = "Add to Route";
             static inline const std::string sync_item = "Sync";
-            static inline const std::string track_room = "Track Room";
             static inline const std::string items_list = "##itemslist";
             static inline const std::string item_list_panel = "Item List";
             static inline const std::string details_panel = "Item Details";

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -8,6 +8,7 @@
 
 #include "IItemsWindow.h"
 #include "../Elements/Item.h"
+#include "../Track/Track.h"
 
 namespace trview
 {
@@ -42,7 +43,6 @@ namespace trview
         virtual void set_level_version(trlevel::LevelVersion version) override;
         virtual void set_model_checker(const std::function<bool(uint32_t)>& checker) override;
     private:
-        void set_track_room(bool value);
         void set_sync_item(bool value);
         void render_items_list();
         void render_item_details();
@@ -53,7 +53,6 @@ namespace trview
         std::string _id{ "Items 0" };
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;
-        bool _track_room{ false };
         uint32_t _current_room{ 0u };
         bool _sync_item{ true };
         std::shared_ptr<IClipboard> _clipboard;
@@ -69,5 +68,6 @@ namespace trview
         trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Unknown };
         std::function<bool(uint32_t)> _model_checker;
         bool _force_sort{ false };
+        Track<Type::Room> _track;
     };
 }

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -76,11 +76,6 @@ namespace trview
         }
     }
 
-    void LightsWindow::set_track_room(bool value)
-    {
-        _track_room = value;
-    }
-
     void LightsWindow::render_lights_list() 
     {
         if (ImGui::BeginChild(Names::light_list_panel.c_str(), ImVec2(230, 0), true))
@@ -88,11 +83,7 @@ namespace trview
             _filters.render();
             ImGui::SameLine();
 
-            bool track_room = _track_room;
-            if (ImGui::Checkbox(Names::track_room.c_str(), &track_room))
-            {
-                set_track_room(track_room);
-            }
+            _track.render();
             ImGui::SameLine();
             bool sync_light = _sync_light;
             if (ImGui::Checkbox(Names::sync_light.c_str(), &sync_light))
@@ -120,7 +111,7 @@ namespace trview
                 for (const auto& light_ptr : _all_lights)
                 {
                     const auto& light = light_ptr.lock();
-                    if (_track_room && light->room() != _current_room || !_filters.match(*light))
+                    if (_track.enabled<Type::Room>() && light->room() != _current_room || !_filters.match(*light))
                     {
                         continue;
                     }

--- a/trview.app/Windows/LightsWindow.h
+++ b/trview.app/Windows/LightsWindow.h
@@ -4,6 +4,7 @@
 #include "../Elements/ILight.h"
 #include "ILightsWindow.h"
 #include "../Filters/Filters.h"
+#include "../Track/Track.h"
 
 namespace trview
 {
@@ -32,7 +33,6 @@ namespace trview
         virtual void set_current_room(uint32_t room) override;
     private:
         void set_sync_light(bool value);
-        void set_track_room(bool value);
         void set_local_selected_light(const std::weak_ptr<ILight>& light);
         void render_lights_list();
         void render_light_details();
@@ -42,7 +42,6 @@ namespace trview
         std::vector<std::weak_ptr<ILight>> _all_lights;
         std::shared_ptr<IClipboard> _clipboard;
         bool _sync_light{ true };
-        bool _track_room{ false };
         trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Tomb5 };
         std::optional<float> _tooltip_timer;
         std::string _id{ "Lights 0" };
@@ -53,5 +52,6 @@ namespace trview
         std::unordered_map<std::string, std::string> _tips;
         Filters<ILight> _filters;
         bool _force_sort{ false };
+        Track<Type::Room> _track;
     };
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -1006,4 +1006,30 @@ namespace trview
             ImGui::EndTable();
         }
     }
+
+    void RoomsWindow::clear_selected_light()
+    {
+        _local_selected_light.reset();
+        _global_selected_light.reset();
+    }
+
+    void RoomsWindow::clear_selected_camera_sink()
+    {
+        _local_selected_camera_sink.reset();
+        _global_selected_camera_sink.reset();
+    }
+
+    void RoomsWindow::set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks)
+    {
+        _global_selected_camera_sink.reset();
+        _local_selected_camera_sink.reset();
+        _all_camera_sinks = camera_sinks;
+    }
+
+    void RoomsWindow::set_lights(const std::vector<std::weak_ptr<ILight>>& lights)
+    {
+        _global_selected_light.reset();
+        _local_selected_light.reset();
+        _all_lights = lights;
+    }
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -459,13 +459,13 @@ namespace trview
                             ImGui::EndTabItem();
                         }
 
-                        if (ImGui::BeginTabItem("Items"))
+                        if (ImGui::BeginTabItem("Items", 0, _scroll_to_item ? ImGuiTabItemFlags_SetSelected : 0))
                         {
                             render_items_tab(room);
                             ImGui::EndTabItem();
                         }
 
-                        if (ImGui::BeginTabItem("Triggers"))
+                        if (ImGui::BeginTabItem("Triggers", 0, _scroll_to_trigger ? ImGuiTabItemFlags_SetSelected : 0))
                         {
                             render_triggers_tab(room);
                             ImGui::EndTabItem();

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -110,6 +110,10 @@ namespace trview
                 set_selected_item(_global_selected_item.value());
             }
         };
+        _token_store += _track.on_toggle<Type::Trigger>() += [&](bool)
+        {
+            set_selected_trigger(_global_selected_trigger);
+        };
     }
 
     void RoomsWindow::set_current_room(uint32_t room)
@@ -172,8 +176,7 @@ namespace trview
     void RoomsWindow::set_selected_item(const Item& item)
     {
         _global_selected_item = item;
-        // if (_track_item)
-        if (_track.enabled(Type::Item))
+        if (_track.enabled<Type::Item>())
         {
             _local_selected_item = item;
             _selected_room = item.room();
@@ -189,7 +192,7 @@ namespace trview
     void RoomsWindow::set_selected_trigger(const std::weak_ptr<ITrigger>& trigger)
     {
         _global_selected_trigger = trigger;
-        if (_track_trigger)
+        if (_track.enabled<Type::Trigger>())
         {
             _local_selected_trigger = trigger;
             if (const auto trigger_ptr = trigger.lock())
@@ -218,27 +221,6 @@ namespace trview
         {
             _sync_room = value;
             set_current_room(_current_room);
-        }
-    }
-
-    void RoomsWindow::set_track_item(bool value)
-    {
-        if (_track_item != value)
-        {
-            _track_item = value;
-            if (_track_item && _global_selected_item.has_value())
-            {
-                set_selected_item(_global_selected_item.value());
-            }
-        }
-    }
-
-    void RoomsWindow::set_track_trigger(bool value)
-    {
-        if (_track_trigger != value)
-        {
-            _track_trigger = value;
-            set_selected_trigger(_global_selected_trigger);
         }
     }
 
@@ -276,62 +258,21 @@ namespace trview
         return stay_open;
     }
 
-    void RoomsWindow::toggle_track_visible()
-    {
-        // if (!_show_track)
-        // {
-        //     ImGui::OpenPopup("Track");
-        // }
-        // _show_track = !_show_track;
-    }
-
     void RoomsWindow::render_rooms_list()
     {
         if (ImGui::BeginChild(Names::rooms_panel.c_str(), ImVec2(270, 0), true))
         {
             _filters.render();
+
             ImGui::SameLine();
             bool sync_room = _sync_room;
             if (ImGui::Checkbox("Sync##syncroom", &sync_room))
             {
                 set_sync_room(sync_room);
             }
-            ImGui::SameLine();
 
+            ImGui::SameLine();
             _track.render();
-            /*
-            bool filter_enabled = true;
-            if (ImGui::Checkbox("##TrackEnable", &filter_enabled))
-            {
-                // _enabled = filter_enabled;
-                // _changed = true;
-            }
-            ImGui::SameLine();
-
-            if (ImGui::Button("Track##track"))
-            {
-                toggle_track_visible();
-            }
-
-            if (_show_track && ImGui::BeginPopup("Track"))
-            {
-                bool track_item = _track_item;
-                if (ImGui::Checkbox("Item##trackitem", &track_item))
-                {
-                    set_track_item(track_item);
-                }
-                bool track_trigger = _track_trigger;
-                if (ImGui::Checkbox("Trigger##tracktrigger", &track_trigger))
-                {
-                    set_track_trigger(track_trigger);
-                }
-
-                ImGui::EndPopup();
-            }
-            else
-            {
-                _show_track = false;
-            }*/
 
             if (ImGui::BeginTable(Names::rooms_list.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedSame, ImVec2(-1, -1)))
             {

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -267,39 +267,62 @@ namespace trview
         return stay_open;
     }
 
+    void RoomsWindow::toggle_track_visible()
+    {
+        // if (!_show_track)
+        // {
+        //     ImGui::OpenPopup("Track");
+        // }
+        // _show_track = !_show_track;
+    }
+
     void RoomsWindow::render_rooms_list()
     {
         if (ImGui::BeginChild(Names::rooms_panel.c_str(), ImVec2(270, 0), true))
         {
-            if (ImGui::BeginTable("##controls", 2, 0, ImVec2(-1, 0)))
+            _filters.render();
+            ImGui::SameLine();
+            bool sync_room = _sync_room;
+            if (ImGui::Checkbox("Sync##syncroom", &sync_room))
             {
-                ImGui::TableNextRow();
-                ImGui::TableNextColumn();
+                set_sync_room(sync_room);
+            }
+            ImGui::SameLine();
 
-                _filters.render();
-                ImGui::TableNextColumn();
+            _track.render();
+            /*
+            bool filter_enabled = true;
+            if (ImGui::Checkbox("##TrackEnable", &filter_enabled))
+            {
+                // _enabled = filter_enabled;
+                // _changed = true;
+            }
+            ImGui::SameLine();
 
-                bool sync_room = _sync_room;
-                if (ImGui::Checkbox("Sync##syncroom", &sync_room))
-                {
-                    set_sync_room(sync_room);
-                }
-                ImGui::TableNextColumn();
+            if (ImGui::Button("Track##track"))
+            {
+                toggle_track_visible();
+            }
 
+            if (_show_track && ImGui::BeginPopup("Track"))
+            {
                 bool track_item = _track_item;
-                if (ImGui::Checkbox("Track Item##trackitem", &track_item))
+                if (ImGui::Checkbox("Item##trackitem", &track_item))
                 {
                     set_track_item(track_item);
                 }
-                ImGui::TableNextColumn();
-
                 bool track_trigger = _track_trigger;
-                if (ImGui::Checkbox("Track Trigger##tracktrigger", &track_trigger))
+                if (ImGui::Checkbox("Trigger##tracktrigger", &track_trigger))
                 {
                     set_track_trigger(track_trigger);
                 }
-                ImGui::EndTable();
+
+                ImGui::EndPopup();
             }
+            else
+            {
+                _show_track = false;
+            }*/
 
             if (ImGui::BeginTable(Names::rooms_list.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedSame, ImVec2(-1, -1)))
             {

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -143,7 +143,6 @@ namespace trview
         if (room != _all_rooms.end())
         {
             auto room_ptr = room->lock();
-            set_lights(room_ptr->lights());
             _map_renderer->load(room_ptr);
         }
     }
@@ -169,6 +168,9 @@ namespace trview
     {
         _all_rooms = rooms;
         _current_room = 0xffffffff;
+        _triggers.clear();
+        _lights.clear();
+        _camera_sinks.clear();
         generate_filters();
         _force_sort = true;
         set_selected_sector(nullptr);

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -142,7 +142,9 @@ namespace trview
             });
         if (room != _all_rooms.end())
         {
-            _map_renderer->load(room->lock());
+            auto room_ptr = room->lock();
+            set_lights(room_ptr->lights());
+            _map_renderer->load(room_ptr);
         }
     }
 
@@ -478,7 +480,7 @@ namespace trview
 
                         if (ImGui::BeginTabItem("Lights", 0, _scroll_to_light ? ImGuiTabItemFlags_SetSelected : 0))
                         {
-                            render_lights_tab(room);
+                            render_lights_tab();
                             ImGui::EndTabItem();
                         }
 
@@ -958,7 +960,7 @@ namespace trview
         }
     }
     
-    void RoomsWindow::render_lights_tab(const std::shared_ptr<IRoom>&room)
+    void RoomsWindow::render_lights_tab()
     {
         if (ImGui::BeginTable("Lights", 2, ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_ScrollY))
         {
@@ -967,16 +969,15 @@ namespace trview
             ImGui::TableSetupScrollFreeze(1, 1);
             ImGui::TableHeadersRow();
 
-            imgui_sort_weak(_all_lights,
+            imgui_sort_weak(_lights,
                 {
                     [](auto&& l, auto&& r) { return l.number() < r.number(); },
                     [&](auto&& l, auto&& r) { return std::tuple(light_type_name(l.type()), l.number()) < std::tuple(light_type_name(r.type()), r.number()); }
                 }, _force_sort);
 
-            for (const auto& light : _all_lights)
+            for (const auto& light : _lights)
             {
-                const auto light_ptr = light.lock();
-                if (light_ptr->room() == room->number())
+                if (auto light_ptr = light.lock())
                 {
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
@@ -1030,6 +1031,6 @@ namespace trview
     {
         _global_selected_light.reset();
         _local_selected_light.reset();
-        _all_lights = lights;
+        _lights = lights;
     }
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -220,7 +220,14 @@ namespace trview
         if (_sync_room != value)
         {
             _sync_room = value;
-            set_current_room(_current_room);
+            uint32_t room = _current_room;
+            if (_sync_room)
+            {
+                // Force room to be different to current room so that the
+                // room details are loaded.
+                _current_room = 0xffffffff;
+            }
+            set_current_room(room);
         }
     }
 

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -265,14 +265,14 @@ namespace trview
             _filters.render();
 
             ImGui::SameLine();
+            _track.render();
+
+            ImGui::SameLine();
             bool sync_room = _sync_room;
             if (ImGui::Checkbox("Sync##syncroom", &sync_room))
             {
                 set_sync_room(sync_room);
             }
-
-            ImGui::SameLine();
-            _track.render();
 
             if (ImGui::BeginTable(Names::rooms_list.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedSame, ImVec2(-1, -1)))
             {

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -102,6 +102,14 @@ namespace trview
         };
 
         generate_filters();
+
+        _token_store += _track.on_toggle<Type::Item>() += [&](bool value)
+        {
+            if (value && _global_selected_item.has_value())
+            {
+                set_selected_item(_global_selected_item.value());
+            }
+        };
     }
 
     void RoomsWindow::set_current_room(uint32_t room)
@@ -164,7 +172,8 @@ namespace trview
     void RoomsWindow::set_selected_item(const Item& item)
     {
         _global_selected_item = item;
-        if (_track_item)
+        // if (_track_item)
+        if (_track.enabled(Type::Item))
         {
             _local_selected_item = item;
             _selected_room = item.room();

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -195,10 +195,10 @@ namespace trview
         _global_selected_trigger = trigger;
         if (_track.enabled<Type::Trigger>())
         {
-            _local_selected_trigger = trigger;
             if (const auto trigger_ptr = trigger.lock())
             {
                 select_room(trigger_ptr->room());
+                _local_selected_trigger = trigger;
                 _scroll_to_room = true;
                 _scroll_to_trigger = true;
                 if (!_sync_room)
@@ -881,10 +881,10 @@ namespace trview
         _global_selected_light = light;
         if (_track.enabled<Type::Light>())
         {
-            _local_selected_light = light;
             if (const auto light_ptr = light.lock())
             {
                 select_room(light_ptr->room());
+                _local_selected_light = light;
                 _scroll_to_room = true;
                 _scroll_to_light = true;
                 if (!_sync_room)
@@ -900,10 +900,10 @@ namespace trview
         _global_selected_camera_sink = camera_sink;
         if (_track.enabled<Type::CameraSink>())
         {
-            _local_selected_camera_sink = camera_sink;
             if (const auto camera_sink_ptr = camera_sink.lock())
             {
                 select_room(actual_room(*camera_sink_ptr));
+                _local_selected_camera_sink = camera_sink;
                 _scroll_to_room = true;
                 _scroll_to_camera_sink = true;
                 if (!_sync_room)
@@ -1052,6 +1052,7 @@ namespace trview
         {
             _lights.clear();
             _camera_sinks.clear();
+            _triggers.clear();
         }
     }
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -182,14 +182,15 @@ namespace trview
         _global_selected_item = item;
         if (_track.enabled<Type::Item>())
         {
-            _local_selected_item = item;
-            select_room(item.room());
-            _scroll_to_room = true;
-            _scroll_to_item = true;
-            if (!_sync_room)
+            if (_selected_room != _current_room)
             {
+                select_room(item.room());
+                _scroll_to_room = true;
                 load_room_details(item.room());
             }
+
+            _local_selected_item = item;
+            _scroll_to_item = true;
         }
     }
 
@@ -200,14 +201,15 @@ namespace trview
         {
             if (const auto trigger_ptr = trigger.lock())
             {
-                select_room(trigger_ptr->room());
-                _local_selected_trigger = trigger;
-                _scroll_to_room = true;
-                _scroll_to_trigger = true;
-                if (!_sync_room)
+                if (_selected_room != _current_room)
                 {
+                    select_room(trigger_ptr->room());
+                    _scroll_to_room = true;
                     load_room_details(trigger_ptr->room());
                 }
+
+                _local_selected_trigger = trigger;
+                _scroll_to_trigger = true;
             }
         }
     }
@@ -893,14 +895,15 @@ namespace trview
         {
             if (const auto light_ptr = light.lock())
             {
-                select_room(light_ptr->room());
-                _local_selected_light = light;
-                _scroll_to_room = true;
-                _scroll_to_light = true;
-                if (!_sync_room)
+                if (_selected_room != _current_room)
                 {
+                    select_room(light_ptr->room());
+                    _scroll_to_room = true;
                     load_room_details(light_ptr->room());
                 }
+
+                _local_selected_light = light;
+                _scroll_to_light = true;
             }
         }
     }
@@ -912,14 +915,15 @@ namespace trview
         {
             if (const auto camera_sink_ptr = camera_sink.lock())
             {
-                select_room(actual_room(*camera_sink_ptr));
-                _local_selected_camera_sink = camera_sink;
-                _scroll_to_room = true;
-                _scroll_to_camera_sink = true;
-                if (!_sync_room)
+                if (_selected_room != _current_room)
                 {
+                    select_room(actual_room(*camera_sink_ptr));
+                    _scroll_to_room = true;
                     load_room_details(actual_room(*camera_sink_ptr));
                 }
+
+                _local_selected_camera_sink = camera_sink;
+                _scroll_to_camera_sink = true;
             }
         }
     }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -152,6 +152,7 @@ namespace trview
         _all_items = items;
         _global_selected_item.reset();
         _local_selected_item.reset();
+        _force_sort = true;
     }
 
     void RoomsWindow::set_level_version(trlevel::LevelVersion version)
@@ -215,6 +216,7 @@ namespace trview
     {
         _local_selected_trigger.reset();
         _triggers = triggers;
+        _force_sort = true;
     }
 
     void RoomsWindow::set_sync_room(bool value)
@@ -1034,12 +1036,14 @@ namespace trview
     {
         _local_selected_camera_sink.reset();
         _camera_sinks = camera_sinks;
+        _force_sort = true;
     }
 
     void RoomsWindow::set_lights(const std::vector<std::weak_ptr<ILight>>& lights)
     {
         _local_selected_light.reset();
         _lights = lights;
+        _force_sort = true;
     }
 
     void RoomsWindow::select_room(uint32_t room)

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -211,7 +211,6 @@ namespace trview
 
     void RoomsWindow::set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers)
     {
-        _global_selected_trigger.reset();
         _local_selected_trigger.reset();
         _triggers = triggers;
     }
@@ -1024,14 +1023,12 @@ namespace trview
 
     void RoomsWindow::set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks)
     {
-        _global_selected_camera_sink.reset();
         _local_selected_camera_sink.reset();
         _camera_sinks = camera_sinks;
     }
 
     void RoomsWindow::set_lights(const std::vector<std::weak_ptr<ILight>>& lights)
     {
-        _global_selected_light.reset();
         _local_selected_light.reset();
         _lights = lights;
     }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -1039,20 +1039,20 @@ namespace trview
     void RoomsWindow::select_room(uint32_t room)
     {
         _selected_room = room;
-        if (room < _all_rooms.size())
+        for (const auto& r : _all_rooms)
         {
-            if (auto room_ptr = _all_rooms[room].lock())
+            auto room_ptr = r.lock();
+            if (room_ptr && room_ptr->number() == _selected_room)
             {
                 set_triggers(room_ptr->triggers());
                 set_lights(room_ptr->lights());
                 set_camera_sinks(room_ptr->camera_sinks());
+                return;
             }
         }
-        else
-        {
-            _lights.clear();
-            _camera_sinks.clear();
-            _triggers.clear();
-        }
+
+        _lights.clear();
+        _camera_sinks.clear();
+        _triggers.clear();
     }
 }

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -49,7 +49,6 @@ namespace trview
         virtual void clear_selected_light() override;
         virtual void clear_selected_camera_sink() override;
         virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) override;
-        virtual void set_lights(const std::vector<std::weak_ptr<ILight>>& lights) override;
     private:
         void set_sync_room(bool value);
         void render_rooms_list();
@@ -64,12 +63,13 @@ namespace trview
         void render_floordata_tab(const std::shared_ptr<IRoom>& room);
         void set_selected_sector(const std::shared_ptr<ISector>& sector);
         void render_camera_sink_tab(const std::shared_ptr<IRoom>& room);
-        void render_lights_tab(const std::shared_ptr<IRoom>& room);
+        void render_lights_tab();
+        void set_lights(const std::vector<std::weak_ptr<ILight>>& lights);
 
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;
-        std::vector<std::weak_ptr<ILight>> _all_lights;
+        std::vector<std::weak_ptr<ILight>> _lights;
         std::vector<std::weak_ptr<ICameraSink>> _all_camera_sinks;
 
         bool _sync_room{ true };

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -44,6 +44,8 @@ namespace trview
         virtual void update(float delta) override;
         virtual void set_number(int32_t number) override;
         virtual void set_floordata(const std::vector<uint16_t>& data) override;
+        virtual void set_selected_light(const std::weak_ptr<ILight>& light) override;
+        virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
     private:
         void set_sync_room(bool value);
         void render_rooms_list();
@@ -57,10 +59,14 @@ namespace trview
         void render_triggers_tab(const std::shared_ptr<IRoom>& room);
         void render_floordata_tab(const std::shared_ptr<IRoom>& room);
         void set_selected_sector(const std::shared_ptr<ISector>& sector);
+        void render_camera_sink_tab(const std::shared_ptr<IRoom>& room);
+        void render_lights_tab(const std::shared_ptr<IRoom>& room);
 
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;
+        std::vector<std::weak_ptr<ILight>> _all_lights;
+        std::vector<std::weak_ptr<ICameraSink>> _all_camera_sinks;
 
         bool _sync_room{ true };
         
@@ -71,6 +77,14 @@ namespace trview
         std::weak_ptr<ITrigger> _global_selected_trigger;
         std::weak_ptr<ITrigger> _local_selected_trigger;
         bool _scroll_to_trigger{ false };
+
+        std::weak_ptr<ILight> _global_selected_light;
+        std::weak_ptr<ILight> _local_selected_light;
+        bool _scroll_to_light{ false };
+
+        std::weak_ptr<ICameraSink> _global_selected_camera_sink;
+        std::weak_ptr<ICameraSink> _local_selected_camera_sink;
+        bool _scroll_to_camera_sink{ false };
 
         uint32_t _current_room{ 0u };
         uint32_t _selected_room{ 0u };

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -9,7 +9,7 @@
 #include "../Elements/Item.h"
 #include "../UI/IMapRenderer.h"
 #include "../Filters/Filters.h"
-
+#include "../Track/Track.h"
 
 namespace trview
 {
@@ -59,6 +59,7 @@ namespace trview
         void render_triggers_tab(const std::shared_ptr<IRoom>& room);
         void render_floordata_tab(const std::shared_ptr<IRoom>& room);
         void set_selected_sector(const std::shared_ptr<ISector>& sector);
+        void toggle_track_visible();
 
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<Item> _all_items;
@@ -98,5 +99,6 @@ namespace trview
         bool _in_floordata_mode{ false };
         std::weak_ptr<ISector> _selected_sector;
         uint32_t _selected_floordata{ 0 };
+        Track<Type::Item, Type::Trigger> _track;
     };
 }

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -94,6 +94,6 @@ namespace trview
         bool _in_floordata_mode{ false };
         std::weak_ptr<ISector> _selected_sector;
         uint32_t _selected_floordata{ 0 };
-        Track<Type::Item, Type::Trigger> _track;
+        Track<Type::Item, Type::Trigger, Type::Light, Type::CameraSink> _track;
     };
 }

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -46,8 +46,6 @@ namespace trview
         virtual void set_floordata(const std::vector<uint16_t>& data) override;
     private:
         void set_sync_room(bool value);
-        void set_track_item(bool value);
-        void set_track_trigger(bool value);
         void render_rooms_list();
         void render_room_details();
         bool render_rooms_window();
@@ -59,15 +57,12 @@ namespace trview
         void render_triggers_tab(const std::shared_ptr<IRoom>& room);
         void render_floordata_tab(const std::shared_ptr<IRoom>& room);
         void set_selected_sector(const std::shared_ptr<ISector>& sector);
-        void toggle_track_visible();
 
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;
 
         bool _sync_room{ true };
-        bool _track_item{ false };
-        bool _track_trigger{ false };
         
         std::optional<Item> _global_selected_item;
         std::optional<Item> _local_selected_item;

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -48,7 +48,6 @@ namespace trview
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
         virtual void clear_selected_light() override;
         virtual void clear_selected_camera_sink() override;
-        virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) override;
     private:
         void set_sync_room(bool value);
         void render_rooms_list();
@@ -62,15 +61,17 @@ namespace trview
         void render_triggers_tab(const std::shared_ptr<IRoom>& room);
         void render_floordata_tab(const std::shared_ptr<IRoom>& room);
         void set_selected_sector(const std::shared_ptr<ISector>& sector);
-        void render_camera_sink_tab(const std::shared_ptr<IRoom>& room);
+        void render_camera_sink_tab();
         void render_lights_tab();
         void set_lights(const std::vector<std::weak_ptr<ILight>>& lights);
+        void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks);
+        void select_room(uint32_t room);
 
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;
         std::vector<std::weak_ptr<ILight>> _lights;
-        std::vector<std::weak_ptr<ICameraSink>> _all_camera_sinks;
+        std::vector<std::weak_ptr<ICameraSink>> _camera_sinks;
 
         bool _sync_room{ true };
         

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -46,6 +46,10 @@ namespace trview
         virtual void set_floordata(const std::vector<uint16_t>& data) override;
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) override;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
+        virtual void clear_selected_light() override;
+        virtual void clear_selected_camera_sink() override;
+        virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) override;
+        virtual void set_lights(const std::vector<std::weak_ptr<ILight>>& lights) override;
     private:
         void set_sync_room(bool value);
         void render_rooms_list();

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -40,7 +40,6 @@ namespace trview
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& rooms) override;
         virtual void set_selected_item(const Item& item) override;
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
-        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void update(float delta) override;
         virtual void set_number(int32_t number) override;
         virtual void set_floordata(const std::vector<uint16_t>& data) override;
@@ -58,18 +57,19 @@ namespace trview
         void render_properties_tab(const std::shared_ptr<IRoom>& room);
         void render_neighbours_tab(const std::shared_ptr<IRoom>& room);
         void render_items_tab(const std::shared_ptr<IRoom>& room);
-        void render_triggers_tab(const std::shared_ptr<IRoom>& room);
+        void render_triggers_tab();
         void render_floordata_tab(const std::shared_ptr<IRoom>& room);
         void set_selected_sector(const std::shared_ptr<ISector>& sector);
         void render_camera_sink_tab();
         void render_lights_tab();
+        void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers);
         void set_lights(const std::vector<std::weak_ptr<ILight>>& lights);
         void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks);
         void select_room(uint32_t room);
 
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<Item> _all_items;
-        std::vector<std::weak_ptr<ITrigger>> _all_triggers;
+        std::vector<std::weak_ptr<ITrigger>> _triggers;
         std::vector<std::weak_ptr<ILight>> _lights;
         std::vector<std::weak_ptr<ICameraSink>> _camera_sinks;
 

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -96,17 +96,6 @@ namespace trview
         }
     }
 
-    void RoomsWindowManager::set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers)
-    {
-        _all_triggers = triggers;
-        _selected_trigger.reset();
-        for (auto& window : _windows)
-        {
-            window.second->clear_selected_trigger();
-            window.second->set_triggers(_all_triggers);
-        }
-    }
-
     std::weak_ptr<IRoomsWindow> RoomsWindowManager::create_window()
     {
         auto rooms_window = _rooms_window_source();
@@ -119,7 +108,6 @@ namespace trview
         rooms_window->on_camera_sink_selected += on_camera_sink_selected;
         rooms_window->set_level_version(_level_version);
         rooms_window->set_items(_all_items);
-        rooms_window->set_triggers(_all_triggers);
         rooms_window->set_rooms(_all_rooms);
         rooms_window->set_current_room(_current_room);
         rooms_window->set_map_colours(_map_colours);

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -124,7 +124,6 @@ namespace trview
         rooms_window->set_current_room(_current_room);
         rooms_window->set_map_colours(_map_colours);
         rooms_window->set_floordata(_floordata);
-        rooms_window->set_camera_sinks(_all_camera_sinks);
         if (_selected_item.has_value())
         {
             rooms_window->set_selected_item(_selected_item.value());
@@ -164,17 +163,6 @@ namespace trview
         for (auto& window : _windows)
         {
             window.second->set_selected_camera_sink(camera_sink);
-        }
-    }
-
-    void RoomsWindowManager::set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks)
-    {
-        _all_camera_sinks = camera_sinks;
-        _selected_camera_sink.reset();
-        for (auto& window : _windows)
-        {
-            window.second->clear_selected_camera_sink();
-            window.second->set_camera_sinks(_all_camera_sinks);
         }
     }
 }

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -125,7 +125,6 @@ namespace trview
         rooms_window->set_map_colours(_map_colours);
         rooms_window->set_floordata(_floordata);
         rooms_window->set_camera_sinks(_all_camera_sinks);
-        rooms_window->set_lights(_all_lights);
         if (_selected_item.has_value())
         {
             rooms_window->set_selected_item(_selected_item.value());
@@ -176,17 +175,6 @@ namespace trview
         {
             window.second->clear_selected_camera_sink();
             window.second->set_camera_sinks(_all_camera_sinks);
-        }
-    }
-
-    void RoomsWindowManager::set_lights(const std::vector<std::weak_ptr<ILight>>& lights)
-    {
-        _all_lights = lights;
-        _selected_light.reset();
-        for (auto& window : _windows)
-        {
-            window.second->clear_selected_light();
-            window.second->set_lights(_all_lights);
         }
     }
 }

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -115,6 +115,8 @@ namespace trview
         rooms_window->on_trigger_selected += on_trigger_selected;
         rooms_window->on_room_visibility += on_room_visibility;
         rooms_window->on_sector_hover += on_sector_hover;
+        rooms_window->on_light_selected += on_light_selected;
+        rooms_window->on_camera_sink_selected += on_camera_sink_selected;
         rooms_window->set_level_version(_level_version);
         rooms_window->set_items(_all_items);
         rooms_window->set_triggers(_all_triggers);
@@ -122,6 +124,15 @@ namespace trview
         rooms_window->set_current_room(_current_room);
         rooms_window->set_map_colours(_map_colours);
         rooms_window->set_floordata(_floordata);
+        rooms_window->set_camera_sinks(_all_camera_sinks);
+        rooms_window->set_lights(_all_lights);
+        if (_selected_item.has_value())
+        {
+            rooms_window->set_selected_item(_selected_item.value());
+        }
+        rooms_window->set_selected_trigger(_selected_trigger);
+        rooms_window->set_selected_camera_sink(_selected_camera_sink);
+        rooms_window->set_selected_light(_selected_light);
         return add_window(rooms_window);
     }
 
@@ -136,6 +147,46 @@ namespace trview
         for (auto& window : _windows)
         {
             window.second->set_floordata(data);
+        }
+    }
+
+    void RoomsWindowManager::set_selected_light(const std::weak_ptr<ILight>& light)
+    {
+        _selected_light = light;
+        for (auto& window : _windows)
+        {
+            window.second->set_selected_light(light);
+        }
+    }
+
+    void RoomsWindowManager::set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink)
+    {
+        _selected_camera_sink = camera_sink;
+        for (auto& window : _windows)
+        {
+            window.second->set_selected_camera_sink(camera_sink);
+        }
+    }
+
+    void RoomsWindowManager::set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks)
+    {
+        _all_camera_sinks = camera_sinks;
+        _selected_camera_sink.reset();
+        for (auto& window : _windows)
+        {
+            window.second->clear_selected_camera_sink();
+            window.second->set_camera_sinks(_all_camera_sinks);
+        }
+    }
+
+    void RoomsWindowManager::set_lights(const std::vector<std::weak_ptr<ILight>>& lights)
+    {
+        _all_lights = lights;
+        _selected_light.reset();
+        for (auto& window : _windows)
+        {
+            window.second->clear_selected_light();
+            window.second->set_lights(_all_lights);
         }
     }
 }

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -38,7 +38,6 @@ namespace trview
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& items) override;
         virtual void set_selected_item(const Item& item) override;
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
-        virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual std::weak_ptr<IRoomsWindow> create_window() override;
         virtual void update(float delta) override;
         virtual void set_floordata(const std::vector<uint16_t>& data) override;
@@ -47,7 +46,6 @@ namespace trview
     private:
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
-        std::vector<std::weak_ptr<ITrigger>> _all_triggers;
         uint32_t _current_room{ 0u };
         std::weak_ptr<ITrigger> _selected_trigger;
         std::optional<Item> _selected_item;

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -45,7 +45,6 @@ namespace trview
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) override;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
         virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) override;
-        virtual void set_lights(const std::vector<std::weak_ptr<ILight>>& lights) override;
     private:
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
@@ -58,7 +57,6 @@ namespace trview
         MapColours _map_colours;
         std::vector<uint16_t> _floordata;
         std::vector<std::weak_ptr<ICameraSink>> _all_camera_sinks;
-        std::vector<std::weak_ptr<ILight>> _all_lights;
         std::weak_ptr<ICameraSink> _selected_camera_sink;
         std::weak_ptr<ILight> _selected_light;
     };

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -44,7 +44,6 @@ namespace trview
         virtual void set_floordata(const std::vector<uint16_t>& data) override;
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) override;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
-        virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) override;
     private:
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -42,6 +42,10 @@ namespace trview
         virtual std::weak_ptr<IRoomsWindow> create_window() override;
         virtual void update(float delta) override;
         virtual void set_floordata(const std::vector<uint16_t>& data) override;
+        virtual void set_selected_light(const std::weak_ptr<ILight>& light) override;
+        virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
+        virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) override;
+        virtual void set_lights(const std::vector<std::weak_ptr<ILight>>& lights) override;
     private:
         std::vector<Item> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
@@ -53,6 +57,10 @@ namespace trview
         trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Unknown };
         MapColours _map_colours;
         std::vector<uint16_t> _floordata;
+        std::vector<std::weak_ptr<ICameraSink>> _all_camera_sinks;
+        std::vector<std::weak_ptr<ILight>> _all_lights;
+        std::weak_ptr<ICameraSink> _selected_camera_sink;
+        std::weak_ptr<ILight> _selected_light;
     };
 }
 

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <trview.common/Windows/IClipboard.h>
+#include <trview.common/TokenStore.h>
 #include "../Filters/Filters.h"
+#include "../Track/Track.h"
 
 #include "ITriggersWindow.h"
 #include "../Elements/Item.h"
@@ -40,7 +42,6 @@ namespace trview
         virtual std::weak_ptr<ITrigger> selected_trigger() const override;
         virtual void update(float delta) override;
     private:
-        void set_track_room(bool value);
         void set_sync_trigger(bool value);
         void render_triggers_list();
         void render_trigger_details();
@@ -56,8 +57,7 @@ namespace trview
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;
         std::vector<std::weak_ptr<ITrigger>> _filtered_triggers;
 
-        /// Whether the trigger window is tracking the current room.
-        bool _track_room{ false };
+        TokenStore _token_store;
         /// The current room number selected for tracking.
         uint32_t _current_room{ 0u };
         /// Whether the room tracking filter has been applied.
@@ -77,5 +77,6 @@ namespace trview
         float _required_number_width{ 0.0f };
         float _required_type_width{ 0.0f };
         bool _force_sort{ false };
+        Track<Type::Room> _track;
     };
 }

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -21,7 +21,6 @@ namespace trview
         {
             static inline const std::string add_to_route = "Add to Route";
             static inline const std::string sync_trigger = "Sync";
-            static inline const std::string track_room = "Track Room";
             static inline const std::string trigger_list_panel = "Trigger List";
             static inline const std::string triggers_list = "##triggerslist";
             static inline const std::string details_panel = "Trigger Details";

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -97,6 +97,9 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Tools\Compass.cpp" />
     <ClCompile Include="Tools\Measure.cpp" />
     <ClCompile Include="Tools\Toolbar.cpp" />
+    <ClInclude Include="Type.inl">
+      <FileType>Document</FileType>
+    </ClInclude>
     <ClCompile Include="UI\CameraControls.cpp" />
     <ClCompile Include="UI\CameraPosition.cpp" />
     <ClCompile Include="UI\Console.cpp" />
@@ -274,6 +277,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Track\Track.h" />
     <ClInclude Include="trview_imgui.h" />
     <ClInclude Include="trview_imgui.hpp" />
+    <ClInclude Include="Type.h" />
     <ClInclude Include="UI\CameraControls.h" />
     <ClInclude Include="UI\CameraPosition.h" />
     <ClInclude Include="UI\Console.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -271,6 +271,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Tools\IMeasure.h" />
     <ClInclude Include="Tools\Measure.h" />
     <ClInclude Include="Tools\Toolbar.h" />
+    <ClInclude Include="Track\Track.h" />
     <ClInclude Include="trview_imgui.h" />
     <ClInclude Include="trview_imgui.hpp" />
     <ClInclude Include="UI\CameraControls.h" />
@@ -350,6 +351,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <Image Include="trview.ico" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Track\Track.inl" />
     <Text Include="Resources\Files\actions.json">
       <FileType>Document</FileType>
     </Text>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -861,6 +861,8 @@
     <ClInclude Include="Track\Track.h">
       <Filter>Track</Filter>
     </ClInclude>
+    <ClInclude Include="Type.h" />
+    <ClInclude Include="Type.inl" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -858,6 +858,9 @@
     <ClInclude Include="Mocks\Windows\ICameraSinkWindow.h">
       <Filter>Mocks\Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Track\Track.h">
+      <Filter>Track</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">
@@ -983,6 +986,9 @@
     <Filter Include="Windows\CameraSink">
       <UniqueIdentifier>{0fb465bf-4265-479e-9d44-1218e1561a71}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Track">
+      <UniqueIdentifier>{895fbf3e-9030-4fa9-8c33-158d155fe655}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <Image Include="Resources\Files\tomb1.png">
@@ -1036,6 +1042,9 @@
     </None>
     <None Include="Resources\Files\Fonts\arial7.bin">
       <Filter>Resources\Files\Fonts</Filter>
+    </None>
+    <None Include="Track\Track.inl">
+      <Filter>Track</Filter>
     </None>
   </ItemGroup>
   <ItemGroup>

--- a/trview.common/Algorithms.h
+++ b/trview.common/Algorithms.h
@@ -5,10 +5,10 @@
 namespace trview
 {
     template <typename T1, typename T2>
-    bool equals_any(T1&& value, T2&& other);
+    constexpr bool equals_any(T1&& value, T2&& other);
 
     template <typename T1, typename T2, typename... Args>
-    bool equals_any(T1&& value, T2&& other, Args&&... set);
+    constexpr bool equals_any(T1&& value, T2&& other, Args&&... set);
 
     template <typename T>
     concept Enum = !std::is_convertible<T, int>::value && std::integral_constant<bool, std::is_enum<T>::value>::value;

--- a/trview.common/Algorithms.hpp
+++ b/trview.common/Algorithms.hpp
@@ -3,13 +3,13 @@
 namespace trview
 {
     template <typename T1, typename T2>
-    bool equals_any(T1&& value, T2&& other)
+    constexpr bool equals_any(T1&& value, T2&& other)
     {
         return value == other;
     }
 
     template <typename T1, typename T2, typename... Args>
-    bool equals_any(T1&& value, T2&& other, Args&&... set)
+    constexpr bool equals_any(T1&& value, T2&& other, Args&&... set)
     {
         return equals_any(value, other) || equals_any(value, set...);
     }


### PR DESCRIPTION
Show the lights and camera/sinks in each room in the rooms window.
Create and use a new reusable tracking UI that has a set of checkboxes behind a button.
Stop passing triggers to the rooms window - take them from each room instead. This is how lights and camera/sinks work as well.
Closes #1088 