### PR TITLE
Lua binding for Sector

### DIFF
--- a/doc/lua/room.md
+++ b/doc/lua/room.md
@@ -17,3 +17,8 @@ The Room library provides information about a room in a [level](level.md).
 | triggers | [Trigger](trigger.md)[] | R | Triggers in the room |
 | visible | boolean | RW | Whether the room is visible in the viewer |
 
+# Functions
+
+| Name | Returns | Parameters | Description |
+| ---- | ------- | ---------- | ----------- |
+| sector | [Sector](sector.md) | number x, number y | Gets the sector at the x and z indices, 1 based |

--- a/doc/lua/room.md
+++ b/doc/lua/room.md
@@ -13,6 +13,8 @@ The Room library provides information about a room in a [level](level.md).
 | level | [Level](level.md) | R | The level that the room is in |
 | lights | [Light](light.md)[] | R | Lights in the room |
 | number | number | R | Room number |
+| num_x_sectors | number | R | Number of sectors in the x dimension |
+| num_z_sectors | number | R | Number of sectors in the z dimension |
 | sectors | [Sector](sector.md)[] | R | Sectors in the room
 | triggers | [Trigger](trigger.md)[] | R | Triggers in the room |
 | visible | boolean | RW | Whether the room is visible in the viewer |

--- a/doc/lua/sector.md
+++ b/doc/lua/sector.md
@@ -6,3 +6,5 @@ The Sector library provides information about a sector in a [Level](level.md)/[R
 | Name | Type | Mode | Description |
 | ---- | ---- | ---- | ---- |
 | number | number | R | Sector number |
+| x | number | R | Sector X location in room |
+| z | number | R | Sector Z location in room |

--- a/doc/lua/sector.md
+++ b/doc/lua/sector.md
@@ -5,13 +5,16 @@ The Sector library provides information about a sector in a [Level](level.md)/[R
 # Properties
 | Name | Type | Mode | Description |
 | ---- | ---- | ---- | ---- |
+| above | [Room](room.md) | R | Room directly above this sector or `nil` |
+| below | [Room](room.md) | R | Room directly below this sector or `nil` |
+| ceiling_corners | number[] | R | Height of ceiling corners in clicks from room ceiling |
+| ceiling_triangulation | string | R | Ceiling triangulation direction (`None`/`NWSE`/`NESW`) |
 | corners | number[] | R | Height of corners in clicks above room floor |
 | flags | [Flags](#flags)| R | Sector flags |
 | number | number | R | Sector number |
 | portal | [Room](room.md) | R | Destination room for portal or `nil` |
 | room | [Room](room.md) | R | Room that the sector is in |
-| above | [Room](room.md) | R | Room directly above this sector or `nil` |
-| below | [Room](room.md) | R | Room directly below this sector or `nil` |
+| triangulation | string | R | Triangulation direction (`None`/`NWSE`/`NESW`) |
 | trigger | [Trigger](trigger.md) | R | Trigger on this sector or `nil` |
 | x | number | R | Sector X location in room |
 | z | number | R | Sector Z location in room |

--- a/doc/lua/sector.md
+++ b/doc/lua/sector.md
@@ -6,7 +6,6 @@ The Sector library provides information about a sector in a [Level](level.md)/[R
 | Name | Type | Mode | Description |
 | ---- | ---- | ---- | ---- |
 | flags | [Flags](#flags)| R | Sector flags |
-| floordata | | R | Floordata values |
 | number | number | R | Sector number |
 | portal | [Room](room.md) | R | Destination room for portal or `nil` |
 | room | [Room](room.md) | R | Room that the sector is in |

--- a/doc/lua/sector.md
+++ b/doc/lua/sector.md
@@ -6,6 +6,9 @@ The Sector library provides information about a sector in a [Level](level.md)/[R
 | Name | Type | Mode | Description |
 | ---- | ---- | ---- | ---- |
 | number | number | R | Sector number |
+| portal | [Room](room.md) | R | Destination room for portal, or `nil` |
 | room | [Room](room.md) | R | Room that the sector is in |
+| room_above | [Room](room.md) | R | Room directly above this sector or `nil` |
+| room_below | [Room](room.md) | R | Room directly below this sector or `nil` |
 | x | number | R | Sector X location in room |
 | z | number | R | Sector Z location in room |

--- a/doc/lua/sector.md
+++ b/doc/lua/sector.md
@@ -6,5 +6,6 @@ The Sector library provides information about a sector in a [Level](level.md)/[R
 | Name | Type | Mode | Description |
 | ---- | ---- | ---- | ---- |
 | number | number | R | Sector number |
+| room | [Room](room.md) | R | Room that the sector is in |
 | x | number | R | Sector X location in room |
 | z | number | R | Sector Z location in room |

--- a/doc/lua/sector.md
+++ b/doc/lua/sector.md
@@ -1,6 +1,6 @@
 # Sector
 
-The Sector library provides information about a sector in a [level](level.md).
+The Sector library provides information about a sector in a [Level](level.md)/[Room](room.md).
 
 # Properties
 | Name | Type | Mode | Description |

--- a/doc/lua/sector.md
+++ b/doc/lua/sector.md
@@ -5,6 +5,7 @@ The Sector library provides information about a sector in a [Level](level.md)/[R
 # Properties
 | Name | Type | Mode | Description |
 | ---- | ---- | ---- | ---- |
+| corners | number[] | R | Height of corners in clicks above room floor |
 | flags | [Flags](#flags)| R | Sector flags |
 | number | number | R | Sector number |
 | portal | [Room](room.md) | R | Destination room for portal or `nil` |

--- a/doc/lua/sector.md
+++ b/doc/lua/sector.md
@@ -10,8 +10,8 @@ The Sector library provides information about a sector in a [Level](level.md)/[R
 | number | number | R | Sector number |
 | portal | [Room](room.md) | R | Destination room for portal or `nil` |
 | room | [Room](room.md) | R | Room that the sector is in |
-| room_above | [Room](room.md) | R | Room directly above this sector or `nil` |
-| room_below | [Room](room.md) | R | Room directly below this sector or `nil` |
+| above | [Room](room.md) | R | Room directly above this sector or `nil` |
+| below | [Room](room.md) | R | Room directly below this sector or `nil` |
 | trigger | [Trigger](trigger.md) | R | Trigger on this sector or `nil` |
 | x | number | R | Sector X location in room |
 | z | number | R | Sector Z location in room |

--- a/doc/lua/sector.md
+++ b/doc/lua/sector.md
@@ -5,11 +5,46 @@ The Sector library provides information about a sector in a [Level](level.md)/[R
 # Properties
 | Name | Type | Mode | Description |
 | ---- | ---- | ---- | ---- |
+| flags | [Flags](#flags)| R | Sector flags |
+| floordata | | R | Floordata values |
 | number | number | R | Sector number |
-| portal | [Room](room.md) | R | Destination room for portal, or `nil` |
+| portal | [Room](room.md) | R | Destination room for portal or `nil` |
 | room | [Room](room.md) | R | Room that the sector is in |
 | room_above | [Room](room.md) | R | Room directly above this sector or `nil` |
 | room_below | [Room](room.md) | R | Room directly below this sector or `nil` |
 | trigger | [Trigger](trigger.md) | R | Trigger on this sector or `nil` |
 | x | number | R | Sector X location in room |
 | z | number | R | Sector Z location in room |
+
+# Functions
+
+| Name | Returns | Parameters | Description |
+| ---- | ------- | ---------- | ----------- |
+| has_flag | boolean | [Flags](#flags) flag | Check whether the flag pattern passed in matches the sector flags - uses bitwise and operation |
+
+# Enumerations
+
+## Flags
+
+```Sector.Flags```
+
+| Name | Value |
+| ---- | ----- |
+| None | 0x0 |
+| Portal | 0x1 |
+| Wall | 0x2 |
+| Trigger | 0x4 |
+| Death | 0x8 |
+| FloorSlant | 0x10 |
+| CeilingSlant | 0x20 |
+| ClimbableNorth | 0x40 |
+| ClimbableEast | 0x80 |
+| ClimbableSouth | 0x100 |
+| ClimbableWest | 0x200 |
+| Climbable | 0x3C0 |
+| MonkeySwing | 0x400 |
+| RoomAbove | 0x800 |
+| RoomBelow | 0x1000 |
+| MinecartLeft |  0x2000 |
+| MinecartRight | 0x4000 |
+| SpecialWall | 0x8000 |

--- a/doc/lua/sector.md
+++ b/doc/lua/sector.md
@@ -10,5 +10,6 @@ The Sector library provides information about a sector in a [Level](level.md)/[R
 | room | [Room](room.md) | R | Room that the sector is in |
 | room_above | [Room](room.md) | R | Room directly above this sector or `nil` |
 | room_below | [Room](room.md) | R | Room directly below this sector or `nil` |
+| trigger | [Trigger](trigger.md) | R | Trigger on this sector or `nil` |
 | x | number | R | Sector X location in room |
 | z | number | R | Sector Z location in room |

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -1,6 +1,7 @@
 #include <trview.app/Application.h>
 #include <trview.app/Mocks/Elements/ILevel.h>
 #include <trview.app/Mocks/Elements/ILight.h>
+#include <trview.app/Mocks/Elements/ISector.h>
 #include <trview.app/Mocks/Elements/ICameraSink.h>
 #include <trview.app/Mocks/Menus/IUpdateChecker.h>
 #include <trview.app/Mocks/Menus/IFileMenu.h>

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -18,6 +18,7 @@
 #include <trview.app/Mocks/Windows/ILogWindowManager.h>
 #include <trview.app/Mocks/Windows/ITexturesWindowManager.h>
 #include <trview.app/Mocks/Windows/ICameraSinkWindowManager.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.common/Mocks/Windows/IShortcuts.h>
 #include <trview.common/Mocks/Windows/IDialogs.h>
 #include <trview.common/Mocks/IFiles.h>

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -12,6 +12,7 @@
 #include <trview.app/Mocks/Elements/ITrigger.h>
 #include <trview.app/Mocks/Elements/ILight.h>
 #include <trview.app/Mocks/Elements/ICameraSink.h>
+#include <trview.app/Mocks/Elements/ISector.h>
 #include <trview.app/Mocks/Camera/ICamera.h>
 #include <trview.graphics/mocks/D3D/ID3D11DeviceContext.h>
 #include <trview.graphics/mocks/IShader.h>

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -657,5 +657,17 @@ TEST(Room, RendersContainedCameraSinks)
 
 TEST(Room, Sector)
 {
-    FAIL();
+    trlevel::tr3_room level_room;
+    level_room.num_x_sectors = 2;
+    level_room.num_z_sectors = 2;
+    level_room.sector_list.resize(4);
+    auto room = register_test_module().with_room(level_room).build();
+
+    auto sector = room->sector(1, 1);
+    auto s = sector.lock();
+    ASSERT_TRUE(s);
+
+    sector = room->sector(2, 2);
+    s = sector.lock();
+    ASSERT_FALSE(s);
 }

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -654,3 +654,8 @@ TEST(Room, RendersContainedCameraSinks)
     room->add_camera_sink(camera_sink);
     room->render_camera_sinks(NiceMock<MockCamera>{});
 }
+
+TEST(Room, Sector)
+{
+    FAIL();
+}

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -38,10 +38,11 @@ namespace
             ISector::Source sector_source{ [](auto&&...) { return mock_shared<MockSector>(); } };
             std::shared_ptr<ILog> log{ mock_shared<MockLog>() };
 
-            std::unique_ptr<Room> build()
+            std::shared_ptr<Room> build()
             {
-                return std::make_unique<Room>(mesh_source, *tr_level, room, level_texture_storage, *mesh_storage,
-                    index, level, Activity(log, "Level", "Room 0"), static_mesh_source, static_mesh_position_source, sector_source);
+                auto new_room = std::make_shared<Room>(room, mesh_source, level_texture_storage, index, level);
+                new_room->initialise(*tr_level, room, *mesh_storage, static_mesh_source, static_mesh_position_source, sector_source, Activity(log, "Level", "Room 0"));
+                return new_room;
             }
 
             test_module& with_level(const std::shared_ptr<ILevel>& level)

--- a/trview.app.tests/Elements/SectorTests.cpp
+++ b/trview.app.tests/Elements/SectorTests.cpp
@@ -1,6 +1,7 @@
 #include <trview.app/Elements/Sector.h>
 #include <trlevel/Mocks/ILevel.h>
 #include <trview.app/Mocks/Elements/IRoom.h>
+#include <trview.tests.common/Mocks.h>
 
 using namespace trview;
 using namespace trview::mocks;
@@ -20,9 +21,9 @@ TEST(Sector, HighNumberedPortal)
     tr_room.num_x_sectors = 1;
     tr_room.num_z_sectors = 1;
     tr_room_sector sector { 1, 0xffff, 255, 0, 255, 0 };
-    NiceMock<MockRoom> room;
+    auto room = trview::tests::mock_shared<MockRoom>();
 
-    Sector s(level, tr_room, sector, 0, 0, room);
+    Sector s(level, tr_room, sector, 0, room);
 
     ASSERT_EQ(s.portal(), 378);
 }

--- a/trview.app.tests/Lua/Elements/Lua_CameraSinkTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_CameraSinkTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Lua/Elements/CameraSink/Lua_CameraSink.h>
 #include <trview.app/Mocks/Elements/ICameraSink.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>

--- a/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Lua/Elements/Item/Lua_Item.h>
 #include <trview.app/Mocks/Elements/IItem.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>

--- a/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
@@ -3,6 +3,7 @@
 #include <trview.app/Mocks/Elements/ILevel.h>
 #include <trview.app/Mocks/Elements/ICameraSink.h>
 #include <trview.app/Mocks/Elements/ILight.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>

--- a/trview.app.tests/Lua/Elements/Lua_LightTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_LightTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Lua/Elements/Light/Lua_Light.h>
 #include <trview.app/Mocks/Elements/ILight.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>

--- a/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
@@ -203,7 +203,18 @@ TEST(Lua_Room, NumZSectors)
 
 TEST(Lua_Room, Sector)
 {
-    FAIL();
+    auto sector = mock_shared<MockSector>()->with_id(123);
+    auto room = mock_shared<MockRoom>();
+    EXPECT_CALL(*room, sector(0, 1)).WillRepeatedly(Return(sector));
+
+    lua_State* L = luaL_newstate();
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return r:sector(1, 2)"));
+    ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return r:sector(1, 2).number"));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
 }
 
 TEST(Lua_Room, Sectors)

--- a/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
@@ -201,6 +201,11 @@ TEST(Lua_Room, NumZSectors)
     ASSERT_EQ(123, lua_tointeger(L, -1));
 }
 
+TEST(Lua_Room, Sector)
+{
+    FAIL();
+}
+
 TEST(Lua_Room, Sectors)
 {
     auto sector1 = mock_shared<MockSector>()->with_id(100);

--- a/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
@@ -175,6 +175,32 @@ TEST(Lua_Room, Number)
     ASSERT_EQ(123, lua_tointeger(L, -1));
 }
 
+TEST(Lua_Room, NumXSectors)
+{
+    auto room = mock_shared<MockRoom>()->with_num_x_sectors(123);
+
+    lua_State* L = luaL_newstate();
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return r.num_x_sectors"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Room, NumZSectors)
+{
+    auto room = mock_shared<MockRoom>()->with_num_z_sectors(123);
+
+    lua_State* L = luaL_newstate();
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return r.num_z_sectors"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
 TEST(Lua_Room, Sectors)
 {
     auto sector1 = mock_shared<MockSector>()->with_id(100);

--- a/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
@@ -2,6 +2,7 @@
 #include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.app/Mocks/Elements/ICameraSink.h>
 #include <trview.app/Mocks/Elements/ILight.h>
+#include <trview.app/Mocks/Elements/ISector.h>
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>

--- a/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Lua/Elements/Sector/Lua_Sector.h>
 #include <trview.app/Mocks/Elements/ISector.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>

--- a/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
@@ -54,6 +54,11 @@ TEST(Lua_Sector, CeilingCorners)
     FAIL();
 }
 
+TEST(Lua_Sector, CeilingTriangulation)
+{
+    FAIL();
+}
+
 TEST(Lua_Sector, Corners)
 {
     FAIL();
@@ -175,4 +180,9 @@ TEST(Lua_Sector, Z)
     ASSERT_EQ(0, luaL_dostring(L, "return s.z"));
     ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
     ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Sector, Triangulation)
+{
+    FAIL();
 }

--- a/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
@@ -61,11 +61,6 @@ TEST(Lua_Sector, Flags)
     ASSERT_EQ(1, lua_tointeger(L, -1));
 }
 
-TEST(Lua_Sector, Floordata)
-{
-    FAIL();
-}
-
 TEST(Lua_Sector, HasFlag)
 {
     auto sector = mock_shared<MockSector>()->with_flags(SectorFlag::Portal);

--- a/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
@@ -69,7 +69,33 @@ TEST(Lua_Sector, CeilingTriangulation)
 
 TEST(Lua_Sector, Corners)
 {
-    FAIL();
+    auto room = mock_shared<MockRoom>();
+    std::array<float, 4> corners
+    {
+        0.0f, 0.0f, 0.0f, 0.0f
+    };
+
+    auto sector = mock_shared<MockSector>()->with_room(room);
+    ON_CALL(*sector, corners).WillByDefault(Return(corners));
+
+    lua_State* L = luaL_newstate();
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.corners"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.corners[1]"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(0, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.corners[2]"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(1, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.corners[3]"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.corners[4]"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(3, lua_tointeger(L, -1));
 }
 
 TEST(Lua_Sector, Flags)

--- a/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
@@ -10,6 +10,76 @@ using namespace trview::tests;
 using namespace testing;
 using namespace DirectX::SimpleMath;
 
+TEST(Lua_Sector, Above)
+{
+    auto level = mock_shared<MockLevel>();
+    auto room = mock_shared<MockRoom>()->with_level(level)->with_number(10);
+    EXPECT_CALL(*level, room(10)).WillRepeatedly(Return(room));
+
+    auto sector = mock_shared<MockSector>()->with_room(room)->with_room_above(10);
+
+    lua_State* L = luaL_newstate();
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.above"));
+    ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.above.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(10, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Sector, Below)
+{
+    auto level = mock_shared<MockLevel>();
+    auto room = mock_shared<MockRoom>()->with_level(level)->with_number(10);
+    EXPECT_CALL(*level, room(10)).WillRepeatedly(Return(room));
+
+    auto sector = mock_shared<MockSector>()->with_room(room)->with_room_below(10);
+
+    lua_State* L = luaL_newstate();
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.below"));
+    ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.below.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(10, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Sector, Flags)
+{
+    auto sector = mock_shared<MockSector>()->with_flags(SectorFlag::Portal);
+
+    lua_State* L = luaL_newstate();
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.flags"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(1, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Sector, Floordata)
+{
+    FAIL();
+}
+
+TEST(Lua_Sector, HasFlag)
+{
+    auto sector = mock_shared<MockSector>()->with_flags(SectorFlag::Portal);
+
+    lua_State* L = luaL_newstate();
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+    lua::sector_register(L);
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s:has_flag(Sector.Flags.Portal)"));
+    ASSERT_EQ(LUA_TBOOLEAN, lua_type(L, -1));
+    ASSERT_EQ(true, lua_toboolean(L, -1));
+}
+
 TEST(Lua_Sector, Number)
 {
     auto sector = mock_shared<MockSector>()->with_id(123);
@@ -19,6 +89,84 @@ TEST(Lua_Sector, Number)
     lua_setglobal(L, "s");
 
     ASSERT_EQ(0, luaL_dostring(L, "return s.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Sector, Portal)
+{
+    auto level = mock_shared<MockLevel>();
+    auto room = mock_shared<MockRoom>()->with_level(level)->with_number(10);
+    ON_CALL(*level, room(10)).WillByDefault(Return(room));
+
+    auto sector = mock_shared<MockSector>()->with_room(room)->with_portal(10);
+    ON_CALL(*sector, is_portal).WillByDefault(Return(true));
+
+    lua_State* L = luaL_newstate();
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.portal"));
+    ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.portal.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(10, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Sector, Room)
+{
+    auto room = mock_shared<MockRoom>()->with_number(10);
+    auto sector = mock_shared<MockSector>()->with_room(room);
+
+    lua_State* L = luaL_newstate();
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.room"));
+    ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.room.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(10, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Sector, Trigger)
+{
+    auto trigger = mock_shared<MockTrigger>()->with_number(10);
+    auto sector = mock_shared<MockSector>()->with_trigger(trigger);
+
+    lua_State* L = luaL_newstate();
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.trigger"));
+    ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.trigger.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(10, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Sector, X)
+{
+    auto sector = mock_shared<MockSector>()->with_x(123);
+
+    lua_State* L = luaL_newstate();
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.x"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Sector, Z)
+{
+    auto sector = mock_shared<MockSector>()->with_z(123);
+
+    lua_State* L = luaL_newstate();
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.z"));
     ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
     ASSERT_EQ(123, lua_tointeger(L, -1));
 }

--- a/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
@@ -56,7 +56,15 @@ TEST(Lua_Sector, CeilingCorners)
 
 TEST(Lua_Sector, CeilingTriangulation)
 {
-    FAIL();
+    auto sector = mock_shared<MockSector>()->with_ceiling_triangulation(ISector::TriangulationDirection::NeSw);
+
+    lua_State* L = luaL_newstate();
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.ceiling_triangulation"));
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    ASSERT_STREQ("NESW", lua_tostring(L, -1));
 }
 
 TEST(Lua_Sector, Corners)
@@ -184,5 +192,13 @@ TEST(Lua_Sector, Z)
 
 TEST(Lua_Sector, Triangulation)
 {
-    FAIL();
+    auto sector = mock_shared<MockSector>()->with_triangulation(ISector::TriangulationDirection::NeSw);
+
+    lua_State* L = luaL_newstate();
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.triangulation"));
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    ASSERT_STREQ("NESW", lua_tostring(L, -1));
 }

--- a/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
@@ -51,7 +51,33 @@ TEST(Lua_Sector, Below)
 
 TEST(Lua_Sector, CeilingCorners)
 {
-    FAIL();
+    auto room = mock_shared<MockRoom>();
+    std::array<float, 4> corners
+    {
+        0.0f, 0.25f, 0.5f, 0.75f
+    };
+
+    auto sector = mock_shared<MockSector>()->with_room(room);
+    ON_CALL(*sector, ceiling_corners).WillByDefault(Return(corners));
+
+    lua_State* L = luaL_newstate();
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.ceiling_corners"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.ceiling_corners[1]"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(0, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.ceiling_corners[2]"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(1, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.ceiling_corners[3]"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.ceiling_corners[4]"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(3, lua_tointeger(L, -1));
 }
 
 TEST(Lua_Sector, CeilingTriangulation)
@@ -72,7 +98,7 @@ TEST(Lua_Sector, Corners)
     auto room = mock_shared<MockRoom>();
     std::array<float, 4> corners
     {
-        0.0f, 0.0f, 0.0f, 0.0f
+        0.0f, -0.25f, -0.5f, -0.75f
     };
 
     auto sector = mock_shared<MockSector>()->with_room(room);

--- a/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
@@ -48,6 +48,16 @@ TEST(Lua_Sector, Below)
     ASSERT_EQ(10, lua_tointeger(L, -1));
 }
 
+TEST(Lua_Sector, CeilingCorners)
+{
+    FAIL();
+}
+
+TEST(Lua_Sector, Corners)
+{
+    FAIL();
+}
+
 TEST(Lua_Sector, Flags)
 {
     auto sector = mock_shared<MockSector>()->with_flags(SectorFlag::Portal);

--- a/trview.app.tests/Lua/Elements/Lua_TriggerTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_TriggerTests.cpp
@@ -1,6 +1,7 @@
 #include <trview.app/Lua/Elements/Trigger/Lua_Trigger.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
 #include <trview.app/Mocks/Elements/ISector.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>

--- a/trview.app.tests/Lua/Elements/Lua_TriggerTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_TriggerTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Lua/Elements/Trigger/Lua_Trigger.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
+#include <trview.app/Mocks/Elements/ISector.h>
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>

--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -5,6 +5,7 @@
 #include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
 #include <trview.app/Mocks/Elements/ISector.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 
 using namespace trview;
 using namespace trview::mocks;

--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -4,6 +4,7 @@
 #include <trview.common/Mocks/Windows/IShortcuts.h>
 #include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
+#include <trview.app/Mocks/Elements/ISector.h>
 
 using namespace trview;
 using namespace trview::mocks;

--- a/trview.app.tests/stdafx.h
+++ b/trview.app.tests/stdafx.h
@@ -51,7 +51,6 @@ namespace testing
 #include <trview.app/Mocks/Elements/IItem.h>
 #include <trview.app/Mocks/Elements/ILevel.h>
 #include <trview.app/Mocks/Elements/IRoom.h>
-#include <trview.app/Mocks/Elements/ISector.h>
 #include <trview.app/Mocks/Elements/IStaticMesh.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
 #include <trview.app/Mocks/Elements/ITypeNameLookup.h>

--- a/trview.app.tests/stdafx.h
+++ b/trview.app.tests/stdafx.h
@@ -50,7 +50,6 @@ namespace testing
 #include <trview.app/Mocks/Geometry/ITransparencyBuffer.h>
 #include <trview.app/Mocks/Elements/IItem.h>
 #include <trview.app/Mocks/Elements/ILevel.h>
-#include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.app/Mocks/Elements/IStaticMesh.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
 #include <trview.app/Mocks/Elements/ITypeNameLookup.h>

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -203,7 +203,13 @@ namespace trview
         auto static_mesh_source = [=](auto&&... args) { return std::make_shared<StaticMesh>(args..., bounding_mesh); };
         auto static_mesh_position_source = [=](auto&&... args) { return std::make_shared<StaticMesh>(args...); };
         auto sector_source = [=](auto&&... args) { return std::make_shared<Sector>(args...); };
-        auto room_source = [=](auto&&... args) { return std::make_shared<Room>( mesh_source, args..., static_mesh_source, static_mesh_position_source, sector_source); };
+        auto room_source = [=](const trlevel::ILevel& level, const trlevel::tr3_room& room,
+            const std::shared_ptr<ILevelTextureStorage>& texture_storage, const IMeshStorage& mesh_storage, uint32_t index, const std::weak_ptr<ILevel>& parent_level, const Activity& activity)
+        {
+            auto new_room = std::make_shared<Room>(room, mesh_source, texture_storage, index, parent_level);
+            new_room->initialise(level, room, mesh_storage, static_mesh_source, static_mesh_position_source, sector_source, activity);
+            return new_room;
+        };
         auto trigger_source = [=](auto&&... args) { return std::make_shared<Trigger>(args..., mesh_transparent_source); };
 
         const auto light_mesh = create_sphere_mesh(mesh_source, 24, 24);

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -202,7 +202,7 @@ namespace trview
         auto bounding_mesh = create_cube_mesh(mesh_source);
         auto static_mesh_source = [=](auto&&... args) { return std::make_shared<StaticMesh>(args..., bounding_mesh); };
         auto static_mesh_position_source = [=](auto&&... args) { return std::make_shared<StaticMesh>(args...); };
-        auto sector_source = [=](auto&&... args) { return std::make_shared<Sector>(args...); };
+        auto sector_source = [=](auto&&... args) { return std::make_shared<Sector>(std::forward<decltype(args)>(args)...); };
         auto room_source = [=](const trlevel::ILevel& level, const trlevel::tr3_room& room,
             const std::shared_ptr<ILevelTextureStorage>& texture_storage, const IMeshStorage& mesh_storage, uint32_t index, const std::weak_ptr<ILevel>& parent_level, const Activity& activity)
         {

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -330,5 +330,6 @@ namespace trview
     std::string to_string(IRoom::AlternateMode mode);
 
     std::string light_mode_name(int16_t light_mode);
+    uint32_t room_number(const std::weak_ptr<IRoom>& room);
 }
 

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -249,6 +249,7 @@ namespace trview
         /// <param name="selected">Whether the room is selected.</param>
         /// <param name="render_filter">What to render.</param>
         virtual void render_contained(const ICamera& camera, SelectionMode selected, RenderFilter render_filter) = 0;
+        virtual std::weak_ptr<ISector> sector(int32_t x, int32_t z) const = 0;
         /// <summary>
         /// Gets all sectors in the room.
         /// </summary>

--- a/trview.app/Elements/ISector.h
+++ b/trview.app/Elements/ISector.h
@@ -129,7 +129,13 @@ namespace trview
 
         virtual void set_trigger(const std::weak_ptr<ITrigger>& trigger) = 0;
         virtual std::weak_ptr<ITrigger> trigger() const = 0;
+
+        virtual TriangulationDirection ceiling_triangulation_function() const = 0;
     };
 
     bool is_no_space(SectorFlag flags);
+    constexpr std::string to_string(ISector::TriangulationDirection direction);
 }
+
+#include "ISector.hpp"
+

--- a/trview.app/Elements/ISector.h
+++ b/trview.app/Elements/ISector.h
@@ -16,7 +16,7 @@ namespace trview
     struct ISector
     {
         using Source = std::function<std::shared_ptr<ISector>(const trlevel::ILevel&, const trlevel::tr3_room&,
-            const trlevel::tr_room_sector&, int, uint32_t, const IRoom&)>;
+            const trlevel::tr_room_sector&, int, const std::weak_ptr<IRoom>&)>;
 
         enum class TriangulationDirection
         {

--- a/trview.app/Elements/ISector.h
+++ b/trview.app/Elements/ISector.h
@@ -114,7 +114,7 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 corner(Corner corner) const = 0;
         virtual DirectX::SimpleMath::Vector3 ceiling(Corner corner) const = 0;
         virtual std::weak_ptr<IRoom> room() const = 0;
-        virtual TriangulationDirection triangulation_function() const = 0;
+        virtual TriangulationDirection triangulation() const = 0;
         virtual std::vector<Triangle> triangles() const = 0;
         virtual bool is_floor() const = 0;
         virtual bool is_wall() const = 0;
@@ -130,7 +130,7 @@ namespace trview
         virtual void set_trigger(const std::weak_ptr<ITrigger>& trigger) = 0;
         virtual std::weak_ptr<ITrigger> trigger() const = 0;
 
-        virtual TriangulationDirection ceiling_triangulation_function() const = 0;
+        virtual TriangulationDirection ceiling_triangulation() const = 0;
     };
 
     bool is_no_space(SectorFlag flags);

--- a/trview.app/Elements/ISector.h
+++ b/trview.app/Elements/ISector.h
@@ -112,7 +112,7 @@ namespace trview
         virtual std::array<float, 4> ceiling_corners() const = 0;
         virtual DirectX::SimpleMath::Vector3 corner(Corner corner) const = 0;
         virtual DirectX::SimpleMath::Vector3 ceiling(Corner corner) const = 0;
-        virtual uint32_t room() const = 0;
+        virtual std::weak_ptr<IRoom> room() const = 0;
         virtual TriangulationDirection triangulation_function() const = 0;
         virtual std::vector<Triangle> triangles() const = 0;
         virtual bool is_floor() const = 0;

--- a/trview.app/Elements/ISector.h
+++ b/trview.app/Elements/ISector.h
@@ -12,6 +12,7 @@
 namespace trview
 {
     struct IRoom;
+    struct ITrigger;
 
     struct ISector
     {
@@ -105,7 +106,7 @@ namespace trview
         virtual std::uint16_t room_below() const = 0;
         virtual std::uint16_t room_above() const = 0;
         virtual SectorFlag flags() const = 0;
-        virtual TriggerInfo trigger() const = 0;
+        virtual TriggerInfo trigger_info() const = 0;
         virtual uint16_t x() const = 0;
         virtual uint16_t z() const = 0;
         virtual std::array<float, 4> corners() const = 0;
@@ -125,6 +126,9 @@ namespace trview
         virtual void generate_triangles() = 0;
         virtual void add_triangle(const ISector::Portal& portal, const Triangle& triangle, std::unordered_set<uint32_t> visited_rooms) = 0;
         virtual void add_flag(SectorFlag flag) = 0;
+
+        virtual void set_trigger(const std::weak_ptr<ITrigger>& trigger) = 0;
+        virtual std::weak_ptr<ITrigger> trigger() const = 0;
     };
 
     bool is_no_space(SectorFlag flags);

--- a/trview.app/Elements/ISector.h
+++ b/trview.app/Elements/ISector.h
@@ -100,10 +100,10 @@ namespace trview
 
         virtual ~ISector() = 0;
         virtual std::uint16_t portal() const = 0;
-        virtual inline int id() const = 0;
+        virtual int id() const = 0;
         virtual std::set<std::uint16_t> neighbours() const = 0;
-        virtual inline std::uint16_t room_below() const = 0;
-        virtual inline std::uint16_t room_above() const = 0;
+        virtual std::uint16_t room_below() const = 0;
+        virtual std::uint16_t room_above() const = 0;
         virtual SectorFlag flags() const = 0;
         virtual TriggerInfo trigger() const = 0;
         virtual uint16_t x() const = 0;

--- a/trview.app/Elements/ISector.hpp
+++ b/trview.app/Elements/ISector.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace trview
+{
+    constexpr std::string to_string(ISector::TriangulationDirection direction)
+    {
+        switch (direction)
+        {
+        case ISector::TriangulationDirection::NeSw:
+            return "NESW";
+        case ISector::TriangulationDirection::NwSe:
+            return "NWSE";
+        }
+        return "None";
+    }
+}

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -490,14 +490,17 @@ namespace trview
         {
             if (has_flag(sector->flags(), SectorFlag::MonkeySwing) && sector->room_above() != 0xff)
             {
-                auto portal = _rooms[sector->room()]->sector_portal(sector->x(), sector->z(), -1, -1);
-                if (has_flag(portal.sector_above->flags(), SectorFlag::MonkeySwing))
+                if (auto room = sector->room().lock())
                 {
-                    return;
-                }
+                    auto portal = room->sector_portal(sector->x(), sector->z(), -1, -1);
+                    if (has_flag(portal.sector_above->flags(), SectorFlag::MonkeySwing))
+                    {
+                        return;
+                    }
 
-                portal.sector_above->add_flag(SectorFlag::MonkeySwing);
-                add_monkey_swing(portal.sector_above);
+                    portal.sector_above->add_flag(SectorFlag::MonkeySwing);
+                    add_monkey_swing(portal.sector_above);
+                }
             }
         };
 
@@ -506,9 +509,12 @@ namespace trview
         {
             if (has_any_flag(sector->flags(), SectorFlag::ClimbableNorth, SectorFlag::ClimbableSouth, SectorFlag::ClimbableWest, SectorFlag::ClimbableEast) && sector->room_above() != 0xff)
             {
-                auto portal = _rooms[sector->room()]->sector_portal(sector->x(), sector->z(), -1, -1);
-                portal.sector_above->add_flag(sector->flags() & SectorFlag::Climbable);
-                add_ladders(portal.sector_above);
+                if (auto room = sector->room().lock())
+                {
+                    auto portal = room->sector_portal(sector->x(), sector->z(), -1, -1);
+                    portal.sector_above->add_flag(sector->flags() & SectorFlag::Climbable);
+                    add_ladders(portal.sector_above);
+                }
             }
         };
 

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -474,8 +474,10 @@ namespace trview
             {
                 if (has_flag(sector->flags(), SectorFlag::Trigger))
                 {
-                    _triggers.push_back(trigger_source(static_cast<uint32_t>(_triggers.size()), i, sector->x(), sector->z(), sector->trigger(), _version, shared_from_this()));
-                    room->add_trigger(_triggers.back());
+                    auto trigger = trigger_source(static_cast<uint32_t>(_triggers.size()), i, sector->x(), sector->z(), sector->trigger_info(), _version, shared_from_this());
+                    _triggers.push_back(trigger);
+                    sector->set_trigger(trigger);
+                    room->add_trigger(trigger);
                 }
             }
         }

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -458,7 +458,7 @@ namespace trview
         for (auto i = 0u; i < room.sector_list.size(); ++i)
         {
             const trlevel::tr_room_sector &sector = room.sector_list[i];
-            _sectors.push_back(sector_source(level, room, sector, i, _index, *this));
+            _sectors.push_back(sector_source(level, room, sector, i, *this));
         }
     }
 

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -819,6 +819,16 @@ namespace trview
         return (_flags & 0x80);
     }
 
+    std::weak_ptr<ISector> Room::sector(int32_t x, int32_t z) const
+    {
+        const auto id = get_sector_id(x, z);
+        if (id < _sectors.size())
+        {
+            return _sectors[id];
+        }
+        return {};
+    }
+
     const std::vector<std::shared_ptr<ISector>> Room::sectors() const
     {
         return _sectors; 

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -46,6 +46,7 @@ namespace trview
         virtual void add_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual void add_light(const std::weak_ptr<ILight>& light) override;
         virtual void add_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
+        std::weak_ptr<ISector> sector(int32_t x, int32_t z) const override;
         virtual const std::vector<std::shared_ptr<ISector>> sectors() const override;
         virtual void generate_sector_triangles() override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, RenderFilter render_filter) override;

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -26,17 +26,11 @@ namespace trview
     class Room final : public IRoom, public std::enable_shared_from_this<IRoom>
     {
     public:
-        explicit Room(const IMesh::Source& mesh_source,
-            const trlevel::ILevel& level,
-            const trlevel::tr3_room& room,
+        explicit Room(const trlevel::tr3_room& room,
+            const IMesh::Source& mesh_source,
             std::shared_ptr<ILevelTextureStorage> texture_storage,
-            const IMeshStorage& mesh_storage,
             uint32_t index,
-            const std::weak_ptr<ILevel>& parent_level,
-            const Activity& activity,
-            const IStaticMesh::MeshSource& static_mesh_mesh_source,
-            const IStaticMesh::PositionSource& static_mesh_position_source,
-            const ISector::Source& sector_source);
+            const std::weak_ptr<ILevel>& parent_level);
 
         Room(const Room&) = delete;
         Room& operator=(const Room&) = delete;
@@ -88,6 +82,13 @@ namespace trview
         int16_t ambient_intensity_1() const override;
         int16_t ambient_intensity_2() const override;
         int16_t light_mode() const override;
+        void initialise(const trlevel::ILevel& level,
+            const trlevel::tr3_room& room,
+            const IMeshStorage& mesh_storage,
+            const IStaticMesh::MeshSource& static_mesh_mesh_source,
+            const IStaticMesh::PositionSource& static_mesh_position_source,
+            const ISector::Source& sector_source,
+            const Activity& activity);
     private:
         void generate_geometry(const IMesh::Source& mesh_source, const trlevel::tr3_room& room);
         void generate_adjacency();

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -331,7 +331,7 @@ namespace trview
         return _room_ptr;
     }
 
-    ISector::TriangulationDirection Sector::triangulation_function() const
+    ISector::TriangulationDirection Sector::triangulation() const
     {
         return _triangulation_function;
     }
@@ -685,7 +685,7 @@ namespace trview
         return _trigger;
     }
 
-    ISector::TriangulationDirection Sector::ceiling_triangulation_function() const
+    ISector::TriangulationDirection Sector::ceiling_triangulation() const
     {
         return _ceiling_triangulation_function;
     }

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -100,16 +100,16 @@ namespace trview
 
                     // Basic trigger setup 
                     const std::uint16_t setup = command.data[++index];
-                    _trigger.timer = setup & 0xFF;
-                    _trigger.oneshot = (setup & 0x100) >> 8;
-                    _trigger.mask = (setup & 0x3E00) >> 9;
-                    _trigger.sector_id = _sector_id;
+                    _trigger_info.timer = setup & 0xFF;
+                    _trigger_info.oneshot = (setup & 0x100) >> 8;
+                    _trigger_info.mask = (setup & 0x3E00) >> 9;
+                    _trigger_info.sector_id = _sector_id;
 
                     // Type of the trigger, e.g. Pad, Switch, etc.
-                    _trigger.type = static_cast<TriggerType>(subfunction);
+                    _trigger_info.type = static_cast<TriggerType>(subfunction);
 
                     bool continue_processing = true;
-                    if (_trigger.type == TriggerType::Key || _trigger.type == TriggerType::Switch)
+                    if (_trigger_info.type == TriggerType::Key || _trigger_info.type == TriggerType::Switch)
                     {
                         // The next element is the lock or switch - ignore.
                         auto reference = command.data[++index];
@@ -127,7 +127,7 @@ namespace trview
                             {
                                 trigger_command = command.data[index];
                                 auto action = static_cast<TriggerCommandType>((trigger_command & 0x7C00) >> 10);
-                                _trigger.commands.emplace_back(action, static_cast<uint16_t>(trigger_command & 0x3FF));
+                                _trigger_info.commands.emplace_back(action, static_cast<uint16_t>(trigger_command & 0x3FF));
                                 if (action == TriggerCommandType::Camera || action == TriggerCommandType::Flyby)
                                 {
                                     // Camera has another uint16_t - skip for now.
@@ -209,9 +209,9 @@ namespace trview
         return _flags;
     }
 
-    TriggerInfo Sector::trigger() const
+    TriggerInfo Sector::trigger_info() const
     {
-        return _trigger;
+        return _trigger_info;
     }
 
     uint16_t Sector::x() const
@@ -673,6 +673,16 @@ namespace trview
     void Sector::add_flag(SectorFlag flag)
     {
         _flags |= flag;
+    }
+
+    void Sector::set_trigger(const std::weak_ptr<ITrigger>& trigger)
+    {
+        _trigger = trigger;
+    }
+
+    std::weak_ptr<ITrigger> Sector::trigger() const
+    {
+        return _trigger;
     }
 
     Triangulation parse_triangulation(uint16_t floor, uint16_t data)

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -7,7 +7,7 @@ using namespace DirectX::SimpleMath;
 
 namespace trview
 {
-    Sector::Sector(const trlevel::ILevel &level, const trlevel::tr3_room& room, const trlevel::tr_room_sector &sector, int sector_id, uint32_t room_number, const IRoom& room_ptr)
+    Sector::Sector(const trlevel::ILevel &level, const trlevel::tr3_room& room, const trlevel::tr_room_sector &sector, int sector_id, uint32_t room_number, const std::weak_ptr<IRoom>& room_ptr)
         : _sector(sector), _sector_id(static_cast<uint16_t>(sector_id)), _room_above(sector.room_above), _room_below(sector.room_below), _room(room_number), _info(room.info), _room_ptr(room_ptr),
         _floordata_index(sector.floordata_index)
     {
@@ -326,9 +326,9 @@ namespace trview
         return Vector3::Zero;
     }
 
-    uint32_t Sector::room() const
+    std::weak_ptr<IRoom> Sector::room() const
     {
-        return _room;
+        return _room_ptr;
     }
 
     ISector::TriangulationDirection Sector::triangulation_function() const
@@ -404,11 +404,17 @@ namespace trview
     {
         auto& tris = _triangles;
 
-        const auto self = _room_ptr.sector_portal(_x, _z, _x, _z);
-        const auto north = _room_ptr.sector_portal(_x, _z, _x, _z + 1);
-        const auto south = _room_ptr.sector_portal(_x, _z, _x, _z - 1);
-        const auto east = _room_ptr.sector_portal(_x, _z, _x + 1, _z);
-        const auto west = _room_ptr.sector_portal(_x, _z, _x - 1, _z);
+        auto room = _room_ptr.lock();
+        if (!room)
+        {
+            return;
+        }
+
+        const auto self = room->sector_portal(_x, _z, _x, _z);
+        const auto north = room->sector_portal(_x, _z, _x, _z + 1);
+        const auto south = room->sector_portal(_x, _z, _x, _z - 1);
+        const auto east = room->sector_portal(_x, _z, _x + 1, _z);
+        const auto west = room->sector_portal(_x, _z, _x - 1, _z);
 
         const SectorFlag ceiling_flags = _flags & ~(SectorFlag::Death | SectorFlag::Climbable);
         const SectorFlag floor_flags = _flags & ~(SectorFlag::MonkeySwing | SectorFlag::Climbable);
@@ -584,21 +590,24 @@ namespace trview
 
             add_triangle(tri);
 
-            if (portal.sector_above && 
-                visited_rooms.find(portal.sector_above->room()) == visited_rooms.end())
+            if (portal.sector_above)
             {
-                Triangle offcut = triangle;
-                offcut.uv0.y = offcut.v0.y = std::min(offcut.v0.y, portal.direct_room->y_top());
-                offcut.uv1.y = offcut.v1.y = std::min(offcut.v1.y, portal.direct_room->y_top());
-                offcut.uv2.y = offcut.v2.y = std::min(offcut.v2.y, portal.direct_room->y_top());
+                auto above = portal.sector_above->room().lock();
+                if (visited_rooms.find(above->number()) == visited_rooms.end())
+                {
+                    Triangle offcut = triangle;
+                    offcut.uv0.y = offcut.v0.y = std::min(offcut.v0.y, portal.direct_room->y_top());
+                    offcut.uv1.y = offcut.v1.y = std::min(offcut.v1.y, portal.direct_room->y_top());
+                    offcut.uv2.y = offcut.v2.y = std::min(offcut.v2.y, portal.direct_room->y_top());
 
-                offcut.v0 -= portal.above_offset;
-                offcut.v1 -= portal.above_offset;
-                offcut.v2 -= portal.above_offset;
+                    offcut.v0 -= portal.above_offset;
+                    offcut.v1 -= portal.above_offset;
+                    offcut.v2 -= portal.above_offset;
 
-                auto above_portal = portal.room_above->sector_portal(portal.sector_above->x(), portal.sector_above->z(),
-                    portal.sector_above->x(), portal.sector_above->z());
-                portal.sector_above->add_triangle(above_portal, offcut, visited_rooms);
+                    auto above_portal = portal.room_above->sector_portal(portal.sector_above->x(), portal.sector_above->z(),
+                        portal.sector_above->x(), portal.sector_above->z());
+                    portal.sector_above->add_triangle(above_portal, offcut, visited_rooms);
+                }
             }
         }
         else if (triangle.v0.y > portal.direct_room->y_bottom() ||

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -685,6 +685,11 @@ namespace trview
         return _trigger;
     }
 
+    ISector::TriangulationDirection Sector::ceiling_triangulation_function() const
+    {
+        return _ceiling_triangulation_function;
+    }
+
     Triangulation parse_triangulation(uint16_t floor, uint16_t data)
     {
         // Not sure what to do with h1 and h2 values yet.

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -7,8 +7,8 @@ using namespace DirectX::SimpleMath;
 
 namespace trview
 {
-    Sector::Sector(const trlevel::ILevel &level, const trlevel::tr3_room& room, const trlevel::tr_room_sector &sector, int sector_id, uint32_t room_number, const std::weak_ptr<IRoom>& room_ptr)
-        : _sector(sector), _sector_id(static_cast<uint16_t>(sector_id)), _room_above(sector.room_above), _room_below(sector.room_below), _room(room_number), _info(room.info), _room_ptr(room_ptr),
+    Sector::Sector(const trlevel::ILevel& level, const trlevel::tr3_room& room, const trlevel::tr_room_sector& sector, int sector_id, const std::weak_ptr<IRoom>& room_ptr)
+        : _sector(sector), _sector_id(static_cast<uint16_t>(sector_id)), _room_above(sector.room_above), _room_below(sector.room_below), _room(room_number(room_ptr)), _info(room.info), _room_ptr(room_ptr),
         _floordata_index(sector.floordata_index)
     {
         _x = static_cast<int16_t>(sector_id / room.num_z_sectors);

--- a/trview.app/Elements/Sector.h
+++ b/trview.app/Elements/Sector.h
@@ -35,7 +35,7 @@ namespace trview
         // Holds "Function" enum bitwise values 
         virtual SectorFlag flags() const override;
         /// Get trigger information for the sector.
-        virtual TriggerInfo trigger() const override;
+        virtual TriggerInfo trigger_info() const override;
         virtual uint16_t x() const override;
         virtual uint16_t z() const override;
         virtual std::array<float, 4> corners() const override;
@@ -54,6 +54,8 @@ namespace trview
         virtual void generate_triangles() override;
         virtual void add_triangle(const ISector::Portal& portal, const Triangle& triangle, std::unordered_set<uint32_t> visited_rooms) override;
         virtual void add_flag(SectorFlag flag) override;
+        void set_trigger(const std::weak_ptr<ITrigger>& trigger) override;
+        std::weak_ptr<ITrigger> trigger() const override;
     private:
         bool parse(const trlevel::ILevel& level);
         void parse_slope();
@@ -74,7 +76,8 @@ namespace trview
         std::uint16_t _floor_slant{ 0 }, _ceiling_slant{ 0 };
 
         // Holds trigger data 
-        TriggerInfo _trigger;
+        TriggerInfo _trigger_info;
+        std::weak_ptr<ITrigger> _trigger;
 
         // ID of the sector 
         uint16_t _sector_id; 

--- a/trview.app/Elements/Sector.h
+++ b/trview.app/Elements/Sector.h
@@ -20,7 +20,7 @@ namespace trview
     {
     public:
         // Constructs sector object and parses floor data automatically 
-        Sector(const trlevel::ILevel &level, const trlevel::tr3_room& room, const trlevel::tr_room_sector &sector, int sector_id, uint32_t room_number, const IRoom& room_ptr);
+        Sector(const trlevel::ILevel &level, const trlevel::tr3_room& room, const trlevel::tr_room_sector &sector, int sector_id, uint32_t room_number, const std::weak_ptr<IRoom>& room_ptr);
         virtual ~Sector() = default;
         // Returns the id of the room that this floor data points to 
         virtual std::uint16_t portal() const override;
@@ -42,7 +42,7 @@ namespace trview
         virtual std::array<float, 4> ceiling_corners() const override;
         virtual DirectX::SimpleMath::Vector3 corner(Corner corner) const override;
         virtual DirectX::SimpleMath::Vector3 ceiling(Corner corner) const override;
-        virtual uint32_t room() const override;
+        std::weak_ptr<IRoom> room() const override;
         virtual TriangulationDirection triangulation_function() const override;
         virtual std::vector<Triangle> triangles() const override;
         virtual uint32_t floordata_index() const override;
@@ -93,6 +93,7 @@ namespace trview
         std::array<float, 4> _ceiling_corners;
 
         uint32_t _room;
+        std::weak_ptr<IRoom> _room_ptr;
 
         std::optional<Triangulation> _floor_triangulation;
         TriangulationDirection _triangulation_function{ TriangulationDirection::NwSe };
@@ -104,7 +105,6 @@ namespace trview
         uint32_t _floordata_index;
         trlevel::tr_room_info _info;
         std::vector<Triangle> _triangles;
-        const IRoom& _room_ptr;
     };
 
     /// <summary>

--- a/trview.app/Elements/Sector.h
+++ b/trview.app/Elements/Sector.h
@@ -56,6 +56,7 @@ namespace trview
         virtual void add_flag(SectorFlag flag) override;
         void set_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         std::weak_ptr<ITrigger> trigger() const override;
+        TriangulationDirection ceiling_triangulation_function() const override;
     private:
         bool parse(const trlevel::ILevel& level);
         void parse_slope();
@@ -99,9 +100,9 @@ namespace trview
         std::weak_ptr<IRoom> _room_ptr;
 
         std::optional<Triangulation> _floor_triangulation;
-        TriangulationDirection _triangulation_function{ TriangulationDirection::NwSe };
+        TriangulationDirection _triangulation_function{ TriangulationDirection::None };
         std::optional<Triangulation> _ceiling_triangulation;
-        TriangulationDirection _ceiling_triangulation_function{ TriangulationDirection::NwSe };
+        TriangulationDirection _ceiling_triangulation_function{ TriangulationDirection::None };
 
         std::set<uint16_t> _neighbours;
 

--- a/trview.app/Elements/Sector.h
+++ b/trview.app/Elements/Sector.h
@@ -43,7 +43,7 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 corner(Corner corner) const override;
         virtual DirectX::SimpleMath::Vector3 ceiling(Corner corner) const override;
         std::weak_ptr<IRoom> room() const override;
-        virtual TriangulationDirection triangulation_function() const override;
+        virtual TriangulationDirection triangulation() const override;
         virtual std::vector<Triangle> triangles() const override;
         virtual uint32_t floordata_index() const override;
         /// Determines whether this is a walkable floor.
@@ -56,7 +56,7 @@ namespace trview
         virtual void add_flag(SectorFlag flag) override;
         void set_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         std::weak_ptr<ITrigger> trigger() const override;
-        TriangulationDirection ceiling_triangulation_function() const override;
+        TriangulationDirection ceiling_triangulation() const override;
     private:
         bool parse(const trlevel::ILevel& level);
         void parse_slope();

--- a/trview.app/Elements/Sector.h
+++ b/trview.app/Elements/Sector.h
@@ -20,7 +20,7 @@ namespace trview
     {
     public:
         // Constructs sector object and parses floor data automatically 
-        Sector(const trlevel::ILevel &level, const trlevel::tr3_room& room, const trlevel::tr_room_sector &sector, int sector_id, uint32_t room_number, const std::weak_ptr<IRoom>& room_ptr);
+        Sector(const trlevel::ILevel& level, const trlevel::tr3_room& room, const trlevel::tr_room_sector& sector, int sector_id, const std::weak_ptr<IRoom>& room_ptr);
         virtual ~Sector() = default;
         // Returns the id of the room that this floor data points to 
         virtual std::uint16_t portal() const override;

--- a/trview.app/Lua/Elements/Room/Lua_Room.cpp
+++ b/trview.app/Lua/Elements/Room/Lua_Room.cpp
@@ -16,6 +16,25 @@ namespace trview
         {
             std::unordered_map<IRoom**, std::shared_ptr<IRoom>> rooms;
 
+            int get_sector(lua_State* L)
+            {
+                auto room = lua::get_self<IRoom>(L);
+
+                auto x = lua_tointeger(L, 2) - 1;
+                auto z = lua_tointeger(L, 3) - 1;
+
+                auto sectors = room->sectors();
+                auto id = x * room->num_z_sectors() + z;
+
+                if (id >= 0 && id < std::ssize(sectors))
+                {
+                    return create_sector(L, sectors[id]);
+                }
+
+                lua_pushnil(L);
+                return 1;
+            }
+
             int room_index(lua_State* L)
             {
                 auto room = lua::get_self<IRoom>(L);
@@ -69,6 +88,11 @@ namespace trview
                 else if (key == "num_z_sectors")
                 {
                     lua_pushinteger(L, room->num_z_sectors());
+                    return 1;
+                }
+                else if (key == "sector")
+                {
+                    lua_pushcfunction(L, get_sector);
                     return 1;
                 }
                 else if (key == "sectors")

--- a/trview.app/Lua/Elements/Room/Lua_Room.cpp
+++ b/trview.app/Lua/Elements/Room/Lua_Room.cpp
@@ -61,6 +61,16 @@ namespace trview
                     lua_pushinteger(L, room->number());
                     return 1;
                 }
+                else if (key == "num_x_sectors")
+                {
+                    lua_pushinteger(L, room->num_x_sectors());
+                    return 1;
+                }
+                else if (key == "num_z_sectors")
+                {
+                    lua_pushinteger(L, room->num_z_sectors());
+                    return 1;
+                }
                 else if (key == "sectors")
                 {
                     return push_list(L, room->sectors(), create_sector);

--- a/trview.app/Lua/Elements/Room/Lua_Room.cpp
+++ b/trview.app/Lua/Elements/Room/Lua_Room.cpp
@@ -18,21 +18,10 @@ namespace trview
 
             int get_sector(lua_State* L)
             {
-                auto room = lua::get_self<IRoom>(L);
-
-                auto x = lua_tointeger(L, 2) - 1;
-                auto z = lua_tointeger(L, 3) - 1;
-
-                auto sectors = room->sectors();
-                auto id = x * room->num_z_sectors() + z;
-
-                if (id >= 0 && id < std::ssize(sectors))
-                {
-                    return create_sector(L, sectors[id]);
-                }
-
-                lua_pushnil(L);
-                return 1;
+                const auto room = lua::get_self<IRoom>(L);
+                const auto x = static_cast<int32_t>(lua_tointeger(L, 2) - 1);
+                const auto z = static_cast<int32_t>(lua_tointeger(L, 3) - 1);
+                return create_sector(L, room->sector(x, z).lock());
             }
 
             int room_index(lua_State* L)

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -59,6 +59,34 @@ namespace trview
                     lua_pushnil(L);
                     return 1;
                 }
+                else if (key == "ceiling_corners")
+                {
+                    lua_newtable(L);
+                    const auto ceilings = sector->ceiling_corners();
+                    lua_pushinteger(L, static_cast<int>(ceilings[0] * trlevel::Scale));
+                    lua_rawseti(L, -2, 1);
+                    lua_pushinteger(L, static_cast<int>(ceilings[1] * trlevel::Scale));
+                    lua_rawseti(L, -2, 2);
+                    lua_pushinteger(L, static_cast<int>(ceilings[2] * trlevel::Scale));
+                    lua_rawseti(L, -2, 3);
+                    lua_pushinteger(L, static_cast<int>(ceilings[3] * trlevel::Scale));
+                    lua_rawseti(L, -2, 4);
+                    return 1;
+                }
+                else if (key == "corners")
+                {
+                    lua_newtable(L);
+                    const auto corners = sector->corners();
+                    lua_pushinteger(L, static_cast<int>(corners[0] * trlevel::Scale));
+                    lua_rawseti(L, -2, 1);
+                    lua_pushinteger(L, static_cast<int>(corners[1] * trlevel::Scale));
+                    lua_rawseti(L, -2, 2);
+                    lua_pushinteger(L, static_cast<int>(corners[2] * trlevel::Scale));
+                    lua_rawseti(L, -2, 3);
+                    lua_pushinteger(L, static_cast<int>(corners[3] * trlevel::Scale));
+                    lua_rawseti(L, -2, 4);
+                    return 1;
+                }
                 else if (key == "flags")
                 {
                     lua_pushinteger(L, static_cast<int>(sector->flags()));

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -64,11 +64,6 @@ namespace trview
                     lua_pushinteger(L, static_cast<int>(sector->flags()));
                     return 1;
                 }
-                else if (key == "floordata")
-                {
-                    lua_pushnil(L);
-                    return 1;
-                }
                 else if (key == "has_flag")
                 {
                     lua_pushcfunction(L, sector_hasflag);

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -2,6 +2,7 @@
 #include "../../../Elements/ILevel.h"
 #include "../Item/Lua_Item.h"
 #include "../Trigger/Lua_Trigger.h"
+#include "../Room/Lua_Room.h"
 #include "../../Lua.h"
 
 namespace trview
@@ -21,6 +22,10 @@ namespace trview
                 {
                     lua_pushinteger(L, sector->id());
                     return 1;
+                }
+                else if (key == "room")
+                {
+                    create_room(L, sector->room());
                 }
                 else if (key == "x")
                 {

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -106,6 +106,11 @@ namespace trview
                     lua_rawseti(L, -2, 4);
                     return 1;
                 }
+                else if (key == "ceiling_triangulation")
+                {
+                    lua_pushstring(L, to_string(sector->ceiling_triangulation_function()).c_str());
+                    return 1;
+                }
                 else if (key == "corners")
                 {
                     lua_newtable(L);
@@ -152,6 +157,11 @@ namespace trview
                 else if (key == "room")
                 {
                     return create_room(L, sector->room().lock());
+                }
+                else if (key == "triangulation")
+                {
+                    lua_pushstring(L, to_string(sector->triangulation_function()).c_str());
+                    return 1;
                 }
                 else if (key == "trigger")
                 {

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -108,7 +108,7 @@ namespace trview
                 }
                 else if (key == "ceiling_triangulation")
                 {
-                    lua_pushstring(L, to_string(sector->ceiling_triangulation_function()).c_str());
+                    lua_pushstring(L, to_string(sector->ceiling_triangulation()).c_str());
                     return 1;
                 }
                 else if (key == "corners")
@@ -160,7 +160,7 @@ namespace trview
                 }
                 else if (key == "triangulation")
                 {
-                    lua_pushstring(L, to_string(sector->triangulation_function()).c_str());
+                    lua_pushstring(L, to_string(sector->triangulation()).c_str());
                     return 1;
                 }
                 else if (key == "trigger")

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -14,7 +14,7 @@ namespace trview
         {
             std::unordered_map<ISector**, std::shared_ptr<ISector>> sectors;
 
-            std::array<int, 4> to_clicks(ISector* sector, const std::array<float, 4>& corners)
+            std::array<int, 4> to_corner_clicks(ISector* sector, const std::array<float, 4>& corners)
             {
                 float base = 0;
                 if (auto room = sector->room().lock())
@@ -27,6 +27,22 @@ namespace trview
                     static_cast<int>((corners[1] - base) / -0.25f),
                     static_cast<int>((corners[2] - base) / -0.25f),
                     static_cast<int>((corners[3] - base) / -0.25f )
+                };
+            }
+
+            std::array<int, 4> to_ceiling_corner_clicks(ISector* sector, const std::array<float, 4>& corners)
+            {
+                float base = 0;
+                if (auto room = sector->room().lock())
+                {
+                    base = room->info().yTop / trlevel::Scale;
+                }
+                return
+                {
+                    static_cast<int>((corners[0] - base) / 0.25f),
+                    static_cast<int>((corners[1] - base) / 0.25f),
+                    static_cast<int>((corners[2] - base) / 0.25f),
+                    static_cast<int>((corners[3] - base) / 0.25f)
                 };
             }
 
@@ -79,21 +95,21 @@ namespace trview
                 else if (key == "ceiling_corners")
                 {
                     lua_newtable(L);
-                    const auto ceilings = sector->ceiling_corners();
-                    lua_pushinteger(L, static_cast<int>(ceilings[0] * trlevel::Scale));
+                    const auto corners = to_ceiling_corner_clicks(sector, sector->ceiling_corners());
+                    lua_pushinteger(L, corners[0]);
                     lua_rawseti(L, -2, 1);
-                    lua_pushinteger(L, static_cast<int>(ceilings[1] * trlevel::Scale));
+                    lua_pushinteger(L, corners[1]);
                     lua_rawseti(L, -2, 2);
-                    lua_pushinteger(L, static_cast<int>(ceilings[2] * trlevel::Scale));
+                    lua_pushinteger(L, corners[2]);
                     lua_rawseti(L, -2, 3);
-                    lua_pushinteger(L, static_cast<int>(ceilings[3] * trlevel::Scale));
+                    lua_pushinteger(L, corners[3]);
                     lua_rawseti(L, -2, 4);
                     return 1;
                 }
                 else if (key == "corners")
                 {
                     lua_newtable(L);
-                    const auto corners = to_clicks(sector, sector->corners());
+                    const auto corners = to_corner_clicks(sector, sector->corners());
                     lua_pushinteger(L, corners[0]);
                     lua_rawseti(L, -2, 1);
                     lua_pushinteger(L, corners[1]);

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -71,8 +71,7 @@ namespace trview
                 }
                 else if (key == "trigger")
                 {
-                    // TODO: Trigger
-                    lua_pushnil(L);
+                    return create_trigger(L, sector->trigger().lock());
                 }
                 else if (key == "x")
                 {

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -4,6 +4,7 @@
 #include "../Trigger/Lua_Trigger.h"
 #include "../Room/Lua_Room.h"
 #include "../../Lua.h"
+#include <trview.common/Algorithms.h>
 
 namespace trview
 {
@@ -12,6 +13,22 @@ namespace trview
         namespace
         {
             std::unordered_map<ISector**, std::shared_ptr<ISector>> sectors;
+
+            std::array<int, 4> to_clicks(ISector* sector, const std::array<float, 4>& corners)
+            {
+                float base = 0;
+                if (auto room = sector->room().lock())
+                {
+                    base = room->info().yBottom / trlevel::Scale;
+                }
+                return
+                {
+                    static_cast<int>((corners[0] - base) / -0.25f),
+                    static_cast<int>((corners[1] - base) / -0.25f),
+                    static_cast<int>((corners[2] - base) / -0.25f),
+                    static_cast<int>((corners[3] - base) / -0.25f )
+                };
+            }
 
             int sector_hasflag(lua_State* L)
             {
@@ -76,14 +93,14 @@ namespace trview
                 else if (key == "corners")
                 {
                     lua_newtable(L);
-                    const auto corners = sector->corners();
-                    lua_pushinteger(L, static_cast<int>(corners[0] * trlevel::Scale));
+                    const auto corners = to_clicks(sector, sector->corners());
+                    lua_pushinteger(L, corners[0]);
                     lua_rawseti(L, -2, 1);
-                    lua_pushinteger(L, static_cast<int>(corners[1] * trlevel::Scale));
+                    lua_pushinteger(L, corners[1]);
                     lua_rawseti(L, -2, 2);
-                    lua_pushinteger(L, static_cast<int>(corners[2] * trlevel::Scale));
+                    lua_pushinteger(L, corners[2]);
                     lua_rawseti(L, -2, 3);
-                    lua_pushinteger(L, static_cast<int>(corners[3] * trlevel::Scale));
+                    lua_pushinteger(L, corners[3]);
                     lua_rawseti(L, -2, 4);
                     return 1;
                 }

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -13,12 +13,37 @@ namespace trview
         {
             std::unordered_map<ISector**, std::shared_ptr<ISector>> sectors;
 
+            int sector_hasflag(lua_State* L)
+            {
+                auto sector = lua::get_self<ISector>(L);
+
+                luaL_checktype(L, -1, LUA_TNUMBER);
+                long long flags = lua_tointeger(L, -1);
+
+                return static_cast<long long>(sector->flags()) & flags;
+            }
+
             int sector_index(lua_State* L)
             {
                 auto sector = lua::get_self<ISector>(L);
 
                 const std::string key = lua_tostring(L, 2);
-                if (key == "number")
+                if (key == "flags")
+                {
+                    lua_pushinteger(L, static_cast<int>(sector->flags()));
+                    return 1;
+                }
+                else if (key == "floordata")
+                {
+                    lua_pushnil(L);
+                    return 1;
+                }
+                else if (key == "has_flag")
+                {
+                    lua_pushcfunction(L, sector_hasflag);
+                    return 1;
+                }
+                else if (key == "number")
                 {
                     lua_pushinteger(L, sector->id());
                     return 1;
@@ -124,6 +149,33 @@ namespace trview
             lua_setfield(L, -2, "__gc");
             lua_setmetatable(L, -2);
             return 1;
+        }
+
+        void sector_register(lua_State* L)
+        {
+            lua_newtable(L);
+            create_enum<SectorFlag>(L, "Flags", 
+            {
+                { "None", SectorFlag::None },
+                { "Portal", SectorFlag::Portal },
+                { "Wall", SectorFlag::Wall },
+                { "Trigger", SectorFlag::Trigger },
+                { "Death", SectorFlag::Death },
+                { "FloorSlant", SectorFlag::FloorSlant },
+                { "CeilingSlant", SectorFlag::CeilingSlant },
+                { "ClimbableNorth", SectorFlag::ClimbableNorth },
+                { "ClimbableEast", SectorFlag::ClimbableEast },
+                { "ClimbableSouth", SectorFlag::ClimbableSouth },
+                { "ClimbableWest", SectorFlag::ClimbableWest },
+                { "MonkeySwing", SectorFlag::MonkeySwing },
+                { "RoomAbove", SectorFlag::RoomAbove },
+                { "RoomBelow", SectorFlag::RoomBelow },
+                { "MinecartLeft", SectorFlag::MinecartLeft },
+                { "MinecartRight", SectorFlag::MinecartRight },
+                { "SpecialWall", SectorFlag::SpecialWall },
+                { "Climbable", SectorFlag::Climbable }
+            });
+            lua_setglobal(L, "Sector");
         }
     }
 }

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -25,7 +25,7 @@ namespace trview
                 }
                 else if (key == "room")
                 {
-                    create_room(L, sector->room());
+                    create_room(L, sector->room().lock());
                 }
                 else if (key == "x")
                 {

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -20,7 +20,8 @@ namespace trview
                 luaL_checktype(L, -1, LUA_TNUMBER);
                 long long flags = lua_tointeger(L, -1);
 
-                return static_cast<long long>(sector->flags()) & flags;
+                lua_pushboolean(L, static_cast<long long>(sector->flags()) & flags);
+                return 1;
             }
 
             int sector_index(lua_State* L)
@@ -28,7 +29,37 @@ namespace trview
                 auto sector = lua::get_self<ISector>(L);
 
                 const std::string key = lua_tostring(L, 2);
-                if (key == "flags")
+                if (key == "above")
+                {
+                    if (sector->room_above() != 0xff)
+                    {
+                        if (auto room = sector->room().lock())
+                        {
+                            if (auto level = room->level().lock())
+                            {
+                                return create_room(L, level->room(sector->room_above()).lock());
+                            }
+                        }
+                    }
+                    lua_pushnil(L);
+                    return 1;
+                }
+                else if (key == "below")
+                {
+                    if (sector->room_below() != 0xff)
+                    {
+                        if (auto room = sector->room().lock())
+                        {
+                            if (auto level = room->level().lock())
+                            {
+                                return create_room(L, level->room(sector->room_below()).lock());
+                            }
+                        }
+                    }
+                    lua_pushnil(L);
+                    return 1;
+                }
+                else if (key == "flags")
                 {
                     lua_pushinteger(L, static_cast<int>(sector->flags()));
                     return 1;
@@ -65,34 +96,6 @@ namespace trview
                 else if (key == "room")
                 {
                     return create_room(L, sector->room().lock());
-                }
-                else if (key == "room_above")
-                {
-                    if (sector->room_above() != 0xff)
-                    {
-                        if (auto room = sector->room().lock())
-                        {
-                            if (auto level = room->level().lock())
-                            {
-                                return create_room(L, level->room(sector->room_above()).lock());
-                            }
-                        }
-                    }
-                    lua_pushnil(L);
-                }
-                else if (key == "room_below")
-                {
-                    if (sector->room_below() != 0xff)
-                    {
-                        if (auto room = sector->room().lock())
-                        {
-                            if (auto level = room->level().lock())
-                            {
-                                return create_room(L, level->room(sector->room_below()).lock());
-                            }
-                        }
-                    }
-                    lua_pushnil(L);
                 }
                 else if (key == "trigger")
                 {

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -23,9 +23,56 @@ namespace trview
                     lua_pushinteger(L, sector->id());
                     return 1;
                 }
+                else if (key == "portal")
+                {
+                    if (sector->is_portal())
+                    {
+                        if (auto room = sector->room().lock())
+                        {
+                            if (auto level = room->level().lock())
+                            {
+                                return create_room(L, level->room(sector->portal()).lock());
+                            }
+                        }
+                    }
+                    lua_pushnil(L);
+                }
                 else if (key == "room")
                 {
-                    create_room(L, sector->room().lock());
+                    return create_room(L, sector->room().lock());
+                }
+                else if (key == "room_above")
+                {
+                    if (sector->room_above() != 0xff)
+                    {
+                        if (auto room = sector->room().lock())
+                        {
+                            if (auto level = room->level().lock())
+                            {
+                                return create_room(L, level->room(sector->room_above()).lock());
+                            }
+                        }
+                    }
+                    lua_pushnil(L);
+                }
+                else if (key == "room_below")
+                {
+                    if (sector->room_below() != 0xff)
+                    {
+                        if (auto room = sector->room().lock())
+                        {
+                            if (auto level = room->level().lock())
+                            {
+                                return create_room(L, level->room(sector->room_below()).lock());
+                            }
+                        }
+                    }
+                    lua_pushnil(L);
+                }
+                else if (key == "trigger")
+                {
+                    // TODO: Trigger
+                    lua_pushnil(L);
                 }
                 else if (key == "x")
                 {

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -22,6 +22,16 @@ namespace trview
                     lua_pushinteger(L, sector->id());
                     return 1;
                 }
+                else if (key == "x")
+                {
+                    lua_pushinteger(L, sector->x());
+                    return 1;
+                }
+                else if (key == "z")
+                {
+                    lua_pushinteger(L, sector->z());
+                    return 1;
+                }
 
                 return 0;
             }

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.h
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.h
@@ -9,5 +9,6 @@ namespace trview
     namespace lua
     {
         int create_sector(lua_State* L, std::shared_ptr<ISector> sector);
+        void sector_register(lua_State* L);
     }
 }

--- a/trview.app/Lua/Elements/Trigger/Lua_Trigger.cpp
+++ b/trview.app/Lua/Elements/Trigger/Lua_Trigger.cpp
@@ -122,12 +122,12 @@ namespace trview
             }
         }
 
-        void create_trigger(lua_State* L, const std::shared_ptr<ITrigger>& trigger)
+        int create_trigger(lua_State* L, const std::shared_ptr<ITrigger>& trigger)
         {
             if (!trigger)
             {
                 lua_pushnil(L);
-                return;
+                return 1;
             }
 
             ITrigger** userdata = static_cast<ITrigger**>(lua_newuserdata(L, sizeof(trigger.get())));
@@ -142,6 +142,7 @@ namespace trview
             lua_pushcfunction(L, trigger_gc);
             lua_setfield(L, -2, "__gc");
             lua_setmetatable(L, -2);
+            return 1;
         }
     }
 }

--- a/trview.app/Lua/Elements/Trigger/Lua_Trigger.h
+++ b/trview.app/Lua/Elements/Trigger/Lua_Trigger.h
@@ -8,6 +8,6 @@ namespace trview
 
     namespace lua
     {
-        void create_trigger(lua_State* L, const std::shared_ptr<ITrigger>& trigger);
+        int create_trigger(lua_State* L, const std::shared_ptr<ITrigger>& trigger);
     }
 }

--- a/trview.app/Lua/Lua.h
+++ b/trview.app/Lua/Lua.h
@@ -34,6 +34,19 @@ namespace trview
 
         template <typename T>
         T* get_self(lua_State* L);
+
+        template <typename T>
+        struct EnumValue
+        {
+            std::string name;
+            T value;
+        };
+
+        template <typename T>
+        void set_enum_value(lua_State* L, const EnumValue<T>& value);
+        
+        template <typename T>
+        void create_enum(lua_State* L, const std::string& name, const std::vector<EnumValue<T>>& values);
     }
 }
 

--- a/trview.app/Lua/Lua.inl
+++ b/trview.app/Lua/Lua.inl
@@ -40,5 +40,23 @@ namespace trview
             luaL_checktype(L, 1, LUA_TUSERDATA);
             return *static_cast<T**>(lua_touserdata(L, 1));
         }
+
+        template <typename T>
+        void set_enum_value(lua_State* L, const EnumValue<T>& value)
+        {
+            lua_pushinteger(L, static_cast<int>(value.value));
+            lua_setfield(L, -2, value.name.c_str());
+        }
+
+        template <typename T>
+        void create_enum(lua_State* L, const std::string& name, const std::vector<EnumValue<T>>& values)
+        {
+            lua_newtable(L);
+            for (const auto& v : values)
+            {
+                set_enum_value(L, v);
+            }
+            lua_setfield(L, -2, name.c_str());
+        }
     }
 }

--- a/trview.app/Lua/trview/trview.cpp
+++ b/trview.app/Lua/trview/trview.cpp
@@ -3,6 +3,7 @@
 #include "../../Application.h"
 #include <trlevel/LevelEncryptedException.h>
 #include "../../UserCancelledException.h"
+#include "../Elements/Sector/Lua_Sector.h"
 
 namespace trview
 {
@@ -92,6 +93,8 @@ namespace trview
             lua_setfield(L, -2, "__newindex");
             lua_setmetatable(L, -2);
             lua_setglobal(L, "trview");
+
+            sector_register(L);
         }
     }
 }

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -40,6 +40,7 @@ namespace trview
             MOCK_METHOD(void, render_lights, (const ICamera&, const std::weak_ptr<ILight>&), (override));
             MOCK_METHOD(void, render_camera_sinks, (const ICamera&), (override));
             MOCK_METHOD(void, render_contained, (const ICamera&, SelectionMode, RenderFilter), (override));;
+            MOCK_METHOD(std::weak_ptr<ISector>, sector, (int32_t, int32_t), (const, override));
             MOCK_METHOD(const std::vector<std::shared_ptr<ISector>>, sectors, (), (const, override));
             MOCK_METHOD(void, set_is_alternate, (int16_t), (override));
             MOCK_METHOD(std::weak_ptr<ITrigger>, trigger_at, (int32_t, int32_t), (const, override));

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -66,6 +66,18 @@ namespace trview
                 return shared_from_this();
             }
 
+            std::shared_ptr<MockRoom> with_num_x_sectors(uint16_t number)
+            {
+                ON_CALL(*this, num_x_sectors).WillByDefault(testing::Return(number));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockRoom> with_num_z_sectors(uint16_t number)
+            {
+                ON_CALL(*this, num_z_sectors).WillByDefault(testing::Return(number));
+                return shared_from_this();
+            }
+
             std::shared_ptr<MockRoom> with_alternate_group(int16_t group)
             {
                 ON_CALL(*this, alternate_group).WillByDefault(testing::Return(group));

--- a/trview.app/Mocks/Elements/ISector.h
+++ b/trview.app/Mocks/Elements/ISector.h
@@ -25,7 +25,7 @@ namespace trview
             MOCK_METHOD((DirectX::SimpleMath::Vector3), corner, (Corner), (const, override));
             MOCK_METHOD((DirectX::SimpleMath::Vector3), ceiling, (Corner), (const, override));
             MOCK_METHOD(std::weak_ptr<IRoom>, room, (), (const, override));
-            MOCK_METHOD(TriangulationDirection, triangulation_function, (), (const, override));
+            MOCK_METHOD(TriangulationDirection, triangulation, (), (const, override));
             MOCK_METHOD(std::vector<Triangle>, triangles, (), (const, override));
             MOCK_METHOD(bool, is_floor, (), (const, override));
             MOCK_METHOD(bool, is_wall, (), (const, override));
@@ -37,7 +37,13 @@ namespace trview
             MOCK_METHOD(void, add_flag, (SectorFlag), (override));
             MOCK_METHOD(void, set_trigger, (const std::weak_ptr<ITrigger>&), (override));
             MOCK_METHOD(std::weak_ptr<ITrigger>, trigger, (), (const, override));
-            MOCK_METHOD(TriangulationDirection, ceiling_triangulation_function, (), (const, override));
+            MOCK_METHOD(TriangulationDirection, ceiling_triangulation, (), (const, override));
+
+            std::shared_ptr<MockSector> with_ceiling_triangulation(ISector::TriangulationDirection triangulation)
+            {
+                ON_CALL(*this, ceiling_triangulation).WillByDefault(testing::Return(triangulation));
+                return shared_from_this();
+            }
 
             std::shared_ptr<MockSector> with_flags(SectorFlag flags)
             {
@@ -72,6 +78,12 @@ namespace trview
             std::shared_ptr<MockSector> with_room(const std::weak_ptr<IRoom>& room)
             {
                 ON_CALL(*this, room).WillByDefault(testing::Return(room));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockSector> with_triangulation(ISector::TriangulationDirection triangulation)
+            {
+                ON_CALL(*this, triangulation).WillByDefault(testing::Return(triangulation));
                 return shared_from_this();
             }
 

--- a/trview.app/Mocks/Elements/ISector.h
+++ b/trview.app/Mocks/Elements/ISector.h
@@ -37,6 +37,7 @@ namespace trview
             MOCK_METHOD(void, add_flag, (SectorFlag), (override));
             MOCK_METHOD(void, set_trigger, (const std::weak_ptr<ITrigger>&), (override));
             MOCK_METHOD(std::weak_ptr<ITrigger>, trigger, (), (const, override));
+            MOCK_METHOD(TriangulationDirection, ceiling_triangulation_function, (), (const, override));
 
             std::shared_ptr<MockSector> with_flags(SectorFlag flags)
             {

--- a/trview.app/Mocks/Elements/ISector.h
+++ b/trview.app/Mocks/Elements/ISector.h
@@ -24,7 +24,7 @@ namespace trview
             MOCK_METHOD((std::array<float, 4>), ceiling_corners, (), (const, override));
             MOCK_METHOD((DirectX::SimpleMath::Vector3), corner, (Corner), (const, override));
             MOCK_METHOD((DirectX::SimpleMath::Vector3), ceiling, (Corner), (const, override));
-            MOCK_METHOD(uint32_t, room, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<IRoom>, room, (), (const, override));
             MOCK_METHOD(TriangulationDirection, triangulation_function, (), (const, override));
             MOCK_METHOD(std::vector<Triangle>, triangles, (), (const, override));
             MOCK_METHOD(bool, is_floor, (), (const, override));

--- a/trview.app/Mocks/Elements/ISector.h
+++ b/trview.app/Mocks/Elements/ISector.h
@@ -38,9 +38,57 @@ namespace trview
             MOCK_METHOD(void, set_trigger, (const std::weak_ptr<ITrigger>&), (override));
             MOCK_METHOD(std::weak_ptr<ITrigger>, trigger, (), (const, override));
 
+            std::shared_ptr<MockSector> with_flags(SectorFlag flags)
+            {
+                ON_CALL(*this, flags).WillByDefault(testing::Return(flags));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockSector> with_room_above(uint16_t above)
+            {
+                ON_CALL(*this, room_above).WillByDefault(testing::Return(above));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockSector> with_room_below(uint16_t below)
+            {
+                ON_CALL(*this, room_below).WillByDefault(testing::Return(below));
+                return shared_from_this();
+            }
+
             std::shared_ptr<MockSector> with_id(uint32_t number)
             {
                 ON_CALL(*this, id).WillByDefault(testing::Return(number));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockSector> with_portal(uint16_t portal)
+            {
+                ON_CALL(*this, portal).WillByDefault(testing::Return(portal));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockSector> with_room(const std::weak_ptr<IRoom>& room)
+            {
+                ON_CALL(*this, room).WillByDefault(testing::Return(room));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockSector> with_trigger(const std::weak_ptr<ITrigger>& trigger)
+            {
+                ON_CALL(*this, trigger).WillByDefault(testing::Return(trigger));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockSector> with_x(uint16_t x)
+            {
+                ON_CALL(*this, x).WillByDefault(testing::Return(x));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockSector> with_z(uint16_t z)
+            {
+                ON_CALL(*this, z).WillByDefault(testing::Return(z));
                 return shared_from_this();
             }
         };

--- a/trview.app/Mocks/Elements/ISector.h
+++ b/trview.app/Mocks/Elements/ISector.h
@@ -17,7 +17,7 @@ namespace trview
             MOCK_METHOD(std::uint16_t, room_above, (), (const, override));
             MOCK_METHOD(SectorFlag, flags, (), (const, override));
             MOCK_METHOD(uint32_t, floordata_index, (), (const, override));
-            MOCK_METHOD(TriggerInfo, trigger, (), (const, override));
+            MOCK_METHOD(TriggerInfo, trigger_info, (), (const, override));
             MOCK_METHOD(uint16_t, x, (), (const, override));
             MOCK_METHOD(uint16_t, z, (), (const, override));
             MOCK_METHOD((std::array<float, 4>), corners, (), (const, override));
@@ -35,6 +35,8 @@ namespace trview
             MOCK_METHOD(void, generate_triangles, (), (override));
             MOCK_METHOD(void, add_triangle, (const ISector::Portal&, const Triangle&, std::unordered_set<uint32_t>), (override));
             MOCK_METHOD(void, add_flag, (SectorFlag), (override));
+            MOCK_METHOD(void, set_trigger, (const std::weak_ptr<ITrigger>&), (override));
+            MOCK_METHOD(std::weak_ptr<ITrigger>, trigger, (), (const, override));
 
             std::shared_ptr<MockSector> with_id(uint32_t number)
             {

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -477,13 +477,14 @@ namespace trview
                 {
                     if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
                     {
+                        uint32_t room = room_number(sector->room());
                         // Select the trigger (if it is a trigger).
                         const auto triggers = _level->triggers();
                         auto trigger = std::find_if(triggers.begin(), triggers.end(),
                             [&](auto t)
                             {
                                 const auto t_ptr = t.lock();
-                                return t_ptr->room() == sector->room() && t_ptr->sector_id() == sector->id();
+                                return t_ptr->room() == room && t_ptr->sector_id() == sector->id();
                             });
 
                         if (trigger == triggers.end() || (GetAsyncKeyState(VK_CONTROL) & 0x8000))

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -105,6 +105,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Tools\Compass.cpp" />
     <ClCompile Include="Tools\Measure.cpp" />
     <ClCompile Include="Tools\Toolbar.cpp" />
+    <ClInclude Include="Elements\ISector.hpp" />
     <ClInclude Include="Lua\Colour.h" />
     <ClInclude Include="Lua\Elements\CameraSink\Lua_CameraSink.h" />
     <ClInclude Include="Lua\Elements\Item\Lua_Item.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -940,6 +940,9 @@
     <ClInclude Include="Mocks\Lua\ILua.h">
       <Filter>Mocks\Lua</Filter>
     </ClInclude>
+    <ClInclude Include="Elements\ISector.hpp">
+      <Filter>Elements\Sector</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.sln
+++ b/trview.sln
@@ -105,12 +105,14 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "lua", "lua", "{D6B95B54-7EBF-4D18-AE50-F82BD0B7CA62}"
 	ProjectSection(SolutionItems) = preProject
 		doc\lua\camera_sink.md = doc\lua\camera_sink.md
-		doc\lua\index.md = doc\lua\index.md
 		doc\lua\colour.md = doc\lua\colour.md
+		doc\lua\command.md = doc\lua\command.md
+		doc\lua\index.md = doc\lua\index.md
 		doc\lua\item.md = doc\lua\item.md
 		doc\lua\level.md = doc\lua\level.md
 		doc\lua\light.md = doc\lua\light.md
 		doc\lua\room.md = doc\lua\room.md
+		doc\lua\sector.md = doc\lua\sector.md
 		doc\lua\trigger.md = doc\lua\trigger.md
 		doc\lua\trview.md = doc\lua\trview.md
 		doc\lua\vector3.md = doc\lua\vector3.md


### PR DESCRIPTION
Add Lua bindings for `Sector`.
Split room constructor logic into constructor and initialise so it can pass `shared_ptr` of itself to newly created sectors.
Closes #1117 