### PR TITLE
Stop minimap from taking mouse input when obscured

### DIFF
--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -158,6 +158,7 @@ TEST(Viewer, ItemVisibilityRaisedForValidItem)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
+    TestImgui imgui;
 
     viewer->open(&level, ILevel::OpenMode::Full);
 
@@ -237,6 +238,7 @@ TEST(Viewer, TriggerVisibilityRaised)
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
+    TestImgui imgui;
 
     NiceMock<MockLevel> level;
     auto trigger = mock_shared<MockTrigger>();
@@ -283,6 +285,7 @@ TEST(Viewer, RemoveWaypointRaised)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
+    TestImgui imgui;
 
     std::optional<uint32_t> removed_waypoint;
     auto token = viewer->on_waypoint_removed += [&removed_waypoint](const auto& waypoint) { removed_waypoint = waypoint; };
@@ -301,6 +304,7 @@ TEST(Viewer, AddWaypointRaised)
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
+    TestImgui imgui;
 
     NiceMock<MockLevel> level;
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
@@ -328,6 +332,7 @@ TEST(Viewer, AddWaypointRaisedUsesItemPosition)
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
+    TestImgui imgui;
 
     NiceMock<MockLevel> level;
     Item item(50, 10, 0, "Test", 0, 0, {}, Vector3::Zero);
@@ -360,6 +365,7 @@ TEST(Viewer, RightClickActivatesContextMenu)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
+    TestImgui imgui;
 
     EXPECT_CALL(ui, set_show_context_menu(false));
     EXPECT_CALL(ui, set_show_context_menu(true)).Times(1);
@@ -616,6 +622,7 @@ TEST(Viewer, WaypointUsesPosition)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
+    TestImgui imgui;
 
     std::optional<Vector3> raised_position;
     auto token = viewer->on_waypoint_added += [&](auto&& position, auto&&...)
@@ -636,6 +643,7 @@ TEST(Viewer, MidWaypointUsesCentroid)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
+    TestImgui imgui;
 
     std::optional<Vector3> raised_position;
     auto token = viewer->on_waypoint_added += [&](auto&& position, auto&&...)
@@ -721,6 +729,7 @@ TEST(Viewer, LightVisibilityRaised)
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
+    TestImgui imgui;
 
     NiceMock<MockLevel> level;
     auto light = mock_shared<MockLight>();
@@ -746,6 +755,7 @@ TEST(Viewer, RoomVisibilityRaised)
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
+    TestImgui imgui;
 
     NiceMock<MockLevel> level;
     auto room = mock_shared<MockRoom>();
@@ -820,6 +830,7 @@ TEST(Viewer, CopyPosition)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto clipboard = mock_shared<MockClipboard>();
+    TestImgui imgui;
 
     EXPECT_CALL(*clipboard, write(std::wstring(L"1024, 2048, 3072"))).Times(1);
 
@@ -836,6 +847,7 @@ TEST(Viewer, CopyRoom)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto clipboard = mock_shared<MockClipboard>();
+    TestImgui imgui;
 
     EXPECT_CALL(*clipboard, write(std::wstring(L"14"))).Times(1);
 
@@ -852,6 +864,7 @@ TEST(Viewer, SetTriggeredBy)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto clipboard = mock_shared<MockClipboard>();
+    TestImgui imgui;
 
     EXPECT_CALL(ui, set_triggered_by).Times(1);
 
@@ -908,6 +921,7 @@ TEST(Viewer, CameraSinkVisibilityRaisedForValidItem)
     auto cs = mock_shared<MockCameraSink>();
     NiceMock<MockLevel> level;
     EXPECT_CALL(level, camera_sink(123)).WillRepeatedly(Return(cs));
+    TestImgui imgui;
 
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
@@ -952,6 +966,7 @@ TEST(Viewer, SetTriggeredByCameraSink)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto clipboard = mock_shared<MockClipboard>();
+    TestImgui imgui;
 
     EXPECT_CALL(ui, set_triggered_by).Times(1);
 

--- a/trview.app/Mocks/UI/IMapRenderer.h
+++ b/trview.app/Mocks/UI/IMapRenderer.h
@@ -27,6 +27,7 @@ namespace trview
             MOCK_METHOD(void, set_render_mode, (RenderMode), (override));
             MOCK_METHOD(void, set_colours, (const MapColours&), (override));
             MOCK_METHOD(void, set_selection, (const std::shared_ptr<ISector>&), (override));
+            MOCK_METHOD(void, clear_hovered_sector, (), (override));
         };
     }
 }

--- a/trview.app/UI/IMapRenderer.h
+++ b/trview.app/UI/IMapRenderer.h
@@ -64,5 +64,7 @@ namespace trview
         virtual void set_colours(const MapColours& colours) = 0;
 
         virtual void set_selection(const std::shared_ptr<ISector>& sector) = 0;
+
+        virtual void clear_hovered_sector() = 0;
     };
 }

--- a/trview.app/UI/MapRenderer.cpp
+++ b/trview.app/UI/MapRenderer.cpp
@@ -81,11 +81,10 @@ namespace trview
             }
 
             // If the cursor is over the tile, then negate colour 
-            Point first = tile.position, last = Point(tile.size.width, tile.size.height) + tile.position;
-            if (_cursor.is_between(first, last) ||
-                (_highlighted_sector.has_value() &&
-                    _highlighted_sector.value().first == tile.sector->x() &&
-                    _highlighted_sector.value().second == tile.sector->z()))
+            if (tile.sector == _previous_sector ||
+                 (_highlighted_sector.has_value() &&
+                     _highlighted_sector.value().first == tile.sector->x() &&
+                     _highlighted_sector.value().second == tile.sector->z()))
             {
                 draw_color.Negate();
                 text_color.Negate();
@@ -223,8 +222,8 @@ namespace trview
         auto sector = sector_at_cursor();
         if(sector != _previous_sector)
         {
-            on_sector_hover(sector);
             _previous_sector = sector;
+            on_sector_hover(sector);
         }
     }
 
@@ -335,6 +334,12 @@ namespace trview
     void MapRenderer::set_selection(const std::shared_ptr<ISector>& sector)
     {
         _selected_sector = sector;
+        _force_redraw = true;
+    }
+
+    void MapRenderer::clear_hovered_sector()
+    {
+        _previous_sector.reset();
         _force_redraw = true;
     }
 };

--- a/trview.app/UI/MapRenderer.h
+++ b/trview.app/UI/MapRenderer.h
@@ -89,6 +89,7 @@ namespace trview
         virtual void set_render_mode(RenderMode mode) override;
         virtual void set_colours(const MapColours& colours) override;
         virtual void set_selection(const std::shared_ptr<ISector>& sector) override;
+        virtual void clear_hovered_sector() override;
     private:
         // Determines the position (on screen) to draw a sector 
         Point get_position(const ISector& sector); 

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -135,6 +135,12 @@ namespace trview
         _map_renderer = map_renderer_source(window.size());
         _token_store += _map_renderer->on_sector_hover += [this](const std::shared_ptr<ISector>& sector)
         {
+            if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
+            {
+                _map_renderer->clear_hovered_sector();
+                return;
+            }
+
             on_sector_hover(sector);
 
             if (!sector)

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -402,7 +402,7 @@ namespace trview
                         ImGui::SetCursorPosY(ImGui::GetCursorPosY() + std::floor(remainder));
 
                         const auto io = ImGui::GetIO();
-                        if (io.WantCaptureMouse)
+                        if (io.WantCaptureMouse && ImGui::IsWindowHovered(ImGuiHoveredFlags_None))
                         {
                             const auto mouse_pos = io.MousePos;
                             auto top_left = ImGui::GetCursorScreenPos();

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -482,33 +482,36 @@ namespace trview
                 }
                 else if (std::shared_ptr<ISector> sector = _ui->current_minimap_sector())
                 {
-                    // Select the trigger (if it is a trigger).
-                    const auto triggers = _level->triggers();
-                    auto trigger = std::find_if(triggers.begin(), triggers.end(),
-                        [&](auto t)
+                    if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
                     {
-                        const auto t_ptr = t.lock();
-                        return t_ptr->room() == sector->room() && t_ptr->sector_id() == sector->id();
-                    });
+                        // Select the trigger (if it is a trigger).
+                        const auto triggers = _level->triggers();
+                        auto trigger = std::find_if(triggers.begin(), triggers.end(),
+                            [&](auto t)
+                            {
+                                const auto t_ptr = t.lock();
+                                return t_ptr->room() == sector->room() && t_ptr->sector_id() == sector->id();
+                            });
 
-                    if (trigger == triggers.end() || (GetAsyncKeyState(VK_CONTROL) & 0x8000))
-                    {
-                        if (has_flag(sector->flags(), SectorFlag::Portal))
+                        if (trigger == triggers.end() || (GetAsyncKeyState(VK_CONTROL) & 0x8000))
                         {
-                            on_room_selected(sector->portal());
+                            if (has_flag(sector->flags(), SectorFlag::Portal))
+                            {
+                                on_room_selected(sector->portal());
+                            }
+                            else if (!_settings.invert_map_controls && has_flag(sector->flags(), SectorFlag::RoomBelow))
+                            {
+                                on_room_selected(sector->room_below());
+                            }
+                            else if (_settings.invert_map_controls && has_flag(sector->flags(), SectorFlag::RoomAbove))
+                            {
+                                on_room_selected(sector->room_above());
+                            }
                         }
-                        else if (!_settings.invert_map_controls && has_flag(sector->flags(), SectorFlag::RoomBelow))
+                        else
                         {
-                            on_room_selected(sector->room_below());
+                            on_trigger_selected(*trigger);
                         }
-                        else if (_settings.invert_map_controls && has_flag(sector->flags(), SectorFlag::RoomAbove))
-                        {
-                            on_room_selected(sector->room_above());
-                        }
-                    }
-                    else
-                    {
-                        on_trigger_selected(*trigger);
                     }
                 }
             }
@@ -516,15 +519,18 @@ namespace trview
             {
                 _ui->set_show_context_menu(false);
 
-                if (auto sector = _ui->current_minimap_sector())
+                if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
                 {
-                    if (!_settings.invert_map_controls && has_flag(sector->flags(), SectorFlag::RoomAbove))
+                    if (auto sector = _ui->current_minimap_sector())
                     {
-                        on_room_selected(sector->room_above());
-                    }
-                    else if (_settings.invert_map_controls && has_flag(sector->flags(), SectorFlag::RoomBelow))
-                    {
-                        on_room_selected(sector->room_below());
+                        if (!_settings.invert_map_controls && has_flag(sector->flags(), SectorFlag::RoomAbove))
+                        {
+                            on_room_selected(sector->room_above());
+                        }
+                        else if (_settings.invert_map_controls && has_flag(sector->flags(), SectorFlag::RoomBelow))
+                        {
+                            on_room_selected(sector->room_below());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The minimap would take mouse clicks even if there were windows over it - this applied to the viewer minimap and the rooms window minimap.
Make it so it doesn't do that.
Closes #1089 