### PR TITLE
Use blank texture on invalid sprite texture

### DIFF
--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -160,7 +160,7 @@ namespace trlevel
         // Get the sprite texture with the specified ID.
         // index: The index of the sprite texture to get.
         // Returns: The sprite texture.
-        virtual tr_sprite_texture get_sprite_texture(uint32_t index) const = 0;
+        virtual std::optional<tr_sprite_texture> get_sprite_texture(uint32_t index) const = 0;
 
         /// Find the first entity with the specified type.
         /// @param type The type ID of the entity.

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -808,9 +808,13 @@ namespace trlevel
         return true;
     }
 
-    tr_sprite_texture Level::get_sprite_texture(uint32_t index) const
+    std::optional<tr_sprite_texture> Level::get_sprite_texture(uint32_t index) const
     {
-        return _sprite_textures[index];
+        if (index < _sprite_textures.size())
+        {
+            return _sprite_textures[index];
+        }
+        return std::nullopt;
     }
 
     void Level::load_tr4(trview::Activity& activity, std::istream& file)

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -162,7 +162,7 @@ namespace trlevel
         // Get the sprite texture with the specified ID.
         // index: The index of the sprite texture to get.
         // Returns: The sprite texture.
-        virtual tr_sprite_texture get_sprite_texture(uint32_t index) const override;
+        virtual std::optional<tr_sprite_texture> get_sprite_texture(uint32_t index) const override;
 
         /// Find the first entity with the specified type.
         /// @param type The type ID of the entity.

--- a/trlevel/Mocks/ILevel.h
+++ b/trlevel/Mocks/ILevel.h
@@ -41,7 +41,7 @@ namespace trlevel
             MOCK_METHOD(tr2_frame, get_frame, (uint32_t, uint32_t), (const, override));
             MOCK_METHOD(LevelVersion, get_version, (), (const, override));
             MOCK_METHOD(bool, get_sprite_sequence_by_id, (int32_t, tr_sprite_sequence&), (const, override));
-            MOCK_METHOD(tr_sprite_texture, get_sprite_texture, (uint32_t), (const, override));
+            MOCK_METHOD(std::optional<tr_sprite_texture>, get_sprite_texture, (uint32_t), (const, override));
             MOCK_METHOD(bool, find_first_entity_by_type, (int16_t, tr2_entity&), (const, override));
             MOCK_METHOD(int16_t, get_mesh_from_type_id, (int16_t), (const, override));
             MOCK_METHOD(std::string, name, (), (const, override));

--- a/trview.app/Geometry/IMesh.h
+++ b/trview.app/Geometry/IMesh.h
@@ -64,7 +64,7 @@ namespace trview
     /// @param offset The output offset.
     std::shared_ptr<IMesh> create_sprite_mesh(
         const IMesh::Source& source,
-        const trlevel::tr_sprite_texture& sprite,
+        const std::optional<trlevel::tr_sprite_texture>& sprite,
         DirectX::SimpleMath::Matrix& scale,
         DirectX::SimpleMath::Vector3& offset,
         SpriteOffsetMode offset_mode);
@@ -75,7 +75,7 @@ namespace trview
     /// @param scale The output scale matrix.
     std::shared_ptr<IMesh> create_sprite_mesh(
         const IMesh::Source& source,
-        const trlevel::tr_sprite_texture& sprite,
+        const std::optional<trlevel::tr_sprite_texture>& sprite,
         DirectX::SimpleMath::Matrix& scale,
         DirectX::SimpleMath::Matrix& offset,
         SpriteOffsetMode offset_mode);


### PR DESCRIPTION
If a room sprite references a sprite texture that doesn't exist use the untextured texture instead of crashing. This just gives a white square at the location of the room sprite.
Closes #1136