### PR TITLE
Add Lua bindings for Level

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,9 @@ The console window will log diagnostic messages in the future and can be used to
 
 The input box allows you to enter Lua scripts.
 
+# Lua Bindings
+trview has [Lua bindings](doc/lua/index.md) that can currently be used in the console and will be usable by plugins in the future.
+
 # Licenses
 
 ## Lua

--- a/doc/lua/index.md
+++ b/doc/lua/index.md
@@ -1,0 +1,6 @@
+# Lua Bindings
+
+# Libraries
+
+- [trview](trview.md)
+- [level](level.md)

--- a/doc/lua/level.md
+++ b/doc/lua/level.md
@@ -1,0 +1,15 @@
+# Level
+
+The Level library provides information about the currently loaded Level in trview.
+
+# Properties
+| Name | Type | Description |
+| ---- | ---- | ---- |
+| cameras_and_sinks | Table of Camera/Sinks | All cameras/sinks in the level |
+| filename | string | The path of the level file |
+| floordata | Table | All floordata |
+| items | Table of Items | All items |
+| lights | table of Lights | All lights |
+| rooms | table of Rooms | All rooms |
+| triggers | table of Trigger | All triggers |
+| version | number | The game number for which this level was made |

--- a/doc/lua/trview.md
+++ b/doc/lua/trview.md
@@ -1,0 +1,9 @@
+# trview
+
+The trview library provides information about the program in general.
+
+# Properties
+
+| Name | Type | Description |
+| ---- | ---- | ---- |
+| level | [Level](level.md) | The current level, or `nil` if no level loaded  |

--- a/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
@@ -1,0 +1,303 @@
+#include <trview.app/Lua/Elements/Level/Lua_Level.h>
+#include <trview.app/Application.h>
+#include <trview.app/Mocks/Menus/IUpdateChecker.h>
+#include <trview.app/Mocks/Menus/IFileMenu.h>
+#include <trview.app/Mocks/Windows/ILightsWindowManager.h>
+#include <trview.app/Mocks/Windows/ILogWindowManager.h>
+#include <trview.app/Mocks/Windows/ITexturesWindowManager.h>
+#include <trview.app/Mocks/Windows/ICameraSinkWindowManager.h>
+#include "NullImGuiBackend.h"
+
+using namespace trview;
+using namespace trview::tests;
+using namespace trview::mocks;
+
+namespace
+{
+    Event<> shortcut_handler;
+
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            Window window{ create_test_window(L"ApplicationLuaTests") };
+            std::unique_ptr<IUpdateChecker> update_checker{ mock_unique<MockUpdateChecker>() };
+            std::unique_ptr<ISettingsLoader> settings_loader{ mock_unique<MockSettingsLoader>() };
+            trlevel::ILevel::Source trlevel_source{ [](auto&&...) { return mock_unique<trlevel::mocks::MockLevel>(); } };
+            std::unique_ptr<IFileMenu> file_menu{ mock_unique<MockFileMenu>() };
+            std::unique_ptr<IViewer> viewer{ mock_unique<MockViewer>() };
+            IRoute::Source route_source{ [](auto&&...) { return mock_shared<MockRoute>(); } };
+            std::shared_ptr<MockShortcuts> shortcuts{ mock_shared<MockShortcuts>() };
+            std::unique_ptr<IItemsWindowManager> items_window_manager{ mock_unique<MockItemsWindowManager>() };
+            std::unique_ptr<ITriggersWindowManager> triggers_window_manager{ mock_unique<MockTriggersWindowManager>() };
+            std::unique_ptr<IRouteWindowManager> route_window_manager{ mock_unique<MockRouteWindowManager>() };
+            std::unique_ptr<IRoomsWindowManager> rooms_window_manager{ mock_unique<MockRoomsWindowManager>() };
+            ILevel::Source level_source{ [](auto&&...) { return mock_unique<trview::mocks::MockLevel>(); } };
+            std::shared_ptr<IStartupOptions> startup_options{ mock_shared<MockStartupOptions>() };
+            std::shared_ptr<IDialogs> dialogs{ mock_shared<MockDialogs>() };
+            std::shared_ptr<IFiles> files{ mock_shared<MockFiles>() };
+            std::unique_ptr<IImGuiBackend> imgui_backend{ std::make_unique<NullImGuiBackend>() };
+            std::unique_ptr<ILightsWindowManager> lights_window_manager{ mock_unique<MockLightsWindowManager>() };
+            std::unique_ptr<ILogWindowManager> log_window_manager{ mock_unique<MockLogWindowManager>() };
+            std::unique_ptr<ITexturesWindowManager> textures_window_manager{ mock_unique<MockTexturesWindowManager>() };
+            std::unique_ptr<ICameraSinkWindowManager> camera_sink_window_manager{ mock_unique<MockCameraSinkWindowManager>() };
+
+            std::unique_ptr<Application> build()
+            {
+                EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
+                return std::make_unique<Application>(window, std::move(update_checker), std::move(settings_loader),
+                    trlevel_source, std::move(file_menu), std::move(viewer), route_source, shortcuts,
+                    std::move(items_window_manager), std::move(triggers_window_manager), std::move(route_window_manager), std::move(rooms_window_manager),
+                    level_source, startup_options, dialogs, files, std::move(imgui_backend), std::move(lights_window_manager), std::move(log_window_manager),
+                    std::move(textures_window_manager), std::move(camera_sink_window_manager));
+            }
+
+            test_module& with_dialogs(std::shared_ptr<IDialogs> dialogs)
+            {
+                this->dialogs = dialogs;
+                return *this;
+            }
+
+            test_module& with_items_window_manager(std::unique_ptr<IItemsWindowManager> items_window_manager)
+            {
+                this->items_window_manager = std::move(items_window_manager);
+                return *this;
+            }
+
+            test_module& with_trlevel_source(trlevel::ILevel::Source trlevel_source)
+            {
+                this->trlevel_source = trlevel_source;
+                return *this;
+            }
+
+            test_module& with_file_menu(std::unique_ptr<IFileMenu> file_menu)
+            {
+                this->file_menu = std::move(file_menu);
+                return *this;
+            }
+
+            test_module& with_rooms_window_manager(std::unique_ptr<IRoomsWindowManager> rooms_window_manager)
+            {
+                this->rooms_window_manager = std::move(rooms_window_manager);
+                return *this;
+            }
+
+            test_module& with_route_source(IRoute::Source route_source)
+            {
+                this->route_source = route_source;
+                return *this;
+            }
+
+            test_module& with_route_window_manager(std::unique_ptr<IRouteWindowManager> route_window_manager)
+            {
+                this->route_window_manager = std::move(route_window_manager);
+                return *this;
+            }
+
+            test_module& with_settings_loader(std::unique_ptr<ISettingsLoader> settings_loader)
+            {
+                this->settings_loader = std::move(settings_loader);
+                return *this;
+            }
+
+            test_module& with_startup_options(std::shared_ptr<IStartupOptions> startup_options)
+            {
+                this->startup_options = startup_options;
+                return *this;
+            }
+
+            test_module& with_triggers_window_manager(std::unique_ptr<ITriggersWindowManager> triggers_window_manager)
+            {
+                this->triggers_window_manager = std::move(triggers_window_manager);
+                return *this;
+            }
+
+            test_module& with_lights_window_manager(std::unique_ptr<ILightsWindowManager> lights_window_manager)
+            {
+                this->lights_window_manager = std::move(lights_window_manager);
+                return *this;
+            }
+
+            test_module& with_update_checker(std::unique_ptr<IUpdateChecker> update_checker)
+            {
+                this->update_checker = std::move(update_checker);
+                return *this;
+            }
+
+            test_module& with_viewer(std::unique_ptr<IViewer> viewer)
+            {
+                this->viewer = std::move(viewer);
+                return *this;
+            }
+
+            test_module& with_files(const std::shared_ptr<IFiles>& files)
+            {
+                this->files = files;
+                return *this;
+            }
+
+            test_module& with_imgui_backend(std::unique_ptr<IImGuiBackend> backend)
+            {
+                this->imgui_backend = std::move(backend);
+                return *this;
+            }
+
+            test_module& with_level_source(ILevel::Source level_source)
+            {
+                this->level_source = level_source;
+                return *this;
+            }
+
+            test_module& with_log_window_manager(std::unique_ptr<ILogWindowManager> log_window_manager)
+            {
+                this->log_window_manager = std::move(log_window_manager);
+                return *this;
+            }
+
+            test_module& with_textures_window_manager(std::unique_ptr<ITexturesWindowManager> textures_window_manager)
+            {
+                this->textures_window_manager = std::move(textures_window_manager);
+                return *this;
+            }
+
+            test_module& with_camera_sink_window_manager(std::unique_ptr<ICameraSinkWindowManager> camera_sink_window_manager)
+            {
+                this->camera_sink_window_manager = std::move(camera_sink_window_manager);
+                return *this;
+            }
+        };
+        return test_module{};
+    }
+}
+
+TEST(Lua_Level, CamerasAndSinks)
+{
+    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
+    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
+    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+
+    auto app = register_test_module()
+        .with_level_source(level_source)
+        .build();
+    app->open("test", ILevel::OpenMode::Full);
+
+    lua_State* L = lua_get_state();
+    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.cameras_and_sinks"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+}
+
+TEST(Lua_Level, Filename)
+{
+    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
+    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
+    ON_CALL(level, filename).WillByDefault(testing::Return("test filename"));
+
+    auto app = register_test_module()
+        .with_level_source(level_source)
+        .build();
+    app->open("test", ILevel::OpenMode::Full);
+
+    lua_State* L = lua_get_state();
+    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.filename"));
+
+    std::string result = lua_tostring(L, -1);
+    ASSERT_EQ(result, "test filename");
+}
+
+TEST(Lua_Level, Floordata)
+{
+    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
+    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
+    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+
+    auto app = register_test_module()
+        .with_level_source(level_source)
+        .build();
+    app->open("test", ILevel::OpenMode::Full);
+
+    lua_State* L = lua_get_state();
+    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.floordata"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+}
+
+TEST(Lua_Level, Items)
+{
+    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
+    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
+    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+
+    auto app = register_test_module()
+        .with_level_source(level_source)
+        .build();
+    app->open("test", ILevel::OpenMode::Full);
+
+    lua_State* L = lua_get_state();
+    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.items"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+}
+
+TEST(Lua_Level, Lights)
+{
+    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
+    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
+    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+
+    auto app = register_test_module()
+        .with_level_source(level_source)
+        .build();
+    app->open("test", ILevel::OpenMode::Full);
+
+    lua_State* L = lua_get_state();
+    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.lights"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+}
+
+TEST(Lua_Level, Rooms)
+{
+    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
+    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
+    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+
+    auto app = register_test_module()
+        .with_level_source(level_source)
+        .build();
+    app->open("test", ILevel::OpenMode::Full);
+
+    lua_State* L = lua_get_state();
+    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.rooms"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+}
+
+TEST(Lua_Level, Triggers)
+{
+    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
+    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
+    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+
+    auto app = register_test_module()
+        .with_level_source(level_source)
+        .build();
+    app->open("test", ILevel::OpenMode::Full);
+
+    lua_State* L = lua_get_state();
+    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.triggers"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+}
+
+TEST(Lua_Level, Version)
+{
+    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
+    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
+    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+
+    auto app = register_test_module()
+        .with_level_source(level_source)
+        .build();
+    app->open("test", ILevel::OpenMode::Full);
+
+    lua_State* L = lua_get_state();
+    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.version"));
+
+    double result = lua_tonumber(L, -1);
+    ASSERT_EQ(result, 4.0);
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -42,6 +42,7 @@
     <ClCompile Include="Graphics\TextureStorage.cpp" />
     <ClCompile Include="ItemsWindowManagerTests.cpp" />
     <ClCompile Include="ItemsWindowTests.cpp" />
+    <ClCompile Include="Lua\Elements\Lua_LevelTests.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Menus\MenuDetectorTests.cpp" />
     <ClCompile Include="NullImGuiBackend.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -176,6 +176,9 @@
     <ClCompile Include="Elements\CameraSinkTests.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
+    <ClCompile Include="Lua\Elements\Lua_LevelTests.cpp">
+      <Filter>Lua\Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">
@@ -210,6 +213,12 @@
     </Filter>
     <Filter Include="Filters">
       <UniqueIdentifier>{ab42e6fa-def3-4b06-8902-61c45b15dfda}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Lua">
+      <UniqueIdentifier>{523c59ce-5d18-4115-91a5-f32e97a5160a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Lua\Elements">
+      <UniqueIdentifier>{de0633ad-2e3e-49f3-89b7-807134869b6a}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -1,5 +1,6 @@
 #include "Application.h"
 #include <trlevel/LevelEncryptedException.h>
+#include "Lua/trview/trview.h"
 
 #include "Resources/resource.h"
 
@@ -204,6 +205,8 @@ namespace trview
             _recent_route_prompted = false;
             open_recent_route();
         }
+
+        lua::set_current_level(_level.get());
     }
 
     std::optional<int> Application::process_message(UINT message, WPARAM wParam, LPARAM)

--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -59,6 +59,11 @@ namespace trview
                     lua_pushinteger(L, static_cast<int>(current_level->version()));
                     return 1;
                 }
+                else if (key == "filename")
+                {
+                    lua_pushstring(L, current_level->filename().c_str());
+                    return 1;
+                }
                 return 0;
             }
 

--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -1,0 +1,91 @@
+#include "Lua_Level.h"
+#include "../../Lua.h"
+#include "../../../Elements/ILevel.h"
+
+namespace trview
+{
+    namespace lua
+    {
+        namespace
+        {
+            ILevel* current_level = nullptr;
+
+            int level_index(lua_State* L)
+            {
+                if (!current_level)
+                {
+                    return 0;
+                }
+
+                const std::string key = lua_tostring(L, 2);
+                if (key == "cameras_and_sinks")
+                {
+                    lua_newtable(L);
+                    // TODO: Cameras/Sinks
+                    return 1;
+                }
+                else if (key == "floordata")
+                {
+                    lua_newtable(L);
+                    // TODO: Floordata
+                    return 1;
+                }
+                else if (key == "items")
+                {
+                    lua_newtable(L);
+                    // TODO: Items
+                    return 1;
+                }
+                else if (key == "lights")
+                {
+                    lua_newtable(L);
+                    // TODO: Lights
+                    return 1;
+                }
+                else if (key == "rooms")
+                {
+                    lua_newtable(L);
+                    // TODO: Rooms
+                    return 1;
+                }
+                else if (key == "triggers")
+                {
+                    lua_newtable(L);
+                    // TODO: Triggers
+                    return 1;
+                }
+                else if (key == "version")
+                {
+                    lua_pushinteger(L, static_cast<int>(current_level->version()));
+                    return 1;
+                }
+                return 0;
+            }
+
+            constexpr struct luaL_Reg level_lib[] =
+            {
+                { "__index", level_index },
+                { NULL, NULL },
+            };
+        }
+
+        void create_level(lua_State* L, ILevel* level)
+        {
+            if (!level)
+            {
+                lua_pushnil(L);
+                return;
+            }
+
+            lua_newtable(L);
+            luaL_setfuncs(L, level_lib, 0);
+            lua_pushvalue(L, -1);
+            lua_setmetatable(L, -2);
+        }
+
+        void level_set_current_level(ILevel* level)
+        {
+            current_level = level;
+        }
+    }
+}

--- a/trview.app/Lua/Elements/Level/Lua_Level.h
+++ b/trview.app/Lua/Elements/Level/Lua_Level.h
@@ -1,0 +1,14 @@
+#pragma once
+
+struct lua_State;
+
+namespace trview
+{
+    struct ILevel;
+
+    namespace lua
+    {
+        void create_level(lua_State* L, ILevel* level);
+        void level_set_current_level(ILevel* level);
+    }
+}

--- a/trview.app/Lua/Lua.cpp
+++ b/trview.app/Lua/Lua.cpp
@@ -290,4 +290,9 @@ namespace trview
             lua_call ( state, 0, 0 );
         }
     }
+
+    lua_State* lua_get_state()
+    {
+        return state;
+    }
 }

--- a/trview.app/Lua/Lua.cpp
+++ b/trview.app/Lua/Lua.cpp
@@ -1,5 +1,6 @@
 #include "Lua.h"
 #include <trview.common/Strings.h>
+#include "trview/trview.h"
 
 namespace trview
 {
@@ -254,6 +255,8 @@ namespace trview
 
         // utility
         lua_register ( L, "print", print );
+
+        lua::trview_register(L);
 
         state = L;
     }

--- a/trview.app/Lua/Lua.h
+++ b/trview.app/Lua/Lua.h
@@ -70,4 +70,5 @@ namespace trview
     void lua_init ( LuaFunctionRegistry * reg );
     void lua_execute ( const std::string& command );
     void lua_fire_event ( LuaEvent type );
+    lua_State* lua_get_state();
 }

--- a/trview.app/Lua/trview/trview.cpp
+++ b/trview.app/Lua/trview/trview.cpp
@@ -1,0 +1,44 @@
+#include "trview.h"
+#include "../Elements/Level/Lua_Level.h"
+
+namespace trview
+{
+    namespace lua
+    {
+        namespace
+        {
+            ILevel* current_level = nullptr;
+
+            int trview_index(lua_State* L)
+            {
+                const std::string key = lua_tostring(L, 2);
+                if (key == "level")
+                {
+                    create_level(L, current_level);
+                    return 1;
+                }
+                return 0;
+            }
+        }
+
+        void trview_register(lua_State* L)
+        {
+            constexpr struct luaL_Reg trview_lib[] =
+            {
+                { "__index", trview_index },
+                { NULL, NULL },
+            };
+
+            luaL_newlib(L, trview_lib);
+            lua_pushvalue(L, -1);
+            lua_setmetatable(L, -2);
+            lua_setglobal(L, "trview");
+        }
+
+        void set_current_level(ILevel* level)
+        {
+            current_level = level;
+            level_set_current_level(level);
+        }
+    }
+}

--- a/trview.app/Lua/trview/trview.h
+++ b/trview.app/Lua/trview/trview.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <external/lua/src/lua.hpp>
+#include "../../Elements/ILevel.h"
+
+namespace trview
+{
+    namespace lua
+    {
+        void trview_register(lua_State* L);
+        void set_current_level(ILevel* level);
+    }
+}

--- a/trview.app/UI/Console.cpp
+++ b/trview.app/UI/Console.cpp
@@ -29,15 +29,17 @@ namespace trview
             if (ImGui::Begin("Console", &_visible))
             {
                 ImGui::InputTextMultiline(Names::log.c_str(), const_cast<char*>(_text.c_str()), _text.size(), ImVec2(-1, -25), ImGuiInputTextFlags_ReadOnly);
-                if (ImGui::IsWindowAppearing())
+                if (ImGui::IsWindowAppearing() || _need_focus)
                 {
                     ImGui::SetKeyboardFocusHere();
+                    _need_focus = false;
                 }
                 std::vector<char> vec;
                 vec.resize(512);
                 ImGui::PushItemWidth(-1);
                 if (ImGui::InputText(Names::input.c_str(), &vec[0], vec.size(), ImGuiInputTextFlags_EnterReturnsTrue))
                 {
+                    _need_focus = true;
                     auto command = std::string(&vec[0]);
                     on_command(command);
                 }

--- a/trview.app/UI/Console.h
+++ b/trview.app/UI/Console.h
@@ -21,5 +21,6 @@ namespace trview
     private:
         std::string _text;
         bool _visible{ false };
+        bool _need_focus{ false };
     };
 }

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -63,6 +63,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Graphics\SectorHighlight.cpp" />
     <ClCompile Include="Graphics\SelectionRenderer.cpp" />
     <ClCompile Include="Graphics\TextureStorage.cpp" />
+    <ClCompile Include="Lua\Elements\Level\Lua_Level.cpp" />
+    <ClCompile Include="Lua\trview\trview.cpp" />
     <ClCompile Include="Menus\FileMenu.cpp" />
     <ClCompile Include="Mocks\Mocks.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/bigobj %(AdditionalOptions)</AdditionalOptions>
@@ -192,7 +194,9 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Graphics\SectorHighlight.h" />
     <ClInclude Include="Graphics\SelectionRenderer.h" />
     <ClInclude Include="Graphics\TextureStorage.h" />
+    <ClInclude Include="Lua\Elements\Level\Lua_Level.h" />
     <ClInclude Include="Lua\Lua.h" />
+    <ClInclude Include="Lua\trview\trview.h" />
     <ClInclude Include="Menus\AlternateGroupToggler.h" />
     <ClInclude Include="Menus\FileMenu.h" />
     <ClInclude Include="Menus\IFileMenu.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -267,6 +267,12 @@
     <ClCompile Include="Windows\CameraSink\CameraSinkWindow.cpp">
       <Filter>Windows\CameraSink</Filter>
     </ClCompile>
+    <ClCompile Include="Lua\trview\trview.cpp">
+      <Filter>Lua\trview</Filter>
+    </ClCompile>
+    <ClCompile Include="Lua\Elements\Level\Lua_Level.cpp">
+      <Filter>Lua\Elements\Level</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -849,11 +855,17 @@
     <ClInclude Include="Mocks\Windows\ITexturesWindow.h">
       <Filter>Mocks\Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Lua\trview\trview.h">
+      <Filter>Lua\trview</Filter>
+    <ClInclude>
     <ClInclude Include="Windows\CameraSink\CameraSinkWindow.h">
       <Filter>Windows\CameraSink</Filter>
     </ClInclude>
     <ClInclude Include="Mocks\Windows\ICameraSinkWindowManager.h">
       <Filter>Mocks\Windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Lua\Elements\Level\Lua_Level.h">
+      <Filter>Lua\Elements\Level</Filter>
     </ClInclude>
     <ClInclude Include="Mocks\Windows\ICameraSinkWindow.h">
       <Filter>Mocks\Windows</Filter>
@@ -981,6 +993,15 @@
     </Filter>
     <Filter Include="Windows\Textures">
       <UniqueIdentifier>{36446548-876c-425f-ad6c-ea61b062a959}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Lua\trview">
+      <UniqueIdentifier>{59194b9b-8854-4c78-9e5b-fba92e6aae93}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Lua\Elements">
+      <UniqueIdentifier>{6169b956-33a5-481f-9554-b71de754cd16}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Lua\Elements\Level">
+      <UniqueIdentifier>{874fd843-0324-4aef-a0ac-d6304389db43}</UniqueIdentifier>
     </Filter>
     <Filter Include="Elements\CameraSink">
       <UniqueIdentifier>{13d4d034-0684-4dd7-b379-accd1fcc5dca}</UniqueIdentifier>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -855,9 +855,7 @@
     <ClInclude Include="Mocks\Windows\ITexturesWindow.h">
       <Filter>Mocks\Windows</Filter>
     </ClInclude>
-    <ClInclude Include="Lua\trview\trview.h">
-      <Filter>Lua\trview</Filter>
-    </ClInclude>
+    <ClInclude Include="Lua\trview\trview.h" Filter="Lua\trview" />
     <ClInclude Include="Windows\CameraSink\CameraSinkWindow.h">
       <Filter>Windows\CameraSink</Filter>
     </ClInclude>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -857,7 +857,7 @@
     </ClInclude>
     <ClInclude Include="Lua\trview\trview.h">
       <Filter>Lua\trview</Filter>
-    <ClInclude>
+    </ClInclude>
     <ClInclude Include="Windows\CameraSink\CameraSinkWindow.h">
       <Filter>Windows\CameraSink</Filter>
     </ClInclude>


### PR DESCRIPTION
Add bindings for the `Level` class.
Implemented are `version` and `filename`. The others are returning empty tables as their types aren't bound yet. They will be updated when the types exist.
Add docs and tests.
Closes #1083 