### PR TITLE
Add Lua bindings for Camera/Sink

### DIFF
--- a/doc/lua/camera_sink.md
+++ b/doc/lua/camera_sink.md
@@ -2,7 +2,28 @@
 
 The CameraSink library provides information about a camera/sink in a [level](level.md).
 
-# Properties
+Cameras and Sinks share a data type, so this type provides access to both sets of properties. To find out which type trview thinks it is, check the `type` property. trview will check for `Current` triggers and `Camera` triggers to determine the type - but if a camera/sink is not referenced by any trigger it may not have the correct type. The `type` property is writable and will change the type in the viewer.
+
+# Camera Properties
 | Name | Type | Mode | Description |
 | ---- | ---- | ---- | ---- |
+| flag | number | R | Flag value |
 | number | number | R | Camera/Sink number |
+| persistent | boolean | R | If true, player can't cancel the camera with guns/look |
+| position | [Vector3](vector3.md) | R | Position of the camera/sink |
+| room | [Room](room.md) | R | Room that contains the Camera |
+| type | string | RW | Type: `Camera` or `Sink` |
+| triggered_by | [Trigger](trigger.md)[] | R | Triggers that reference the camera | 
+| visible | boolean | RW | Whether the room is visible in the viewer |
+
+# Sink Properties
+| Name | Type | Mode | Description |
+| ---- | ---- | ---- | ---- |
+| box_index | number | R | Box index |
+| inferred_rooms | [Room](room.md)[] | R | Rooms that trview thinks this sink is in |
+| number | number | R | Camera/Sink number |
+| position | [Vector3](vector3.md) | R | Position of the camera/sink |
+| strength | number | R | How quickly this moves Lara |
+| type | string | RW | Type: `Camera` or `Sink` |
+| triggered_by | [Trigger](trigger.md)[] | R | Triggers that reference the sink | 
+| visible | boolean | RW | Whether the room is visible in the viewer |

--- a/trview.app.tests/Lua/Elements/Lua_CameraSinkTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_CameraSinkTests.cpp
@@ -1,0 +1,253 @@
+#include <trview.app/Lua/Elements/CameraSink/Lua_CameraSink.h>
+#include <trview.app/Mocks/Elements/ICameraSink.h>
+#include <trview.tests.common/Mocks.h>
+#include <external/lua/src/lua.hpp>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace trview::tests;
+using namespace testing;
+using namespace DirectX::SimpleMath;
+
+TEST(Lua_CameraSink, BoxIndex)
+{
+    auto cs = mock_shared<MockCameraSink>();
+    EXPECT_CALL(*cs, box_index).WillOnce(Return(123));
+
+    lua_State* L = luaL_newstate();
+    lua::create_camera_sink(L, cs);
+    lua_setglobal(L, "c");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return c.box_index"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_CameraSink, Flag)
+{
+    auto cs = mock_shared<MockCameraSink>();
+    EXPECT_CALL(*cs, flag).WillOnce(Return(123));
+
+    lua_State* L = luaL_newstate();
+    lua::create_camera_sink(L, cs);
+    lua_setglobal(L, "c");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return c.flag"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_CameraSink, InferredRooms)
+{
+    auto room1 = mock_shared<MockRoom>()->with_number(100);
+    auto room2 = mock_shared<MockRoom>()->with_number(200);
+
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, room(100)).WillRepeatedly(Return(room1));
+    EXPECT_CALL(*level, room(200)).WillRepeatedly(Return(room2));
+
+    auto cs = mock_shared<MockCameraSink>();
+    EXPECT_CALL(*cs, level).WillRepeatedly(Return(level));
+    EXPECT_CALL(*cs, inferred_rooms).WillRepeatedly(Return(std::vector<uint16_t>{ 100, 200 }));
+
+    lua_State* L = luaL_newstate();
+    lua::create_camera_sink(L, cs);
+    lua_setglobal(L, "c");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return c.inferred_rooms"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return #c.inferred_rooms"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return c.inferred_rooms[1].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(100, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return c.inferred_rooms[2].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(200, lua_tointeger(L, -1));
+}
+
+TEST(Lua_CameraSink, Number)
+{
+    auto cs = mock_shared<MockCameraSink>();
+    EXPECT_CALL(*cs, number).WillOnce(Return(123));
+
+    lua_State* L = luaL_newstate();
+    lua::create_camera_sink(L, cs);
+    lua_setglobal(L, "c");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return c.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_CameraSink, Persistent)
+{
+    auto cs = mock_shared<MockCameraSink>();
+    EXPECT_CALL(*cs, persistent).WillOnce(Return(true));
+
+    lua_State* L = luaL_newstate();
+    lua::create_camera_sink(L, cs);
+    lua_setglobal(L, "c");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return c.persistent"));
+    ASSERT_EQ(LUA_TBOOLEAN, lua_type(L, -1));
+    ASSERT_EQ(true, lua_toboolean(L, -1));
+}
+
+TEST(Lua_CameraSink, Position)
+{
+    auto cs = mock_shared<MockCameraSink>();
+    EXPECT_CALL(*cs, position).WillRepeatedly(Return(Vector3(1, 2, 3)));
+
+    lua_State* L = luaL_newstate();
+    lua::create_camera_sink(L, cs);
+    lua_setglobal(L, "c");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return c.position"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return c.position.x"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_DOUBLE_EQ(1024.0, lua_tonumber(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return c.position.y"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_DOUBLE_EQ(2048.0, lua_tonumber(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return c.position.z"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_DOUBLE_EQ(3072.0, lua_tonumber(L, -1));
+}
+
+TEST(Lua_CameraSink, Room)
+{
+    auto room = mock_shared<MockRoom>()->with_number(100);
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, room(100)).WillRepeatedly(Return(room));
+
+    auto cs = mock_shared<MockCameraSink>();
+    EXPECT_CALL(*cs, level).WillRepeatedly(Return(level));
+    EXPECT_CALL(*cs, room).WillRepeatedly(Return(100));
+
+    lua_State* L = luaL_newstate();
+    lua::create_camera_sink(L, cs);
+    lua_setglobal(L, "c");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return c.room"));
+    ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return c.room.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(100, lua_tointeger(L, -1));
+}
+
+TEST(Lua_CameraSink, Strength)
+{
+    auto cs = mock_shared<MockCameraSink>();
+    EXPECT_CALL(*cs, strength).WillOnce(Return(123));
+
+    lua_State* L = luaL_newstate();
+    lua::create_camera_sink(L, cs);
+    lua_setglobal(L, "c");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return c.strength"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_CameraSink, Type)
+{
+    auto cs = mock_shared<MockCameraSink>();
+    EXPECT_CALL(*cs, type).WillOnce(Return(ICameraSink::Type::Camera));
+
+    lua_State* L = luaL_newstate();
+    lua::create_camera_sink(L, cs);
+    lua_setglobal(L, "c");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return c.type"));
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    ASSERT_STREQ("Camera", lua_tostring(L, -1));
+
+    EXPECT_CALL(*cs, type).WillOnce(Return(ICameraSink::Type::Sink));
+    ASSERT_EQ(0, luaL_dostring(L, "return c.type"));
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    ASSERT_STREQ("Sink", lua_tostring(L, -1));
+}
+
+TEST(Lua_CameraSink, TriggeredBy)
+{
+    auto trigger1 = mock_shared<MockTrigger>()->with_number(100);
+    auto trigger2 = mock_shared<MockTrigger>()->with_number(200);
+
+    auto cs = mock_shared<MockCameraSink>();
+    EXPECT_CALL(*cs, triggers).WillRepeatedly(Return(std::vector<std::weak_ptr<ITrigger>>{ trigger1, trigger2 }));
+
+    lua_State* L = luaL_newstate();
+    lua::create_camera_sink(L, cs);
+    lua_setglobal(L, "c");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return c.triggered_by"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return #c.triggered_by"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return c.triggered_by[1].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(100, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return c.triggered_by[2].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(200, lua_tointeger(L, -1));
+}
+
+TEST(Lua_CameraSink, Visible)
+{
+    auto cs = mock_shared<MockCameraSink>();
+    EXPECT_CALL(*cs, visible).WillOnce(Return(true));
+
+    lua_State* L = luaL_newstate();
+    lua::create_camera_sink(L, cs);
+    lua_setglobal(L, "c");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return c.visible"));
+    ASSERT_EQ(LUA_TBOOLEAN, lua_type(L, -1));
+    ASSERT_EQ(true, lua_toboolean(L, -1));
+}
+
+TEST(Lua_CameraSink, SetType)
+{
+    auto level = mock_shared<MockLevel>();
+
+    bool level_changed_raised = false;
+    auto token = level->on_level_changed += [&]()
+    {
+        level_changed_raised = true;
+    };
+
+    auto cs = mock_shared<MockCameraSink>();
+    EXPECT_CALL(*cs, visible).WillOnce(Return(true));
+    EXPECT_CALL(*cs, level).WillRepeatedly(Return(level));
+    EXPECT_CALL(*cs, set_type(ICameraSink::Type::Sink)).Times(1);
+
+    lua_State* L = luaL_newstate();
+    lua::create_camera_sink(L, cs);
+    lua_setglobal(L, "c");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return c.type"));
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    ASSERT_STREQ("Camera", lua_tostring(L, -1));
+
+    ASSERT_EQ(0, luaL_dostring(L, "c.type = \"Sink\""));
+    ASSERT_TRUE(level_changed_raised);
+}
+
+TEST(Lua_CameraSink, SetVisible)
+{
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, set_camera_sink_visibility(100, true));
+
+    auto cs = mock_shared<MockCameraSink>()->with_number(100);
+    EXPECT_CALL(*cs, level).WillRepeatedly(Return(level));
+
+    lua_State* L = luaL_newstate();
+    lua::create_camera_sink(L, cs);
+    lua_setglobal(L, "c");
+
+    ASSERT_EQ(0, luaL_dostring(L, "c.visible = true"));
+}

--- a/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Lua/Elements/Level/Lua_Level.h>
 #include <trview.app/Mocks/Elements/ILevel.h>
+#include <trview.app/Mocks/Elements/ICameraSink.h>
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.hpp>
 
@@ -10,7 +11,11 @@ using namespace testing;
 
 TEST(Lua_Level, CamerasAndSinks)
 {
+    auto cs1 = mock_shared<MockCameraSink>()->with_number(1);
+    auto cs2 = mock_shared<MockCameraSink>()->with_number(2);
+
     auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, camera_sinks).WillRepeatedly(Return(std::vector<std::weak_ptr<ICameraSink>>{ cs1, cs2 }));
 
     lua_State* L = luaL_newstate();
     lua::create_level(L, level);
@@ -18,6 +23,15 @@ TEST(Lua_Level, CamerasAndSinks)
 
     ASSERT_EQ(0, luaL_dostring(L, "return l.cameras_and_sinks"));
     ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return #l.cameras_and_sinks"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.cameras_and_sinks[1].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(1, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.cameras_and_sinks[2].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2, lua_tointeger(L, -1));
 }
 
 TEST(Lua_Level, Filename)

--- a/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Lua/Elements/Room/Lua_Room.h>
 #include <trview.app/Mocks/Elements/IRoom.h>
+#include <trview.app/Mocks/Elements/ICameraSink.h>
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.hpp>
 
@@ -69,7 +70,11 @@ TEST(Lua_Room, AlternateRoom)
 
 TEST(Lua_Room, CamerasAndSinks)
 {
+    auto cs1 = mock_shared<MockCameraSink>()->with_number(1);
+    auto cs2 = mock_shared<MockCameraSink>()->with_number(2);
+
     auto room = mock_shared<MockRoom>();
+    EXPECT_CALL(*room, camera_sinks).WillRepeatedly(Return(std::vector<std::weak_ptr<ICameraSink>>{ cs1, cs2 }));
 
     lua_State* L = luaL_newstate();
     lua::create_room(L, room);
@@ -79,7 +84,13 @@ TEST(Lua_Room, CamerasAndSinks)
     ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
     ASSERT_EQ(0, luaL_dostring(L, "return #r.cameras_and_sinks"));
     ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
-    ASSERT_EQ(0, lua_tointeger(L, -1));
+    ASSERT_EQ(2, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return r.cameras_and_sinks[1].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(1, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return r.cameras_and_sinks[2].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2, lua_tointeger(L, -1));
 }
 
 TEST(Lua_Room, Items)

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -41,6 +41,7 @@
     <ClCompile Include="Graphics\TextureStorage.cpp" />
     <ClCompile Include="ItemsWindowManagerTests.cpp" />
     <ClCompile Include="ItemsWindowTests.cpp" />
+    <ClCompile Include="Lua\Elements\Lua_CameraSinkTests.cpp" />
     <ClCompile Include="Lua\Elements\Lua_ItemTests.cpp" />
     <ClCompile Include="Lua\Elements\Lua_LevelTests.cpp" />
     <ClCompile Include="Lua\Elements\Lua_RoomTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -191,6 +191,9 @@
     <ClCompile Include="Windows\ConsoleManagerTests.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
+    <ClCompile Include="Lua\Elements\Lua_CameraSinkTests.cpp">
+      <Filter>Lua\Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Elements/CameraSink/CameraSink.cpp
+++ b/trview.app/Elements/CameraSink/CameraSink.cpp
@@ -135,7 +135,12 @@ namespace trview
 
     uint16_t actual_room(const ICameraSink& camera_sink)
     {
-        return camera_sink.type() == ICameraSink::Type::Camera ? camera_sink.room() : camera_sink.inferred_rooms().front();
+        if (camera_sink.type() == ICameraSink::Type::Camera)
+        {
+            return camera_sink.room();
+        }
+        const auto inferred = camera_sink.inferred_rooms();
+        return inferred.empty() ? 0 : inferred.front();
     }
 
     std::string to_string(ICameraSink::Type type)

--- a/trview.app/Elements/CameraSink/CameraSink.cpp
+++ b/trview.app/Elements/CameraSink/CameraSink.cpp
@@ -36,6 +36,11 @@ namespace trview
     {
     }
 
+    std::weak_ptr<ILevel> CameraSink::level() const
+    {
+        return _level;
+    }
+
     std::vector<uint16_t> CameraSink::inferred_rooms() const
     {
         return _inferred_rooms;
@@ -91,6 +96,11 @@ namespace trview
     uint16_t CameraSink::room() const
     {
         return _room;
+    }
+
+    void CameraSink::set_level(const std::weak_ptr<ILevel>& level)
+    {
+        _level = level;
     }
 
     void CameraSink::set_type(Type type)

--- a/trview.app/Elements/CameraSink/CameraSink.h
+++ b/trview.app/Elements/CameraSink/CameraSink.h
@@ -15,6 +15,7 @@ namespace trview
         virtual uint16_t box_index() const override;
         virtual uint16_t flag() const override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
+        std::weak_ptr<ILevel> level() const override;
         virtual std::vector<uint16_t> inferred_rooms() const override;
         virtual uint32_t number() const override;
         virtual bool persistent() const override;
@@ -22,6 +23,7 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 position() const override;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual uint16_t room() const override;
+        void set_level(const std::weak_ptr<ILevel>& level) override;
         virtual void set_type(Type type) override;
         virtual void set_visible(bool value) override;
         virtual uint16_t strength() const override;
@@ -38,6 +40,7 @@ namespace trview
         Type _type{ Type::Camera };
         std::shared_ptr<IMesh> _mesh;
         std::vector<std::weak_ptr<ITrigger>> _triggers;
+        std::weak_ptr<ILevel> _level;
 
         graphics::Texture _camera_texture;
         graphics::Texture _sink_texture;

--- a/trview.app/Elements/CameraSink/ICameraSink.h
+++ b/trview.app/Elements/CameraSink/ICameraSink.h
@@ -23,11 +23,13 @@ namespace trview
         virtual uint16_t box_index() const = 0;
         virtual uint16_t flag() const = 0;
         virtual std::vector<uint16_t> inferred_rooms() const = 0;
+        virtual std::weak_ptr<ILevel> level() const = 0;
         virtual uint32_t number() const = 0;
         virtual bool persistent() const = 0;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
         virtual uint16_t room() const = 0;
+        virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
         virtual uint16_t strength() const = 0;
         virtual Type type() const = 0;
         virtual void set_type(Type type) = 0;

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1206,6 +1206,11 @@ namespace trview
             trigger->set_level(shared_from_this());
         }
 
+        for (auto& camera_sink : _camera_sinks)
+        {
+            camera_sink->set_level(shared_from_this());
+        }
+
         for (auto& room : _rooms)
         {
             room->set_level(shared_from_this());

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1129,21 +1129,17 @@ namespace trview
             std::vector<uint16_t> in_space_rooms;
             std::vector<uint16_t> in_portal_rooms;
 
-            const ICameraSink::Type type = is_camera ? ICameraSink::Type::Camera : ICameraSink::Type::Sink;
-            if (type == ICameraSink::Type::Sink)
+            for (const auto& room : _rooms)
             {
-                for (const auto& room : _rooms)
+                if (std::shared_ptr<ISector> sector = sector_from_point(*room, point))
                 {
-                    if (std::shared_ptr<ISector> sector = sector_from_point(*room, point))
+                    if (sector && sector->is_portal())
                     {
-                        if (sector && sector->is_portal())
-                        {
-                            in_portal_rooms.push_back(static_cast<uint16_t>(room->number()));
-                        }
-                        else
-                        {
-                            in_space_rooms.push_back(static_cast<uint16_t>(room->number()));
-                        }
+                        in_portal_rooms.push_back(static_cast<uint16_t>(room->number()));
+                    }
+                    else
+                    {
+                        in_space_rooms.push_back(static_cast<uint16_t>(room->number()));
                     }
                 }
             }
@@ -1159,6 +1155,7 @@ namespace trview
 
             const std::vector<uint16_t> inferred_rooms{ in_space_rooms.empty() ? in_portal_rooms : in_space_rooms };
 
+            const ICameraSink::Type type = is_camera ? ICameraSink::Type::Camera : ICameraSink::Type::Sink;
             auto new_camera_sink = camera_sink_source(i, camera_sink, type, inferred_rooms, relevant_triggers);
             _camera_sinks.push_back(new_camera_sink);
 

--- a/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.cpp
+++ b/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.cpp
@@ -1,6 +1,9 @@
 #include "Lua_CameraSink.h"
 #include "../../../Elements/ILevel.h"
 #include "../../Lua.h"
+#include "../../Vector3.h"
+#include "../Room/Lua_Room.h"
+#include "../Trigger/Lua_Trigger.h"
 
 namespace trview
 {
@@ -14,9 +17,66 @@ namespace trview
             {
                 ICameraSink* camera_sink = *static_cast<ICameraSink**>(lua_touserdata(L, 1));
                 const std::string key = lua_tostring(L, 2);
-                if (key == "number")
+                if (key == "box_index")
+                {
+                    lua_pushinteger(L, camera_sink->box_index());
+                    return 1;
+                }
+                else if (key == "flag")
+                {
+                    lua_pushinteger(L, camera_sink->flag());
+                    return 1;
+                }
+                else if (key == "inferred_rooms")
+                {
+                    if (auto level = camera_sink->level().lock())
+                    {
+                        std::vector<std::weak_ptr<IRoom>> inferred_rooms;
+                        std::ranges::transform(camera_sink->inferred_rooms(),
+                            std::back_inserter(inferred_rooms),
+                            [&level](const auto& r) { return level->room(r); });
+                        return push_list(L, inferred_rooms, { create_room });
+                    }
+                }
+                else if (key == "number")
                 {
                     lua_pushinteger(L, camera_sink->number());
+                    return 1;
+                }
+                else if (key == "persistent")
+                {
+                    lua_pushboolean(L, camera_sink->persistent());
+                    return 1;
+                }
+                else if (key == "position")
+                {
+                    create_vector3(L, camera_sink->position() * trlevel::Scale);
+                    return 1;
+                }
+                else if (key == "room")
+                {
+                    if (auto level = camera_sink->level().lock())
+                    {
+                        return create_room(L, level->room(camera_sink->room()).lock());
+                    }
+                }
+                else if (key == "strength")
+                {
+                    lua_pushinteger(L, camera_sink->strength());
+                    return 1;
+                }
+                else if (key == "type")
+                {
+                    lua_pushstring(L, to_string(camera_sink->type()).c_str());
+                    return 1;
+                }
+                else if (key == "triggered_by")
+                {
+                    return push_list(L, camera_sink->triggers(), { create_trigger });
+                }
+                else if (key == "visible")
+                {
+                    lua_pushboolean(L, camera_sink->visible());
                     return 1;
                 }
                 return 0;
@@ -25,7 +85,29 @@ namespace trview
             int camera_sink_newindex(lua_State* L)
             {
                 ICameraSink* camera_sink = *static_cast<ICameraSink**>(lua_touserdata(L, 1));
-                camera_sink;
+
+                const std::string key = lua_tostring(L, 2);
+                if (key == "type")
+                {
+                    if (auto level = camera_sink->level().lock())
+                    {
+                        const char* type_str = lua_tostring(L, -1);
+                        if (type_str)
+                        {
+                            std::string type = type_str;
+                            camera_sink->set_type(type == "Camera" ? ICameraSink::Type::Camera : ICameraSink::Type::Sink);
+                            level->on_level_changed();
+                        }
+                    }
+                }
+                else if (key == "visible")
+                {
+                    if (auto level = camera_sink->level().lock())
+                    {
+                        level->set_camera_sink_visibility(camera_sink->number(), lua_toboolean(L, -1));
+                    }
+                }
+
                 return 0;
             }
 

--- a/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.cpp
+++ b/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.cpp
@@ -95,8 +95,24 @@ namespace trview
                         if (type_str)
                         {
                             std::string type = type_str;
-                            camera_sink->set_type(type == "Camera" ? ICameraSink::Type::Camera : ICameraSink::Type::Sink);
-                            level->on_level_changed();
+                            if (type == "Camera")
+                            {
+                                camera_sink->set_type(ICameraSink::Type::Camera);
+                                level->on_level_changed();
+                            }
+                            else if (type == "Camera")
+                            {
+                                camera_sink->set_type(ICameraSink::Type::Sink);
+                                level->on_level_changed();
+                            }
+                            else
+                            {
+                                return luaL_error(L, "%s is not a valid type for Camera/Sink. Valid values are \"Camera\" and \"Sink\"", type.c_str());
+                            }
+                        }
+                        else
+                        {
+                            return luaL_error(L, "nil is not a valid type for Camera/Sink. Valid values are \"Camera\" and \"Sink\"");
                         }
                     }
                 }

--- a/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.cpp
+++ b/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.cpp
@@ -100,7 +100,7 @@ namespace trview
                                 camera_sink->set_type(ICameraSink::Type::Camera);
                                 level->on_level_changed();
                             }
-                            else if (type == "Camera")
+                            else if (type == "Sink")
                             {
                                 camera_sink->set_type(ICameraSink::Type::Sink);
                                 level->on_level_changed();

--- a/trview.app/Mocks/Elements/ICameraSink.h
+++ b/trview.app/Mocks/Elements/ICameraSink.h
@@ -14,12 +14,14 @@ namespace trview
             MOCK_METHOD(uint16_t, flag, (), (const, override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(std::vector<uint16_t>, inferred_rooms, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
             MOCK_METHOD(uint32_t, number, (), (const, override));
             MOCK_METHOD(bool, persistent, (), (const, override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(uint16_t, room, (), (const, override));
+            MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(void, set_type, (Type), (override));
             MOCK_METHOD(uint16_t, strength, (), (const, override));


### PR DESCRIPTION
Add Lua bindings for Camera/Sink
Add tests for Lua bindings
Change camera/sink room inference to always run even if it's a camera - this way you can change the type later.
Closes #1101 