### PR TITLE
Move Level assignment closer to construction

### DIFF
--- a/doc/lua/room.md
+++ b/doc/lua/room.md
@@ -10,6 +10,7 @@ The Room library provides information about a room in a [level](level.md).
 | alternate_room | [Room](room.md) | R | Alternate room or nil if not present |
 | cameras_and_sinks | [CameraSink](camera_sink.md)[] | R | Camera/Sinks in the room |
 | items | [Item](item.md)[] | R | Items in the room |
+| level | [Level](level.md) | R | The level that the room is in |
 | lights | [Light](light.md)[] | R | Lights in the room |
 | number | number | R | Room number |
 | sectors | [Sector](sector.md)[] | R | Sectors in the room

--- a/trview.app.tests/Elements/CameraSinkTests.cpp
+++ b/trview.app.tests/Elements/CameraSinkTests.cpp
@@ -19,10 +19,11 @@ namespace
             tr_camera camera{};
             std::vector<uint16_t> inferred_rooms;
             std::vector<std::weak_ptr<ITrigger>> triggers;
+            std::shared_ptr<trview::ILevel> level{ mock_shared<MockLevel>() };
 
             CameraSink build()
             {
-                return CameraSink(mesh, texture_storage, number, camera, type, inferred_rooms, triggers);
+                return CameraSink(mesh, texture_storage, number, camera, type, inferred_rooms, triggers, level);
             }
 
             test_module& with_camera_sink(const tr_camera& camera)

--- a/trview.app.tests/Elements/ItemTests.cpp
+++ b/trview.app.tests/Elements/ItemTests.cpp
@@ -24,10 +24,11 @@ namespace
             bool is_pickup{ false };
             std::string type{ "Lara" };
             std::vector<std::weak_ptr<ITrigger>> triggers;
+            std::shared_ptr<ILevel> owning_level{ mock_shared<MockLevel>() };
 
             std::unique_ptr<Item> build()
             {
-                return std::make_unique<Item>(mesh_source, *level, entity, *mesh_storage, index, type, triggers, is_pickup);
+                return std::make_unique<Item>(mesh_source, *level, entity, *mesh_storage, owning_level, index, type, triggers, is_pickup);
             }
 
             test_module& with_level(const std::shared_ptr<trlevel::ILevel>& level)

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -53,10 +53,11 @@ namespace
             graphics::IBuffer::ConstantSource buffer_source{ [](auto&&...) { return mock_unique<MockBuffer>(); } };
             ICameraSink::Source camera_sink_source{ [](auto&&...) { return mock_shared<MockCameraSink>(); } };
 
-            std::unique_ptr<Level> build()
+            std::shared_ptr<Level> build()
             {
-                return std::make_unique<Level>(device, shader_storage, std::move(level), level_texture_storage, std::move(mesh_storage), std::move(transparency_buffer),
-                    std::move(selection_renderer), entity_source, ai_source, room_source, trigger_source, light_source, log, buffer_source, camera_sink_source);
+                auto new_level = std::make_shared<Level>(device, shader_storage, level_texture_storage, std::move(transparency_buffer), std::move(selection_renderer), log, buffer_source);
+                new_level->initialise(std::move(level), std::move(mesh_storage), entity_source, ai_source, room_source, trigger_source, light_source, camera_sink_source);
+                return new_level;
             }
 
             test_module& with_level(std::unique_ptr<trlevel::ILevel>&& level)

--- a/trview.app.tests/Elements/LightTests.cpp
+++ b/trview.app.tests/Elements/LightTests.cpp
@@ -16,10 +16,11 @@ namespace
             uint32_t number{ 0u };
             uint32_t room{ 0u };
             tr_x_room_light light{};
+            std::shared_ptr<trview::ILevel> level{ mock_shared<MockLevel>() };
 
             Light build()
             {
-                return Light(mesh, number, room, light);
+                return Light(mesh, number, room, light, level);
             }
 
             test_module& with_light(const tr_x_room_light& light)

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -41,7 +41,7 @@ namespace
             std::unique_ptr<Room> build()
             {
                 return std::make_unique<Room>(mesh_source, *tr_level, room, level_texture_storage, *mesh_storage,
-                    index, *level, Activity(log, "Level", "Room 0"), static_mesh_source, static_mesh_position_source, sector_source);
+                    index, level, Activity(log, "Level", "Room 0"), static_mesh_source, static_mesh_position_source, sector_source);
             }
 
             test_module& with_level(const std::shared_ptr<ILevel>& level)

--- a/trview.app.tests/Elements/TriggerTests.cpp
+++ b/trview.app.tests/Elements/TriggerTests.cpp
@@ -19,10 +19,11 @@ namespace
             TriggerInfo trigger_info{};
             trlevel::LevelVersion level_version{ trlevel::LevelVersion::Tomb3 };
             IMesh::TransparentSource mesh_source{ [](auto&&...) { return mock_shared<MockMesh>(); } };
+            std::shared_ptr<trview::ILevel> level{ mock_shared<MockLevel>() };
 
             std::unique_ptr<Trigger> build()
             {
-                return std::make_unique<Trigger>(number, room, x, z, trigger_info, level_version, mesh_source);
+                return std::make_unique<Trigger>(number, room, x, z, trigger_info, level_version, level, mesh_source);
             }
 
             test_module& with_info(const TriggerInfo& info)

--- a/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
@@ -120,6 +120,22 @@ TEST(Lua_Room, Items)
     ASSERT_EQ(200, lua_tointeger(L, -1));
 }
 
+TEST(Lua_Room, Level)
+{
+    auto level = mock_shared<MockLevel>()->with_version(trlevel::LevelVersion::Tomb4);
+    auto room = mock_shared<MockRoom>()->with_level(level);
+
+    lua_State* L = luaL_newstate();
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return r.level"));
+    ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return r.level.version"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(4, lua_tointeger(L, -1));
+}
+
 TEST(Lua_Room, Lights)
 {
     auto light1 = mock_shared<MockLight>()->with_number(100);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -818,7 +818,6 @@ namespace trview
     {
         std::unique_ptr<trlevel::ILevel> new_level = _trlevel_source(filename);
         auto level = _level_source(std::move(new_level));
-        level->initialise();
         level->set_filename(filename);
         return level;
     }

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -217,19 +217,24 @@ namespace trview
         {
             auto level_texture_storage = std::make_shared<LevelTextureStorage>(device, std::make_unique<TextureStorage>(device), *level);
             auto mesh_storage = std::make_unique<MeshStorage>(mesh_source, *level, *level_texture_storage);
-            return std::make_shared<Level>(device, shader_storage, std::move(level),
+            auto new_level = std::make_shared<Level>(
+                device, 
+                shader_storage, 
                 level_texture_storage,
-                std::move(mesh_storage),
                 std::make_unique<TransparencyBuffer>(device),
                 std::make_unique<SelectionRenderer>(device, shader_storage, std::make_unique<TransparencyBuffer>(device), render_target_source),
+                log,
+                buffer_source);
+            new_level->initialise(
+                std::move(level),
+                std::move(mesh_storage),
                 entity_source,
                 ai_source,
                 room_source,
                 trigger_source,
                 light_source,
-                log,
-                buffer_source,
                 camera_sink_source);
+            return new_level;
         };
 
         auto viewer_ui = std::make_unique<ViewerUI>(

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -184,17 +184,17 @@ namespace trview
                 waypoint_source, settings_loader->load_user_settings());
         };
 
-        auto entity_source = [=](auto&& level, auto&& entity, auto&& index, auto&& triggers, auto&& mesh_storage)
+        auto entity_source = [=](auto&& level, auto&& entity, auto&& index, auto&& triggers, auto&& mesh_storage, auto&& owning_level)
         {
-            return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, index,
+            return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index,
                 type_name_lookup->lookup_type_name(level.get_version(), entity.TypeID, entity.Flags),
                 triggers,
                 type_name_lookup->is_pickup(level.get_version(), entity.TypeID));
         };
 
-        auto ai_source = [=](auto&& level, auto&& entity, auto&& index, auto&& mesh_storage)
+        auto ai_source = [=](auto&& level, auto&& entity, auto&& index, auto&& mesh_storage, auto&& owning_level)
         {
-            return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, index, type_name_lookup->lookup_type_name(level.get_version(), entity.type_id, entity.flags), std::vector<std::weak_ptr<ITrigger>>{});
+            return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index, type_name_lookup->lookup_type_name(level.get_version(), entity.type_id, entity.flags), std::vector<std::weak_ptr<ITrigger>>{});
         };
 
         auto log = std::make_shared<Log>();

--- a/trview.app/Elements/CameraSink/CameraSink.cpp
+++ b/trview.app/Elements/CameraSink/CameraSink.cpp
@@ -6,8 +6,10 @@ using namespace DirectX::SimpleMath;
 namespace trview
 {
     CameraSink::CameraSink(const std::shared_ptr<IMesh>& mesh, const std::shared_ptr<ITextureStorage>& texture_storage, 
-        uint32_t number, const trlevel::tr_camera& camera, Type type, const std::vector<uint16_t>& inferred_rooms, const std::vector<std::weak_ptr<ITrigger>>& triggers)
-        : _mesh(mesh), _number(number), _position(camera.position()), _room(camera.Room), _flag(camera.Flag), _inferred_rooms(inferred_rooms), _type(type), _triggers(triggers)
+        uint32_t number, const trlevel::tr_camera& camera, Type type, const std::vector<uint16_t>& inferred_rooms, const std::vector<std::weak_ptr<ITrigger>>& triggers,
+        const std::weak_ptr<ILevel>& level)
+        : _mesh(mesh), _number(number), _position(camera.position()), _room(camera.Room), _flag(camera.Flag), _inferred_rooms(inferred_rooms), _type(type), _triggers(triggers),
+        _level(level)
     {
         _camera_texture = texture_storage->lookup("camera_texture");
         _sink_texture = texture_storage->lookup("sink_texture");
@@ -96,11 +98,6 @@ namespace trview
     uint16_t CameraSink::room() const
     {
         return _room;
-    }
-
-    void CameraSink::set_level(const std::weak_ptr<ILevel>& level)
-    {
-        _level = level;
     }
 
     void CameraSink::set_type(Type type)

--- a/trview.app/Elements/CameraSink/CameraSink.h
+++ b/trview.app/Elements/CameraSink/CameraSink.h
@@ -9,7 +9,8 @@ namespace trview
     {
     public:
         explicit CameraSink(const std::shared_ptr<IMesh>& mesh, const std::shared_ptr<ITextureStorage>& texture_storage,
-            uint32_t number, const trlevel::tr_camera& camera, Type type, const std::vector<uint16_t>& inferred_rooms, const std::vector<std::weak_ptr<ITrigger>>& triggers);
+            uint32_t number, const trlevel::tr_camera& camera, Type type, const std::vector<uint16_t>& inferred_rooms, const std::vector<std::weak_ptr<ITrigger>>& triggers,
+            const std::weak_ptr<ILevel>& level);
         virtual ~CameraSink() = default;
         virtual DirectX::BoundingBox bounding_box() const override;
         virtual uint16_t box_index() const override;
@@ -23,7 +24,6 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 position() const override;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual uint16_t room() const override;
-        void set_level(const std::weak_ptr<ILevel>& level) override;
         virtual void set_type(Type type) override;
         virtual void set_visible(bool value) override;
         virtual uint16_t strength() const override;

--- a/trview.app/Elements/CameraSink/ICameraSink.h
+++ b/trview.app/Elements/CameraSink/ICameraSink.h
@@ -16,7 +16,7 @@ namespace trview
             Sink
         };
 
-        using Source = std::function<std::shared_ptr<ICameraSink>(uint32_t, const trlevel::tr_camera&, Type, const std::vector<uint16_t>& inferred_rooms, const std::vector<std::weak_ptr<ITrigger>>& triggers)>;
+        using Source = std::function<std::shared_ptr<ICameraSink>(uint32_t, const trlevel::tr_camera&, Type, const std::vector<uint16_t>& inferred_rooms, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<ILevel>&)>;
 
         virtual ~ICameraSink() = 0;
         virtual DirectX::BoundingBox bounding_box() const = 0;
@@ -29,7 +29,6 @@ namespace trview
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
         virtual uint16_t room() const = 0;
-        virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
         virtual uint16_t strength() const = 0;
         virtual Type type() const = 0;
         virtual void set_type(Type type) = 0;

--- a/trview.app/Elements/IItem.h
+++ b/trview.app/Elements/IItem.h
@@ -15,9 +15,9 @@ namespace trview
     struct IItem : public IRenderable
     {
         using EntitySource =
-            std::function<std::shared_ptr<IItem> (const trlevel::ILevel&, const trlevel::tr2_entity&, uint32_t, const std::vector<std::weak_ptr<ITrigger>>&, const IMeshStorage&)>;
+            std::function<std::shared_ptr<IItem> (const trlevel::ILevel&, const trlevel::tr2_entity&, uint32_t, const std::vector<std::weak_ptr<ITrigger>>&, const IMeshStorage&, const std::weak_ptr<ILevel>&)>;
         using AiSource =
-            std::function<std::shared_ptr<IItem>(const trlevel::ILevel&, const trlevel::tr4_ai_object&, uint32_t, const IMeshStorage&)>;
+            std::function<std::shared_ptr<IItem>(const trlevel::ILevel&, const trlevel::tr4_ai_object&, uint32_t, const IMeshStorage&, const std::weak_ptr<ILevel>&)>;
 
         virtual ~IItem() = 0;
         virtual uint32_t number() const = 0;
@@ -42,7 +42,6 @@ namespace trview
         virtual bool clear_body_flag() const = 0;
         virtual bool invisible_flag() const = 0;
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
-        virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
         virtual std::weak_ptr<ILevel> level() const = 0;
     };
 

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -132,10 +132,6 @@ namespace trview
         /// <returns>All triggers in the level.</returns>
         virtual std::vector<std::weak_ptr<ITrigger>> triggers() const = 0;
         virtual trlevel::LevelVersion version() const = 0;
-        /// <summary>
-        /// Perform extra post-load initialisation.
-        /// </summary>
-        virtual void initialise() = 0;
         // Event raised when the level needs to change the selected room.
         Event<uint16_t> on_room_selected;
         // Event raised when the level needs to change the alternate mode.

--- a/trview.app/Elements/ILight.h
+++ b/trview.app/Elements/ILight.h
@@ -10,7 +10,7 @@ namespace trview
 {
     struct ILight : public IRenderable
     {
-        using Source = std::function<std::shared_ptr<ILight>(uint32_t, uint32_t, const trlevel::tr_x_room_light&)>;
+        using Source = std::function<std::shared_ptr<ILight>(uint32_t, uint32_t, const trlevel::tr_x_room_light&, const std::weak_ptr<ILevel>&)>;
         virtual ~ILight() = 0;
         virtual uint32_t number() const = 0;
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
@@ -31,7 +31,6 @@ namespace trview
         virtual float cutoff() const = 0;
         virtual float radius() const = 0;
         virtual float density() const = 0;
-        virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
         virtual void set_position(const DirectX::SimpleMath::Vector3& position) = 0;
         virtual void render_direction(const ICamera& camera, const ILevelTextureStorage& texture_storage) = 0;
         virtual trlevel::LevelVersion level_version() const = 0;

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -90,7 +90,7 @@ namespace trview
         /// Create a new implementation of <see cref="IRoom"/>.
         /// </summary>
         using Source = std::function<std::shared_ptr<IRoom>(const trlevel::ILevel&, const trlevel::tr3_room&,
-            const std::shared_ptr<ILevelTextureStorage>&, const IMeshStorage&, uint32_t, const ILevel&, const Activity& activity)>;
+            const std::shared_ptr<ILevelTextureStorage>&, const IMeshStorage&, uint32_t, const std::weak_ptr<ILevel>&, const Activity& activity)>;
         /// <summary>
         /// Destructor for <see cref="IRoom"/>.
         /// </summary>
@@ -316,7 +316,6 @@ namespace trview
         virtual std::vector<std::weak_ptr<ICameraSink>> camera_sinks() const = 0;
         virtual std::vector<std::weak_ptr<ITrigger>> triggers() const = 0;
         virtual std::vector<std::weak_ptr<IItem>> items() const = 0;
-        virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
         virtual std::weak_ptr<ILevel> level() const = 0;
     };
 

--- a/trview.app/Elements/ITrigger.h
+++ b/trview.app/Elements/ITrigger.h
@@ -13,7 +13,7 @@ namespace trview
 
     struct ITrigger : public IRenderable
     {
-        using Source = std::function<std::shared_ptr<ITrigger>(uint32_t, uint32_t, uint16_t, uint16_t, const TriggerInfo&, trlevel::LevelVersion)>;
+        using Source = std::function<std::shared_ptr<ITrigger>(uint32_t, uint32_t, uint16_t, uint16_t, const TriggerInfo&, trlevel::LevelVersion, const std::weak_ptr<ILevel>&)>;
 
         virtual ~ITrigger() = 0;
         virtual uint32_t number() const = 0;
@@ -31,7 +31,6 @@ namespace trview
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
         virtual void set_position(const DirectX::SimpleMath::Vector3& position) = 0;
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
-        virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
         virtual std::weak_ptr<ILevel> level() const = 0;
     };
 

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -62,20 +62,20 @@ namespace trview
     {
     }
 
-    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, bool is_pickup)
-        : Item(mesh_source, mesh_storage, level, entity.Room, number, entity.TypeID, entity.position(), entity.Angle, level.get_version() >= trlevel::LevelVersion::Tomb4 ? entity.Intensity2 : 0, type, triggers, entity.Flags, is_pickup)
+    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, bool is_pickup)
+        : Item(mesh_source, mesh_storage, level, owning_level, entity.Room, number, entity.TypeID, entity.position(), entity.Angle, level.get_version() >= trlevel::LevelVersion::Tomb4 ? entity.Intensity2 : 0, type, triggers, entity.Flags, is_pickup)
     {
         
     }
 
-    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers)
-        : Item(mesh_source, mesh_storage, level, entity.room, number, entity.type_id, entity.position(), entity.angle, entity.ocb, type, triggers, entity.flags, false)
+    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers)
+        : Item(mesh_source, mesh_storage, level, owning_level, entity.room, number, entity.type_id, entity.position(), entity.angle, entity.ocb, type, triggers, entity.flags, false)
     {
     }
 
-    Item::Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint16_t room, uint32_t number, uint16_t type_id,
+    Item::Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, uint16_t room, uint32_t number, uint16_t type_id,
         const Vector3& position, int32_t angle, int32_t ocb, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags, bool is_pickup)
-        : _room(room), _number(number), _type(type), _triggers(triggers), _type_id(type_id), _ocb(ocb), _flags(flags)
+        : _room(room), _number(number), _type(type), _triggers(triggers), _type_id(type_id), _ocb(ocb), _flags(flags), _level(owning_level)
     {
         // Extract the meshes required from the model.
         load_meshes(level, type_id, mesh_storage);
@@ -437,11 +437,6 @@ namespace trview
     Vector3 Item::position() const
     {
         return _position;
-    }
-
-    void Item::set_level(const std::weak_ptr<ILevel>& level)
-    {
-        _level = level;
     }
 
     std::weak_ptr<ILevel> Item::level() const

--- a/trview.app/Elements/Item.h
+++ b/trview.app/Elements/Item.h
@@ -28,8 +28,8 @@ namespace trview
     class Item final : public IItem
     {
     public:
-        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, bool is_pickup);
-        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers);
+        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, bool is_pickup);
+        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers);
         virtual ~Item() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual uint16_t room() const override;
@@ -52,10 +52,9 @@ namespace trview
         bool clear_body_flag() const override;
         bool invisible_flag() const override;
         DirectX::SimpleMath::Vector3 position() const override;
-        void set_level(const std::weak_ptr<ILevel>& level) override;
         std::weak_ptr<ILevel> level() const override;
     private:
-        Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, uint16_t room, uint32_t number, uint16_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags, bool is_pickup);
+        Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, uint16_t room, uint32_t number, uint16_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags, bool is_pickup);
 
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1140,7 +1140,7 @@ namespace trview
             const std::vector<uint16_t> inferred_rooms{ in_space_rooms.empty() ? in_portal_rooms : in_space_rooms };
 
             const ICameraSink::Type type = is_camera ? ICameraSink::Type::Camera : ICameraSink::Type::Sink;
-            auto new_camera_sink = camera_sink_source(i, camera_sink, type, inferred_rooms, relevant_triggers);
+            auto new_camera_sink = camera_sink_source(i, camera_sink, type, inferred_rooms, relevant_triggers, shared_from_this());
             _camera_sinks.push_back(new_camera_sink);
 
             if (is_camera)
@@ -1204,11 +1204,6 @@ namespace trview
         for (auto& trigger : _triggers)
         {
             trigger->set_level(shared_from_this());
-        }
-
-        for (auto& camera_sink : _camera_sinks)
-        {
-            camera_sink->set_level(shared_from_this());
         }
     }
 

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -442,7 +442,7 @@ namespace trview
         {
             Activity room_activity(generate_rooms_activity, std::format("Room {}", i));
             auto room = level.get_room(i);
-            _rooms.push_back(room_source(level, room, _texture_storage, mesh_storage, i, *this, room_activity));
+            _rooms.push_back(room_source(level, room, _texture_storage, mesh_storage, i, shared_from_this(), room_activity));
         }
 
         std::set<uint32_t> alternate_groups;
@@ -1214,11 +1214,6 @@ namespace trview
         for (auto& camera_sink : _camera_sinks)
         {
             camera_sink->set_level(shared_from_this());
-        }
-
-        for (auto& room : _rooms)
-        {
-            room->set_level(shared_from_this());
         }
 
         for (auto& light : _lights)

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -545,7 +545,7 @@ namespace trview
             }
 
             auto level_entity = level.get_entity(i);
-            auto entity = entity_source(level, level_entity, i, relevant_triggers, mesh_storage);
+            auto entity = entity_source(level, level_entity, i, relevant_triggers, mesh_storage, shared_from_this());
             _rooms[entity->room()]->add_entity(entity);
             _entities.push_back(entity);
         }
@@ -554,7 +554,7 @@ namespace trview
         for (uint32_t i = 0; i < num_ai_objects; ++i)
         {
             auto ai_object = level.get_ai_object(i);
-            auto entity = ai_source(level, ai_object, num_entities + i, mesh_storage);
+            auto entity = ai_source(level, ai_object, num_entities + i, mesh_storage, shared_from_this());
             _rooms[entity->room()]->add_entity(entity);
             _entities.push_back(entity);
         }
@@ -1200,11 +1200,6 @@ namespace trview
         }
 
         apply_ocb_adjustment();
-
-        for (auto& ent : _entities)
-        {
-            ent->set_level(shared_from_this());
-        }
 
         for (auto& trigger : _triggers)
         {

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -474,7 +474,7 @@ namespace trview
             {
                 if (has_flag(sector->flags(), SectorFlag::Trigger))
                 {
-                    _triggers.push_back(trigger_source(static_cast<uint32_t>(_triggers.size()), i, sector->x(), sector->z(), sector->trigger(), _version));
+                    _triggers.push_back(trigger_source(static_cast<uint32_t>(_triggers.size()), i, sector->x(), sector->z(), sector->trigger(), _version, shared_from_this()));
                     room->add_trigger(_triggers.back());
                 }
             }
@@ -1200,11 +1200,6 @@ namespace trview
         }
 
         apply_ocb_adjustment();
-
-        for (auto& trigger : _triggers)
-        {
-            trigger->set_level(shared_from_this());
-        }
     }
 
     bool find_item_by_type_id(const ILevel& level, uint32_t type_id, std::weak_ptr<IItem>& output_item)

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -936,7 +936,7 @@ namespace trview
             auto room = level.get_room(i);
             for (const auto& light : room.lights)
             {
-                _lights.push_back(light_source(static_cast<uint32_t>(_lights.size()), i, light));
+                _lights.push_back(light_source(static_cast<uint32_t>(_lights.size()), i, light, shared_from_this()));
                 _rooms[i]->add_light(_lights.back());
             }
         }
@@ -1209,11 +1209,6 @@ namespace trview
         for (auto& camera_sink : _camera_sinks)
         {
             camera_sink->set_level(shared_from_this());
-        }
-
-        for (auto& light : _lights)
-        {
-            light->set_level(shared_from_this());
         }
     }
 

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -31,19 +31,11 @@ namespace trview
     public:
         Level(const std::shared_ptr<graphics::IDevice>& device,
             const std::shared_ptr<graphics::IShaderStorage>& shader_storage,
-            std::unique_ptr<trlevel::ILevel> level,
             std::shared_ptr<ILevelTextureStorage> level_texture_storage,
-            std::unique_ptr<IMeshStorage> mesh_storage,
             std::unique_ptr<ITransparencyBuffer> transparency_buffer,
             std::unique_ptr<ISelectionRenderer> selection_renderer,
-            const IItem::EntitySource& entity_source,
-            const IItem::AiSource& ai_source,
-            const IRoom::Source& room_source,
-            const ITrigger::Source& trigger_source,
-            const ILight::Source& light_source,
             const std::shared_ptr<ILog>& log,
-            const graphics::IBuffer::ConstantSource& buffer_source,
-            const ICameraSink::Source& camera_sink_source);
+            const graphics::IBuffer::ConstantSource& buffer_source);
         virtual ~Level() = default;
         virtual std::vector<RoomInfo> room_info() const override;
         virtual RoomInfo room_info(uint32_t room) const override;
@@ -110,7 +102,15 @@ namespace trview
         virtual void set_show_camera_sinks(bool show) override;
         virtual std::optional<uint32_t> selected_camera_sink() const override;
         virtual bool show_camera_sinks() const override;
-        void initialise() override;
+        void initialise(
+            std::unique_ptr<trlevel::ILevel> level,
+            std::unique_ptr<IMeshStorage> mesh_storage,
+            const IItem::EntitySource& entity_source,
+            const IItem::AiSource& ai_source,
+            const IRoom::Source& room_source,
+            const ITrigger::Source& trigger_source,
+            const ILight::Source& light_source,
+            const ICameraSink::Source& camera_sink_source);
     private:
         void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage);
         void generate_triggers(const ITrigger::Source& trigger_source);

--- a/trview.app/Elements/Light.cpp
+++ b/trview.app/Elements/Light.cpp
@@ -5,11 +5,11 @@ namespace trview
     using namespace DirectX;
     using namespace DirectX::SimpleMath;
 
-    Light::Light(const std::shared_ptr<IMesh>& mesh, uint32_t number, uint32_t room, const trlevel::tr_x_room_light& light)
+    Light::Light(const std::shared_ptr<IMesh>& mesh, uint32_t number, uint32_t room, const trlevel::tr_x_room_light& light, const std::weak_ptr<ILevel>& level)
         : _mesh(mesh), _number(number), _room(room), _position(light.position()), _colour(light.colour()), _type(light.type()),
         _intensity(light.intensity()), _fade(light.fade()), _direction(light.direction()), _in(light.in()), _out(light.out()),
         _rad_in(light.rad_in()), _rad_out(light.rad_out()), _length(light.length()), _cutoff(light.cutoff()), _range(light.range()),
-        _radius(light.radius()), _density(light.density()), _level_version(light.level_version)
+        _radius(light.radius()), _density(light.density()), _level_version(light.level_version), _level(level)
     {
     }
 
@@ -180,11 +180,6 @@ namespace trview
     float Light::density() const
     {
         return _density;
-    }
-
-    void Light::set_level(const std::weak_ptr<ILevel>& level)
-    {
-        _level = level;
     }
 
     void Light::set_position(const Vector3& position)

--- a/trview.app/Elements/Light.h
+++ b/trview.app/Elements/Light.h
@@ -8,7 +8,7 @@ namespace trview
     class Light final : public ILight
     {
     public:
-        explicit Light(const std::shared_ptr<IMesh>& mesh, uint32_t number, uint32_t room, const trlevel::tr_x_room_light& light);
+        explicit Light(const std::shared_ptr<IMesh>& mesh, uint32_t number, uint32_t room, const trlevel::tr_x_room_light& light, const std::weak_ptr<ILevel>& level);
         virtual ~Light() = default;
         virtual uint32_t number() const override;
         virtual DirectX::SimpleMath::Vector3 position() const override;
@@ -34,7 +34,6 @@ namespace trview
         virtual float cutoff() const override;
         virtual float radius() const override;
         virtual float density() const override;
-        void set_level(const std::weak_ptr<ILevel>& level) override;
         virtual void set_position(const DirectX::SimpleMath::Vector3& position) override;
         virtual trlevel::LevelVersion level_version() const override;
     private:

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -32,7 +32,7 @@ namespace trview
             std::shared_ptr<ILevelTextureStorage> texture_storage,
             const IMeshStorage& mesh_storage,
             uint32_t index,
-            const ILevel& parent_level,
+            const std::weak_ptr<ILevel>& parent_level,
             const Activity& activity,
             const IStaticMesh::MeshSource& static_mesh_mesh_source,
             const IStaticMesh::PositionSource& static_mesh_position_source,
@@ -83,7 +83,6 @@ namespace trview
         virtual std::vector<std::weak_ptr<ICameraSink>> camera_sinks() const override;
         virtual std::vector<std::weak_ptr<ITrigger>> triggers() const override;
         std::vector<std::weak_ptr<IItem>> items() const override;
-        void set_level(const std::weak_ptr<ILevel>& level) override;
         std::weak_ptr<ILevel> level() const override;
         Colour ambient() const override;
         int16_t ambient_intensity_1() const override;
@@ -137,7 +136,6 @@ namespace trview
         TokenStore _token_store;
         std::unordered_map<uint32_t, std::weak_ptr<ITrigger>> _triggers;
         uint16_t _flags{ 0 };
-        const ILevel& _parent_level;
         std::shared_ptr<ILevelTextureStorage> _texture_storage;
         std::vector<std::weak_ptr<ILight>> _lights;
         IMesh::Source _mesh_source;

--- a/trview.app/Elements/Trigger.cpp
+++ b/trview.app/Elements/Trigger.cpp
@@ -23,10 +23,10 @@ namespace trview
         return _index;
     }
 
-    Trigger::Trigger(uint32_t number, uint32_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info, trlevel::LevelVersion level_version, const IMesh::TransparentSource& mesh_source)
+    Trigger::Trigger(uint32_t number, uint32_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info, trlevel::LevelVersion level_version, const std::weak_ptr<ILevel>& level, const IMesh::TransparentSource& mesh_source)
         : _number(number), _room(room), _x(x), _z(z), _type(trigger_info.type), _only_once(trigger_info.oneshot), _flags(trigger_info.mask),
         _timer(level_version >= trlevel::LevelVersion::Tomb4 ? static_cast<int8_t>(trigger_info.timer) : trigger_info.timer), _sector_id(trigger_info.sector_id),
-        _level_version(level_version), _mesh_source(mesh_source)
+        _level_version(level_version), _mesh_source(mesh_source), _level(level)
     {
         uint32_t command_index = 0;
         for (auto action : trigger_info.commands)
@@ -155,11 +155,6 @@ namespace trview
     void Trigger::set_visible(bool value)
     {
         _visible = value;
-    }
-
-    void Trigger::set_level(const std::weak_ptr<ILevel>& level)
-    {
-        _level = level;
     }
 
     std::weak_ptr<ILevel> Trigger::level() const

--- a/trview.app/Elements/Trigger.h
+++ b/trview.app/Elements/Trigger.h
@@ -11,7 +11,7 @@ namespace trview
     class Trigger final : public ITrigger
     {
     public:
-        explicit Trigger(uint32_t number, uint32_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info, trlevel::LevelVersion level_version, const IMesh::TransparentSource& mesh_source);
+        explicit Trigger(uint32_t number, uint32_t room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info, trlevel::LevelVersion level_version, const std::weak_ptr<ILevel>& level, const IMesh::TransparentSource& mesh_source);
         virtual ~Trigger() = default;
         virtual uint32_t number() const override;
         virtual uint32_t room() const override;
@@ -32,7 +32,6 @@ namespace trview
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;
-        void set_level(const std::weak_ptr<ILevel>& level) override;
         std::weak_ptr<ILevel> level() const override;
     private:
         std::vector<uint16_t> _objects;

--- a/trview.app/Lua/Elements/Room/Lua_Room.cpp
+++ b/trview.app/Lua/Elements/Room/Lua_Room.cpp
@@ -6,6 +6,7 @@
 #include "../CameraSink/Lua_CameraSink.h"
 #include "../Light/Lua_Light.h"
 #include "../../Lua.h"
+#include "../Level/Lua_Level.h"
 
 namespace trview
 {
@@ -46,6 +47,10 @@ namespace trview
                 else if (key == "items")
                 {
                     return push_list_p(L, room->items(), create_item);
+                }
+                else if (key == "level")
+                {
+                    return create_level(L, room->level().lock());
                 }
                 else if (key == "lights")
                 {

--- a/trview.app/Mocks/Elements/ICameraSink.h
+++ b/trview.app/Mocks/Elements/ICameraSink.h
@@ -21,7 +21,6 @@ namespace trview
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(uint16_t, room, (), (const, override));
-            MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(void, set_type, (Type), (override));
             MOCK_METHOD(uint16_t, strength, (), (const, override));

--- a/trview.app/Mocks/Elements/IItem.h
+++ b/trview.app/Mocks/Elements/IItem.h
@@ -29,7 +29,6 @@ namespace trview
             MOCK_METHOD(bool, clear_body_flag, (), (const, override));
             MOCK_METHOD(bool, invisible_flag, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
-            MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
 
             std::shared_ptr<MockItem> with_number(uint32_t number)

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -6,7 +6,7 @@ namespace trview
 {
     namespace mocks
     {
-        struct MockLevel : public ILevel
+        struct MockLevel : public ILevel, public std::enable_shared_from_this<MockLevel>
         {
             MockLevel();
             virtual ~MockLevel();
@@ -75,6 +75,12 @@ namespace trview
             MOCK_METHOD(void, set_camera_sink_visibility, (uint32_t, bool), (override));
             MOCK_METHOD(void, set_show_camera_sinks, (bool), (override));
             MOCK_METHOD(std::optional<uint32_t>, selected_camera_sink, (), (const, override));
+
+            std::shared_ptr<MockLevel> with_version(trlevel::LevelVersion version)
+            {
+                ON_CALL(*this, version).WillByDefault(testing::Return(version));
+                return shared_from_this();
+            }
         };
     }
 }

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -75,7 +75,6 @@ namespace trview
             MOCK_METHOD(void, set_camera_sink_visibility, (uint32_t, bool), (override));
             MOCK_METHOD(void, set_show_camera_sinks, (bool), (override));
             MOCK_METHOD(std::optional<uint32_t>, selected_camera_sink, (), (const, override));
-            MOCK_METHOD(void, initialise, (), (override));
         };
     }
 }

--- a/trview.app/Mocks/Elements/ILight.h
+++ b/trview.app/Mocks/Elements/ILight.h
@@ -33,7 +33,6 @@ namespace trview
             MOCK_METHOD(float, cutoff, (), (const, override));
             MOCK_METHOD(float, radius, (), (const override));
             MOCK_METHOD(float, density, (), (const, override));
-            MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
             MOCK_METHOD(void, set_position, (const DirectX::SimpleMath::Vector3&), (override));
             MOCK_METHOD(void, render_direction, (const ICamera&, const ILevelTextureStorage&), (override));
             MOCK_METHOD(trlevel::LevelVersion, level_version, (), (const, override));

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -77,6 +77,12 @@ namespace trview
                 ON_CALL(*this, alternate_room).WillByDefault(testing::Return(alternate));
                 return shared_from_this();
             }
+
+            std::shared_ptr<MockRoom> with_level(const std::weak_ptr<ILevel>& level)
+            {
+                ON_CALL(*this, level).WillByDefault(testing::Return(level));
+                return shared_from_this();
+            }
         };
     }
 }

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -57,7 +57,6 @@ namespace trview
             MOCK_METHOD(std::vector<std::weak_ptr<ICameraSink>>, camera_sinks, (), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<ITrigger>>, triggers, (), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<IItem>>, items, (), (const, override));
-            MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
 
 

--- a/trview.app/Mocks/Elements/ITrigger.h
+++ b/trview.app/Mocks/Elements/ITrigger.h
@@ -29,7 +29,6 @@ namespace trview
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
             MOCK_METHOD(void, set_position, (const DirectX::SimpleMath::Vector3&), (override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
-            MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
 
             std::shared_ptr<MockTrigger> with_number(uint32_t number)

--- a/trview.app/Windows/Console/Console.cpp
+++ b/trview.app/Windows/Console/Console.cpp
@@ -29,6 +29,7 @@ namespace trview
             _text += '\n';
         }
         _text += text;
+        _need_scroll = true;
     }
 
     void Console::render()
@@ -108,6 +109,15 @@ namespace trview
             }
 
             ImGui::InputTextMultiline(Names::log.c_str(), const_cast<char*>(_text.c_str()), _text.size(), ImVec2(-1, -25), ImGuiInputTextFlags_ReadOnly);
+            if (ImGui::BeginChild(Names::log.c_str()))
+            {
+                if (_need_scroll)
+                {
+                    ImGui::SetScrollHereY(1.0f);
+                    _need_scroll = false;
+                }
+                ImGui::EndChild();
+            }
             if (ImGui::IsWindowAppearing() || _need_focus)
             {
                 ImGui::SetKeyboardFocusHere();

--- a/trview.app/Windows/Console/Console.h
+++ b/trview.app/Windows/Console/Console.h
@@ -33,6 +33,7 @@ namespace trview
         std::string _text;
         bool _need_focus{ false };
         bool _go_to_eol{ false };
+        bool _need_scroll{ false };
         ImFont* _font{ nullptr };
         std::string _id{ "Console 0" };
         std::vector<std::string> _recent_files;


### PR DESCRIPTION
Add an `initialise` function to the `ILevel::Source` so elements can be given a `shared_ptr` - as the object has been created by this point.
Closes #1125 