### PR TITLE
Add Lua bindings for Item

### DIFF
--- a/doc/lua/index.md
+++ b/doc/lua/index.md
@@ -2,5 +2,8 @@
 
 # Libraries
 
-- [trview](trview.md)
+- [item](item.md)
 - [level](level.md)
+- [room](room.md)
+- [trigger](trigger.md)
+- [trview](trview.md)

--- a/doc/lua/item.md
+++ b/doc/lua/item.md
@@ -1,0 +1,16 @@
+# Item
+
+The Item library provides information about an item in a [level](level.md).
+
+# Properties
+| Name | Type | Mode | Description |
+| ---- | ---- | ---- | ---- |
+| activation_flags | number | R | Bit flags used in combination with trigger flags |
+| number | number | R | Item number |
+| ocb | number | R | Object code bit, used for extra actions in TR4+ |
+| position | [Vector3](vector3.md) | R | Position of the object in game units
+| room | [Room](room.md) | R | The room that the item is in |
+| triggered_by | [Trigger](trigger.md)[] | R | The triggers that reference this item |
+| type | string | R | The item type name e.g Lara |
+| type_id | number | R | The item type number |
+| visible | boolean | RW | Whether the item is visible in the viewer |

--- a/doc/lua/level.md
+++ b/doc/lua/level.md
@@ -3,13 +3,13 @@
 The Level library provides information about the currently loaded Level in trview.
 
 # Properties
-| Name | Type | Description |
-| ---- | ---- | ---- |
-| cameras_and_sinks | Table of Camera/Sinks | All cameras/sinks in the level |
-| filename | string | The path of the level file |
-| floordata | Table | All floordata |
-| items | Table of Items | All items |
-| lights | table of Lights | All lights |
-| rooms | table of Rooms | All rooms |
-| triggers | table of Trigger | All triggers |
-| version | number | The game number for which this level was made |
+| Name | Type | Mode | Description |
+| ---- | ---- | ---- | ---- |
+| cameras_and_sinks | Table of Camera/Sinks | R | All cameras/sinks in the level |
+| filename | string | R | The path of the level file |
+| floordata | Table | R | All floordata |
+| items | [Item](item.md)[] | R | All items |
+| lights | table of Lights | R | All lights |
+| rooms | [Room](room.md) | R | All rooms |
+| triggers | [Trigger](trigger.md) | R | All triggers |
+| version | number | R | The game number for which this level was made |

--- a/doc/lua/room.md
+++ b/doc/lua/room.md
@@ -1,0 +1,14 @@
+# Room
+
+The Room library provides information about a room in a [level](level.md).
+
+# Properties
+| Name | Type | Mode | Description |
+| ---- | ---- | ---- | ---- |
+| alternate_mode | string | R | node/has_alternate/is_alternate |
+| items | [Item](item.md)[] | R | Items in the room |
+| lights | [Light](light.md)[] | R | Lights in the room |
+| number | number | R | Room number |
+| triggers | [Trigger](trigger.md)[] | R | Triggers in the room |
+| visible | boolean | RW | Whether the room is visible in the viewer |
+

--- a/doc/lua/trigger.md
+++ b/doc/lua/trigger.md
@@ -1,0 +1,9 @@
+# Trigger
+
+The Trigger library provides information about a trigger in a [level](level.md).
+
+# Properties
+| Name | Type | Mode | Description |
+| ---- | ---- | ---- | ---- |
+| number | number | R | Trigger number |
+| visible | boolean | RW | Whether the trigger is visible in the viewer |

--- a/doc/lua/vector3.md
+++ b/doc/lua/vector3.md
@@ -1,0 +1,8 @@
+# Vector3
+
+# Properties
+| Name | Type | Mode | Description |
+| ---- | ---- | ---- | ---- |
+| x | number | RW | |
+| y | number | RW | |
+| z | number | RW | |

--- a/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
@@ -25,8 +25,7 @@ TEST(Lua_Item, ActivationFlags)
 
 TEST(Lua_Item, Number)
 {
-    auto item = mock_shared<MockItem>();
-    EXPECT_CALL(*item, number).WillOnce(Return(123));
+    auto item = mock_shared<MockItem>()->with_number(123);
 
     lua_State* L = luaL_newstate();
     lua::create_item(L, item);
@@ -75,14 +74,11 @@ TEST(Lua_Item, Position)
 
 TEST(Lua_Item, Room)
 {
-    auto room = mock_shared<MockRoom>();
-    EXPECT_CALL(*room, number).WillRepeatedly(Return(100));
-
+    auto room = mock_shared<MockRoom>()->with_number(100);
     auto level = mock_shared<MockLevel>();
     EXPECT_CALL(*level, room).WillRepeatedly(Return(room));
 
-    auto item = mock_shared<MockItem>();
-    EXPECT_CALL(*item, room).WillRepeatedly(Return(100));
+    auto item = mock_shared<MockItem>()->with_number(100);
     EXPECT_CALL(*item, level).WillRepeatedly(Return(level));
 
     lua_State* L = luaL_newstate();
@@ -98,10 +94,8 @@ TEST(Lua_Item, Room)
 
 TEST(Lua_Item, TriggeredBy)
 {
-    auto trigger1 = mock_shared<MockTrigger>();
-    EXPECT_CALL(*trigger1, number).WillRepeatedly(Return(100));
-    auto trigger2 = mock_shared<MockTrigger>();
-    EXPECT_CALL(*trigger2, number).WillRepeatedly(Return(200));
+    auto trigger1 = mock_shared<MockTrigger>()->with_number(100);
+    auto trigger2 = mock_shared<MockTrigger>()->with_number(200);
 
     auto item = mock_shared<MockItem>();
     EXPECT_CALL(*item, triggers).WillRepeatedly(Return(std::vector<std::weak_ptr<ITrigger>>{ trigger1, trigger2 }));
@@ -134,7 +128,7 @@ TEST(Lua_Item, Type)
 
     ASSERT_EQ(0, luaL_dostring(L, "return i.type"));
     ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
-    ASSERT_EQ(std::string("Lara"), lua_tostring(L, -1));
+    ASSERT_STREQ("Lara", lua_tostring(L, -1));
 }
 
 TEST(Lua_Item, TypeId)
@@ -163,4 +157,19 @@ TEST(Lua_Item, Visible)
     ASSERT_EQ(0, luaL_dostring(L, "return i.visible"));
     ASSERT_EQ(LUA_TBOOLEAN, lua_type(L, -1));
     ASSERT_EQ(true, lua_toboolean(L, -1));
+}
+
+TEST(Lua_Item, SetVisible)
+{
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, set_item_visibility(100, true));
+
+    auto item = mock_shared<MockItem>()->with_number(100);
+    EXPECT_CALL(*item, level).WillRepeatedly(Return(level));
+
+    lua_State* L = luaL_newstate();
+    lua::create_item(L, item);
+    lua_setglobal(L, "i");
+
+    ASSERT_EQ(0, luaL_dostring(L, "i.visible = true"));
 }

--- a/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
@@ -1,0 +1,166 @@
+#include <trview.app/Lua/Elements/Item/Lua_Item.h>
+#include <trview.app/Mocks/Elements/IItem.h>
+#include <trview.tests.common/Mocks.h>
+#include <external/lua/src/lua.hpp>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace trview::tests;
+using namespace testing;
+using namespace DirectX::SimpleMath;
+
+TEST(Lua_Item, ActivationFlags)
+{
+    auto item = mock_shared<MockItem>();
+    EXPECT_CALL(*item, activation_flags).WillOnce(Return(123));
+
+    lua_State* L = luaL_newstate();
+    lua::create_item(L, item);
+    lua_setglobal(L, "i");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return i.activation_flags"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Item, Number)
+{
+    auto item = mock_shared<MockItem>();
+    EXPECT_CALL(*item, number).WillOnce(Return(123));
+
+    lua_State* L = luaL_newstate();
+    lua::create_item(L, item);
+    lua_setglobal(L, "i");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return i.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Item, Ocb)
+{
+    auto item = mock_shared<MockItem>();
+    EXPECT_CALL(*item, ocb).WillOnce(Return(123));
+
+    lua_State* L = luaL_newstate();
+    lua::create_item(L, item);
+    lua_setglobal(L, "i");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return i.ocb"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Item, Position)
+{
+    auto item = mock_shared<MockItem>();
+    EXPECT_CALL(*item, position).WillRepeatedly(Return(Vector3(1, 2, 3)));
+
+    lua_State* L = luaL_newstate();
+    lua::create_item(L, item);
+    lua_setglobal(L, "i");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return i.position"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return i.position.x"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_DOUBLE_EQ(1024.0, lua_tonumber(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return i.position.y"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_DOUBLE_EQ(2048.0, lua_tonumber(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return i.position.z"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_DOUBLE_EQ(3072.0, lua_tonumber(L, -1));
+}
+
+TEST(Lua_Item, Room)
+{
+    auto room = mock_shared<MockRoom>();
+    EXPECT_CALL(*room, number).WillRepeatedly(Return(100));
+
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, room).WillRepeatedly(Return(room));
+
+    auto item = mock_shared<MockItem>();
+    EXPECT_CALL(*item, room).WillRepeatedly(Return(100));
+    EXPECT_CALL(*item, level).WillRepeatedly(Return(level));
+
+    lua_State* L = luaL_newstate();
+    lua::create_item(L, item);
+    lua_setglobal(L, "i");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return i.room"));
+    ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return i.room.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(100, lua_tonumber(L, -1));
+}
+
+TEST(Lua_Item, TriggeredBy)
+{
+    auto trigger1 = mock_shared<MockTrigger>();
+    EXPECT_CALL(*trigger1, number).WillRepeatedly(Return(100));
+    auto trigger2 = mock_shared<MockTrigger>();
+    EXPECT_CALL(*trigger2, number).WillRepeatedly(Return(200));
+
+    auto item = mock_shared<MockItem>();
+    EXPECT_CALL(*item, triggers).WillRepeatedly(Return(std::vector<std::weak_ptr<ITrigger>>{ trigger1, trigger2 }));
+
+    lua_State* L = luaL_newstate();
+    lua::create_item(L, item);
+    lua_setglobal(L, "i");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return i.triggered_by"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return #i.triggered_by"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return i.triggered_by[1].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(100, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return i.triggered_by[2].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(200, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Item, Type)
+{
+    auto item = mock_shared<MockItem>();
+    EXPECT_CALL(*item, type).WillOnce(Return("Lara"));
+
+    lua_State* L = luaL_newstate();
+    lua::create_item(L, item);
+    lua_setglobal(L, "i");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return i.type"));
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    ASSERT_EQ(std::string("Lara"), lua_tostring(L, -1));
+}
+
+TEST(Lua_Item, TypeId)
+{
+    auto item = mock_shared<MockItem>();
+    EXPECT_CALL(*item, type_id).WillOnce(Return(123));
+
+    lua_State* L = luaL_newstate();
+    lua::create_item(L, item);
+    lua_setglobal(L, "i");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return i.type_id"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Item, Visible)
+{
+    auto item = mock_shared<MockItem>();
+    EXPECT_CALL(*item, visible).WillOnce(Return(true));
+
+    lua_State* L = luaL_newstate();
+    lua::create_item(L, item);
+    lua_setglobal(L, "i");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return i.visible"));
+    ASSERT_EQ(LUA_TBOOLEAN, lua_type(L, -1));
+    ASSERT_EQ(true, lua_toboolean(L, -1));
+}

--- a/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
@@ -1,303 +1,144 @@
 #include <trview.app/Lua/Elements/Level/Lua_Level.h>
-#include <trview.app/Application.h>
-#include <trview.app/Mocks/Menus/IUpdateChecker.h>
-#include <trview.app/Mocks/Menus/IFileMenu.h>
-#include <trview.app/Mocks/Windows/ILightsWindowManager.h>
-#include <trview.app/Mocks/Windows/ILogWindowManager.h>
-#include <trview.app/Mocks/Windows/ITexturesWindowManager.h>
-#include <trview.app/Mocks/Windows/ICameraSinkWindowManager.h>
-#include "NullImGuiBackend.h"
+#include <trview.app/Mocks/Elements/ILevel.h>
+#include <trview.tests.common/Mocks.h>
+#include <external/lua/src/lua.hpp>
 
 using namespace trview;
 using namespace trview::tests;
 using namespace trview::mocks;
-
-namespace
-{
-    Event<> shortcut_handler;
-
-    auto register_test_module()
-    {
-        struct test_module
-        {
-            Window window{ create_test_window(L"ApplicationLuaTests") };
-            std::unique_ptr<IUpdateChecker> update_checker{ mock_unique<MockUpdateChecker>() };
-            std::unique_ptr<ISettingsLoader> settings_loader{ mock_unique<MockSettingsLoader>() };
-            trlevel::ILevel::Source trlevel_source{ [](auto&&...) { return mock_unique<trlevel::mocks::MockLevel>(); } };
-            std::unique_ptr<IFileMenu> file_menu{ mock_unique<MockFileMenu>() };
-            std::unique_ptr<IViewer> viewer{ mock_unique<MockViewer>() };
-            IRoute::Source route_source{ [](auto&&...) { return mock_shared<MockRoute>(); } };
-            std::shared_ptr<MockShortcuts> shortcuts{ mock_shared<MockShortcuts>() };
-            std::unique_ptr<IItemsWindowManager> items_window_manager{ mock_unique<MockItemsWindowManager>() };
-            std::unique_ptr<ITriggersWindowManager> triggers_window_manager{ mock_unique<MockTriggersWindowManager>() };
-            std::unique_ptr<IRouteWindowManager> route_window_manager{ mock_unique<MockRouteWindowManager>() };
-            std::unique_ptr<IRoomsWindowManager> rooms_window_manager{ mock_unique<MockRoomsWindowManager>() };
-            ILevel::Source level_source{ [](auto&&...) { return mock_unique<trview::mocks::MockLevel>(); } };
-            std::shared_ptr<IStartupOptions> startup_options{ mock_shared<MockStartupOptions>() };
-            std::shared_ptr<IDialogs> dialogs{ mock_shared<MockDialogs>() };
-            std::shared_ptr<IFiles> files{ mock_shared<MockFiles>() };
-            std::unique_ptr<IImGuiBackend> imgui_backend{ std::make_unique<NullImGuiBackend>() };
-            std::unique_ptr<ILightsWindowManager> lights_window_manager{ mock_unique<MockLightsWindowManager>() };
-            std::unique_ptr<ILogWindowManager> log_window_manager{ mock_unique<MockLogWindowManager>() };
-            std::unique_ptr<ITexturesWindowManager> textures_window_manager{ mock_unique<MockTexturesWindowManager>() };
-            std::unique_ptr<ICameraSinkWindowManager> camera_sink_window_manager{ mock_unique<MockCameraSinkWindowManager>() };
-
-            std::unique_ptr<Application> build()
-            {
-                EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-                return std::make_unique<Application>(window, std::move(update_checker), std::move(settings_loader),
-                    trlevel_source, std::move(file_menu), std::move(viewer), route_source, shortcuts,
-                    std::move(items_window_manager), std::move(triggers_window_manager), std::move(route_window_manager), std::move(rooms_window_manager),
-                    level_source, startup_options, dialogs, files, std::move(imgui_backend), std::move(lights_window_manager), std::move(log_window_manager),
-                    std::move(textures_window_manager), std::move(camera_sink_window_manager));
-            }
-
-            test_module& with_dialogs(std::shared_ptr<IDialogs> dialogs)
-            {
-                this->dialogs = dialogs;
-                return *this;
-            }
-
-            test_module& with_items_window_manager(std::unique_ptr<IItemsWindowManager> items_window_manager)
-            {
-                this->items_window_manager = std::move(items_window_manager);
-                return *this;
-            }
-
-            test_module& with_trlevel_source(trlevel::ILevel::Source trlevel_source)
-            {
-                this->trlevel_source = trlevel_source;
-                return *this;
-            }
-
-            test_module& with_file_menu(std::unique_ptr<IFileMenu> file_menu)
-            {
-                this->file_menu = std::move(file_menu);
-                return *this;
-            }
-
-            test_module& with_rooms_window_manager(std::unique_ptr<IRoomsWindowManager> rooms_window_manager)
-            {
-                this->rooms_window_manager = std::move(rooms_window_manager);
-                return *this;
-            }
-
-            test_module& with_route_source(IRoute::Source route_source)
-            {
-                this->route_source = route_source;
-                return *this;
-            }
-
-            test_module& with_route_window_manager(std::unique_ptr<IRouteWindowManager> route_window_manager)
-            {
-                this->route_window_manager = std::move(route_window_manager);
-                return *this;
-            }
-
-            test_module& with_settings_loader(std::unique_ptr<ISettingsLoader> settings_loader)
-            {
-                this->settings_loader = std::move(settings_loader);
-                return *this;
-            }
-
-            test_module& with_startup_options(std::shared_ptr<IStartupOptions> startup_options)
-            {
-                this->startup_options = startup_options;
-                return *this;
-            }
-
-            test_module& with_triggers_window_manager(std::unique_ptr<ITriggersWindowManager> triggers_window_manager)
-            {
-                this->triggers_window_manager = std::move(triggers_window_manager);
-                return *this;
-            }
-
-            test_module& with_lights_window_manager(std::unique_ptr<ILightsWindowManager> lights_window_manager)
-            {
-                this->lights_window_manager = std::move(lights_window_manager);
-                return *this;
-            }
-
-            test_module& with_update_checker(std::unique_ptr<IUpdateChecker> update_checker)
-            {
-                this->update_checker = std::move(update_checker);
-                return *this;
-            }
-
-            test_module& with_viewer(std::unique_ptr<IViewer> viewer)
-            {
-                this->viewer = std::move(viewer);
-                return *this;
-            }
-
-            test_module& with_files(const std::shared_ptr<IFiles>& files)
-            {
-                this->files = files;
-                return *this;
-            }
-
-            test_module& with_imgui_backend(std::unique_ptr<IImGuiBackend> backend)
-            {
-                this->imgui_backend = std::move(backend);
-                return *this;
-            }
-
-            test_module& with_level_source(ILevel::Source level_source)
-            {
-                this->level_source = level_source;
-                return *this;
-            }
-
-            test_module& with_log_window_manager(std::unique_ptr<ILogWindowManager> log_window_manager)
-            {
-                this->log_window_manager = std::move(log_window_manager);
-                return *this;
-            }
-
-            test_module& with_textures_window_manager(std::unique_ptr<ITexturesWindowManager> textures_window_manager)
-            {
-                this->textures_window_manager = std::move(textures_window_manager);
-                return *this;
-            }
-
-            test_module& with_camera_sink_window_manager(std::unique_ptr<ICameraSinkWindowManager> camera_sink_window_manager)
-            {
-                this->camera_sink_window_manager = std::move(camera_sink_window_manager);
-                return *this;
-            }
-        };
-        return test_module{};
-    }
-}
+using namespace testing;
 
 TEST(Lua_Level, CamerasAndSinks)
 {
-    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
-    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
-    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+    auto level = mock_shared<MockLevel>();
 
-    auto app = register_test_module()
-        .with_level_source(level_source)
-        .build();
-    app->open("test", ILevel::OpenMode::Full);
+    lua_State* L = luaL_newstate();
+    lua::create_level(L, level);
+    lua_setglobal(L, "l");
 
-    lua_State* L = lua_get_state();
-    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.cameras_and_sinks"));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.cameras_and_sinks"));
     ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
 }
 
 TEST(Lua_Level, Filename)
 {
-    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
-    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
-    ON_CALL(level, filename).WillByDefault(testing::Return("test filename"));
+    auto level = mock_shared<MockLevel>();
+    ON_CALL(*level, filename).WillByDefault(testing::Return("test filename"));
 
-    auto app = register_test_module()
-        .with_level_source(level_source)
-        .build();
-    app->open("test", ILevel::OpenMode::Full);
+    lua_State* L = luaL_newstate();
+    lua::create_level(L, level);
+    lua_setglobal(L, "l"); 
 
-    lua_State* L = lua_get_state();
-    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.filename"));
-
-    std::string result = lua_tostring(L, -1);
-    ASSERT_EQ(result, "test filename");
+    ASSERT_EQ(0, luaL_dostring(L, "return l.filename"));
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    ASSERT_STREQ("test filename", lua_tostring(L, -1));
 }
 
 TEST(Lua_Level, Floordata)
 {
-    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
-    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
-    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+    auto level = mock_shared<MockLevel>();
 
-    auto app = register_test_module()
-        .with_level_source(level_source)
-        .build();
-    app->open("test", ILevel::OpenMode::Full);
+    lua_State* L = luaL_newstate();
+    lua::create_level(L, level);
+    lua_setglobal(L, "l");
 
-    lua_State* L = lua_get_state();
-    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.floordata"));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.floordata"));
     ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
 }
 
 TEST(Lua_Level, Items)
 {
-    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
-    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
-    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+    auto item1 = mock_shared<MockItem>()->with_number(100);
+    auto item2 = mock_shared<MockItem>()->with_number(200);
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, items).WillRepeatedly(Return(std::vector<std::weak_ptr<IItem>>{ item1, item2 }));
 
-    auto app = register_test_module()
-        .with_level_source(level_source)
-        .build();
-    app->open("test", ILevel::OpenMode::Full);
+    lua_State* L = luaL_newstate();
+    lua::create_level(L, level);
+    lua_setglobal(L, "l");
 
-    lua_State* L = lua_get_state();
-    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.items"));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.items"));
     ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return #l.items"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2, lua_tonumber(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.items[1].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(100, lua_tonumber(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.items[2].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(200, lua_tonumber(L, -1));
 }
 
 TEST(Lua_Level, Lights)
 {
-    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
-    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
-    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+    auto level = mock_shared<MockLevel>();
 
-    auto app = register_test_module()
-        .with_level_source(level_source)
-        .build();
-    app->open("test", ILevel::OpenMode::Full);
+    lua_State* L = luaL_newstate();
+    lua::create_level(L, level);
+    lua_setglobal(L, "l");
 
-    lua_State* L = lua_get_state();
-    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.lights"));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.lights"));
     ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
 }
 
 TEST(Lua_Level, Rooms)
 {
-    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
-    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
-    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+    auto room1 = mock_shared<MockRoom>()->with_number(100);
+    auto room2 = mock_shared<MockRoom>()->with_number(200);
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, rooms).WillRepeatedly(Return(std::vector<std::weak_ptr<IRoom>>{ room1, room2 }));
 
-    auto app = register_test_module()
-        .with_level_source(level_source)
-        .build();
-    app->open("test", ILevel::OpenMode::Full);
+    lua_State* L = luaL_newstate();
+    lua::create_level(L, level);
+    lua_setglobal(L, "l");
 
-    lua_State* L = lua_get_state();
-    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.rooms"));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.rooms"));
     ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return #l.rooms"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2, lua_tonumber(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.rooms[1].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(100, lua_tonumber(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.rooms[2].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(200, lua_tonumber(L, -1));
 }
 
 TEST(Lua_Level, Triggers)
 {
-    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
-    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
-    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+    auto trigger1 = mock_shared<MockTrigger>()->with_number(100);
+    auto trigger2 = mock_shared<MockTrigger>()->with_number(200);
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, triggers).WillRepeatedly(Return(std::vector<std::weak_ptr<ITrigger>>{ trigger1, trigger2 }));
 
-    auto app = register_test_module()
-        .with_level_source(level_source)
-        .build();
-    app->open("test", ILevel::OpenMode::Full);
+    lua_State* L = luaL_newstate();
+    lua::create_level(L, level);
+    lua_setglobal(L, "l");
 
-    lua_State* L = lua_get_state();
-    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.triggers"));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.triggers"));
     ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return #l.triggers"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2, lua_tonumber(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.triggers[1].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(100, lua_tonumber(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.triggers[2].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(200, lua_tonumber(L, -1));
 }
 
 TEST(Lua_Level, Version)
 {
-    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
-    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
-    ON_CALL(level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
+    auto level = mock_shared<MockLevel>();
+    ON_CALL(*level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
 
-    auto app = register_test_module()
-        .with_level_source(level_source)
-        .build();
-    app->open("test", ILevel::OpenMode::Full);
+    lua_State* L = luaL_newstate();
+    lua::create_level(L, level);
+    lua_setglobal(L, "l");
 
-    lua_State* L = lua_get_state();
-    ASSERT_EQ(0, luaL_dostring(L, "return trview.level.version"));
-
-    double result = lua_tonumber(L, -1);
-    ASSERT_EQ(result, 4.0);
+    ASSERT_EQ(0, luaL_dostring(L, "return l.version"));
+    ASSERT_EQ(4.0, lua_tonumber(L, -1));
 }

--- a/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
@@ -1,0 +1,141 @@
+#include <trview.app/Lua/Elements/Room/Lua_Room.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
+#include <trview.tests.common/Mocks.h>
+#include <external/lua/src/lua.hpp>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace trview::tests;
+using namespace testing;
+using namespace DirectX::SimpleMath;
+
+TEST(Lua_Room, AlternateMode)
+{
+    auto room = mock_shared<MockRoom>();
+
+    lua_State* L = luaL_newstate();
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    EXPECT_CALL(*room, alternate_mode).WillOnce(Return(IRoom::AlternateMode::None));
+    ASSERT_EQ(0, luaL_dostring(L, "return r.alternate_mode"));
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    ASSERT_STREQ("none", lua_tostring(L, -1));
+
+    EXPECT_CALL(*room, alternate_mode).WillOnce(Return(IRoom::AlternateMode::HasAlternate));
+    ASSERT_EQ(0, luaL_dostring(L, "return r.alternate_mode"));
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    ASSERT_STREQ("has_alternate", lua_tostring(L, -1));
+
+    EXPECT_CALL(*room, alternate_mode).WillOnce(Return(IRoom::AlternateMode::IsAlternate));
+    ASSERT_EQ(0, luaL_dostring(L, "return r.alternate_mode"));
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    ASSERT_STREQ("is_alternate", lua_tostring(L, -1));
+}
+
+TEST(Lua_Room, Items)
+{
+    auto item1 = mock_shared<MockItem>()->with_number(100);
+    auto item2 = mock_shared<MockItem>()->with_number(200);
+
+    auto room = mock_shared<MockRoom>();
+    EXPECT_CALL(*room, items).WillRepeatedly(Return(std::vector<std::weak_ptr<IItem>>{ item1, item2 }));
+
+    lua_State* L = luaL_newstate();
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return r.items"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return #r.items"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return r.items[1].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(100, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return r.items[2].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(200, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Room, Lights)
+{
+    auto room = mock_shared<MockRoom>();
+
+    lua_State* L = luaL_newstate();
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return r.lights"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return #r.lights"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(0, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Room, Number)
+{
+    auto room = mock_shared<MockRoom>()->with_number(123);
+
+    lua_State* L = luaL_newstate();
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return r.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Room, Triggers)
+{
+    auto trigger1 = mock_shared<MockTrigger>()->with_number(100);
+    auto trigger2 = mock_shared<MockTrigger>()->with_number(200);
+
+    auto room = mock_shared<MockRoom>();
+    EXPECT_CALL(*room, triggers).WillRepeatedly(Return(std::vector<std::weak_ptr<ITrigger>>{ trigger1, trigger2 }));
+
+    lua_State* L = luaL_newstate();
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return r.triggers"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return #r.triggers"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2, lua_tonumber(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return r.triggers[1].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(100, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return r.triggers[2].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(200, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Room, Visible)
+{
+    auto room = mock_shared<MockRoom>();
+    EXPECT_CALL(*room, visible).WillOnce(Return(true));
+
+    lua_State* L = luaL_newstate();
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return r.visible"));
+    ASSERT_EQ(LUA_TBOOLEAN, lua_type(L, -1));
+    ASSERT_EQ(true, lua_toboolean(L, -1));
+}
+
+TEST(Lua_Room, SetVisible)
+{
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, set_room_visibility(100, true));
+
+    auto room = mock_shared<MockRoom>()->with_number(100);
+    EXPECT_CALL(*room, level).WillRepeatedly(Return(level));
+
+    lua_State* L = luaL_newstate();
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "r.visible = true"));
+}

--- a/trview.app.tests/Lua/Elements/Lua_TriggerTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_TriggerTests.cpp
@@ -1,0 +1,23 @@
+#include <trview.app/Lua/Elements/Trigger/Lua_Trigger.h>
+#include <trview.app/Mocks/Elements/ITrigger.h>
+#include <trview.tests.common/Mocks.h>
+#include <external/lua/src/lua.hpp>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace trview::tests;
+using namespace testing;
+using namespace DirectX::SimpleMath;
+
+TEST(Lua_Trigger, Number)
+{
+    auto trigger = mock_shared<MockTrigger>()->with_number(123);
+
+    lua_State* L = luaL_newstate();
+    lua::create_trigger(L, trigger);
+    lua_setglobal(L, "t");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return t.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -41,6 +41,7 @@
     <ClCompile Include="Graphics\TextureStorage.cpp" />
     <ClCompile Include="ItemsWindowManagerTests.cpp" />
     <ClCompile Include="ItemsWindowTests.cpp" />
+    <ClCompile Include="Lua\Elements\Lua_ItemTests.cpp" />
     <ClCompile Include="Lua\Elements\Lua_LevelTests.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Menus\MenuDetectorTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -43,6 +43,7 @@
     <ClCompile Include="ItemsWindowTests.cpp" />
     <ClCompile Include="Lua\Elements\Lua_ItemTests.cpp" />
     <ClCompile Include="Lua\Elements\Lua_LevelTests.cpp" />
+    <ClCompile Include="Lua\Elements\Lua_RoomTests.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Menus\MenuDetectorTests.cpp" />
     <ClCompile Include="NullImGuiBackend.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -44,6 +44,7 @@
     <ClCompile Include="Lua\Elements\Lua_ItemTests.cpp" />
     <ClCompile Include="Lua\Elements\Lua_LevelTests.cpp" />
     <ClCompile Include="Lua\Elements\Lua_RoomTests.cpp" />
+    <ClCompile Include="Lua\Elements\Lua_TriggerTests.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="Menus\MenuDetectorTests.cpp" />
     <ClCompile Include="NullImGuiBackend.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -182,6 +182,9 @@
     <ClCompile Include="Lua\Elements\Lua_RoomTests.cpp">
       <Filter>Lua\Elements</Filter>
     </ClCompile>
+    <ClCompile Include="Lua\Elements\Lua_TriggerTests.cpp">
+      <Filter>Lua\Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -179,6 +179,9 @@
     <ClCompile Include="Lua\Elements\Lua_ItemTests.cpp">
       <Filter>Lua\Elements</Filter>
     </ClCompile>
+    <ClCompile Include="Lua\Elements\Lua_RoomTests.cpp">
+      <Filter>Lua\Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -176,6 +176,9 @@
     <ClCompile Include="Lua\Elements\Lua_LevelTests.cpp">
       <Filter>Lua\Elements</Filter>
     </ClCompile>
+    <ClCompile Include="Lua\Elements\Lua_ItemTests.cpp">
+      <Filter>Lua\Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -81,7 +81,7 @@ namespace trview
         setup_viewer(*startup_options);
 
         register_lua();
-        lua_init(&lua_registry);
+        lua_init(&lua_registry, this);
     }
 
     Application::~Application()
@@ -124,8 +124,9 @@ namespace trview
         _settings_loader->save_user_settings(_settings);
         _viewer->set_settings(_settings);
 
-        auto old_level = std::move(_level);
+        auto old_level = _level;
         _level = _level_source(std::move(new_level));
+        _level->initialise();
         _level->set_filename(filename);
 
         _level->set_map_colours(_settings.map_colours);
@@ -204,8 +205,6 @@ namespace trview
             _recent_route_prompted = false;
             open_recent_route();
         }
-
-        lua::set_current_level(_level.get());
     }
 
     std::optional<int> Application::process_message(UINT message, WPARAM wParam, LPARAM)
@@ -881,5 +880,10 @@ namespace trview
         _viewer->select_camera_sink(camera_sink);
         _camera_sink_windows->set_selected_camera_sink(camera_sink);
         _rooms_windows->set_selected_camera_sink(camera_sink);
+    }
+
+    std::weak_ptr<ILevel> Application::current_level() const
+    {
+        return _level;
     }
 }

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -34,6 +34,7 @@ namespace trview
     {
         virtual ~IApplication() = 0;
         virtual int run() = 0;
+        virtual std::weak_ptr<ILevel> current_level() const = 0;
         Event<> on_closing;
     };
 
@@ -69,6 +70,7 @@ namespace trview
         virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         virtual int run() override;
         void render();
+        std::weak_ptr<ILevel> current_level() const override;
     private:
         // Window setup functions.
         void setup_view_menu();
@@ -125,7 +127,7 @@ namespace trview
 
         // Level data components
         std::unique_ptr<ITypeNameLookup> _type_name_lookup;
-        std::unique_ptr<ILevel> _level;
+        std::shared_ptr<ILevel> _level;
         ILevel::Source _level_source;
 
         // Routing and tools.

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -215,7 +215,7 @@ namespace trview
         {
             auto level_texture_storage = std::make_shared<LevelTextureStorage>(device, std::make_unique<TextureStorage>(device), *level);
             auto mesh_storage = std::make_unique<MeshStorage>(mesh_source, *level, *level_texture_storage);
-            return std::make_unique<Level>(device, shader_storage, std::move(level),
+            return std::make_shared<Level>(device, shader_storage, std::move(level),
                 level_texture_storage,
                 std::move(mesh_storage),
                 std::make_unique<TransparencyBuffer>(device),

--- a/trview.app/Elements/IItem.h
+++ b/trview.app/Elements/IItem.h
@@ -42,6 +42,8 @@ namespace trview
         virtual bool clear_body_flag() const = 0;
         virtual bool invisible_flag() const = 0;
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
+        virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
+        virtual std::weak_ptr<ILevel> level() const = 0;
     };
 
     bool is_mutant_egg(const IItem& item);

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -14,7 +14,7 @@ namespace trview
 {
     struct ILevel
     {
-        using Source = std::function<std::unique_ptr<ILevel>(std::unique_ptr<trlevel::ILevel>)>;
+        using Source = std::function<std::shared_ptr<ILevel>(std::unique_ptr<trlevel::ILevel>)>;
 
         enum class OpenMode
         {
@@ -132,6 +132,10 @@ namespace trview
         /// <returns>All triggers in the level.</returns>
         virtual std::vector<std::weak_ptr<ITrigger>> triggers() const = 0;
         virtual trlevel::LevelVersion version() const = 0;
+        /// <summary>
+        /// Perform extra post-load initialisation.
+        /// </summary>
+        virtual void initialise() = 0;
         // Event raised when the level needs to change the selected room.
         Event<uint16_t> on_room_selected;
         // Event raised when the level needs to change the alternate mode.

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -307,6 +307,7 @@ namespace trview
         virtual std::vector<std::weak_ptr<ILight>> lights() const = 0;
         virtual std::vector<std::weak_ptr<ICameraSink>> camera_sinks() const = 0;
         virtual std::vector<std::weak_ptr<ITrigger>> triggers() const = 0;
+        virtual std::vector<std::weak_ptr<IItem>> items() const = 0;
     };
 
     /// <summary>

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -316,5 +316,7 @@ namespace trview
     /// <param name="point">The point to test.</param>
     /// <returns>The sector or nullptr if no match.</returns>
     std::shared_ptr<ISector> sector_from_point(const IRoom& room, const DirectX::SimpleMath::Vector3& point);
+
+    std::string to_string(IRoom::AlternateMode mode);
 }
 

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -308,6 +308,8 @@ namespace trview
         virtual std::vector<std::weak_ptr<ICameraSink>> camera_sinks() const = 0;
         virtual std::vector<std::weak_ptr<ITrigger>> triggers() const = 0;
         virtual std::vector<std::weak_ptr<IItem>> items() const = 0;
+        virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
+        virtual std::weak_ptr<ILevel> level() const = 0;
     };
 
     /// <summary>

--- a/trview.app/Elements/ITrigger.h
+++ b/trview.app/Elements/ITrigger.h
@@ -9,6 +9,8 @@
 
 namespace trview
 {
+    struct ILevel;
+
     struct ITrigger : public IRenderable
     {
         using Source = std::function<std::shared_ptr<ITrigger>(uint32_t, uint32_t, uint16_t, uint16_t, const TriggerInfo&, trlevel::LevelVersion)>;
@@ -29,6 +31,8 @@ namespace trview
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
         virtual void set_position(const DirectX::SimpleMath::Vector3& position) = 0;
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
+        virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
+        virtual std::weak_ptr<ILevel> level() const = 0;
     };
 
 

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -439,6 +439,16 @@ namespace trview
         return _position;
     }
 
+    void Item::set_level(const std::weak_ptr<ILevel>& level)
+    {
+        _level = level;
+    }
+
+    std::weak_ptr<ILevel> Item::level() const
+    {
+        return _level;
+    }
+
     bool is_mutant_egg(const IItem& item)
     {
         return is_mutant_egg(item.type_id());

--- a/trview.app/Elements/Item.h
+++ b/trview.app/Elements/Item.h
@@ -52,6 +52,8 @@ namespace trview
         bool clear_body_flag() const override;
         bool invisible_flag() const override;
         DirectX::SimpleMath::Vector3 position() const override;
+        void set_level(const std::weak_ptr<ILevel>& level) override;
+        std::weak_ptr<ILevel> level() const override;
     private:
         Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint16_t room, uint32_t number, uint16_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags, bool is_pickup);
 
@@ -82,5 +84,7 @@ namespace trview
         uint32_t _type_id{ 0u };
         int32_t _ocb{ 0u };
         uint16_t _flags{ 0u };
+
+        std::weak_ptr<ILevel> _level;
     };
 }

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1196,6 +1196,11 @@ namespace trview
         {
             ent->set_level(shared_from_this());
         }
+
+        for (auto& trigger : _triggers)
+        {
+            trigger->set_level(shared_from_this());
+        }
     }
 
     bool find_item_by_type_id(const ILevel& level, uint32_t type_id, std::weak_ptr<IItem>& output_item)

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1190,6 +1190,14 @@ namespace trview
         return has_flag(_render_filters, RenderFilter::CameraSinks);
     }
 
+    void Level::initialise()
+    {
+        for (auto& ent : _entities)
+        {
+            ent->set_level(shared_from_this());
+        }
+    }
+
     bool find_item_by_type_id(const ILevel& level, uint32_t type_id, std::weak_ptr<IItem>& output_item)
     {
         const auto& items = level.items();

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1201,6 +1201,11 @@ namespace trview
         {
             trigger->set_level(shared_from_this());
         }
+
+        for (auto& room : _rooms)
+        {
+            room->set_level(shared_from_this());
+        }
     }
 
     bool find_item_by_type_id(const ILevel& level, uint32_t type_id, std::weak_ptr<IItem>& output_item)

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -26,7 +26,7 @@ namespace trview
         struct IShader;
     }
 
-    class Level final : public ILevel
+    class Level final : public ILevel, public std::enable_shared_from_this<ILevel>
     {
     public:
         Level(const std::shared_ptr<graphics::IDevice>& device,
@@ -110,6 +110,7 @@ namespace trview
         virtual void set_show_camera_sinks(bool show) override;
         virtual std::optional<uint32_t> selected_camera_sink() const override;
         virtual bool show_camera_sinks() const override;
+        void initialise() override;
     private:
         void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage);
         void generate_triggers(const ITrigger::Source& trigger_source);

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -1017,7 +1017,12 @@ namespace trview
             triggers.push_back(t.second);
         }
         return triggers;
-    };
+    }
+
+    std::vector<std::weak_ptr<IItem>> Room::items() const
+    {
+        return _entities;
+    }
 
     std::shared_ptr<ISector> sector_from_point(const IRoom& room, const Vector3& point)
     {

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -1041,4 +1041,20 @@ namespace trview
         }
         return {};
     }
+
+    std::string to_string(IRoom::AlternateMode mode)
+    {
+        switch (mode)
+        {
+        case IRoom::AlternateMode::HasAlternate:
+            return "has_alternate";
+            break;
+        case IRoom::AlternateMode::IsAlternate:
+            return "is_alternate";
+            break;
+        default:
+            return "none";
+            break;
+        }
+    }
 }

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -83,6 +83,8 @@ namespace trview
         virtual std::vector<std::weak_ptr<ICameraSink>> camera_sinks() const override;
         virtual std::vector<std::weak_ptr<ITrigger>> triggers() const override;
         std::vector<std::weak_ptr<IItem>> items() const override;
+        void set_level(const std::weak_ptr<ILevel>& level) override;
+        std::weak_ptr<ILevel> level() const override;
     private:
         void generate_geometry(const IMesh::Source& mesh_source, const trlevel::tr3_room& room);
         void generate_adjacency();
@@ -131,7 +133,7 @@ namespace trview
         TokenStore _token_store;
         std::unordered_map<uint32_t, std::weak_ptr<ITrigger>> _triggers;
         uint16_t _flags{ 0 };
-        const ILevel& _level;
+        const ILevel& _parent_level;
         std::shared_ptr<ILevelTextureStorage> _texture_storage;
         std::vector<std::weak_ptr<ILight>> _lights;
         IMesh::Source _mesh_source;
@@ -141,5 +143,6 @@ namespace trview
         bool _visible{ true };
         
         std::vector<std::weak_ptr<ICameraSink>> _camera_sinks;
+        std::weak_ptr<ILevel> _level;
     };
 }

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -82,6 +82,7 @@ namespace trview
         virtual std::vector<std::weak_ptr<ILight>> lights() const override;
         virtual std::vector<std::weak_ptr<ICameraSink>> camera_sinks() const override;
         virtual std::vector<std::weak_ptr<ITrigger>> triggers() const override;
+        std::vector<std::weak_ptr<IItem>> items() const override;
     private:
         void generate_geometry(const IMesh::Source& mesh_source, const trlevel::tr3_room& room);
         void generate_adjacency();

--- a/trview.app/Elements/Trigger.cpp
+++ b/trview.app/Elements/Trigger.cpp
@@ -156,4 +156,14 @@ namespace trview
     {
         _visible = value;
     }
+
+    void Trigger::set_level(const std::weak_ptr<ILevel>& level)
+    {
+        _level = level;
+    }
+
+    std::weak_ptr<ILevel> Trigger::level() const
+    {
+        return _level;
+    }
 }

--- a/trview.app/Elements/Trigger.h
+++ b/trview.app/Elements/Trigger.h
@@ -32,6 +32,8 @@ namespace trview
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;
+        void set_level(const std::weak_ptr<ILevel>& level) override;
+        std::weak_ptr<ILevel> level() const override;
     private:
         std::vector<uint16_t> _objects;
         std::vector<Command> _commands;
@@ -49,5 +51,6 @@ namespace trview
         uint16_t _sector_id;
         bool _visible{ true };
         trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Unknown };
+        std::weak_ptr<ILevel> _level;
     };
 }

--- a/trview.app/Lua/Elements/Item/Lua_Item.cpp
+++ b/trview.app/Lua/Elements/Item/Lua_Item.cpp
@@ -17,16 +17,52 @@ namespace trview
                 IItem* item = *static_cast<IItem**>(lua_touserdata(L, 1));
 
                 const std::string key = lua_tostring(L, 2);
-                if (key == "visible")
+                if (key == "activation_flags")
                 {
-                    lua_pushboolean(L, item->visible());
+                    lua_pushinteger(L, item->activation_flags());
+                    return 1;
+                }
+                else if (key == "number")
+                {
+                    lua_pushinteger(L, item->number());
+                    return 1;
+                }
+                else if (key == "ocb")
+                {
+                    lua_pushinteger(L, item->ocb());
                     return 1;
                 }
                 else if (key == "room")
                 {
-                    // Todo: Get the level somehow.
-                    // create_room(L, level->room(item.value().room()).lock());
-                    lua_pushnil(L);
+                    if (auto level = item->level().lock())
+                    {
+                        create_room(L, level->room(item->room()).lock());
+                    }
+                    else
+                    {
+                        lua_pushnil(L);
+                    }
+                    return 1;
+                }
+                else if (key == "triggered_by")
+                {
+                    // TODO: Triggers
+                    lua_newtable(L);
+                    return 1;
+                }
+                else if (key == "type")
+                {
+                    lua_pushstring(L, item->type().c_str());
+                    return 1;
+                }
+                else if (key == "type_id")
+                {
+                    lua_pushinteger(L, item->type_id());
+                    return 1;
+                }
+                else if (key == "visible")
+                {
+                    lua_pushboolean(L, item->visible());
                     return 1;
                 }
 
@@ -78,24 +114,8 @@ namespace trview
             lua_setfield(L, -2, "__gc");
             lua_setmetatable(L, -2);
 
-            /*
-            // TODO: Room
-            lua_pushinteger(L, item.type_id());
-            lua_setfield(L, -2, "type_id");
-
-            lua_pushstring(L, item.type().c_str());
-            lua_setfield(L, -2, "type");
-
-            lua_pushinteger(L, item.ocb());
-            lua_setfield(L, -2, "ocb");
-
-            lua_pushinteger(L, item.activation_flags());
-            lua_setfield(L, -2, "activation_flags");
-            */
             // TODO: Specific flags
-            // TODO: Triggers
             // TODO: Position
-            // TODO: Visible
         }
     }
 }

--- a/trview.app/Lua/Elements/Item/Lua_Item.cpp
+++ b/trview.app/Lua/Elements/Item/Lua_Item.cpp
@@ -76,9 +76,10 @@ namespace trview
                 const std::string key = lua_tostring(L, 2);
                 if (key == "visible")
                 {
-                    bool visibility = lua_toboolean(L, -1);
-                    // TODO: Do this through level, or notify level in some way?
-                    item->set_visible(visibility);
+                    if (auto level = item->level().lock())
+                    {
+                        level->set_item_visibility(item->number(), lua_toboolean(L, -1));
+                    }
                     return 0;
                 }
 
@@ -93,7 +94,7 @@ namespace trview
             }
         }
 
-        void create_item(lua_State* L, std::shared_ptr<IItem> item)
+        void create_item(lua_State* L, const std::shared_ptr<IItem>& item)
         {
             if (!item)
             {

--- a/trview.app/Lua/Elements/Item/Lua_Item.cpp
+++ b/trview.app/Lua/Elements/Item/Lua_Item.cpp
@@ -1,0 +1,117 @@
+#include "Lua_Item.h"
+#include "../../../Elements/ILevel.h"
+#include "../Level/Lua_Level.h"
+#include "../../Lua.h"
+
+namespace trview
+{
+    namespace lua
+    {
+        namespace
+        {
+            std::optional<Item> get_item(lua_State* L, ILevel* level)
+            {
+                lua_getfield(L, -1, "number");
+                uint32_t item_number = static_cast<uint32_t>(lua_tointeger(L, -1));
+                lua_pop(L, 1);
+                return level->item(item_number);
+            }
+
+            int item_index(lua_State* L)
+            {
+                ILevel* level = level_current_level();
+                if (!level)
+                {
+                    return 0;
+                }
+
+                auto item = get_item(L, level);
+                if (!item)
+                {
+                    return 0;
+                }
+
+                const std::string key = lua_tostring(L, 2);
+                if (key == "visible")
+                {
+                    lua_pushboolean(L, item.value().visible());
+                    return 1;
+                }
+                else if (key == "room")
+                {
+                    // TODO: Room
+                    lua_newtable(L);
+                    return 1;
+                }
+
+                return 0;
+            }
+
+            int item_newindex(lua_State* L)
+            {
+                ILevel* level = level_current_level();
+                if (!level)
+                {
+                    return 0;
+                }
+
+                lua_getfield(L, 1, "number");
+                uint32_t item_number = static_cast<uint32_t>(lua_tointeger(L, -1));
+                lua_pop(L, 1);
+
+                auto item = level->item(item_number);
+                if (!item)
+                {
+                    return 0;
+                }
+
+                const std::string key = lua_tostring(L, 2);
+                if (key == "visible")
+                {
+                    bool visibility = lua_toboolean(L, -1);
+                    level->set_item_visibility(item_number, visibility);
+                    return 0;
+                }
+
+                return 0;
+            }
+
+            constexpr struct luaL_Reg item_lib[] =
+            {
+                { "__index", item_index },
+                { "__newindex", item_newindex },
+                { NULL, NULL },
+            };
+        }
+
+        void create_item(lua_State* L, const Item& item)
+        {
+            lua_newtable(L);
+
+            lua_pushinteger(L, item.number());
+            lua_setfield(L, -2, "number");
+
+            luaL_setfuncs(L, item_lib, 0);
+            lua_pushvalue(L, -1);
+            lua_setmetatable(L, -2);
+            /*
+            // TODO: Room
+            lua_pushinteger(L, item.type_id());
+            lua_setfield(L, -2, "type_id");
+
+            lua_pushstring(L, item.type().c_str());
+            lua_setfield(L, -2, "type");
+
+            lua_pushinteger(L, item.ocb());
+            lua_setfield(L, -2, "ocb");
+
+            lua_pushinteger(L, item.activation_flags());
+            lua_setfield(L, -2, "activation_flags");
+            */
+            // TODO: Specific flags
+            // TODO: Triggers
+            // TODO: Position
+            // TODO: Visible
+        }
+    }
+}

--- a/trview.app/Lua/Elements/Item/Lua_Item.cpp
+++ b/trview.app/Lua/Elements/Item/Lua_Item.cpp
@@ -1,8 +1,9 @@
 #include "Lua_Item.h"
+#include "../../Lua.h"
 #include "../../../Elements/ILevel.h"
 #include "../Level/Lua_Level.h"
-#include "../../Lua.h"
 #include "../Room/Lua_Room.h"
+#include "../Trigger/Lua_Trigger.h"
 
 namespace trview
 {
@@ -46,9 +47,7 @@ namespace trview
                 }
                 else if (key == "triggered_by")
                 {
-                    // TODO: Triggers
-                    lua_newtable(L);
-                    return 1;
+                    return push_list(L, item->triggers(), { create_trigger });
                 }
                 else if (key == "type")
                 {

--- a/trview.app/Lua/Elements/Item/Lua_Item.cpp
+++ b/trview.app/Lua/Elements/Item/Lua_Item.cpp
@@ -4,6 +4,7 @@
 #include "../Level/Lua_Level.h"
 #include "../Room/Lua_Room.h"
 #include "../Trigger/Lua_Trigger.h"
+#include "../../Vector3.h"
 
 namespace trview
 {
@@ -32,6 +33,10 @@ namespace trview
                 {
                     lua_pushinteger(L, item->ocb());
                     return 1;
+                }
+                else if (key == "position")
+                {
+                    return create_vector3(L, item->position() * trlevel::Scale);
                 }
                 else if (key == "room")
                 {

--- a/trview.app/Lua/Elements/Item/Lua_Item.cpp
+++ b/trview.app/Lua/Elements/Item/Lua_Item.cpp
@@ -2,6 +2,7 @@
 #include "../../../Elements/ILevel.h"
 #include "../Level/Lua_Level.h"
 #include "../../Lua.h"
+#include "../Room/Lua_Room.h"
 
 namespace trview
 {
@@ -39,8 +40,7 @@ namespace trview
                 }
                 else if (key == "room")
                 {
-                    // TODO: Room
-                    lua_newtable(L);
+                    create_room(L, level->room(item.value().room()).lock());
                     return 1;
                 }
 

--- a/trview.app/Lua/Elements/Item/Lua_Item.h
+++ b/trview.app/Lua/Elements/Item/Lua_Item.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "../../../Elements/Item.h"
+
+struct lua_State;
+
+namespace trview
+{
+    namespace lua
+    {
+        void create_item(lua_State* L, const Item& item);
+    }
+}

--- a/trview.app/Lua/Elements/Item/Lua_Item.h
+++ b/trview.app/Lua/Elements/Item/Lua_Item.h
@@ -8,6 +8,6 @@ namespace trview
 {
     namespace lua
     {
-        void create_item(lua_State* L, std::shared_ptr<IItem> item);
+        void create_item(lua_State* L, const std::shared_ptr<IItem>& item);
     }
 }

--- a/trview.app/Lua/Elements/Item/Lua_Item.h
+++ b/trview.app/Lua/Elements/Item/Lua_Item.h
@@ -8,6 +8,6 @@ namespace trview
 {
     namespace lua
     {
-        void create_item(lua_State* L, const Item& item);
+        void create_item(lua_State* L, std::shared_ptr<IItem> item);
     }
 }

--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -1,6 +1,7 @@
 #include "Lua_Level.h"
 #include "../../Lua.h"
 #include "../../../Elements/ILevel.h"
+#include "../Item/Lua_Item.h"
 
 namespace trview
 {
@@ -33,7 +34,14 @@ namespace trview
                 else if (key == "items")
                 {
                     lua_newtable(L);
-                    // TODO: Items
+                    int index = 1;
+                    for (const auto& item : current_level->items())
+                    {
+                        lua_pushnumber(L, index);
+                        create_item(L, item);
+                        lua_settable(L, -3);
+                        ++index;
+                    }
                     return 1;
                 }
                 else if (key == "lights")
@@ -86,6 +94,11 @@ namespace trview
             luaL_setfuncs(L, level_lib, 0);
             lua_pushvalue(L, -1);
             lua_setmetatable(L, -2);
+        }
+
+        ILevel* level_current_level()
+        {
+            return current_level;
         }
 
         void level_set_current_level(ILevel* level)

--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -1,6 +1,7 @@
 #include "Lua_Level.h"
 #include "../../Lua.h"
 #include "../../../Elements/ILevel.h"
+#include "../Room/Lua_Room.h"
 #include "../Item/Lua_Item.h"
 
 namespace trview
@@ -53,7 +54,14 @@ namespace trview
                 else if (key == "rooms")
                 {
                     lua_newtable(L);
-                    // TODO: Rooms
+                    int index = 1;
+                    for (const auto& room : current_level->rooms())
+                    {
+                        lua_pushnumber(L, index);
+                        create_room(L, room.lock());
+                        lua_settable(L, -3);
+                        ++index;
+                    }
                     return 1;
                 }
                 else if (key == "triggers")

--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -80,7 +80,7 @@ namespace trview
             if (!level)
             {
                 lua_pushnil(L);
-                return;
+                return 1;
             }
 
             ILevel** userdata = static_cast<ILevel**>(lua_newuserdata(L, sizeof(level.get())));

--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -39,7 +39,7 @@ namespace trview
                     for (const auto& item : current_level->items())
                     {
                         lua_pushnumber(L, index);
-                        create_item(L, item);
+                        create_item(L, item.lock());
                         lua_settable(L, -3);
                         ++index;
                     }

--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -31,16 +31,7 @@ namespace trview
                 }
                 else if (key == "items")
                 {
-                    lua_newtable(L);
-                    int index = 1;
-                    for (const auto& item : level->items())
-                    {
-                        lua_pushnumber(L, index);
-                        create_item(L, item.lock());
-                        lua_settable(L, -3);
-                        ++index;
-                    }
-                    return 1;
+                    return push_list(L, level->items(), { create_item });
                 }
                 else if (key == "lights")
                 {
@@ -50,16 +41,7 @@ namespace trview
                 }
                 else if (key == "rooms")
                 {
-                    lua_newtable(L);
-                    int index = 1;
-                    for (const auto& room : level->rooms())
-                    {
-                        lua_pushnumber(L, index);
-                        create_room(L, room.lock());
-                        lua_settable(L, -3);
-                        ++index;
-                    }
-                    return 1;
+                    return push_list(L, level->rooms(), { create_room });
                 }
                 else if (key == "triggers")
                 {
@@ -93,7 +75,7 @@ namespace trview
             }
         }
 
-        void create_level(lua_State* L, const std::shared_ptr<ILevel>& level)
+        int create_level(lua_State* L, const std::shared_ptr<ILevel>& level)
         {
             if (!level)
             {
@@ -113,6 +95,7 @@ namespace trview
             lua_pushcfunction(L, level_gc);
             lua_setfield(L, -2, "__gc");
             lua_setmetatable(L, -2);
+            return 1;
         }
     }
 }

--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -3,6 +3,7 @@
 #include "../../../Elements/ILevel.h"
 #include "../Room/Lua_Room.h"
 #include "../Item/Lua_Item.h"
+#include "../Trigger/Lua_Trigger.h"
 
 namespace trview
 {
@@ -45,9 +46,7 @@ namespace trview
                 }
                 else if (key == "triggers")
                 {
-                    lua_newtable(L);
-                    // TODO: Triggers
-                    return 1;
+                    return push_list(L, level->triggers(), { create_trigger });
                 }
                 else if (key == "version")
                 {

--- a/trview.app/Lua/Elements/Level/Lua_Level.h
+++ b/trview.app/Lua/Elements/Level/Lua_Level.h
@@ -9,6 +9,7 @@ namespace trview
     namespace lua
     {
         void create_level(lua_State* L, ILevel* level);
+        ILevel* level_current_level();
         void level_set_current_level(ILevel* level);
     }
 }

--- a/trview.app/Lua/Elements/Level/Lua_Level.h
+++ b/trview.app/Lua/Elements/Level/Lua_Level.h
@@ -8,6 +8,6 @@ namespace trview
 
     namespace lua
     {
-        void create_level(lua_State* L, const std::shared_ptr<ILevel>& level);
+        int create_level(lua_State* L, const std::shared_ptr<ILevel>& level);
     }
 }

--- a/trview.app/Lua/Elements/Level/Lua_Level.h
+++ b/trview.app/Lua/Elements/Level/Lua_Level.h
@@ -8,8 +8,6 @@ namespace trview
 
     namespace lua
     {
-        void create_level(lua_State* L, ILevel* level);
-        ILevel* level_current_level();
-        void level_set_current_level(ILevel* level);
+        void create_level(lua_State* L, const std::shared_ptr<ILevel>& level);
     }
 }

--- a/trview.app/Lua/Elements/Room/Lua_Room.cpp
+++ b/trview.app/Lua/Elements/Room/Lua_Room.cpp
@@ -40,13 +40,27 @@ namespace trview
                     lua_newtable(L);
                     return 1;
                 }
+                else if (key == "visible")
+                {
+                    lua_pushboolean(L, room->visible());
+                    return 1;
+                }
 
                 return 0;
             }
 
-            int room_newindex(lua_State*)
+            int room_newindex(lua_State* L)
             {
-                // IRoom* room = *static_cast<IRoom**>(lua_touserdata(L, 1));
+                IRoom* room = *static_cast<IRoom**>(lua_touserdata(L, 1));
+
+                const std::string key = lua_tostring(L, 2);
+                if (key == "visible")
+                {
+                    if (auto level = room->level().lock())
+                    {
+                        level->set_room_visibility(room->number(), lua_toboolean(L, -1));
+                    }
+                }
 
                 return 0;
             }

--- a/trview.app/Lua/Elements/Room/Lua_Room.cpp
+++ b/trview.app/Lua/Elements/Room/Lua_Room.cpp
@@ -1,0 +1,80 @@
+#include "Lua_Room.h"
+#include "../../../Elements/ILevel.h"
+#include "../Level/Lua_Level.h"
+#include "../../Lua.h"
+
+namespace trview
+{
+    namespace lua
+    {
+        namespace
+        {
+            std::unordered_map<IRoom**, std::shared_ptr<IRoom>> rooms;
+
+            int room_index(lua_State* L)
+            {
+                IRoom* room = *static_cast<IRoom**>(lua_touserdata(L, 1));
+
+                const std::string key = lua_tostring(L, 2);
+                if (key == "alternate_mode")
+                {
+                    lua_pushstring(L, to_string(room->alternate_mode()).c_str());
+                    return 1;
+                }
+                else if (key == "lights")
+                {
+                    lua_newtable(L);
+                    return 1;
+                }
+                else if (key == "number")
+                {
+                    lua_pushinteger(L, room->number());
+                    return 1;
+                }
+                else if (key == "triggers")
+                {
+                    lua_newtable(L);
+                    return 1;
+                }
+
+                return 0;
+            }
+
+            int room_newindex(lua_State*)
+            {
+                // IRoom* room = *static_cast<IRoom**>(lua_touserdata(L, 1));
+
+                return 0;
+            }
+
+            int room_gc(lua_State*L)
+            {
+                IRoom** userdata = static_cast<IRoom**>(lua_touserdata(L, 1));
+                rooms.erase(userdata);
+                return 0;
+            }
+        }
+
+        void create_room(lua_State* L, std::shared_ptr<IRoom> room)
+        {
+            if (!room)
+            {
+                lua_pushnil(L);
+                return;
+            }
+
+            IRoom** userdata = static_cast<IRoom**>(lua_newuserdata(L, sizeof(room.get())));
+            *userdata = room.get();
+            rooms[userdata] = room;
+
+            lua_newtable(L);
+            lua_pushcfunction(L, room_index);
+            lua_setfield(L, -2, "__index");
+            lua_pushcfunction(L, room_newindex);
+            lua_setfield(L, -2, "__newindex");
+            lua_pushcfunction(L, room_gc);
+            lua_setfield(L, -2, "__gc");
+            lua_setmetatable(L, -2);
+        }
+    }
+}

--- a/trview.app/Lua/Elements/Room/Lua_Room.cpp
+++ b/trview.app/Lua/Elements/Room/Lua_Room.cpp
@@ -1,6 +1,6 @@
 #include "Lua_Room.h"
 #include "../../../Elements/ILevel.h"
-#include "../Level/Lua_Level.h"
+#include "../Item/Lua_Item.h"
 #include "../../Lua.h"
 
 namespace trview
@@ -20,6 +20,10 @@ namespace trview
                 {
                     lua_pushstring(L, to_string(room->alternate_mode()).c_str());
                     return 1;
+                }
+                else if (key == "items")
+                {
+                    return push_list(L, room->items(), { create_item });
                 }
                 else if (key == "lights")
                 {

--- a/trview.app/Lua/Elements/Room/Lua_Room.cpp
+++ b/trview.app/Lua/Elements/Room/Lua_Room.cpp
@@ -1,6 +1,7 @@
 #include "Lua_Room.h"
 #include "../../../Elements/ILevel.h"
 #include "../Item/Lua_Item.h"
+#include "../Trigger/Lua_Trigger.h"
 #include "../../Lua.h"
 
 namespace trview
@@ -37,8 +38,7 @@ namespace trview
                 }
                 else if (key == "triggers")
                 {
-                    lua_newtable(L);
-                    return 1;
+                    return push_list(L, room->triggers(), { create_trigger });
                 }
                 else if (key == "visible")
                 {

--- a/trview.app/Lua/Elements/Room/Lua_Room.h
+++ b/trview.app/Lua/Elements/Room/Lua_Room.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "../../../Elements/IRoom.h"
+
+struct lua_State;
+
+namespace trview
+{
+    namespace lua
+    {
+        void create_room(lua_State* L, std::shared_ptr<IRoom> room);
+    }
+}

--- a/trview.app/Lua/Elements/Trigger/Lua_Trigger.cpp
+++ b/trview.app/Lua/Elements/Trigger/Lua_Trigger.cpp
@@ -1,0 +1,74 @@
+#include "Lua_Trigger.h"
+#include "../../Lua.h"
+#include "../../../Elements/ITrigger.h"
+#include "../../../Elements/ILevel.h"
+
+namespace trview
+{
+    namespace lua
+    {
+        namespace
+        {
+            std::unordered_map<ITrigger**, std::shared_ptr<ITrigger>> triggers;
+
+            int trigger_index(lua_State* L)
+            {
+                ITrigger* trigger = *static_cast<ITrigger**>(lua_touserdata(L, 1));
+
+                const std::string key = lua_tostring(L, 2);
+                if (key == "number")
+                {
+                    lua_pushinteger(L, trigger->number());
+                    return 1;
+                }
+
+                return 0;
+            }
+
+            int trigger_newindex(lua_State* L)
+            {
+                ITrigger* trigger = *static_cast<ITrigger**>(lua_touserdata(L, 1));
+
+                const std::string key = lua_tostring(L, 2);
+                if (key == "visible")
+                {
+                    if (auto level = trigger->level().lock())
+                    {
+                        level->set_trigger_visibility(trigger->number(), lua_toboolean(L, -1));
+                    }
+                }
+
+                return 0;
+            }
+
+            int trigger_gc(lua_State* L)
+            {
+                ITrigger** userdata = static_cast<ITrigger**>(lua_touserdata(L, 1));
+                triggers.erase(userdata);
+                return 0;
+            }
+        }
+
+        void create_trigger(lua_State* L, const std::shared_ptr<ITrigger>& trigger)
+        {
+            if (!trigger)
+            {
+                lua_pushnil(L);
+                return;
+            }
+
+            ITrigger** userdata = static_cast<ITrigger**>(lua_newuserdata(L, sizeof(trigger.get())));
+            *userdata = trigger.get();
+            triggers[userdata] = trigger;
+
+            lua_newtable(L);
+            lua_pushcfunction(L, trigger_index);
+            lua_setfield(L, -2, "__index");
+            lua_pushcfunction(L, trigger_newindex);
+            lua_setfield(L, -2, "__newindex");
+            lua_pushcfunction(L, trigger_gc);
+            lua_setfield(L, -2, "__gc");
+            lua_setmetatable(L, -2);
+        }
+    }
+}

--- a/trview.app/Lua/Elements/Trigger/Lua_Trigger.h
+++ b/trview.app/Lua/Elements/Trigger/Lua_Trigger.h
@@ -1,0 +1,13 @@
+#pragma once
+
+struct lua_State;
+
+namespace trview
+{
+    struct ITrigger;
+
+    namespace lua
+    {
+        void create_trigger(lua_State* L, const std::shared_ptr<ITrigger>& trigger);
+    }
+}

--- a/trview.app/Lua/Lua.cpp
+++ b/trview.app/Lua/Lua.cpp
@@ -228,7 +228,7 @@ namespace trview
         { NULL, NULL },
     };
 
-    void lua_init ( LuaFunctionRegistry* reg )
+    void lua_init(LuaFunctionRegistry* reg, IApplication* application)
     {
         op = reg;
         lua_State* L = luaL_newstate ();
@@ -256,7 +256,7 @@ namespace trview
         // utility
         lua_register ( L, "print", print );
 
-        lua::trview_register(L);
+        lua::trview_register(L, application);
 
         state = L;
     }

--- a/trview.app/Lua/Lua.h
+++ b/trview.app/Lua/Lua.h
@@ -8,6 +8,8 @@
 
 namespace trview
 {
+    struct IApplication;
+
     enum class LuaEvent
     {
         ON_RENDER,
@@ -67,7 +69,7 @@ namespace trview
 
     extern LuaFunctionRegistry lua_registry;
 
-    void lua_init ( LuaFunctionRegistry * reg );
+    void lua_init(LuaFunctionRegistry * reg, IApplication* application);
     void lua_execute ( const std::string& command );
     void lua_fire_event ( LuaEvent type );
     lua_State* lua_get_state();

--- a/trview.app/Lua/Lua.h
+++ b/trview.app/Lua/Lua.h
@@ -73,4 +73,12 @@ namespace trview
     void lua_execute ( const std::string& command );
     void lua_fire_event ( LuaEvent type );
     lua_State* lua_get_state();
+
+    namespace lua
+    {
+        template <typename T>
+        int push_list(lua_State* L, const std::vector<std::weak_ptr<T>>& range, const std::function<void(lua_State*, const std::shared_ptr<T>&)>& func);
+    }
 }
+
+#include "Lua.inl"

--- a/trview.app/Lua/Lua.inl
+++ b/trview.app/Lua/Lua.inl
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace trview
+{
+    namespace lua
+    {
+        template <typename T>
+        int push_list(lua_State* L, const std::vector<std::weak_ptr<T>>& range, const std::function<void(lua_State*, const std::shared_ptr<T>&)>& func)
+        {
+            lua_newtable(L);
+            int index = 1;
+            for (const auto& item : range)
+            {
+                lua_pushnumber(L, index);
+                func(L, item.lock());
+                lua_settable(L, -3);
+                ++index;
+            }
+            return 1;
+        }
+    }
+}

--- a/trview.app/Lua/Vector3.cpp
+++ b/trview.app/Lua/Vector3.cpp
@@ -1,0 +1,22 @@
+#include "Vector3.h"
+#include "Lua.h"
+
+using namespace DirectX::SimpleMath;
+
+namespace trview
+{
+    namespace lua
+    {
+        int create_vector3(lua_State* L, const Vector3& value)
+        {
+            lua_newtable(L);
+            lua_pushnumber(L, value.x);
+            lua_setfield(L, -2, "x");
+            lua_pushnumber(L, value.y);
+            lua_setfield(L, -2, "y");
+            lua_pushnumber(L, value.z);
+            lua_setfield(L, -2, "z");
+            return 1;
+        }
+    }
+}

--- a/trview.app/Lua/Vector3.h
+++ b/trview.app/Lua/Vector3.h
@@ -1,0 +1,11 @@
+#pragma once
+
+struct lua_State;
+
+namespace trview
+{
+    namespace lua
+    {
+        int create_vector3(lua_State* L, const DirectX::SimpleMath::Vector3& value);
+    }
+}

--- a/trview.app/Lua/trview/trview.cpp
+++ b/trview.app/Lua/trview/trview.cpp
@@ -1,5 +1,6 @@
 #include "trview.h"
 #include "../Elements/Level/Lua_Level.h"
+#include "../../Application.h"
 
 namespace trview
 {
@@ -7,38 +8,37 @@ namespace trview
     {
         namespace
         {
-            ILevel* current_level = nullptr;
-
             int trview_index(lua_State* L)
             {
+                IApplication* application = *static_cast<IApplication**>(lua_touserdata(L, 1));
+
                 const std::string key = lua_tostring(L, 2);
                 if (key == "level")
                 {
-                    create_level(L, current_level);
+                    create_level(L, application->current_level().lock());
                     return 1;
                 }
                 return 0;
             }
+
+            int trview_newindex(lua_State*)
+            {
+                return 0;
+            }
         }
 
-        void trview_register(lua_State* L)
+        void trview_register(lua_State* L, IApplication* application)
         {
-            constexpr struct luaL_Reg trview_lib[] =
-            {
-                { "__index", trview_index },
-                { NULL, NULL },
-            };
+            IApplication** userdata = static_cast<IApplication**>(lua_newuserdata(L, sizeof(application)));
+            *userdata = application;
 
-            luaL_newlib(L, trview_lib);
-            lua_pushvalue(L, -1);
+            lua_newtable(L);
+            lua_pushcfunction(L, trview_index);
+            lua_setfield(L, -2, "__index");
+            lua_pushcfunction(L, trview_newindex);
+            lua_setfield(L, -2, "__newindex");
             lua_setmetatable(L, -2);
             lua_setglobal(L, "trview");
-        }
-
-        void set_current_level(ILevel* level)
-        {
-            current_level = level;
-            level_set_current_level(level);
         }
     }
 }

--- a/trview.app/Lua/trview/trview.cpp
+++ b/trview.app/Lua/trview/trview.cpp
@@ -15,8 +15,7 @@ namespace trview
                 const std::string key = lua_tostring(L, 2);
                 if (key == "level")
                 {
-                    create_level(L, application->current_level().lock());
-                    return 1;
+                    return create_level(L, application->current_level().lock());
                 }
                 return 0;
             }

--- a/trview.app/Lua/trview/trview.h
+++ b/trview.app/Lua/trview/trview.h
@@ -5,9 +5,10 @@
 
 namespace trview
 {
+    struct IApplication;
+
     namespace lua
     {
-        void trview_register(lua_State* L);
-        void set_current_level(ILevel* level);
+        void trview_register(lua_State* L, IApplication* application);
     }
 }

--- a/trview.app/Mocks/Elements/IItem.h
+++ b/trview.app/Mocks/Elements/IItem.h
@@ -29,6 +29,8 @@ namespace trview
             MOCK_METHOD(bool, clear_body_flag, (), (const, override));
             MOCK_METHOD(bool, invisible_flag, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
+            MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
+            MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
 
             std::shared_ptr<MockItem> with_number(uint32_t number)
             {

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -75,6 +75,7 @@ namespace trview
             MOCK_METHOD(void, set_camera_sink_visibility, (uint32_t, bool), (override));
             MOCK_METHOD(void, set_show_camera_sinks, (bool), (override));
             MOCK_METHOD(std::optional<uint32_t>, selected_camera_sink, (), (const, override));
+            MOCK_METHOD(void, initialise, (), (override));
         };
     }
 }

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -52,6 +52,7 @@ namespace trview
             MOCK_METHOD(std::vector<std::weak_ptr<ILight>>, lights, (), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<ICameraSink>>, camera_sinks, (), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<ITrigger>>, triggers, (), (const, override));
+            MOCK_METHOD(std::vector<std::weak_ptr<IItem>>, items, (), (const, override));
 
 
             std::shared_ptr<MockRoom> with_number(uint32_t number)

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -53,6 +53,8 @@ namespace trview
             MOCK_METHOD(std::vector<std::weak_ptr<ICameraSink>>, camera_sinks, (), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<ITrigger>>, triggers, (), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<IItem>>, items, (), (const, override));
+            MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
+            MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
 
 
             std::shared_ptr<MockRoom> with_number(uint32_t number)

--- a/trview.app/Mocks/Elements/ITrigger.h
+++ b/trview.app/Mocks/Elements/ITrigger.h
@@ -29,6 +29,8 @@ namespace trview
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
             MOCK_METHOD(void, set_position, (const DirectX::SimpleMath::Vector3&), (override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
+            MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
+            MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
 
             std::shared_ptr<MockTrigger> with_number(uint32_t number)
             {

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -62,6 +62,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Graphics\SectorHighlight.cpp" />
     <ClCompile Include="Graphics\SelectionRenderer.cpp" />
     <ClCompile Include="Graphics\TextureStorage.cpp" />
+    <ClCompile Include="Lua\Elements\Item\Lua_Item.cpp" />
     <ClCompile Include="Lua\Elements\Level\Lua_Level.cpp" />
     <ClCompile Include="Lua\trview\trview.cpp" />
     <ClCompile Include="Menus\FileMenu.cpp" />
@@ -98,6 +99,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Tools\Compass.cpp" />
     <ClCompile Include="Tools\Measure.cpp" />
     <ClCompile Include="Tools\Toolbar.cpp" />
+    <ClInclude Include="Lua\Elements\Item\Lua_Item.h" />
     <ClInclude Include="Type.inl">
       <FileType>Document</FileType>
     </ClInclude>

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -67,6 +67,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Lua\Elements\Room\Lua_Room.cpp" />
     <ClCompile Include="Lua\Elements\Trigger\Lua_Trigger.cpp" />
     <ClCompile Include="Lua\trview\trview.cpp" />
+    <ClCompile Include="Lua\Vector3.cpp" />
     <ClCompile Include="Menus\FileMenu.cpp" />
     <ClCompile Include="Mocks\Mocks.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">/bigobj %(AdditionalOptions)</AdditionalOptions>
@@ -104,6 +105,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Lua\Elements\Item\Lua_Item.h" />
     <ClInclude Include="Lua\Elements\Room\Lua_Room.h" />
     <ClInclude Include="Lua\Elements\Trigger\Lua_Trigger.h" />
+    <ClInclude Include="Lua\Vector3.h" />
     <ClInclude Include="Type.inl">
       <FileType>Document</FileType>
     </ClInclude>

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -64,6 +64,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Graphics\TextureStorage.cpp" />
     <ClCompile Include="Lua\Elements\Item\Lua_Item.cpp" />
     <ClCompile Include="Lua\Elements\Level\Lua_Level.cpp" />
+    <ClCompile Include="Lua\Elements\Room\Lua_Room.cpp" />
     <ClCompile Include="Lua\trview\trview.cpp" />
     <ClCompile Include="Menus\FileMenu.cpp" />
     <ClCompile Include="Mocks\Mocks.cpp">
@@ -100,6 +101,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Tools\Measure.cpp" />
     <ClCompile Include="Tools\Toolbar.cpp" />
     <ClInclude Include="Lua\Elements\Item\Lua_Item.h" />
+    <ClInclude Include="Lua\Elements\Room\Lua_Room.h" />
     <ClInclude Include="Type.inl">
       <FileType>Document</FileType>
     </ClInclude>

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -361,6 +361,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <Image Include="trview.ico" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="Lua\Lua.inl" />
     <None Include="Track\Track.inl" />
     <Text Include="Resources\Files\actions.json">
       <FileType>Document</FileType>

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -65,6 +65,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Lua\Elements\Item\Lua_Item.cpp" />
     <ClCompile Include="Lua\Elements\Level\Lua_Level.cpp" />
     <ClCompile Include="Lua\Elements\Room\Lua_Room.cpp" />
+    <ClCompile Include="Lua\Elements\Trigger\Lua_Trigger.cpp" />
     <ClCompile Include="Lua\trview\trview.cpp" />
     <ClCompile Include="Menus\FileMenu.cpp" />
     <ClCompile Include="Mocks\Mocks.cpp">
@@ -102,6 +103,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Tools\Toolbar.cpp" />
     <ClInclude Include="Lua\Elements\Item\Lua_Item.h" />
     <ClInclude Include="Lua\Elements\Room\Lua_Room.h" />
+    <ClInclude Include="Lua\Elements\Trigger\Lua_Trigger.h" />
     <ClInclude Include="Type.inl">
       <FileType>Document</FileType>
     </ClInclude>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -1082,6 +1082,9 @@
     <None Include="Track\Track.inl">
       <Filter>Track</Filter>
     </None>
+    <None Include="Lua\Lua.inl">
+      <Filter>Lua</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Resources\trview.app.rc">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -267,6 +267,9 @@
     <ClCompile Include="Lua\Elements\Level\Lua_Level.cpp">
       <Filter>Lua\Elements\Level</Filter>
     </ClCompile>
+    <ClCompile Include="Lua\Elements\Item\Lua_Item.cpp">
+      <Filter>Lua\Elements\Item</Filter>
+    </ClCompile>
     <ClCompile Include="Elements\Item.cpp">
       <Filter>Elements\Item</Filter>
     </ClCompile>
@@ -861,6 +864,9 @@
     </ClInclude>
     <ClInclude Include="Type.h" />
     <ClInclude Include="Type.inl" />
+    <ClInclude Include="Lua\Elements\Item\Lua_Item.h">
+      <Filter>Lua\Elements\Item</Filter>
+    </ClInclude>
     <ClInclude Include="Elements\Item.h">
       <Filter>Elements\Item</Filter>
     </ClInclude>
@@ -1003,6 +1009,9 @@
     </Filter>
     <Filter Include="Track">
       <UniqueIdentifier>{895fbf3e-9030-4fa9-8c33-158d155fe655}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Lua\Elements\Item">
+      <UniqueIdentifier>{ea79c6fd-3a30-48a0-9862-5f18492d6e64}</UniqueIdentifier>
     </Filter>
     <Filter Include="Elements\Item">
       <UniqueIdentifier>{85b61b5c-df65-4d5d-9cc3-9ec05bf007cd}</UniqueIdentifier>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -279,6 +279,9 @@
     <ClCompile Include="Lua\Elements\Trigger\Lua_Trigger.cpp">
       <Filter>Lua\Elements\Trigger</Filter>
     </ClCompile>
+    <ClCompile Include="Lua\Vector3.cpp">
+      <Filter>Lua</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -884,6 +887,9 @@
     </ClInclude>
     <ClInclude Include="Lua\Elements\Trigger\Lua_Trigger.h">
       <Filter>Lua\Elements\Trigger</Filter>
+    </ClInclude>
+    <ClInclude Include="Lua\Vector3.h">
+      <Filter>Lua</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -270,6 +270,9 @@
     <ClCompile Include="Lua\Elements\Item\Lua_Item.cpp">
       <Filter>Lua\Elements\Item</Filter>
     </ClCompile>
+    <ClCompile Include="Lua\Elements\Room\Lua_Room.cpp">
+      <Filter>Lua\Elements\Room</Filter>
+    </ClCompile>
     <ClCompile Include="Elements\Item.cpp">
       <Filter>Elements\Item</Filter>
     </ClCompile>
@@ -867,6 +870,9 @@
     <ClInclude Include="Lua\Elements\Item\Lua_Item.h">
       <Filter>Lua\Elements\Item</Filter>
     </ClInclude>
+    <ClInclude Include="Lua\Elements\Room\Lua_Room.h">
+      <Filter>Lua\Elements\Room</Filter>
+    </ClInclude>
     <ClInclude Include="Elements\Item.h">
       <Filter>Elements\Item</Filter>
     </ClInclude>
@@ -1012,6 +1018,9 @@
     </Filter>
     <Filter Include="Lua\Elements\Item">
       <UniqueIdentifier>{ea79c6fd-3a30-48a0-9862-5f18492d6e64}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Lua\Elements\Room">
+      <UniqueIdentifier>{80448327-8af3-4738-961e-77bda4e963d0}</UniqueIdentifier>
     </Filter>
     <Filter Include="Elements\Item">
       <UniqueIdentifier>{85b61b5c-df65-4d5d-9cc3-9ec05bf007cd}</UniqueIdentifier>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -276,6 +276,9 @@
     <ClCompile Include="Elements\Item.cpp">
       <Filter>Elements\Item</Filter>
     </ClCompile>
+    <ClCompile Include="Lua\Elements\Trigger\Lua_Trigger.cpp">
+      <Filter>Lua\Elements\Trigger</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -879,6 +882,9 @@
     <ClInclude Include="Elements\IItem.h">
       <Filter>Elements\Item</Filter>
     </ClInclude>
+    <ClInclude Include="Lua\Elements\Trigger\Lua_Trigger.h">
+      <Filter>Lua\Elements\Trigger</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">
@@ -1024,6 +1030,9 @@
     </Filter>
     <Filter Include="Elements\Item">
       <UniqueIdentifier>{85b61b5c-df65-4d5d-9cc3-9ec05bf007cd}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Lua\Elements\Trigger">
+      <UniqueIdentifier>{f81db82b-9195-47f1-ba38-25bdcc6e67ae}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/trview.sln
+++ b/trview.sln
@@ -102,6 +102,17 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "trlevel.tests", "trlevel.te
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "DirectXTK_Desktop", "external\DirectXTK\DirectXTK_Desktop.vcxproj", "{A11566D3-4081-42C9-94C5-F4057EDD9D50}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "lua", "lua", "{D6B95B54-7EBF-4D18-AE50-F82BD0B7CA62}"
+	ProjectSection(SolutionItems) = preProject
+		doc\lua\index.md = doc\lua\index.md
+		doc\lua\item.md = doc\lua\item.md
+		doc\lua\level.md = doc\lua\level.md
+		doc\lua\room.md = doc\lua\room.md
+		doc\lua\trigger.md = doc\lua\trigger.md
+		doc\lua\trview.md = doc\lua\trview.md
+		doc\lua\vector3.md = doc\lua\vector3.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -291,6 +302,7 @@ Global
 		{A01CD1C0-7CDB-4562-A6B1-2655E9BA2B64} = {B3A7F8A1-CC61-4082-BFF5-A072AF85754C}
 		{9A66D582-DCDB-46FA-988B-50C7AC0C19EB} = {B3A7F8A1-CC61-4082-BFF5-A072AF85754C}
 		{A11566D3-4081-42C9-94C5-F4057EDD9D50} = {14424861-057E-431A-97B1-0F482C6DD4E0}
+		{D6B95B54-7EBF-4D18-AE50-F82BD0B7CA62} = {B3A7F8A1-CC61-4082-BFF5-A072AF85754C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E1BD837F-81FB-40A7-879E-E411807799F4}


### PR DESCRIPTION
Add basic Lua bindings for `Item` properties. Also add some for `Room` and `Trigger`.
Update `Level` tests to no longer need `Application`.
Updated docs.
Closes #1082 