### PR TITLE
Lua: Initial UI bindings and plugin system

### DIFF
--- a/doc/lua/imgui.md
+++ b/doc/lua/imgui.md
@@ -1,0 +1,40 @@
+# ImGui
+
+The ImGui library allows plugins to render UI elements.
+
+# Functions
+
+| Name | Returns | Parameters | Description |
+| ---- | ------- | ---------- | ----------- |
+| Begin | `boolean result, boolean is_open`  | `{ string name, boolean open, ImGuiWindowFlags flags }` | Begin a new window. `open` and `flags` are optional parameters. `result` indicates whether to continue rendering the window. `is_open` indicates whether the user has closed the window. You must always call `End` even if `Begin` returns `false`. |
+| BeginChild |`boolean result`|||
+| BeginCombo |`boolean result`|||
+| BeginTable |`boolean result`|||
+| Button |`boolean result`|||
+| Checkbox | `boolean result, boolean checked` | `{ string label, boolean checked }` | Make a checkbox. The checked parameter indicates whether the checkbox is checked and the new state is in the second return value. |
+| End ||| End rendering a window |
+| EndChild ||||
+| EndCombo ||||
+| EndTable ||||
+| SameLine ||||
+| Selectable |`boolean result`|||
+| TableHeadersRow ||||
+| TableNextColumn |`boolean result`|||
+| TableNextRow ||||
+| TableSetupColumn ||||
+| TableSetupScrollFreeze ||||
+| Text || `{ string text } `| Draw some text. |
+
+# Enumerations
+
+## ImGuiWindowFlags
+
+## ImGuiComboFlags
+
+## ImGuiSelectableFlags
+
+## ImGuiTableColumnFlags
+
+## ImGuiTableFlags
+
+## ImGuiButtonFlags

--- a/doc/lua/imgui.md
+++ b/doc/lua/imgui.md
@@ -7,22 +7,22 @@ The ImGui library allows plugins to render UI elements.
 | Name | Returns | Parameters | Description |
 | ---- | ------- | ---------- | ----------- |
 | Begin | `boolean result, boolean is_open`  | `{ string name, boolean open, ImGuiWindowFlags flags }` | Begin a new window. `open` and `flags` are optional parameters. `result` indicates whether to continue rendering the window. `is_open` indicates whether the user has closed the window. You must always call `End` even if `Begin` returns `false`. |
-| BeginChild |`boolean result`|||
+| BeginChild |`boolean result`|`{ string name, ImGuiWindowFlags flags }`||
 | BeginCombo |`boolean result`|||
-| BeginTable |`boolean result`|||
-| Button |`boolean result`|||
+| BeginTable |`boolean result`|`{ string id, number column, ImGuiTableFlags flags }`||
+| Button |`boolean result`|`{ string label, ImGuiButtonFlags flags }`||
 | Checkbox | `boolean result, boolean checked` | `{ string label, boolean checked }` | Make a checkbox. The checked parameter indicates whether the checkbox is checked and the new state is in the second return value. |
 | End ||| End rendering a window |
 | EndChild ||||
 | EndCombo ||||
 | EndTable ||||
 | SameLine ||||
-| Selectable |`boolean result`|||
+| Selectable |`boolean result`|`{ string label, boolean selected, ImGuiSelectableFlags flags }`||
 | TableHeadersRow ||||
 | TableNextColumn |`boolean result`|||
 | TableNextRow ||||
-| TableSetupColumn ||||
-| TableSetupScrollFreeze ||||
+| TableSetupColumn ||`{ string label, ImGuiTableColumnFlags flags }`||
+| TableSetupScrollFreeze ||`{ number cols, number rows }`||
 | Text || `{ string text } `| Draw some text. |
 
 # Enumerations

--- a/doc/lua/index.md
+++ b/doc/lua/index.md
@@ -5,6 +5,7 @@
 
 # Libraries
 
+- [ImGui](imgui.md)
 - [item](item.md)
 - [level](level.md)
 - [room](room.md)

--- a/doc/lua/index.md
+++ b/doc/lua/index.md
@@ -1,9 +1,13 @@
 # Lua Bindings
 
+# Plugins System
+- [Plugins](plugins.md)
+
 # Libraries
 
 - [item](item.md)
 - [level](level.md)
 - [room](room.md)
+- [sector](sector.md)
 - [trigger](trigger.md)
 - [trview](trview.md)

--- a/doc/lua/level.md
+++ b/doc/lua/level.md
@@ -12,7 +12,7 @@ The Level library provides information about the currently loaded Level in trvie
 | items | [Item](item.md)[] | R | All items |
 | lights | [Light](light.md)[] | R | All lights |
 | rooms | [Room](room.md)[] | R | All rooms |
-| selected_itm | [Item](item.md) | RW | Currently selected item |
+| selected_item | [Item](item.md) | RW | Currently selected item |
 | selected_room | [Room](room.md) | RW | Currently selected room |
 | triggers | [Trigger](trigger.md)[] | R | All triggers |
 | version | number | R | The game number for which this level was made |

--- a/doc/lua/level.md
+++ b/doc/lua/level.md
@@ -12,6 +12,7 @@ The Level library provides information about the currently loaded Level in trvie
 | items | [Item](item.md)[] | R | All items |
 | lights | [Light](light.md)[] | R | All lights |
 | rooms | [Room](room.md)[] | R | All rooms |
+| selected_itm | [Item](item.md) | RW | Currently selected item |
 | selected_room | [Room](room.md) | RW | Currently selected room |
 | triggers | [Trigger](trigger.md)[] | R | All triggers |
 | version | number | R | The game number for which this level was made |

--- a/doc/lua/plugins.md
+++ b/doc/lua/plugins.md
@@ -1,0 +1,36 @@
+# Plugins
+
+# Required Files
+To be recognised by trview a plugin needs to have the following folder structure
+
+```
+plugin_folder_name
+    manifest.json
+    plugin.lua
+```
+
+The plugin folder then goes inside one of the user's configured plugin folders.
+
+## manifest.json
+The manifest gives some information about the plugin to show to the user. This information will be shown in the Plugins window.
+
+### Example Manifest
+
+```
+{
+    "name": "Example Plugin",
+    "author": "trview doc author",
+    "description": "This plugin is used as an example plugin"
+}
+```
+
+## plugin.lua
+This is the Lua file that will be loaded by trview and should contain the plugin script.
+
+# Defined Functions
+trview will attempt to call the following functions if they are defined in the plugin script
+
+|Function|Parameters|When is it called?|Purpose|
+|--------|----------|------------|-------|
+|render_ui|None|During trview UI rendering|Used for drawing any plugin windows required|
+|render_toolbar|None|When trview is rendering the toolbar at the bottom of the screen|Used to add a button or other control to the tool`bar - for example if you want a way to open the main plugin window|

--- a/doc/lua/trview.md
+++ b/doc/lua/trview.md
@@ -8,6 +8,7 @@ The trview library provides information about the program in general.
 | ---- | ---- | ---- | ----------- |
 | level | [Level](level.md) | RW | The current level, or `nil` if no level loaded. Can be set to a `Level` instance. Will raise an error if the level could not be loaded or the user cancelled the operation.   |
 | recent_files | string[] | R | The table of recently opened filenames |
+| local_levels | string[] | R | Filenames of levels that are in the level switcher |
 
 # Functions
 

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -543,6 +543,8 @@ TEST(Application, WindowManagersAndViewerRendered)
     EXPECT_CALL(console_manager, initialise_ui).Times(1);
     auto [plugins_window_manager_ptr, plugins_window_manager] = create_mock<MockPluginsWindowManager>();
     EXPECT_CALL(plugins_window_manager, render).Times(1);
+    auto plugins = mock_shared<MockPlugins>();
+    EXPECT_CALL(*plugins, render_ui).Times(1);
 
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
     EXPECT_CALL(viewer, render).Times(1);
@@ -562,6 +564,7 @@ TEST(Application, WindowManagersAndViewerRendered)
         .with_plugins_window_manager(std::move(plugins_window_manager_ptr))
         .with_viewer(std::move(viewer_ptr))
         .with_files(files)
+        .with_plugins(plugins)
         .build();
     application->render();
 }
@@ -1074,4 +1077,18 @@ TEST(Application, PluginsInitialised)
     auto application = register_test_module()
         .with_plugins(plugins)
         .build();
+}
+
+TEST(Application, LocalLevels)
+{
+    std::vector<std::string> files{ "test", "test2" };
+    auto [file_menu_ptr, file_menu] = create_mock<MockFileMenu>();
+    EXPECT_CALL(file_menu, local_levels).WillRepeatedly(Return(files));
+
+    auto application = register_test_module()
+        .with_file_menu(std::move(file_menu_ptr))
+        .build();
+
+    auto result = application->local_levels();
+    ASSERT_EQ(result, files);
 }

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -9,6 +9,7 @@
 #include <trview.app/Mocks/UI/IContextMenu.h>
 #include <trview.app/Mocks/UI/ICameraControls.h>
 #include <trview.common/Mocks/Windows/IShell.h>
+#include <trview.app/Mocks/Tools/IToolbar.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -30,11 +31,12 @@ namespace
             std::unique_ptr<IViewOptions> view_options{ mock_unique<MockViewOptions>() };
             std::unique_ptr<trview::IContextMenu> context_menu{ mock_unique<MockContextMenu>() };
             std::unique_ptr<ICameraControls> camera_controls{ mock_unique<MockCameraControls>() };
+            std::unique_ptr<IToolbar> toolbar{ mock_unique<MockToolbar>() };
 
             std::unique_ptr<ViewerUI> build()
             {
                 EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-                return std::make_unique<ViewerUI>(window, texture_storage, shortcuts, map_renderer_source, std::move(settings_window), std::move(view_options), std::move(context_menu), std::move(camera_controls));
+                return std::make_unique<ViewerUI>(window, texture_storage, shortcuts, map_renderer_source, std::move(settings_window), std::move(view_options), std::move(context_menu), std::move(camera_controls), std::move(toolbar));
             }
 
             test_module& with_settings_window(std::unique_ptr<ISettingsWindow> window)

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -119,6 +119,9 @@
     <ProjectReference Include="..\trview.graphics\trview.graphics.vcxproj">
       <Project>{3270fd29-edab-40be-8ca1-dabc5e261e4c}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\trview.lua.imgui\trview.lua.imgui.vcxproj">
+      <Project>{cdbc4705-e8e2-4c5c-a1a6-ea66fe4b699b}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\trview.tests.common\trview.tests.common.vcxproj">
       <Project>{3ab44a93-dbba-405e-8164-e5b20866ee1d}</Project>
     </ProjectReference>

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -691,6 +691,7 @@ namespace trview
         _camera_sink_windows->render();
         _console_manager->render();
         _plugins_windows->render();
+        _plugins->render_ui();
 
         ImGui::PopFont();
         ImGui::Render();
@@ -915,5 +916,10 @@ namespace trview
     UserSettings Application::settings() const
     {
         return _settings;
+    }
+
+    std::vector<std::string> Application::local_levels() const
+    {
+        return _file_menu->local_levels();
     }
 }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -826,6 +826,11 @@ namespace trview
 
     void Application::set_current_level(const std::shared_ptr<ILevel>& level, ILevel::OpenMode open_mode, bool prompt_user)
     {
+        if (level == _level)
+        {
+            return;
+        }
+
         if (prompt_user && open_mode == ILevel::OpenMode::Full && !should_discard_changes())
         {
             throw UserCancelledException();

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -38,6 +38,7 @@ namespace trview
         virtual int run() = 0;
         virtual std::weak_ptr<ILevel> current_level() const = 0;
         virtual std::shared_ptr<ILevel> load(const std::string& filename) = 0;
+        virtual std::vector<std::string> local_levels() const = 0;
         virtual void set_current_level(const std::shared_ptr<ILevel>& level, ILevel::OpenMode open_mode, bool prompt_user) = 0;
         virtual UserSettings settings() const = 0;
         Event<> on_closing;
@@ -80,6 +81,7 @@ namespace trview
         void render();
         std::weak_ptr<ILevel> current_level() const override;
         std::shared_ptr<ILevel> load(const std::string& filename) override;
+        std::vector<std::string> local_levels() const override;
         void set_current_level(const std::shared_ptr<ILevel>& level, ILevel::OpenMode open_mode, bool prompt_user) override;
         UserSettings settings() const override;
     private:

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -66,6 +66,7 @@
 #include "Plugins/Plugin.h"
 #include "Windows/Plugins/PluginsWindowManager.h"
 #include "Windows/Plugins/PluginsWindow.h"
+#include "Tools/Toolbar.h"
 
 namespace trview
 {
@@ -250,6 +251,14 @@ namespace trview
         auto dialogs = std::make_shared<Dialogs>(window);
         auto shell = std::make_shared<Shell>();
 
+        auto plugin_source = [=](auto&&... args) { return std::make_shared<Plugin>(files, std::make_unique<Lua>(), args...); };
+        auto plugins = std::make_shared<Plugins>(
+            files,
+            std::make_shared<Plugin>(std::make_unique<Lua>(), "Default", "trview", "Default Lua plugin for trview"),
+            plugin_source,
+            settings_loader->load_user_settings());
+        auto plugins_window_source = [=]() { return std::make_shared<PluginsWindow>(plugins, shell); };
+
         auto viewer_ui = std::make_unique<ViewerUI>(
             window,
             texture_storage,
@@ -258,7 +267,8 @@ namespace trview
             std::make_unique<SettingsWindow>(dialogs, shell),
             std::make_unique<ViewOptions>(),
             std::make_unique<ContextMenu>(),
-            std::make_unique<CameraControls>());
+            std::make_unique<CameraControls>(),
+            std::make_unique<Toolbar>(plugins));
 
         auto clipboard = std::make_shared<Clipboard>(window);
 
@@ -288,14 +298,6 @@ namespace trview
         auto camera_sink_window_source = [=]() { return std::make_shared<CameraSinkWindow>(clipboard); };
 
         auto decrypter = std::make_shared<trlevel::Decrypter>();
-
-        auto plugin_source = [=](auto&&... args) { return std::make_shared<Plugin>(files, std::make_unique<Lua>(), args...); };
-        auto plugins = std::make_shared<Plugins>(
-            files, 
-            std::make_shared<Plugin>(std::make_unique<Lua>(), "Default", "trview", "Default Lua plugin for trview"),
-            plugin_source,
-            settings_loader->load_user_settings());
-        auto plugins_window_source = [=]() { return std::make_shared<PluginsWindow>(plugins, shell); };
 
         auto trlevel_source = [=](auto&& filename) { return std::make_unique<trlevel::Level>(filename, files, decrypter, log); };
         auto textures_window_source = [=]() { return std::make_shared<TexturesWindow>(); };

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -134,7 +134,7 @@ namespace trview
         virtual trlevel::LevelVersion version() const = 0;
         Event<std::weak_ptr<IItem>> on_item_selected;
         // Event raised when the level needs to change the selected room.
-        Event<uint16_t> on_room_selected;
+        Event<uint32_t> on_room_selected;
         // Event raised when the level needs to change the alternate mode.
         Event<bool> on_alternate_mode_selected;
         /// Event raised when the level needs to change the alternate group mode.

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -132,6 +132,7 @@ namespace trview
         /// <returns>All triggers in the level.</returns>
         virtual std::vector<std::weak_ptr<ITrigger>> triggers() const = 0;
         virtual trlevel::LevelVersion version() const = 0;
+        Event<std::weak_ptr<IItem>> on_item_selected;
         // Event raised when the level needs to change the selected room.
         Event<uint16_t> on_room_selected;
         // Event raised when the level needs to change the alternate mode.

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -188,33 +188,40 @@ namespace trview
 
     void Level::set_selected_room(uint16_t index)
     { 
-        _selected_room = index;
-        regenerate_neighbours();
-
-        // If the user has selected a room that is or has an alternate mode, raise the event that the
-        // alternate mode needs to change so that the correct rooms can be rendered.
-        const auto& room = *_rooms[index];
-        if (is_alternate_mismatch(room))
+        if (_selected_room != index)
         {
-            if (version() >= trlevel::LevelVersion::Tomb4)
-            {
-                on_alternate_group_selected(room.alternate_group(), !is_alternate_group_set(room.alternate_group()));
-            }
-            else
-            {
-                on_alternate_mode_selected(!_alternate_mode);
-            }
-        }
+            _selected_room = index;
+            regenerate_neighbours();
 
-        on_level_changed();
-        on_room_selected(index);
+            // If the user has selected a room that is or has an alternate mode, raise the event that the
+            // alternate mode needs to change so that the correct rooms can be rendered.
+            const auto& room = *_rooms[index];
+            if (is_alternate_mismatch(room))
+            {
+                if (version() >= trlevel::LevelVersion::Tomb4)
+                {
+                    on_alternate_group_selected(room.alternate_group(), !is_alternate_group_set(room.alternate_group()));
+                }
+                else
+                {
+                    on_alternate_mode_selected(!_alternate_mode);
+                }
+            }
+
+            on_level_changed();
+            on_room_selected(index);
+        }
     }
 
     void Level::set_selected_item(uint32_t index)
     {
-        _selected_item = _entities[index];
-        on_level_changed();
-        on_item_selected(_selected_item);
+        const auto selected_item = _entities[index];
+        if (_selected_item.lock() != selected_item)
+        {
+            _selected_item = selected_item;
+            on_level_changed();
+            on_item_selected(_selected_item);
+        }
     }
 
     void Level::set_neighbour_depth(uint32_t depth)

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -214,6 +214,7 @@ namespace trview
     {
         _selected_item = _entities[index];
         on_level_changed();
+        on_item_selected(_selected_item);
     }
 
     void Level::set_neighbour_depth(uint32_t depth)

--- a/trview.app/Lua/Elements/Item/Lua_Item.cpp
+++ b/trview.app/Lua/Elements/Item/Lua_Item.cpp
@@ -106,12 +106,12 @@ namespace trview
             }
         }
 
-        void create_item(lua_State* L, const std::shared_ptr<IItem>& item)
+        int create_item(lua_State* L, const std::shared_ptr<IItem>& item)
         {
             if (!item)
             {
                 lua_pushnil(L);
-                return;
+                return 1;
             }
 
             IItem** userdata = static_cast<IItem**>(lua_newuserdata(L, sizeof(item.get())));
@@ -126,6 +126,19 @@ namespace trview
             lua_pushcfunction(L, item_gc);
             lua_setfield(L, -2, "__gc");
             lua_setmetatable(L, -2);
+            return 1;
+        }
+
+        std::shared_ptr<IItem> to_item(lua_State* L, int index)
+        {
+            luaL_checktype(L, index, LUA_TUSERDATA);
+            IItem** userdata = static_cast<IItem**>(lua_touserdata(L, index));
+            auto found = items.find(userdata);
+            if (found == items.end())
+            {
+                return {};
+            }
+            return found->second;
         }
     }
 }

--- a/trview.app/Lua/Elements/Item/Lua_Item.h
+++ b/trview.app/Lua/Elements/Item/Lua_Item.h
@@ -8,6 +8,7 @@ namespace trview
 {
     namespace lua
     {
-        void create_item(lua_State* L, const std::shared_ptr<IItem>& item);
+        int create_item(lua_State* L, const std::shared_ptr<IItem>& item);
+        std::shared_ptr<IItem> to_item(lua_State* L, int index);
     }
 }

--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -47,6 +47,16 @@ namespace trview
                 {
                     return push_list_p(L, level->rooms(), create_room);
                 }
+                else if (key == "selected_item")
+                {
+                    auto item = level->selected_item();
+                    if (item)
+                    {
+                        return create_item(L, level->item(item.value()).lock());
+                    }
+                    lua_pushnil(L);
+                    return 1;
+                }
                 else if (key == "selected_room")
                 {
                     return create_room(L, level->room(level->selected_room()).lock());
@@ -77,6 +87,13 @@ namespace trview
                 {
                     luaL_checktype(L, -1, LUA_TBOOLEAN);
                     level->set_alternate_mode(lua_toboolean(L, -1));
+                }
+                else if (key == "selected_item")
+                {
+                    if (auto item = to_item(L, -1))
+                    {
+                        level->set_selected_item(item->number());
+                    }
                 }
                 else if (key == "selected_room")
                 {

--- a/trview.app/Lua/Lua.cpp
+++ b/trview.app/Lua/Lua.cpp
@@ -2,6 +2,7 @@
 #include <trview.common/Strings.h>
 #include "trview/trview.h"
 #include <external/lua/src/lualib.h>
+#include <trview.lua.imgui/trview.lua.imgui.h>
 
 namespace trview
 {
@@ -83,6 +84,7 @@ namespace trview
         lua_pushcclosure(L, print, 1);
         lua_setglobal(L, "print");
         lua::trview_register(L, application);
+        lua::imgui_register(L);
     }
 
     namespace lua

--- a/trview.app/Lua/trview/trview.cpp
+++ b/trview.app/Lua/trview/trview.cpp
@@ -6,12 +6,36 @@
 #include "../Elements/Sector/Lua_Sector.h"
 #include "Lua/Lua.h"
 
+#include <future>
+
 namespace trview
 {
     namespace lua
     {
         namespace
         {
+            struct LoadRequest
+            {
+                std::future<std::shared_ptr<ILevel>> level;
+            };
+            std::mutex request_mutex;
+            std::vector<std::unique_ptr<LoadRequest>> active_requests;
+
+            int trview_yield_load(lua_State* L, int, lua_KContext context)
+            {
+                LoadRequest* request = reinterpret_cast<LoadRequest*>(context);
+                if (request->level._Is_ready())
+                {
+                    auto level = request->level.get();
+                    {
+                        std::lock_guard lock{ request_mutex };
+                        std::erase_if(active_requests, [=](const auto& r) { return r.get() == request; });
+                    }
+                    return create_level(L, level);
+                }
+                return lua_yieldk(L, 0, context, trview_yield_load);
+            }
+
             int trview_load(lua_State* L)
             {
                 auto application = lua::get_self<IApplication>(L);
@@ -21,15 +45,23 @@ namespace trview
 
                 try
                 {
-                    return create_level(L, application->load(filename));
+                    auto request = std::make_unique<LoadRequest>();
+                    std::string file = filename;
+                    request->level = std::async(std::launch::async, [=]() { return application->load(file); });
+                    auto p = request.get();
+                    {
+                        std::lock_guard lock{ request_mutex };
+                        active_requests.push_back(std::move(request));
+                    }
+                    return lua_yieldk(L, 0, reinterpret_cast<lua_KContext>(p), trview_yield_load);
                 }
                 catch (trlevel::LevelEncryptedException&)
                 {
-                    luaL_error(L, "Level is encrypted and cannot be loaded (%s)", filename);
+                    luaL_error(L, "Level is encrypted and cannot be loaded (%s)", "");
                 }
-                catch (...)
+                catch (std::exception&)
                 {
-                    luaL_error(L, "Failed to load level (%s)", filename);
+                    luaL_error(L, "Failed to load level (%s)", "");
                 }
                 return 0;
             }
@@ -47,6 +79,10 @@ namespace trview
                 {
                     lua_pushcfunction(L, trview_load);
                     return 1;
+                }
+                else if (key == "local_levels")
+                {
+                    return push_list(L, application->local_levels(), push_string);
                 }
                 else if (key == "recent_files")
                 {

--- a/trview.app/Menus/FileMenu.cpp
+++ b/trview.app/Menus/FileMenu.cpp
@@ -186,4 +186,14 @@ namespace trview
             on_file_open(iter->path);
         }
     }
+
+    std::vector<std::string> FileMenu::local_levels() const
+    {
+        std::vector<std::string> files;
+        for (const auto& f : _file_switcher_list)
+        {
+            files.push_back(f.path);
+        }
+        return files;
+    }
 }

--- a/trview.app/Menus/FileMenu.h
+++ b/trview.app/Menus/FileMenu.h
@@ -18,6 +18,7 @@ namespace trview
             const std::shared_ptr<IDialogs>& dialogs,
             const std::shared_ptr<IFiles>& files);
         virtual ~FileMenu() = default;
+        std::vector<std::string> local_levels() const override;
         virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         virtual void open_file(const std::string& filename) override;
         virtual void set_recent_files(const std::list<std::string>& files) override;

--- a/trview.app/Menus/IFileMenu.h
+++ b/trview.app/Menus/IFileMenu.h
@@ -9,6 +9,9 @@ namespace trview
     struct IFileMenu
     {
         virtual ~IFileMenu() = 0;
+
+        virtual std::vector<std::string> local_levels() const = 0;
+
         /// <summary>
         /// Open the specified file. This will populate the switcher menu.
         /// </summary>

--- a/trview.app/Mocks/IApplication.h
+++ b/trview.app/Mocks/IApplication.h
@@ -13,6 +13,7 @@ namespace trview
             MOCK_METHOD(int, run, (), (override));
             MOCK_METHOD(std::weak_ptr<ILevel>, current_level, (), (const, override));
             MOCK_METHOD(std::shared_ptr<ILevel>, load, (const std::string&), (override));
+            MOCK_METHOD(std::vector<std::string>, local_levels, (), (const, override));
             MOCK_METHOD(void, set_current_level, (const std::shared_ptr<ILevel>&, ILevel::OpenMode, bool), (override));
             MOCK_METHOD(UserSettings, settings, (), (const, override));
         };

--- a/trview.app/Mocks/Menus/IFileMenu.h
+++ b/trview.app/Mocks/Menus/IFileMenu.h
@@ -10,6 +10,7 @@ namespace trview
         {
             MockFileMenu();
             virtual ~MockFileMenu();
+            MOCK_METHOD(std::vector<std::string>, local_levels, (), (const, override));
             MOCK_METHOD(void, open_file, (const std::string&), (override));
             MOCK_METHOD(void, set_recent_files, (const std::list<std::string>&), (override));
         };

--- a/trview.app/Mocks/Mocks.cpp
+++ b/trview.app/Mocks/Mocks.cpp
@@ -58,6 +58,7 @@
 #include "Plugins/IPlugin.h"
 #include "Mocks/Windows/IPluginsWindow.h"
 #include "Mocks/Windows/IPluginsWindowManager.h"
+#include "Mocks/Tools/IToolbar.h"
 
 namespace trview
 {
@@ -233,5 +234,8 @@ namespace trview
 
         MockPluginsWindowManager::MockPluginsWindowManager() {}
         MockPluginsWindowManager::~MockPluginsWindowManager() {}
+
+        MockToolbar::MockToolbar() {}
+        MockToolbar::~MockToolbar() {}
     }
 }

--- a/trview.app/Mocks/Plugins/IPlugin.h
+++ b/trview.app/Mocks/Plugins/IPlugin.h
@@ -21,6 +21,7 @@ namespace trview
             MOCK_METHOD(void, do_file, (const std::string&), (override));
             MOCK_METHOD(void, clear_messages, (), (override));
             MOCK_METHOD(void, reload, (), (override));
+            MOCK_METHOD(void, render_toolbar, (), (override));
             MOCK_METHOD(void, render_ui, (), (override));
         };
     }

--- a/trview.app/Mocks/Plugins/IPlugin.h
+++ b/trview.app/Mocks/Plugins/IPlugin.h
@@ -21,6 +21,7 @@ namespace trview
             MOCK_METHOD(void, do_file, (const std::string&), (override));
             MOCK_METHOD(void, clear_messages, (), (override));
             MOCK_METHOD(void, reload, (), (override));
+            MOCK_METHOD(void, render_ui, (), (override));
         };
     }
 }

--- a/trview.app/Mocks/Plugins/IPlugins.h
+++ b/trview.app/Mocks/Plugins/IPlugins.h
@@ -12,6 +12,7 @@ namespace trview
             virtual ~MockPlugins();
             MOCK_METHOD(std::vector<std::weak_ptr<IPlugin>>, plugins, (), (const, override));
             MOCK_METHOD(void, initialise, (IApplication*), (override));
+            MOCK_METHOD(void, render_ui, (), (override));
         };
     }
 }

--- a/trview.app/Mocks/Tools/IToolbar.h
+++ b/trview.app/Mocks/Tools/IToolbar.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "../../Tools/IToolbar.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockToolbar : public IToolbar
+        {
+            MockToolbar();
+            ~MockToolbar();
+            MOCK_METHOD(void, add_tool, (const std::string&), (override));
+            MOCK_METHOD(void, render, (), (override));
+        };
+    }
+}

--- a/trview.app/Plugins/IPlugin.h
+++ b/trview.app/Plugins/IPlugin.h
@@ -23,6 +23,7 @@ namespace trview
         virtual void do_file(const std::string& path) = 0;
         virtual void clear_messages() = 0;
         virtual void reload() = 0;
+        virtual void render_toolbar() = 0;
         virtual void render_ui() = 0;
 
         Event<std::string> on_message;

--- a/trview.app/Plugins/IPlugin.h
+++ b/trview.app/Plugins/IPlugin.h
@@ -23,6 +23,7 @@ namespace trview
         virtual void do_file(const std::string& path) = 0;
         virtual void clear_messages() = 0;
         virtual void reload() = 0;
+        virtual void render_ui() = 0;
 
         Event<std::string> on_message;
     };

--- a/trview.app/Plugins/IPlugins.h
+++ b/trview.app/Plugins/IPlugins.h
@@ -11,5 +11,6 @@ namespace trview
         virtual ~IPlugins() = 0;
         virtual std::vector<std::weak_ptr<IPlugin>> plugins() const = 0;
         virtual void initialise(IApplication* application) = 0;
+        virtual void render_ui() = 0;
     };
 }

--- a/trview.app/Plugins/Plugin.cpp
+++ b/trview.app/Plugins/Plugin.cpp
@@ -119,4 +119,9 @@ namespace trview
             _lua->do_file(_script);
         }
     }
+
+    void Plugin::render_ui()
+    {
+        _lua->execute("if render_ui ~= nil then render_ui() end");
+    }
 }

--- a/trview.app/Plugins/Plugin.cpp
+++ b/trview.app/Plugins/Plugin.cpp
@@ -120,6 +120,11 @@ namespace trview
         }
     }
 
+    void Plugin::render_toolbar()
+    {
+        _lua->execute("if render_toolbar ~= nil then render_toolbox() end");
+    }
+
     void Plugin::render_ui()
     {
         _lua->execute("if render_ui ~= nil then render_ui() end");

--- a/trview.app/Plugins/Plugin.cpp
+++ b/trview.app/Plugins/Plugin.cpp
@@ -122,7 +122,7 @@ namespace trview
 
     void Plugin::render_toolbar()
     {
-        _lua->execute("if render_toolbar ~= nil then render_toolbox() end");
+        _lua->execute("if render_toolbar ~= nil then render_toolbar() end");
     }
 
     void Plugin::render_ui()

--- a/trview.app/Plugins/Plugin.h
+++ b/trview.app/Plugins/Plugin.h
@@ -26,6 +26,7 @@ namespace trview
         void do_file(const std::string& path) override;
         void clear_messages() override;
         void reload() override;
+        void render_ui() override;
     private:
         void load();
         void load_script();

--- a/trview.app/Plugins/Plugin.h
+++ b/trview.app/Plugins/Plugin.h
@@ -26,6 +26,7 @@ namespace trview
         void do_file(const std::string& path) override;
         void clear_messages() override;
         void reload() override;
+        void render_toolbar() override;
         void render_ui() override;
     private:
         void load();

--- a/trview.app/Plugins/Plugins.cpp
+++ b/trview.app/Plugins/Plugins.cpp
@@ -37,4 +37,9 @@ namespace trview
             plugin->initialise(application);
         }
     }
+
+    void Plugins::render_ui()
+    {
+        std::ranges::for_each(_plugins, [](auto&& p) { p->render_ui(); });
+    }
 }

--- a/trview.app/Plugins/Plugins.h
+++ b/trview.app/Plugins/Plugins.h
@@ -17,6 +17,7 @@ namespace trview
         virtual ~Plugins() = default;
         std::vector<std::weak_ptr<IPlugin>> plugins() const override;
         void initialise(IApplication* application) override;
+        void render_ui() override;
     private:
         std::vector<std::shared_ptr<IPlugin>> _plugins;
     };

--- a/trview.app/Tools/IToolbar.h
+++ b/trview.app/Tools/IToolbar.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace trview
+{
+    struct IToolbar
+    {
+        virtual ~IToolbar() = 0;
+        virtual void add_tool(const std::string& name) = 0;
+        virtual void render() = 0;
+
+        /// Event raised when a tool button is clicked.
+        /// @remarks The name of the tool is passed as a parameter.
+        Event<const std::string&> on_tool_clicked;
+    };
+}

--- a/trview.app/Tools/Toolbar.cpp
+++ b/trview.app/Tools/Toolbar.cpp
@@ -2,6 +2,15 @@
 
 namespace trview
 {
+    IToolbar::~IToolbar()
+    {
+    }
+
+    Toolbar::Toolbar(const std::weak_ptr<IPlugins>& plugins)
+        : _plugins(plugins)
+    {
+    }
+
     void Toolbar::add_tool(const std::string& name)
     {
         _tools.push_back(name);
@@ -20,6 +29,18 @@ namespace trview
                     on_tool_clicked(tool);
                 }
                 ImGui::SameLine();
+            }
+
+            if (auto plugins = _plugins.lock())
+            {
+                for (const auto plugin_ptr : plugins->plugins())
+                {
+                    if (auto plugin = plugin_ptr.lock())
+                    {
+                        plugin->render_toolbar();
+                    }
+                    ImGui::SameLine();
+                }
             }
         }
         ImGui::End();

--- a/trview.app/Tools/Toolbar.h
+++ b/trview.app/Tools/Toolbar.h
@@ -4,23 +4,24 @@
 #pragma once
 
 #include <string>
+#include "../Plugins/IPlugins.h"
+#include "IToolbar.h"
 
 namespace trview
 {
     /// Window that contains buttons for speedrun planning tools.
-    class Toolbar final
+    class Toolbar final : public IToolbar
     {
     public:
+        explicit Toolbar(const std::weak_ptr<IPlugins>& plugins);
+
         /// Add a new tool to the toolbar.
         /// @param name The name of the tool
-        void add_tool(const std::string& name);
+        void add_tool(const std::string& name) override;
 
-        void render();
-
-        /// Event raised when a tool button is clicked.
-        /// @remarks The name of the tool is passed as a parameter.
-        Event<const std::string&> on_tool_clicked;
+        void render() override;
     private:
         std::vector<std::string> _tools;
+        std::weak_ptr<IPlugins> _plugins;
     };
 }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -17,9 +17,10 @@ namespace trview
         std::unique_ptr<ISettingsWindow> settings_window,
         std::unique_ptr<IViewOptions> view_options,
         std::unique_ptr<IContextMenu> context_menu,
-        std::unique_ptr<ICameraControls> camera_controls)
+        std::unique_ptr<ICameraControls> camera_controls,
+        std::unique_ptr<IToolbar> toolbar)
         : _mouse(window, std::make_unique<input::WindowTester>(window)), _window(window), _camera_controls(std::move(camera_controls)),
-        _view_options(std::move(view_options)), _settings_window(std::move(settings_window)), _context_menu(std::move(context_menu))
+        _view_options(std::move(view_options)), _settings_window(std::move(settings_window)), _context_menu(std::move(context_menu)), _toolbar(std::move(toolbar))
     {
         _token_store += _mouse.mouse_move += [&](long, long)
         {
@@ -59,7 +60,6 @@ namespace trview
             }
         };
 
-        _toolbar = std::make_unique<Toolbar>();
         _toolbar->add_tool("Measure");
         _token_store += _toolbar->on_tool_clicked += [this](const std::string& tool)
         {

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <trview.app/Tools/Toolbar.h>
+#include <trview.app/Tools/IToolbar.h>
 #include <trview.app/UI/ICameraControls.h>
 #include <trview.app/UI/CameraPosition.h>
 #include <trview.app/UI/IContextMenu.h>
@@ -27,7 +27,8 @@ namespace trview
             std::unique_ptr<ISettingsWindow> settings_window,
             std::unique_ptr<IViewOptions> view_options,
             std::unique_ptr<IContextMenu> context_menu,
-            std::unique_ptr<ICameraControls> camera_controls);
+            std::unique_ptr<ICameraControls> camera_controls,
+            std::unique_ptr<IToolbar> toolbar);
         virtual ~ViewerUI() = default;
         virtual void clear_minimap_highlight() override;
         virtual std::shared_ptr<ISector> current_minimap_sector() const override;
@@ -79,7 +80,7 @@ namespace trview
         std::unique_ptr<GoTo> _go_to;
         std::unique_ptr<RoomNavigator> _room_navigator;
         std::unique_ptr<IViewOptions> _view_options;
-        std::unique_ptr<Toolbar> _toolbar;
+        std::unique_ptr<IToolbar> _toolbar;
         std::unique_ptr<LevelInfo> _level_info;
         std::unique_ptr<ISettingsWindow> _settings_window;
         std::unique_ptr<ICameraControls> _camera_controls;

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -583,15 +583,15 @@ namespace trview
         _token_store += _level->on_alternate_mode_selected += [&](bool enabled) { set_alternate_mode(enabled); };
         _token_store += _level->on_alternate_group_selected += [&](uint16_t group, bool enabled) { set_alternate_group(group, enabled); };
         _token_store += _level->on_level_changed += [&]() { _scene_changed = true; };
-        _token_store += _level->on_room_selected += [&](uint16_t room) { select_room(room); };
-        _token_store += _level->on_item_selected += [&](auto&& item) { select_item(item); };
+        _level->on_room_selected += on_room_selected;
+        _level->on_item_selected += on_item_selected;
 
         _level->set_show_triggers(_ui->toggle(Options::triggers));
         _level->set_show_geometry(_ui->toggle(Options::geometry));
         _level->set_show_water(_ui->toggle(Options::water));
         _level->set_show_wireframe(_ui->toggle(Options::wireframe)); 
         _level->set_show_bounding_boxes(_ui->toggle(Options::show_bounding_boxes));
-        _level->set_show_lights(_ui->toggle(Options::lights));
+        _level->set_show_lights(_ui->toggle( Options::lights));
         _level->set_show_items(_ui->toggle(Options::items));
         _level->set_show_rooms(_ui->toggle(Options::rooms));
         _level->set_show_camera_sinks(_ui->toggle(Options::camera_sinks));

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -580,9 +580,16 @@ namespace trview
         ILevel* old_level = _level;
         _level = level;
 
-        _token_store += _level->on_alternate_mode_selected += [&](bool enabled) { set_alternate_mode(enabled); };
-        _token_store += _level->on_alternate_group_selected += [&](uint16_t group, bool enabled) { set_alternate_group(group, enabled); };
-        _token_store += _level->on_level_changed += [&]() { _scene_changed = true; };
+        _level_token_store.clear();
+        if (old_level)
+        {
+            old_level->on_room_selected -= on_room_selected;
+            old_level->on_item_selected -= on_item_selected;
+        }
+
+        _level_token_store += _level->on_alternate_mode_selected += [&](bool enabled) { set_alternate_mode(enabled); };
+        _level_token_store += _level->on_alternate_group_selected += [&](uint16_t group, bool enabled) { set_alternate_group(group, enabled); };
+        _level_token_store += _level->on_level_changed += [&]() { _scene_changed = true; };
         _level->on_room_selected += on_room_selected;
         _level->on_item_selected += on_item_selected;
 

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -584,6 +584,7 @@ namespace trview
         _token_store += _level->on_alternate_group_selected += [&](uint16_t group, bool enabled) { set_alternate_group(group, enabled); };
         _token_store += _level->on_level_changed += [&]() { _scene_changed = true; };
         _token_store += _level->on_room_selected += [&](uint16_t room) { select_room(room); };
+        _token_store += _level->on_item_selected += [&](auto&& item) { select_item(item); };
 
         _level->set_show_triggers(_ui->toggle(Options::triggers));
         _level->set_show_geometry(_ui->toggle(Options::geometry));

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -146,6 +146,7 @@ namespace trview
         PickResult _current_pick;
         WindowResizer _window_resizer;
         TokenStore _token_store;
+        TokenStore _level_token_store;
         AlternateGroupToggler _alternate_group_toggler;
         DirectX::SimpleMath::Vector3 _target;
         bool _show_selection{ true };

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -123,6 +123,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\Lua\ILua.h" />
     <ClInclude Include="Mocks\Plugins\IPlugin.h" />
     <ClInclude Include="Mocks\Plugins\IPlugins.h" />
+    <ClInclude Include="Mocks\Tools\IToolbar.h" />
     <ClInclude Include="Mocks\Windows\IConsole.h" />
     <ClInclude Include="Mocks\Windows\IConsoleManager.h" />
     <ClInclude Include="Mocks\Windows\IPluginsWindow.h" />
@@ -131,6 +132,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Plugins\IPlugins.h" />
     <ClInclude Include="Plugins\Plugin.h" />
     <ClInclude Include="Plugins\Plugins.h" />
+    <ClInclude Include="Tools\IToolbar.h" />
     <ClInclude Include="Type.inl">
       <FileType>Document</FileType>
     </ClInclude>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -991,6 +991,12 @@
     <ClInclude Include="Mocks\Windows\IPluginsWindowManager.h">
       <Filter>Mocks\Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Tools\IToolbar.h">
+      <Filter>Tools</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\Tools\IToolbar.h">
+      <Filter>Mocks\Tools</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.common.tests/EventTests.cpp
+++ b/trview.common.tests/EventTests.cpp
@@ -109,3 +109,26 @@ TEST(Event, TokenExpiryRemovesToken)
     event();
     ASSERT_EQ(1, times_called);
 }
+
+TEST(Event, RemoveEvent)
+{
+    int value = 0;
+    int times_called = 0;
+
+    Event<int> first, second;
+    first += second;
+    auto token = second += [&](int parameter)
+    {
+        ++times_called;
+        value = parameter;
+    };
+    first(100);
+
+    ASSERT_EQ(1, times_called);
+    ASSERT_EQ(100, value);
+
+    first -= second;
+
+    ASSERT_EQ(1, times_called);
+    ASSERT_EQ(100, value);
+}

--- a/trview.common/Event.h
+++ b/trview.common/Event.h
@@ -64,6 +64,13 @@ namespace trview
         /// @param listener The event that will be raised when the event is raised.
         Event<Args...>& operator += (Event<Args...>& listener);
 
+        /// <summary>
+        /// Remove an event listener from this event.
+        /// </summary>
+        /// <param name="listener">The listener to remove.</param>
+        /// <returns>The event.</returns>
+        Event<Args...>& operator -= (Event<Args...>& listener);
+
         /// Add a function as a listener to this event.
         /// @param listener The function that will be called when the event is raised.
         Token operator += (std::function<void(Args...)> listener);

--- a/trview.common/Event.inl
+++ b/trview.common/Event.inl
@@ -26,6 +26,14 @@ namespace trview
     }
 
     template <typename... Args>
+    Event<Args...>& Event<Args...>::operator -= (Event<Args...>& listener)
+    {
+        std::erase(_listener_events, &listener);
+        std::erase(listener._subscriptions, this);
+        return *this;
+    }
+
+    template <typename... Args>
     void Event<Args...>::operator()(Args... arguments)
     {
         for (const auto& listener : _listeners)

--- a/trview.common/Logs/Log.h
+++ b/trview.common/Logs/Log.h
@@ -2,6 +2,7 @@
 
 #include "ILog.h"
 #include "Message.h"
+#include <mutex>
 
 namespace trview
 {
@@ -18,5 +19,6 @@ namespace trview
         virtual void clear() override;
     private:
         std::vector<Message> _messages;
+        mutable std::mutex _mutex;
     };
 }

--- a/trview.common/TokenStore.cpp
+++ b/trview.common/TokenStore.cpp
@@ -2,6 +2,11 @@
 
 namespace trview
 {
+    void TokenStore::clear()
+    {
+        _tokens.clear();
+    }
+
     TokenStore& TokenStore::operator += (EventBase::Token&& token)
     {
         _tokens.emplace_back(std::move(token));

--- a/trview.common/TokenStore.h
+++ b/trview.common/TokenStore.h
@@ -9,6 +9,7 @@ namespace trview
     {
     public:
         TokenStore& operator += (EventBase::Token&& token);
+        void clear();
     private:
         std::vector<EventBase::Token> _tokens;
     };

--- a/trview.lua.imgui/framework.h
+++ b/trview.lua.imgui/framework.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN             // Exclude rarely-used stuff from Windows headers

--- a/trview.lua.imgui/pch.cpp
+++ b/trview.lua.imgui/pch.cpp
@@ -1,0 +1,5 @@
+// pch.cpp: source file corresponding to the pre-compiled header
+
+#include "pch.h"
+
+// When you are using pre-compiled headers, this source file is necessary for compilation to succeed.

--- a/trview.lua.imgui/pch.h
+++ b/trview.lua.imgui/pch.h
@@ -1,0 +1,13 @@
+// pch.h: This is a precompiled header file.
+// Files listed below are compiled only once, improving build performance for future builds.
+// This also affects IntelliSense performance, including code completion and many code browsing features.
+// However, files listed here are ALL re-compiled if any one of them is updated between builds.
+// Do not add files here that you will be updating frequently as this negates the performance advantage.
+
+#ifndef PCH_H
+#define PCH_H
+
+// add headers that you want to pre-compile here
+#include "framework.h"
+
+#endif //PCH_H

--- a/trview.lua.imgui/trview.lua.imgui.cpp
+++ b/trview.lua.imgui/trview.lua.imgui.cpp
@@ -249,6 +249,13 @@ namespace trview
             int end_combo(lua_State* L)
             {
                 ImGui::EndCombo();
+                return 0;
+            }
+
+            int same_line(lua_State* L)
+            {
+                ImGui::SameLine();
+                return 0;
             }
         }
 
@@ -447,6 +454,9 @@ namespace trview
                     { "SetNavIdOnHover", ImGuiSelectableFlags_SetNavIdOnHover },
                     { "NoPadWithHalfSpacing", ImGuiSelectableFlags_NoPadWithHalfSpacing }
                 });
+
+            lua_pushcfunction(L, same_line);
+            lua_setfield(L, -2, "SameLine");
 
             lua_setglobal(L, "ImGui");
         }

--- a/trview.lua.imgui/trview.lua.imgui.cpp
+++ b/trview.lua.imgui/trview.lua.imgui.cpp
@@ -6,6 +6,8 @@
 #include "trview.lua.imgui.h"
 
 #include <external/imgui/imgui.h>
+#include <optional>
+#include <string>
 
 namespace trview
 {
@@ -13,15 +15,71 @@ namespace trview
     {
         namespace
         {
+            /// <summary>
+            /// Get an optional bool named field from a table.
+            /// </summary>
+            /// <param name="L">Lua state.</param>
+            /// <param name="index">Index of the table on the stack.</param>
+            /// <param name="name">Field name.</param>
+            /// <returns>Optional - empty if not set, or boolean.</returns>
+            std::optional<bool> get_optional_bool(lua_State* L, int index, const std::string& name)
+            {
+                luaL_checktype(L, index, LUA_TTABLE);
+                lua_getfield(L, index, name.c_str());
+                if (lua_isnil(L, -1))
+                {
+                    lua_pop(L, 1);
+                    return std::nullopt;
+                }
+                luaL_checktype(L, -1, LUA_TBOOLEAN);
+                bool value = lua_toboolean(L, -1);
+                lua_pop(L, 1);
+                return value;
+            }
+
+            bool get_bool(lua_State* L, int index, const std::string& name)
+            {
+                luaL_checktype(L, index, LUA_TTABLE);
+                lua_getfield(L, index, name.c_str());
+                luaL_checktype(L, -1, LUA_TBOOLEAN);
+                bool value = lua_toboolean(L, -1);
+                lua_pop(L, 1);
+                return value;
+            }
+
+            int get_integer(lua_State* L, int index, const std::string& name)
+            {
+                luaL_checktype(L, index, LUA_TTABLE);
+                lua_getfield(L, index, name.c_str());
+                luaL_checktype(L, -1, LUA_TNUMBER);
+                int value = lua_tointeger(L, -1);
+                lua_pop(L, 1);
+                return value;
+            }
+
+            std::string get_string(lua_State* L, int index, const std::string& name)
+            {
+                luaL_checktype(L, index, LUA_TTABLE);
+                lua_getfield(L, index, name.c_str());
+                luaL_checktype(L, -1, LUA_TSTRING);
+                std::string value = lua_tostring(L, -1);
+                lua_pop(L, 1);
+                return value;
+            }
+
             int begin(lua_State* L)
             {
                 luaL_checktype(L, 1, LUA_TTABLE);
-                lua_getfield(L, 1, "name");
-                luaL_checktype(L, -1, LUA_TSTRING);
-                bool result = ImGui::Begin(lua_tostring(L, -1), 0, 0);
-                lua_pop(L, 1);
+                const auto name = get_string(L, 1, "name");
+                const auto open = get_optional_bool(L, 1, "open");
+                bool is_open = open.value_or(true);
+                bool result = ImGui::Begin(
+                    name.c_str(),
+                    open.has_value() ? &is_open : nullptr,
+                    0);
                 lua_pushboolean(L, result);
-                return 1;
+                lua_pushboolean(L, is_open);
+                return 2;
             }
 
             int finish(lua_State* L)
@@ -32,8 +90,9 @@ namespace trview
 
             int button(lua_State* L)
             {
-                luaL_checktype(L, 1, LUA_TSTRING);
-                bool result = ImGui::Button(lua_tostring(L, 1), ImVec2(0, 0));
+                luaL_checktype(L, 1, LUA_TTABLE);
+                const auto label = get_string(L, 1, "label");
+                bool result = ImGui::Button(label.c_str(), ImVec2(0, 0));
                 lua_pushboolean(L, result);
                 return 1;
             }
@@ -41,13 +100,9 @@ namespace trview
             int checkbox(lua_State* L)
             {
                 luaL_checktype(L, 1, LUA_TTABLE);
-                lua_getfield(L, 1, "label");
-                luaL_checktype(L, -1, LUA_TSTRING);
-                lua_getfield(L, 1, "checked");
-                luaL_checktype(L, -1, LUA_TBOOLEAN);
-
-                bool checked = lua_toboolean(L, -1);
-                bool result = ImGui::Checkbox(lua_tostring(L, -2), &checked);
+                const auto label = get_string(L, 1, "label");
+                auto checked = get_bool(L, 1, "checked");
+                bool result = ImGui::Checkbox(label.c_str(), &checked);
                 
                 lua_pushboolean(L, result);
                 lua_pushboolean(L, checked);
@@ -57,9 +112,51 @@ namespace trview
             int text(lua_State* L)
             {
                 luaL_checktype(L, 1, LUA_TTABLE);
-                lua_getfield(L, 1, "text");
-                luaL_checktype(L, -1, LUA_TSTRING);
-                ImGui::Text(lua_tostring(L, -1));
+                auto text = get_string(L, 1, "text");
+                ImGui::Text(text.c_str());
+                return 0;
+            }
+
+            int begin_table(lua_State* L)
+            {
+                luaL_checktype(L, 1, LUA_TTABLE);
+                auto id = get_string(L, 1, "id");
+                auto column = get_integer(L, 1, "column");
+                bool result = ImGui::BeginTable(id.c_str(), column);
+                lua_pushboolean(L, result);
+                return 1;
+            }
+
+            int end_table(lua_State* L)
+            {
+                ImGui::EndTable();
+                return 0;
+            }
+
+            int table_setup_column(lua_State* L)
+            {
+                const auto label = get_string(L, 1, "label");
+                ImGui::TableSetupColumn(label.c_str());
+                return 0;
+            }
+
+            int table_next_column(lua_State* L)
+            {
+                lua_pushboolean(L, ImGui::TableNextColumn());
+                return 1;
+            }
+
+            int table_headers_row(lua_State* L)
+            {
+                ImGui::TableHeadersRow();
+                return 0;
+            }
+
+            int table_setup_scroll_freeze(lua_State* L)
+            {
+                const auto cols = get_integer(L, 1, "cols");
+                const auto rows = get_integer(L, 1, "rows");
+                ImGui::TableSetupScrollFreeze(cols, rows);
                 return 0;
             }
         }
@@ -67,16 +164,34 @@ namespace trview
         void imgui_register(lua_State* L)
         {
             lua_newtable(L);
+            // Windows
             lua_pushcfunction(L, begin);
             lua_setfield(L, -2, "Begin");
             lua_pushcfunction(L, finish);
             lua_setfield(L, -2, "End");
+            // Buttons
             lua_pushcfunction(L, button);
             lua_setfield(L, -2, "Button");
+            // Checkbox
             lua_pushcfunction(L, checkbox);
             lua_setfield(L, -2, "Checkbox");
+            // Text
             lua_pushcfunction(L, text);
             lua_setfield(L, -2, "Text");
+            // Table
+            lua_pushcfunction(L, begin_table);
+            lua_setfield(L, -2, "BeginTable");
+            lua_pushcfunction(L, end_table);
+            lua_setfield(L, -2, "EndTable");
+            lua_pushcfunction(L, table_next_column);
+            lua_setfield(L, -2, "TableNextColumn");
+            lua_pushcfunction(L, table_setup_column);
+            lua_setfield(L, -2, "TableSetupColumn");
+            lua_pushcfunction(L, table_headers_row);
+            lua_setfield(L, -2, "TableHeadersRow");
+            lua_pushcfunction(L, table_setup_scroll_freeze);
+            lua_setfield(L, -2, "TableSetupScrollFreeze");
+
             lua_setglobal(L, "ImGui");
         }
     }

--- a/trview.lua.imgui/trview.lua.imgui.cpp
+++ b/trview.lua.imgui/trview.lua.imgui.cpp
@@ -133,7 +133,8 @@ namespace trview
             int begin_child(lua_State* L)
             {
                 const auto name = get_string(L, 1, "name");
-                bool result = ImGui::BeginChild(name.c_str());
+                const auto flags = get_optional_integer(L, 1, "flags");
+                bool result = ImGui::BeginChild(name.c_str(), ImVec2(0,0), false, flags.value_or(ImGuiWindowFlags_None));
                 lua_pushboolean(L, result);
                 return 1;
             }
@@ -196,7 +197,8 @@ namespace trview
             int table_setup_column(lua_State* L)
             {
                 const auto label = get_string(L, 1, "label");
-                ImGui::TableSetupColumn(label.c_str());
+                const auto flags = get_optional_integer(L, 1, "flags");
+                ImGui::TableSetupColumn(label.c_str(), flags.value_or(ImGuiTableColumnFlags_None));
                 return 0;
             }
 

--- a/trview.lua.imgui/trview.lua.imgui.cpp
+++ b/trview.lua.imgui/trview.lua.imgui.cpp
@@ -81,9 +81,23 @@ namespace trview
                 return 2;
             }
 
-            int finish(lua_State* L)
+            int begin_child(lua_State* L)
+            {
+                const auto name = get_string(L, 1, "name");
+                bool result = ImGui::BeginChild(name.c_str());
+                lua_pushboolean(L, result);
+                return 1;
+            }
+
+            int end(lua_State* L)
             {
                 ImGui::End();
+                return 0;
+            }
+
+            int end_child(lua_State* L)
+            {
+                ImGui::EndChild();
                 return 0;
             }
 
@@ -117,7 +131,7 @@ namespace trview
             {
                 auto id = get_string(L, 1, "id");
                 auto column = get_integer(L, 1, "column");
-                bool result = ImGui::BeginTable(id.c_str(), column);
+                bool result = ImGui::BeginTable(id.c_str(), column, ImGuiTableFlags_ScrollY);
                 lua_pushboolean(L, result);
                 return 1;
             }
@@ -154,6 +168,15 @@ namespace trview
                 ImGui::TableSetupScrollFreeze(cols, rows);
                 return 0;
             }
+
+            int selectable(lua_State* L)
+            {
+                const auto label = get_string(L, 1, "label");
+                auto selected = get_bool(L, 1, "selected");
+                bool result = ImGui::Selectable(label.c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns);
+                lua_pushboolean(L, result);
+                return 1;
+            }
         }
 
         void imgui_register(lua_State* L)
@@ -162,8 +185,12 @@ namespace trview
             // Windows
             lua_pushcfunction(L, begin);
             lua_setfield(L, -2, "Begin");
-            lua_pushcfunction(L, finish);
+            lua_pushcfunction(L, begin_child);
+            lua_setfield(L, -2, "BeginChild");
+            lua_pushcfunction(L, end);
             lua_setfield(L, -2, "End");
+            lua_pushcfunction(L, end_child);
+            lua_setfield(L, -2, "EndChild");
             // Buttons
             lua_pushcfunction(L, button);
             lua_setfield(L, -2, "Button");
@@ -186,6 +213,9 @@ namespace trview
             lua_setfield(L, -2, "TableHeadersRow");
             lua_pushcfunction(L, table_setup_scroll_freeze);
             lua_setfield(L, -2, "TableSetupScrollFreeze");
+            // Selectable
+            lua_pushcfunction(L, selectable);
+            lua_setfield(L, -2, "Selectable");
 
             lua_setglobal(L, "ImGui");
         }

--- a/trview.lua.imgui/trview.lua.imgui.cpp
+++ b/trview.lua.imgui/trview.lua.imgui.cpp
@@ -1,0 +1,83 @@
+// trview.lua.imgui.cpp : Defines the functions for the static library.
+//
+
+#include "pch.h"
+#include "framework.h"
+#include "trview.lua.imgui.h"
+
+#include <external/imgui/imgui.h>
+
+namespace trview
+{
+    namespace lua
+    {
+        namespace
+        {
+            int begin(lua_State* L)
+            {
+                luaL_checktype(L, 1, LUA_TTABLE);
+                lua_getfield(L, 1, "name");
+                luaL_checktype(L, -1, LUA_TSTRING);
+                bool result = ImGui::Begin(lua_tostring(L, -1), 0, 0);
+                lua_pop(L, 1);
+                lua_pushboolean(L, result);
+                return 1;
+            }
+
+            int finish(lua_State* L)
+            {
+                ImGui::End();
+                return 0;
+            }
+
+            int button(lua_State* L)
+            {
+                luaL_checktype(L, 1, LUA_TSTRING);
+                bool result = ImGui::Button(lua_tostring(L, 1), ImVec2(0, 0));
+                lua_pushboolean(L, result);
+                return 1;
+            }
+
+            int checkbox(lua_State* L)
+            {
+                luaL_checktype(L, 1, LUA_TTABLE);
+                lua_getfield(L, 1, "label");
+                luaL_checktype(L, -1, LUA_TSTRING);
+                lua_getfield(L, 1, "checked");
+                luaL_checktype(L, -1, LUA_TBOOLEAN);
+
+                bool checked = lua_toboolean(L, -1);
+                bool result = ImGui::Checkbox(lua_tostring(L, -1), &checked);
+                
+                lua_pushboolean(L, result);
+                lua_pushboolean(L, checked);
+                return 2;
+            }
+
+            int text(lua_State* L)
+            {
+                luaL_checktype(L, 1, LUA_TTABLE);
+                lua_getfield(L, 1, "text");
+                luaL_checktype(L, -1, LUA_TSTRING);
+                ImGui::Text(lua_tostring(L, -1));
+                return 0;
+            }
+        }
+
+        void imgui_register(lua_State* L)
+        {
+            lua_newtable(L);
+            lua_pushcfunction(L, begin);
+            lua_setfield(L, -2, "Begin");
+            lua_pushcfunction(L, finish);
+            lua_setfield(L, -2, "End");
+            lua_pushcfunction(L, button);
+            lua_setfield(L, -2, "Button");
+            lua_pushcfunction(L, checkbox);
+            lua_setfield(L, -2, "Checkbox");
+            lua_pushcfunction(L, text);
+            lua_setfield(L, -2, "Text");
+            lua_setglobal(L, "ImGui");
+        }
+    }
+}

--- a/trview.lua.imgui/trview.lua.imgui.cpp
+++ b/trview.lua.imgui/trview.lua.imgui.cpp
@@ -119,11 +119,12 @@ namespace trview
             {
                 const auto name = get_string(L, 1, "name");
                 const auto open = get_optional_bool(L, 1, "open");
+                const auto flags = get_optional_integer(L, 1, "flags");
                 bool is_open = open.value_or(true);
                 bool result = ImGui::Begin(
                     name.c_str(),
                     open.has_value() ? &is_open : nullptr,
-                    0);
+                    flags.value_or(ImGuiWindowFlags_None));
                 lua_pushboolean(L, result);
                 lua_pushboolean(L, is_open);
                 return 2;
@@ -177,9 +178,10 @@ namespace trview
 
             int begin_table(lua_State* L)
             {
-                auto id = get_string(L, 1, "id");
-                auto column = get_integer(L, 1, "column");
-                bool result = ImGui::BeginTable(id.c_str(), column, ImGuiTableFlags_ScrollY);
+                const auto id = get_string(L, 1, "id");
+                const auto column = get_integer(L, 1, "column");
+                const auto flags = get_optional_integer(L, 1, "flags");
+                bool result = ImGui::BeginTable(id.c_str(), column, flags.value_or(ImGuiTableFlags_None));
                 lua_pushboolean(L, result);
                 return 1;
             }
@@ -226,6 +228,21 @@ namespace trview
                 lua_pushboolean(L, result);
                 return 1;
             }
+
+            int begin_combo(lua_State* L)
+            {
+                const auto label = get_string(L, 1, "label");
+                const auto preview_value = get_string(L, 1, "preview_value");
+                const auto flags = get_optional_integer(L, 1, "flags");
+                bool result = ImGui::BeginCombo(label.c_str(), preview_value.c_str(), flags.value_or(ImGuiComboFlags_None));
+                lua_pushboolean(L, result);
+                return 1;
+            }
+
+            int end_combo(lua_State* L)
+            {
+                ImGui::EndCombo();
+            }
         }
 
         void imgui_register(lua_State* L)
@@ -240,12 +257,57 @@ namespace trview
             lua_setfield(L, -2, "End");
             lua_pushcfunction(L, end_child);
             lua_setfield(L, -2, "EndChild");
+
+            set_enum(L, "WindowFlags", -1,
+                {
+                    { "None", ImGuiWindowFlags_None },
+                    { "NoTitleBar", ImGuiWindowFlags_NoTitleBar },
+                    { "NoResize", ImGuiWindowFlags_NoResize },
+                    { "NoMove", ImGuiWindowFlags_NoMove },
+                    { "NoScrollbar", ImGuiWindowFlags_NoScrollbar },
+                    { "NoScrollWithMouse", ImGuiWindowFlags_NoScrollWithMouse },
+                    { "NoCollapse", ImGuiWindowFlags_NoCollapse },
+                    { "AlwaysAutoResize", ImGuiWindowFlags_AlwaysAutoResize },
+                    { "NoBackground", ImGuiWindowFlags_NoBackground },
+                    { "NoSavedSettings", ImGuiWindowFlags_NoSavedSettings },
+                    { "NoMouseInputs", ImGuiWindowFlags_NoMouseInputs },
+                    { "MenuBar", ImGuiWindowFlags_MenuBar },
+                    { "HorizontalScrollbar", ImGuiWindowFlags_HorizontalScrollbar },
+                    { "NoFocusOnAppearing", ImGuiWindowFlags_NoFocusOnAppearing },
+                    { "NoBringToFrontOnFocus", ImGuiWindowFlags_NoBringToFrontOnFocus },
+                    { "AlwaysVerticalScrollbar", ImGuiWindowFlags_AlwaysVerticalScrollbar },
+                    { "AlwaysHorizontalScrollbar", ImGuiWindowFlags_AlwaysHorizontalScrollbar },
+                    { "AlwaysUseWindowPadding", ImGuiWindowFlags_AlwaysUseWindowPadding },
+                    { "NoNavInputs", ImGuiWindowFlags_NoNavInputs },
+                    { "NoNavFocus", ImGuiWindowFlags_NoNavFocus },
+                    { "UnsavedDocument", ImGuiWindowFlags_UnsavedDocument },
+                    { "NoDocking", ImGuiWindowFlags_NoDocking }
+                });
+
             // Buttons
             lua_pushcfunction(L, button);
             lua_setfield(L, -2, "Button");
             // Checkbox
             lua_pushcfunction(L, checkbox);
             lua_setfield(L, -2, "Checkbox");
+            // Combo
+            lua_pushcfunction(L, begin_combo);
+            lua_setfield(L, -2, "BeginCombo");
+            lua_pushcfunction(L, end_combo);
+            lua_setfield(L, -2, "EndCombo");
+
+            set_enum(L, "ComboFlags", -1,
+                {
+                    { "None", ImGuiComboFlags_None },
+                    { "PopupAlignLeft", ImGuiComboFlags_PopupAlignLeft },
+                    { "HeightSmall", ImGuiComboFlags_HeightSmall },
+                    { "HeightRegular", ImGuiComboFlags_HeightRegular },
+                    { "HeightLarge", ImGuiComboFlags_HeightLarge },
+                    { "HeightLargest", ImGuiComboFlags_HeightLargest },
+                    { "NoArrowButton", ImGuiComboFlags_NoArrowButton },
+                    { "NoPreview", ImGuiComboFlags_NoPreview }
+                });
+
             // Text
             lua_pushcfunction(L, text);
             lua_setfield(L, -2, "Text");
@@ -262,6 +324,73 @@ namespace trview
             lua_setfield(L, -2, "TableHeadersRow");
             lua_pushcfunction(L, table_setup_scroll_freeze);
             lua_setfield(L, -2, "TableSetupScrollFreeze");
+
+            set_enum(L, "TableFlags", -1,
+                {
+                    { "None", ImGuiTableFlags_None },
+                    { "Resizable", ImGuiTableFlags_Resizable },
+                    { "Reorderable", ImGuiTableFlags_Reorderable },
+                    { "Hideable", ImGuiTableFlags_Hideable },
+                    { "Sortable", ImGuiTableFlags_Sortable },
+                    { "NoSavedSettings", ImGuiTableFlags_NoSavedSettings },
+                    { "ContextMenuInBody", ImGuiTableFlags_ContextMenuInBody },
+                    { "RowBg", ImGuiTableFlags_RowBg },
+                    { "BordersInnerH", ImGuiTableFlags_BordersInnerH },
+                    { "BordersOuterH", ImGuiTableFlags_BordersOuterH },
+                    { "BordersInnerV", ImGuiTableFlags_BordersInnerV },
+                    { "BordersOuterV", ImGuiTableFlags_BordersOuterV },
+                    { "BordersH", ImGuiTableFlags_BordersH },
+                    { "BordersV", ImGuiTableFlags_BordersV },
+                    { "BordersInner", ImGuiTableFlags_BordersInner },
+                    { "BordersOuter", ImGuiTableFlags_BordersOuter },
+                    { "Borders", ImGuiTableFlags_Borders },
+                    { "NoBordersInBody", ImGuiTableFlags_NoBordersInBody },
+                    { "NoBordersInBodyUntilResize", ImGuiTableFlags_NoBordersInBodyUntilResize },
+                    { "SizingFixedFit", ImGuiTableFlags_SizingFixedFit },
+                    { "SizingFixedSame", ImGuiTableFlags_SizingFixedSame },
+                    { "SizingStretchProp", ImGuiTableFlags_SizingStretchProp },
+                    { "SizingStretchSame", ImGuiTableFlags_SizingStretchSame },
+                    { "NoHostExtendX", ImGuiTableFlags_NoHostExtendX },
+                    { "NoHostExtendY", ImGuiTableFlags_NoHostExtendY },
+                    { "NoKeepColumnsVisible", ImGuiTableFlags_NoKeepColumnsVisible },
+                    { "PreciseWidths", ImGuiTableFlags_PreciseWidths },
+                    { "NoClip", ImGuiTableFlags_NoClip },
+                    { "PadOuterX", ImGuiTableFlags_PadOuterX },
+                    { "NoPadOuterX", ImGuiTableFlags_NoPadOuterX },
+                    { "NoPadInnerX", ImGuiTableFlags_NoPadInnerX },
+                    { "ScrollX", ImGuiTableFlags_ScrollX },
+                    { "ScrollY", ImGuiTableFlags_ScrollY },
+                    { "SortMulti", ImGuiTableFlags_SortMulti },
+                    { "SortTristate", ImGuiTableFlags_SortTristate }
+                });
+
+            set_enum(L, "TableColumnFlags", -1,
+                {
+                    { "None", ImGuiTableColumnFlags_None },
+                    { "Disabled", ImGuiTableColumnFlags_Disabled },
+                    { "DefaultHide", ImGuiTableColumnFlags_DefaultHide },
+                    { "DefaultSort", ImGuiTableColumnFlags_DefaultSort },
+                    { "WidthStretch", ImGuiTableColumnFlags_WidthStretch },
+                    { "WidthFixed", ImGuiTableColumnFlags_WidthFixed },
+                    { "NoResize", ImGuiTableColumnFlags_NoResize },
+                    { "NoReorder", ImGuiTableColumnFlags_NoReorder },
+                    { "NoHide", ImGuiTableColumnFlags_NoHide },
+                    { "NoClip", ImGuiTableColumnFlags_NoClip },
+                    { "NoSort", ImGuiTableColumnFlags_NoSort },
+                    { "NoSortAscending", ImGuiTableColumnFlags_NoSortAscending },
+                    { "NoSortDescending", ImGuiTableColumnFlags_NoSortDescending },
+                    { "NoHeaderLabel", ImGuiTableColumnFlags_NoHeaderLabel },
+                    { "NoHeaderWidth", ImGuiTableColumnFlags_NoHeaderWidth },
+                    { "PreferSortAscending", ImGuiTableColumnFlags_PreferSortAscending },
+                    { "PreferSortDescending", ImGuiTableColumnFlags_PreferSortDescending },
+                    { "IndentEnable", ImGuiTableColumnFlags_IndentEnable },
+                    { "IndentDisable", ImGuiTableColumnFlags_IndentDisable },
+                    { "IsEnabled", ImGuiTableColumnFlags_IsEnabled },
+                    { "IsVisible", ImGuiTableColumnFlags_IsVisible },
+                    { "IsSorted", ImGuiTableColumnFlags_IsSorted },
+                    { "IsHovered", ImGuiTableColumnFlags_IsHovered }
+                });
+
             // Selectable
             lua_pushcfunction(L, selectable);
             lua_setfield(L, -2, "Selectable");

--- a/trview.lua.imgui/trview.lua.imgui.cpp
+++ b/trview.lua.imgui/trview.lua.imgui.cpp
@@ -9,6 +9,7 @@
 #include <external/imgui/imgui_internal.h>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace trview
 {
@@ -90,6 +91,27 @@ namespace trview
                     index += lua_gettop(L) + 1;
                 }
                 lua_pushinteger(L, value);
+                lua_setfield(L, index, name.c_str());
+            }
+
+            struct EnumValue
+            {
+                std::string name;
+                int value;
+            };
+
+            void set_enum(lua_State* L, const std::string& name, int index, const std::vector<EnumValue>& values)
+            {
+                if (index < 0)
+                {
+                    index += lua_gettop(L) + 1;
+                }
+
+                lua_newtable(L);
+                for (const auto& v : values)
+                {
+                    set_integer(L, -1, v.name.c_str(), v.value);
+                }
                 lua_setfield(L, index, name.c_str());
             }
 
@@ -244,22 +266,23 @@ namespace trview
             lua_pushcfunction(L, selectable);
             lua_setfield(L, -2, "Selectable");
 
-            lua_newtable(L);
-            set_integer(L, -1, "None", ImGuiSelectableFlags_None);
-            set_integer(L, -1, "DontClosePopups", ImGuiSelectableFlags_DontClosePopups);
-            set_integer(L, -1, "SpanAllColumns", ImGuiSelectableFlags_SpanAllColumns);
-            set_integer(L, -1, "AllowDoubleClick", ImGuiSelectableFlags_AllowDoubleClick);
-            set_integer(L, -1, "Disabled", ImGuiSelectableFlags_Disabled);
-            set_integer(L, -1, "AllowItemOverlap", ImGuiSelectableFlags_AllowItemOverlap);
-            set_integer(L, -1, "NoHoldingActiveID", ImGuiSelectableFlags_NoHoldingActiveID);
-            set_integer(L, -1, "SelectOnNav", ImGuiSelectableFlags_SelectOnNav);
-            set_integer(L, -1, "SelectOnClick", ImGuiSelectableFlags_SelectOnClick);
-            set_integer(L, -1, "SelectOnRelease", ImGuiSelectableFlags_SelectOnRelease);
-            set_integer(L, -1, "SpanAvailWidth", ImGuiSelectableFlags_SpanAvailWidth);
-            set_integer(L, -1, "DrawHoveredWhenHeld", ImGuiSelectableFlags_DrawHoveredWhenHeld);
-            set_integer(L, -1, "SetNavIdOnHover", ImGuiSelectableFlags_SetNavIdOnHover);
-            set_integer(L, -1, "NoPadWithHalfSpacing", ImGuiSelectableFlags_NoPadWithHalfSpacing);
-            lua_setfield(L, -2, "SelectableFlags");
+            set_enum(L, "SelectableFlags", -1, 
+                {
+                    { "None", ImGuiSelectableFlags_None },
+                    { "DontClosePopups", ImGuiSelectableFlags_DontClosePopups },
+                    { "SpanAllColumns", ImGuiSelectableFlags_SpanAllColumns },
+                    { "AllowDoubleClick", ImGuiSelectableFlags_AllowDoubleClick },
+                    { "Disabled", ImGuiSelectableFlags_Disabled },
+                    { "AllowItemOverlap", ImGuiSelectableFlags_AllowItemOverlap },
+                    { "NoHoldingActiveID", ImGuiSelectableFlags_NoHoldingActiveID },
+                    { "SelectOnNav", ImGuiSelectableFlags_SelectOnNav },
+                    { "SelectOnClick", ImGuiSelectableFlags_SelectOnClick },
+                    { "SelectOnRelease", ImGuiSelectableFlags_SelectOnRelease },
+                    { "SpanAvailWidth", ImGuiSelectableFlags_SpanAvailWidth },
+                    { "DrawHoveredWhenHeld", ImGuiSelectableFlags_DrawHoveredWhenHeld },
+                    { "SetNavIdOnHover", ImGuiSelectableFlags_SetNavIdOnHover },
+                    { "NoPadWithHalfSpacing", ImGuiSelectableFlags_NoPadWithHalfSpacing }
+                });
 
             lua_setglobal(L, "ImGui");
         }

--- a/trview.lua.imgui/trview.lua.imgui.cpp
+++ b/trview.lua.imgui/trview.lua.imgui.cpp
@@ -69,7 +69,6 @@ namespace trview
 
             int begin(lua_State* L)
             {
-                luaL_checktype(L, 1, LUA_TTABLE);
                 const auto name = get_string(L, 1, "name");
                 const auto open = get_optional_bool(L, 1, "open");
                 bool is_open = open.value_or(true);
@@ -90,7 +89,6 @@ namespace trview
 
             int button(lua_State* L)
             {
-                luaL_checktype(L, 1, LUA_TTABLE);
                 const auto label = get_string(L, 1, "label");
                 bool result = ImGui::Button(label.c_str(), ImVec2(0, 0));
                 lua_pushboolean(L, result);
@@ -99,11 +97,10 @@ namespace trview
 
             int checkbox(lua_State* L)
             {
-                luaL_checktype(L, 1, LUA_TTABLE);
                 const auto label = get_string(L, 1, "label");
                 auto checked = get_bool(L, 1, "checked");
                 bool result = ImGui::Checkbox(label.c_str(), &checked);
-                
+
                 lua_pushboolean(L, result);
                 lua_pushboolean(L, checked);
                 return 2;
@@ -111,7 +108,6 @@ namespace trview
 
             int text(lua_State* L)
             {
-                luaL_checktype(L, 1, LUA_TTABLE);
                 auto text = get_string(L, 1, "text");
                 ImGui::Text(text.c_str());
                 return 0;
@@ -119,7 +115,6 @@ namespace trview
 
             int begin_table(lua_State* L)
             {
-                luaL_checktype(L, 1, LUA_TTABLE);
                 auto id = get_string(L, 1, "id");
                 auto column = get_integer(L, 1, "column");
                 bool result = ImGui::BeginTable(id.c_str(), column);

--- a/trview.lua.imgui/trview.lua.imgui.cpp
+++ b/trview.lua.imgui/trview.lua.imgui.cpp
@@ -47,7 +47,7 @@ namespace trview
                 luaL_checktype(L, -1, LUA_TBOOLEAN);
 
                 bool checked = lua_toboolean(L, -1);
-                bool result = ImGui::Checkbox(lua_tostring(L, -1), &checked);
+                bool result = ImGui::Checkbox(lua_tostring(L, -2), &checked);
                 
                 lua_pushboolean(L, result);
                 lua_pushboolean(L, checked);

--- a/trview.lua.imgui/trview.lua.imgui.cpp
+++ b/trview.lua.imgui/trview.lua.imgui.cpp
@@ -153,7 +153,8 @@ namespace trview
             int button(lua_State* L)
             {
                 const auto label = get_string(L, 1, "label");
-                bool result = ImGui::Button(label.c_str(), ImVec2(0, 0));
+                const auto flags = get_optional_integer(L, 1, "flags");
+                bool result = ImGui::ButtonEx(label.c_str(), ImVec2(0, 0), flags.value_or(ImGuiButtonFlags_None));
                 lua_pushboolean(L, result);
                 return 1;
             }
@@ -203,6 +204,12 @@ namespace trview
             {
                 lua_pushboolean(L, ImGui::TableNextColumn());
                 return 1;
+            }
+
+            int table_next_row(lua_State* L)
+            {
+                ImGui::TableNextRow();
+                return 0;
             }
 
             int table_headers_row(lua_State* L)
@@ -287,6 +294,32 @@ namespace trview
             // Buttons
             lua_pushcfunction(L, button);
             lua_setfield(L, -2, "Button");
+
+            set_enum(L, "ButtonFlags", -1,
+                {
+                    { "None", ImGuiButtonFlags_None },
+                    { "MouseButtonLeft", ImGuiButtonFlags_MouseButtonLeft },
+                    { "MouseButtonRight", ImGuiButtonFlags_MouseButtonRight },
+                    { "MouseButtonMiddle", ImGuiButtonFlags_MouseButtonMiddle },
+                    { "PressedOnClick", ImGuiButtonFlags_PressedOnClick },
+                    { "PressedOnClickRelease", ImGuiButtonFlags_PressedOnClickRelease },
+                    { "PressedOnClickReleaseAnywhere", ImGuiButtonFlags_PressedOnClickReleaseAnywhere },
+                    { "PressedOnRelease", ImGuiButtonFlags_PressedOnRelease },
+                    { "PressedOnDoubleClick", ImGuiButtonFlags_PressedOnDoubleClick },
+                    { "PressedOnDragDropHold", ImGuiButtonFlags_PressedOnDragDropHold },
+                    { "Repeat", ImGuiButtonFlags_Repeat },
+                    { "FlattenChildren", ImGuiButtonFlags_FlattenChildren },
+                    { "AllowItemOverlap", ImGuiButtonFlags_AllowItemOverlap },
+                    { "DontClosePopups", ImGuiButtonFlags_DontClosePopups },
+                    { "AlignTextBaseLine", ImGuiButtonFlags_AlignTextBaseLine },
+                    { "NoKeyModifiers", ImGuiButtonFlags_NoKeyModifiers },
+                    { "NoHoldingActiveId", ImGuiButtonFlags_NoHoldingActiveId },
+                    { "NoNavFocus", ImGuiButtonFlags_NoNavFocus },
+                    { "NoHoveredOnFocus", ImGuiButtonFlags_NoHoveredOnFocus },
+                    { "PressedOnMask_", ImGuiButtonFlags_PressedOnMask_ },
+                    { "PressedOnDefault_", ImGuiButtonFlags_PressedOnDefault_ },
+                });
+
             // Checkbox
             lua_pushcfunction(L, checkbox);
             lua_setfield(L, -2, "Checkbox");
@@ -322,6 +355,8 @@ namespace trview
             lua_setfield(L, -2, "TableSetupColumn");
             lua_pushcfunction(L, table_headers_row);
             lua_setfield(L, -2, "TableHeadersRow");
+            lua_pushcfunction(L, table_next_row);
+            lua_setfield(L, -2, "TableNextRow");
             lua_pushcfunction(L, table_setup_scroll_freeze);
             lua_setfield(L, -2, "TableSetupScrollFreeze");
 

--- a/trview.lua.imgui/trview.lua.imgui.h
+++ b/trview.lua.imgui/trview.lua.imgui.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <external/lua/src/lua.h>
+#include <external/lua/src/lauxlib.h>
+
+namespace trview
+{
+    namespace lua
+    {
+        void imgui_register(lua_State* L);
+    }
+}

--- a/trview.lua.imgui/trview.lua.imgui.vcxproj
+++ b/trview.lua.imgui/trview.lua.imgui.vcxproj
@@ -1,0 +1,170 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{cdbc4705-e8e2-4c5c-a1a6-ea66fe4b699b}</ProjectGuid>
+    <RootNamespace>trviewluaimgui</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>
+      </SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="framework.h" />
+    <ClInclude Include="pch.h" />
+    <ClInclude Include="trview.lua.imgui.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="pch.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="trview.lua.imgui.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/trview.lua.imgui/trview.lua.imgui.vcxproj.filters
+++ b/trview.lua.imgui/trview.lua.imgui.vcxproj.filters
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="framework.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="pch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="trview.lua.imgui.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="trview.lua.imgui.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="pch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/trview.sln
+++ b/trview.sln
@@ -118,6 +118,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "lua", "lua", "{D6B95B54-7EB
 		doc\lua\vector3.md = doc\lua\vector3.md
 	EndProjectSection
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "trview.lua.imgui", "trview.lua.imgui\trview.lua.imgui.vcxproj", "{CDBC4705-E8E2-4C5C-A1A6-EA66FE4B699B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -292,6 +294,14 @@ Global
 		{A11566D3-4081-42C9-94C5-F4057EDD9D50}.Release|x64.Build.0 = Release|x64
 		{A11566D3-4081-42C9-94C5-F4057EDD9D50}.Release|x86.ActiveCfg = Release|Win32
 		{A11566D3-4081-42C9-94C5-F4057EDD9D50}.Release|x86.Build.0 = Release|Win32
+		{CDBC4705-E8E2-4C5C-A1A6-EA66FE4B699B}.Debug|x64.ActiveCfg = Debug|x64
+		{CDBC4705-E8E2-4C5C-A1A6-EA66FE4B699B}.Debug|x64.Build.0 = Debug|x64
+		{CDBC4705-E8E2-4C5C-A1A6-EA66FE4B699B}.Debug|x86.ActiveCfg = Debug|Win32
+		{CDBC4705-E8E2-4C5C-A1A6-EA66FE4B699B}.Debug|x86.Build.0 = Debug|Win32
+		{CDBC4705-E8E2-4C5C-A1A6-EA66FE4B699B}.Release|x64.ActiveCfg = Release|x64
+		{CDBC4705-E8E2-4C5C-A1A6-EA66FE4B699B}.Release|x64.Build.0 = Release|x64
+		{CDBC4705-E8E2-4C5C-A1A6-EA66FE4B699B}.Release|x86.ActiveCfg = Release|Win32
+		{CDBC4705-E8E2-4C5C-A1A6-EA66FE4B699B}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/trview.sln
+++ b/trview.sln
@@ -111,6 +111,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "lua", "lua", "{D6B95B54-7EB
 		doc\lua\item.md = doc\lua\item.md
 		doc\lua\level.md = doc\lua\level.md
 		doc\lua\light.md = doc\lua\light.md
+		doc\lua\plugins.md = doc\lua\plugins.md
 		doc\lua\room.md = doc\lua\room.md
 		doc\lua\sector.md = doc\lua\sector.md
 		doc\lua\trigger.md = doc\lua\trigger.md

--- a/trview.sln
+++ b/trview.sln
@@ -107,6 +107,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "lua", "lua", "{D6B95B54-7EB
 		doc\lua\camera_sink.md = doc\lua\camera_sink.md
 		doc\lua\colour.md = doc\lua\colour.md
 		doc\lua\command.md = doc\lua\command.md
+		doc\lua\imgui.md = doc\lua\imgui.md
 		doc\lua\index.md = doc\lua\index.md
 		doc\lua\item.md = doc\lua\item.md
 		doc\lua\level.md = doc\lua\level.md

--- a/trview/trview.vcxproj
+++ b/trview/trview.vcxproj
@@ -209,6 +209,9 @@
     <ProjectReference Include="..\trview.lau\trview.lau.vcxproj">
       <Project>{2ac76373-f9a6-426d-b732-80e6bd6bfab4}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\trview.lua.imgui\trview.lua.imgui.vcxproj">
+      <Project>{cdbc4705-e8e2-4c5c-a1a6-ea66fe4b699b}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
Add the initial ImGui bindings. These aren't complete but have been enough to make the monkey finder example plugin. More will be added in batches.

Add a way of unregistering from an event handler - this is required as trview hasn't had levels surviving and coming back before (Lua can now keep them alive).

Lua:
- Add `selected_item` property to `level`.
- Add `local_levels` property to `trview`.
- Change `trview:load` to be a coroutine - this allows for plugins to load levels in the background. A mutex was added to log as otherwise this was causing crashes.

Plugins can now have `render_toolbar` and `render_ui` functions that the application will call if they're present. UI is for rendering regular windows and toolbar is for rendering a button into the bottom toolbar.

#1129 
