### PR TITLE
Add Room Lighting mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ CTRL + M    | New Rooms window
 CTRL + L    | New Lights window
 CTRL + K    | New Camera/Sink window
 CTRL + P    | New Plugins window
+CTRL + H    | Toggle room lighting
 F1          | Toggle settings window
 F5          | Reload current level
 F6          | Load previous level in directory
@@ -126,6 +127,7 @@ Depth Selector      | Choose the depth of neighbours to show
 Wireframe           | Enable wireframe rendering mode
 Bounds              | Show static mesh bounding boxes
 Lights              | Toggle lights visibility
+Lighting            | Toggle using room lighting
 Flip                | Toggle the level flipmap (if present in the level). In TR4+ this will be a flipmap group selector.
 
 ## Room Navigator

--- a/external/DirectXTK/DirectXTK_Desktop.vcxproj
+++ b/external/DirectXTK/DirectXTK_Desktop.vcxproj
@@ -152,6 +152,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>5262</DisableSpecificWarnings>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -178,6 +179,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableSpecificWarnings>5262</DisableSpecificWarnings>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -202,6 +204,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>5262</DisableSpecificWarnings>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -228,6 +231,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DisableSpecificWarnings>5262</DisableSpecificWarnings>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trlevel.tests/trlevel.tests.vcxproj
+++ b/trlevel.tests/trlevel.tests.vcxproj
@@ -83,6 +83,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -104,6 +105,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -125,6 +127,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -146,6 +149,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -123,9 +123,13 @@ namespace trlevel
                 {
                     room.data.vertices = convert_vertices(read_vector<int16_t, tr_room_vertex>(file));
                 }
+                else if (version == LevelVersion::Tomb2)
+                {
+                    room.data.vertices = convert_vertices(read_vector<int16_t, tr2_room_vertex>(file));
+                }
                 else
                 {
-                    room.data.vertices = read_vector<int16_t, tr3_room_vertex>(file);
+                    room.data.vertices = convert_vertices(read_vector<int16_t, tr3_room_vertex>(file));
                 }
                 activity.log(std::format("Read {} vertices", room.data.vertices.size()));
 

--- a/trlevel/tr_rooms.cpp
+++ b/trlevel/tr_rooms.cpp
@@ -7,12 +7,18 @@ namespace trlevel
 {
     namespace
     {
+        /// <summary>
+        /// Convert TR1/2 brightness to Color.
+        /// </summary>
         constexpr Color lighting_to_colour(int16_t lighting) noexcept
         {
             const float value = 1.0f - static_cast<float>(lighting) / 8191.0f;
             return Color(value, value, value);
         }
 
+        /// <summary>
+        /// Convert TR3/4 colour to Color. Doubles values to look like PSX.
+        /// </summary>
         constexpr Color to_colour(uint16_t colour) noexcept
         {
             const int32_t r = (colour & 0x7c00) >> 10;
@@ -21,12 +27,15 @@ namespace trlevel
             return Color(r / 16.5f, g / 16.5f, b / 16.5f);
         }
 
+        /// <summary>
+        /// Convert TR5 colour to Color. Doubles values to look like PSX.
+        /// </summary>
         constexpr Color to_colour(uint32_t colour) noexcept
         {
             const int32_t r = (colour & 0x00ff0000) >> 16;
             const int32_t g = (colour & 0x0000ff00) >> 8;
             const int32_t b = (colour & 0x000000ff);
-            return Color(r / 255.0f, g / 255.0f, b / 255.0f);
+            return Color(r / 128.0f, g / 128.0f, b / 128.0f);
         }
     }
 

--- a/trlevel/tr_rooms.cpp
+++ b/trlevel/tr_rooms.cpp
@@ -1,0 +1,84 @@
+#include "stdafx.h"
+#include "tr_rooms.h"
+
+using namespace DirectX::SimpleMath;
+
+namespace trlevel
+{
+    namespace
+    {
+        constexpr Color lighting_to_colour(int16_t lighting) noexcept
+        {
+            const float value = 1.0f - static_cast<float>(lighting) / 8191.0f;
+            return Color(value, value, value);
+        }
+
+        constexpr Color to_colour(uint16_t colour) noexcept
+        {
+            const int32_t r = (colour & 0x7c00) >> 10;
+            const int32_t g = (colour & 0x03E0) >> 5;
+            const int32_t b = (colour & 0x001F);
+            return Color(r / 31.0f, g / 31.0f, b / 31.0f);
+        }
+
+        constexpr Color to_colour(uint32_t colour) noexcept
+        {
+            const int32_t r = (colour & 0x00ff0000) >> 16;
+            const int32_t g = (colour & 0x0000ff00) >> 8;
+            const int32_t b = (colour & 0x000000ff);
+            return Color(r / 255.0f, g / 255.0f, b / 255.0f);
+        }
+    }
+
+    std::vector<trview_room_vertex> convert_vertices(std::vector<tr_room_vertex> vertices)
+    {
+        std::vector<trview_room_vertex> new_vertices;
+        new_vertices.reserve(vertices.size());
+        std::transform(vertices.begin(), vertices.end(),
+            std::back_inserter(new_vertices), [](const auto& vert)
+            {
+                trview_room_vertex new_vertex{ vert.vertex, vert.lighting, 0, lighting_to_colour(vert.lighting) };
+                return new_vertex;
+            });
+        return new_vertices;
+    }
+
+    std::vector<trview_room_vertex> convert_vertices(std::vector<tr2_room_vertex> vertices)
+    {
+        std::vector<trview_room_vertex> new_vertices;
+        new_vertices.reserve(vertices.size());
+        std::transform(vertices.begin(), vertices.end(),
+            std::back_inserter(new_vertices), [](const auto& vert)
+            {
+                trview_room_vertex new_vertex{ vert.vertex, vert.lighting2, 0, lighting_to_colour(vert.lighting2) };
+                return new_vertex;
+            });
+        return new_vertices;
+    }
+
+    std::vector<trview_room_vertex> convert_vertices(std::vector<tr3_room_vertex> vertices)
+    {
+        std::vector<trview_room_vertex> new_vertices;
+        new_vertices.reserve(vertices.size());
+        std::transform(vertices.begin(), vertices.end(),
+            std::back_inserter(new_vertices), [](const auto& vert)
+            {
+                trview_room_vertex new_vertex{ vert.vertex, vert.lighting, vert.attributes, to_colour(vert.colour) };
+                return new_vertex;
+            });
+        return new_vertices;
+    }
+
+    std::vector<trview_room_vertex> convert_vertices(std::vector<tr5_room_vertex> vertices)
+    {
+        std::vector<trview_room_vertex> new_vertices;
+        new_vertices.reserve(vertices.size());
+        std::transform(vertices.begin(), vertices.end(),
+            std::back_inserter(new_vertices), [](const auto& vert)
+            {
+                tr_vertex vertex{ static_cast<int16_t>(vert.vertex.x), static_cast<int16_t>(vert.vertex.y), static_cast<int16_t>(vert.vertex.z) };
+                return trview_room_vertex{ vertex, 0, 0, to_colour(vert.colour) };
+            });
+        return new_vertices;
+    }
+}

--- a/trlevel/tr_rooms.cpp
+++ b/trlevel/tr_rooms.cpp
@@ -18,7 +18,7 @@ namespace trlevel
             const int32_t r = (colour & 0x7c00) >> 10;
             const int32_t g = (colour & 0x03E0) >> 5;
             const int32_t b = (colour & 0x001F);
-            return Color(r / 31.0f, g / 31.0f, b / 31.0f);
+            return Color(r / 16.5f, g / 16.5f, b / 16.5f);
         }
 
         constexpr Color to_colour(uint32_t colour) noexcept

--- a/trlevel/tr_rooms.h
+++ b/trlevel/tr_rooms.h
@@ -5,9 +5,17 @@
 
 namespace trlevel
 {
+    struct trview_room_vertex
+    {
+        tr_vertex vertex;
+        int16_t lighting;
+        uint16_t attributes;
+        DirectX::SimpleMath::Color colour;
+    };
+
     struct tr3_room_data
     {
-        std::vector<tr3_room_vertex> vertices;
+        std::vector<trview_room_vertex> vertices;
         std::vector<tr4_mesh_face4> rectangles;
         std::vector<tr4_mesh_face3> triangles;
         std::vector<tr_room_sprite> sprites;
@@ -40,4 +48,9 @@ namespace trlevel
         uint8_t reverb_info;
         uint8_t alternate_group{ 0xff };
     };
+
+    std::vector<trview_room_vertex> convert_vertices(std::vector<tr_room_vertex> vertices);
+    std::vector<trview_room_vertex> convert_vertices(std::vector<tr2_room_vertex> vertices);
+    std::vector<trview_room_vertex> convert_vertices(std::vector<tr3_room_vertex> vertices);
+    std::vector<trview_room_vertex> convert_vertices(std::vector<tr5_room_vertex> vertices);
 }

--- a/trlevel/trlevel.vcxproj
+++ b/trlevel/trlevel.vcxproj
@@ -95,6 +95,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/utf-8</AdditionalOptions>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -114,6 +115,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/utf-8</AdditionalOptions>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -135,6 +137,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalOptions>/utf-8</AdditionalOptions>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -158,6 +161,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalOptions>/utf-8</AdditionalOptions>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trlevel/trlevel.vcxproj
+++ b/trlevel/trlevel.vcxproj
@@ -203,6 +203,7 @@
     </ClCompile>
     <ClCompile Include="trtypes.cpp" />
     <ClCompile Include="tr_lights.cpp" />
+    <ClCompile Include="tr_rooms.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\external\zlib\contrib\vstudio\vc14\zlibstat.vcxproj">

--- a/trlevel/trlevel.vcxproj.filters
+++ b/trlevel/trlevel.vcxproj.filters
@@ -27,6 +27,7 @@
     <ClCompile Include="Mocks\MockLevel.cpp">
       <Filter>Mocks</Filter>
     </ClCompile>
+    <ClCompile Include="tr_rooms.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">

--- a/trlevel/trtypes.cpp
+++ b/trlevel/trtypes.cpp
@@ -42,34 +42,6 @@ namespace trlevel
         return a << 24 | b << 16 | g << 8 | r;
     }
 
-    // Convert a set of Tomb Raider I vertices into a vertex format compatible
-    // with Tomb Raider III (what the viewer is currently using).
-    std::vector<tr3_room_vertex> convert_vertices(std::vector<tr_room_vertex> vertices)
-    {
-        std::vector<tr3_room_vertex> new_vertices;
-        new_vertices.reserve(vertices.size());
-        std::transform(vertices.begin(), vertices.end(),
-            std::back_inserter(new_vertices), [](const auto& vert)
-        {
-            tr3_room_vertex new_vertex { vert.vertex, vert.lighting, 0, 0xffff };
-            return new_vertex;
-        });
-        return new_vertices;
-    }
-
-    std::vector<tr3_room_vertex> convert_vertices(std::vector<tr5_room_vertex> vertices)
-    {
-        std::vector<tr3_room_vertex> new_vertices;
-        new_vertices.reserve(vertices.size());
-        std::transform(vertices.begin(), vertices.end(),
-            std::back_inserter(new_vertices), [](const auto& vert)
-        {
-            tr_vertex vertex{ static_cast<int16_t>(vert.vertex.x), static_cast<int16_t>(vert.vertex.y), static_cast<int16_t>(vert.vertex.z) };
-            return tr3_room_vertex { vertex, 0, 0, 0xffff };
-        });
-        return new_vertices;
-    }
-
     // Convert a set of Tomb Raider I static meshes into a format compatible
     // with Tomb Raider III (what the viewer is currently using).
     std::vector<tr3_room_staticmesh> convert_room_static_meshes(std::vector<tr_room_staticmesh> meshes)

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -431,6 +431,14 @@ namespace trlevel
         int16_t   lighting;
     };
 
+    struct tr2_room_vertex
+    {
+        tr_vertex vertex;
+        int16_t   lighting;
+        uint16_t  attributes;
+        int16_t  lighting2;
+    };
+
     struct tr3_room_vertex
     {
         tr_vertex   vertex;
@@ -696,16 +704,6 @@ namespace trlevel
 
     // Convert a 16 bit textile into a 32 bit argb value.
     uint32_t convert_textile16(uint16_t t);
-
-    // Convert a set of Tomb Raider I vertices into a vertex format compatible
-    // with Tomb Raider III (what the viewer is currently using).
-    std::vector<tr3_room_vertex> convert_vertices(std::vector<tr_room_vertex> vertices);
-
-    /// Convert a set of Tomb Raider 5 vertices into a vertex format compatible
-    /// with Tomb Raider III (what the viewer is currently using).
-    /// @param vertices The vertices to convert.
-    /// @return The converted vertices.
-    std::vector<tr3_room_vertex> convert_vertices(std::vector<tr5_room_vertex> vertices);
 
     // Convert a set of Tomb Raider I static meshes into a format compatible
     // with Tomb Raider III (what the viewer is currently using).

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -778,3 +778,14 @@ TEST(Level, CameraSinksRenderedWhenEnabled)
     level->set_show_camera_sinks(true);
     level->render(camera, false);
 }
+
+TEST(Level, SetShowLightingRaisesLevelChangedEvent)
+{
+    auto level = register_test_module().build();
+
+    uint32_t times_called = 0;
+    auto token = level->on_level_changed += [&](auto&&...) { ++times_called; };
+
+    level->set_show_lighting(true);
+    ASSERT_EQ(times_called, 1u);
+}

--- a/trview.app.tests/Elements/StaticMeshTests.cpp
+++ b/trview.app.tests/Elements/StaticMeshTests.cpp
@@ -14,7 +14,7 @@ TEST(StaticMesh, BoundingBoxRendered)
 {
     auto actual_mesh = mock_shared<MockMesh>();
     auto bounding_mesh = mock_shared<MockMesh>();
-    EXPECT_CALL(*bounding_mesh, render(A<const Matrix&>(), A<const ILevelTextureStorage&>(), A<const Color&>(), A<float>(), A<Vector3>(), A<bool>())).Times(1);
+    EXPECT_CALL(*bounding_mesh, render(A<const Matrix&>(), A<const ILevelTextureStorage&>(), A<const Color&>(), A<float>(), A<Vector3>(), A<bool>(), A<bool>())).Times(1);
 
     StaticMesh mesh({}, {}, actual_mesh, {}, bounding_mesh);
     mesh.render_bounding_box(NiceMock<MockCamera>{}, NiceMock<MockLevelTextureStorage>{}, Colour::White);

--- a/trview.app.tests/UI/ViewOptionsTests.cpp
+++ b/trview.app.tests/UI/ViewOptionsTests.cpp
@@ -399,3 +399,33 @@ TEST(ViewOptions, CameraSinksCheckboxUpdated)
     imgui.render();
     ASSERT_TRUE(imgui.status_flags(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::camera_sinks)) & ImGuiItemStatusFlags_Checked);
 }
+
+TEST(ViewOptions, LightingCheckboxToggle)
+{
+    ViewOptions view_options;
+
+    std::optional<std::tuple<std::string, bool>> clicked;
+    auto token = view_options.on_toggle_changed += [&](const std::string& name, bool value)
+    {
+        clicked = { name, value };
+    };
+
+    tests::TestImgui imgui([&]() { view_options.render(); });
+    imgui.click_element(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::lighting));
+
+    ASSERT_TRUE(clicked.has_value());
+    ASSERT_EQ(std::get<0>(clicked.value()), IViewer::Options::lighting);
+    ASSERT_FALSE(std::get<1>(clicked.value()));
+}
+
+TEST(ViewOptions, LightingCheckboxUpdated)
+{
+    ViewOptions view_options;
+
+    tests::TestImgui imgui([&]() { view_options.render(); });
+    ASSERT_TRUE(imgui.status_flags(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::lighting)) & ImGuiItemStatusFlags_Checked);
+
+    view_options.set_toggle(IViewer::Options::lighting, false);
+    imgui.render();
+    ASSERT_FALSE(imgui.status_flags(imgui.id("View Options").push(ViewOptions::Names::flags).id(IViewer::Options::lighting)) & ImGuiItemStatusFlags_Checked);
+}

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -975,3 +975,19 @@ TEST(Viewer, SetTriggeredByCameraSink)
 
     activate_context_menu(picking, mouse, PickResult::Type::CameraSink, 14);
 }
+
+TEST(Viewer, SetShowLighting)
+{
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
+
+    EXPECT_CALL(level, set_show_lighting(false)).Times(1);
+    EXPECT_CALL(ui, set_toggle(testing::A<const std::string&>(), testing::A<bool>())).Times(testing::AtLeast(0));
+    EXPECT_CALL(ui, set_toggle(IViewer::Options::lighting, true)).Times(1);
+    EXPECT_CALL(level, set_show_lighting(true)).Times(1);
+
+    viewer->open(&level, ILevel::OpenMode::Full);
+    ui.on_toggle_changed(IViewer::Options::lighting, true);
+}
+

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -204,6 +204,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -227,6 +228,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -248,6 +250,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -271,6 +274,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -104,6 +104,7 @@ namespace trview
         virtual void set_show_water(bool show) = 0;
         virtual void set_show_wireframe(bool show) = 0;
         virtual void set_show_bounding_boxes(bool show) = 0;
+        virtual void set_show_lighting(bool show) = 0;
         virtual void set_show_lights(bool show) = 0;
         virtual void set_show_items(bool show) = 0;
         virtual void set_show_rooms(bool show) = 0;
@@ -117,6 +118,7 @@ namespace trview
         virtual void set_camera_sink_visibility(uint32_t index, bool state) = 0;
         virtual bool show_camera_sinks() const = 0;
         virtual bool show_geometry() const = 0;
+        virtual bool show_lighting() const = 0;
         virtual bool show_lights() const = 0;
         virtual bool show_triggers() const = 0;
         virtual bool show_items() const = 0;

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -818,6 +818,13 @@ namespace trview
         on_level_changed();
     }
 
+    void Level::set_show_lighting(bool show)
+    {
+        _render_filters = set_flag(_render_filters, RenderFilter::Lighting, show);
+        _regenerate_transparency = true;
+        on_level_changed();
+    }
+
     void Level::set_show_lights(bool show)
     {
         _render_filters = set_flag(_render_filters, RenderFilter::Lights, show);
@@ -842,6 +849,11 @@ namespace trview
     bool Level::show_triggers() const
     {
         return has_flag(_render_filters, RenderFilter::Triggers);
+    }
+
+    bool Level::show_lighting() const
+    {
+        return has_flag(_render_filters, RenderFilter::Lighting);
     }
 
     bool Level::show_lights() const

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -72,9 +72,11 @@ namespace trview
         virtual void set_show_water(bool show) override;
         virtual void set_show_wireframe(bool show) override;
         virtual void set_show_bounding_boxes(bool show) override;
+        void set_show_lighting(bool show) override;
         virtual void set_show_lights(bool show) override;
         virtual void set_show_items(bool show) override;
         virtual void set_show_rooms(bool show) override;
+        bool show_lighting() const override;
         virtual bool show_lights() const override;
         virtual bool show_triggers() const override;
         virtual bool show_items() const override;

--- a/trview.app/Elements/RenderFilter.h
+++ b/trview.app/Elements/RenderFilter.h
@@ -13,6 +13,7 @@ namespace trview
         BoundingBoxes = 0x20,
         Lights = 0x40,
         CameraSinks = 0x80,
+        Lighting = 0x100,
         All = 0xffffffff,
         Default = Rooms | Entities | Triggers | Water
     };

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -254,7 +254,7 @@ namespace trview
             }
             else
             {
-                _mesh->render(_room_offset * camera.view_projection(), *_texture_storage, colour, 1.0f, Vector3::Zero);
+                _mesh->render(_room_offset * camera.view_projection(), *_texture_storage, colour, 1.0f, Vector3::Zero, false, true);
                 for (const auto& mesh : _static_meshes)
                 {
                     mesh->render(camera, *_texture_storage, colour);

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -375,10 +375,6 @@ namespace trview
 
     void Room::generate_geometry(const IMesh::Source& mesh_source, const trlevel::tr3_room& room)
     {
-        std::vector<trlevel::tr_vertex> room_vertices;
-        std::transform(room.data.vertices.begin(), room.data.vertices.end(), std::back_inserter(room_vertices),
-            [](const auto& v) { return v.vertex; });
-
         std::vector<MeshVertex> vertices;
         std::vector<TransparentTriangle> transparent_triangles;
 
@@ -387,8 +383,8 @@ namespace trview
         
         std::vector<Triangle> collision_triangles;
 
-        process_textured_rectangles(room.data.rectangles, room_vertices, *_texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
-        process_textured_triangles(room.data.triangles, room_vertices, *_texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
+        process_textured_rectangles(room.data.rectangles, room.data.vertices, *_texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
+        process_textured_triangles(room.data.triangles, room.data.vertices, *_texture_storage, vertices, indices, transparent_triangles, collision_triangles, false);
         process_collision_transparency(transparent_triangles, collision_triangles);
 
         _mesh = mesh_source(vertices, indices, std::vector<uint32_t>{}, transparent_triangles, collision_triangles);

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -254,7 +254,7 @@ namespace trview
             }
             else
             {
-                _mesh->render(_room_offset * camera.view_projection(), *_texture_storage, colour, 1.0f, Vector3::Zero, false, true);
+                _mesh->render(_room_offset * camera.view_projection(), *_texture_storage, colour, 1.0f, Vector3::Zero, false, !has_flag(render_filter, RenderFilter::Lighting));
                 for (const auto& mesh : _static_meshes)
                 {
                     mesh->render(camera, *_texture_storage, colour);

--- a/trview.app/Geometry/IMesh.h
+++ b/trview.app/Geometry/IMesh.h
@@ -91,7 +91,7 @@ namespace trview
     /// @param transparent_collision Whether to add transparent rectangles as collision triangles.
     void process_textured_rectangles(
         const std::vector<trlevel::tr4_mesh_face4>& rectangles,
-        const std::vector<trlevel::tr_vertex>& input_vertices,
+        const std::vector<trlevel::trview_room_vertex>& input_vertices,
         const ILevelTextureStorage& texture_storage,
         std::vector<MeshVertex>& output_vertices,
         std::vector<std::vector<uint32_t>>& output_indices,
@@ -110,7 +110,7 @@ namespace trview
     /// @param transparent_collision Whether to add transparent rectangles as collision triangles.
     void process_textured_triangles(
         const std::vector<trlevel::tr4_mesh_face3>& triangles,
-        const std::vector<trlevel::tr_vertex>& input_vertices,
+        const std::vector<trlevel::trview_room_vertex>& input_vertices,
         const ILevelTextureStorage& texture_storage,
         std::vector<MeshVertex>& output_vertices,
         std::vector<std::vector<uint32_t>>& output_indices,
@@ -127,7 +127,7 @@ namespace trview
     // collision_triangles: The collection to add collision triangles to.
     void process_coloured_rectangles(
         const std::vector<trlevel::tr_face4>& rectangles,
-        const std::vector<trlevel::tr_vertex>& input_vertices,
+        const std::vector<trlevel::trview_room_vertex>& input_vertices,
         const ILevelTextureStorage& texture_storage,
         std::vector<MeshVertex>& output_vertices,
         std::vector<uint32_t>& output_indices,
@@ -142,7 +142,7 @@ namespace trview
     // collision_triangles: The collection to add collision triangles to.
     void process_coloured_triangles(
         const std::vector<trlevel::tr_face3>& triangles,
-        const std::vector<trlevel::tr_vertex>& input_vertices,
+        const std::vector<trlevel::trview_room_vertex>& input_vertices,
         const ILevelTextureStorage& texture_storage,
         std::vector<MeshVertex>& output_vertices,
         std::vector<uint32_t>& output_indices,

--- a/trview.app/Geometry/IMesh.h
+++ b/trview.app/Geometry/IMesh.h
@@ -23,7 +23,8 @@ namespace trview
             const DirectX::SimpleMath::Color& colour,
             float light_intensity = 1.0f,
             DirectX::SimpleMath::Vector3 light_direction = DirectX::SimpleMath::Vector3::Zero,
-            bool geometry_mode = false) = 0;
+            bool geometry_mode = false,
+            bool use_colour_override = false) = 0;
 
         virtual void render(const DirectX::SimpleMath::Matrix& world_view_projection,
             const graphics::Texture& replacement_texture,
@@ -162,6 +163,8 @@ namespace trview
         DirectX::SimpleMath::Vector4 light_dir;
         float light_intensity{ 1.0f };
         int light_enabled{ 0 };
+        int colour_override_enabled{ 0 };
+        DirectX::SimpleMath::Vector4 colour_override { 1, 1, 1, 1 };
     };
 #pragma warning(pop)
 }

--- a/trview.app/Geometry/Mesh.cpp
+++ b/trview.app/Geometry/Mesh.cpp
@@ -115,7 +115,7 @@ namespace trview
         _bounding_box.Center = minimum + half_size;
     }
 
-    void Mesh::render(const Matrix& world_view_projection, const ILevelTextureStorage& texture_storage, const Color& colour, float light_intensity, Vector3 light_direction, bool geometry_mode)
+    void Mesh::render(const Matrix& world_view_projection, const ILevelTextureStorage& texture_storage, const Color& colour, float light_intensity, Vector3 light_direction, bool geometry_mode, bool use_colour_override)
     {
         // There are no vertices.
         if (!_vertex_buffer)
@@ -128,7 +128,7 @@ namespace trview
         D3D11_MAPPED_SUBRESOURCE mapped_resource;
         memset(&mapped_resource, 0, sizeof(mapped_resource));
 
-        MeshData data{ world_view_projection, colour, Vector4(light_direction.x, light_direction.y, light_direction.z, 1), light_intensity, light_direction != Vector3::Zero };
+        MeshData data{ world_view_projection, colour, Vector4(light_direction.x, light_direction.y, light_direction.z, 1), light_intensity, light_direction != Vector3::Zero, use_colour_override };
         context->Map(_matrix_buffer.Get(), 0, D3D11_MAP_WRITE_DISCARD, 0, &mapped_resource); 
         memcpy(mapped_resource.pData, &data, sizeof(data));
         context->Unmap(_matrix_buffer.Get(), 0);

--- a/trview.app/Geometry/Mesh.h
+++ b/trview.app/Geometry/Mesh.h
@@ -39,7 +39,8 @@ namespace trview
             const DirectX::SimpleMath::Color& colour,
             float light_intensity = 1.0f,
             DirectX::SimpleMath::Vector3 light_direction = DirectX::SimpleMath::Vector3::Zero,
-            bool geometry_mode = false) override;
+            bool geometry_mode = false,
+            bool use_colour_override = false) override;
 
         virtual void render(const DirectX::SimpleMath::Matrix& world_view_projection,
             const graphics::Texture& replacement_texture,

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -52,6 +52,7 @@ namespace trview
             MOCK_METHOD(void, set_show_water, (bool), (override));
             MOCK_METHOD(void, set_show_wireframe, (bool), (override));
             MOCK_METHOD(void, set_show_bounding_boxes, (bool), (override));
+            MOCK_METHOD(void, set_show_lighting, (bool), (override));
             MOCK_METHOD(void, set_show_lights, (bool), (override));
             MOCK_METHOD(void, set_show_items, (bool), (override));
             MOCK_METHOD(void, set_show_rooms, (bool), (override));
@@ -62,6 +63,7 @@ namespace trview
             MOCK_METHOD(void, set_light_visibility, (uint32_t, bool), (override));
             MOCK_METHOD(void, set_room_visibility, (uint32_t, bool), (override));
             MOCK_METHOD(bool, show_camera_sinks, (), (const, override));
+            MOCK_METHOD(bool, show_lighting, (), (const, override));
             MOCK_METHOD(bool, show_geometry, (), (const, override));
             MOCK_METHOD(bool, show_lights, (), (const, override));
             MOCK_METHOD(bool, show_triggers, (), (const, override));

--- a/trview.app/Mocks/Geometry/IMesh.h
+++ b/trview.app/Mocks/Geometry/IMesh.h
@@ -10,7 +10,7 @@ namespace trview
         {
             MockMesh();
             virtual ~MockMesh();
-            MOCK_METHOD(void, render, (const DirectX::SimpleMath::Matrix&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&, float, DirectX::SimpleMath::Vector3, bool), (override));
+            MOCK_METHOD(void, render, (const DirectX::SimpleMath::Matrix&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&, float, DirectX::SimpleMath::Vector3, bool, bool), (override));
             MOCK_METHOD(void, render, (const DirectX::SimpleMath::Matrix&, const graphics::Texture&, const DirectX::SimpleMath::Color&, float, DirectX::SimpleMath::Vector3), (override));
             MOCK_METHOD(std::vector<TransparentTriangle>, transparent_triangles, (), (const, override));
             MOCK_METHOD(const DirectX::BoundingBox&, bounding_box, (), (const, override));

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -21,6 +21,7 @@ namespace trview
         _toggles[IViewer::Options::items] = true;
         _toggles[IViewer::Options::rooms] = true;
         _toggles[IViewer::Options::camera_sinks] = false;
+        _toggles[IViewer::Options::lighting] = true;
     }
 
     void ViewOptions::render()
@@ -64,6 +65,8 @@ namespace trview
                 ImGui::TableNextRow();
                 add_toggle(IViewer::Options::wireframe);
                 add_toggle(IViewer::Options::geometry);
+                ImGui::TableNextRow();
+                add_toggle(IViewer::Options::lighting);
                 ImGui::TableNextRow();
                 if (!_use_alternate_groups)
                 {

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -30,6 +30,7 @@ namespace trview
             inline static const std::string items = "Items";
             inline static const std::string rooms = "Rooms";
             inline static const std::string camera_sinks = "Camera/Sink";
+            inline static const std::string lighting = "Lighting";
         };
 
         virtual ~IViewer() = 0;

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -67,6 +67,7 @@ namespace trview
         toggles[Options::items] = [this](bool value) { set_show_items(value); };
         toggles[Options::rooms] = [this](bool value) { set_show_rooms(value); };
         toggles[Options::camera_sinks] = [this](bool value) { set_show_camera_sinks(value); };
+        toggles[Options::lighting] = [this](bool value) { set_show_lighting(value); };
 
         std::unordered_map<std::string, std::function<void(int32_t)>> scalars;
         scalars[Options::depth] = [this](int32_t value) { if (_level) { _level->set_neighbour_depth(value); } };
@@ -412,6 +413,7 @@ namespace trview
             _camera.set_zoom(8.f);
         });
         add_shortcut(false, 'L', [&]() { toggle_show_lights(); });
+        add_shortcut(true, 'H', [&]() { toggle_show_lighting(); });
         add_shortcut(false, 'K', [&]() { toggle_show_camera_sinks(); });
 
         _token_store += _keyboard.on_key_down += [&](uint16_t key, bool control, bool)
@@ -602,6 +604,7 @@ namespace trview
         _level->set_show_items(_ui->toggle(Options::items));
         _level->set_show_rooms(_ui->toggle(Options::rooms));
         _level->set_show_camera_sinks(_ui->toggle(Options::camera_sinks));
+        _level->set_show_lighting(_ui->toggle(Options::lighting));
 
         // Set up the views.
         auto rooms = _level->rooms();
@@ -1369,6 +1372,23 @@ namespace trview
         if (_level)
         {
             set_show_camera_sinks(!_level->show_camera_sinks());
+        }
+    }
+
+    void Viewer::set_show_lighting(bool show)
+    {
+        if (_level)
+        {
+            _level->set_show_lighting(show);
+            _ui->set_toggle(Options::lighting, show);
+        }
+    }
+
+    void Viewer::toggle_show_lighting()
+    {
+        if (_level)
+        {
+            set_show_lighting(!_level->show_lighting());
         }
     }
 }

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -128,6 +128,8 @@ namespace trview
         void set_sector_highlight(const std::shared_ptr<ISector>& sector);
         void set_show_camera_sinks(bool show);
         void toggle_show_camera_sinks();
+        void set_show_lighting(bool show);
+        void toggle_show_lighting();
 
         const std::shared_ptr<graphics::IDevice> _device;
         const std::shared_ptr<IShortcuts>& _shortcuts;

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -519,6 +519,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DiagnosticsFormat>Column</DiagnosticsFormat>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -546,6 +547,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DiagnosticsFormat>Column</DiagnosticsFormat>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -571,6 +573,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DiagnosticsFormat>Column</DiagnosticsFormat>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -598,6 +601,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DiagnosticsFormat>Column</DiagnosticsFormat>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trview.common.tests/trview.common.tests.vcxproj
+++ b/trview.common.tests/trview.common.tests.vcxproj
@@ -126,6 +126,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -145,6 +146,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -166,6 +168,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -189,6 +192,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -166,6 +166,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -189,6 +190,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -214,6 +216,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -241,6 +244,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trview.graphics.tests/trview.graphics.tests.vcxproj
+++ b/trview.graphics.tests/trview.graphics.tests.vcxproj
@@ -116,6 +116,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -135,6 +136,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -156,6 +158,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -179,6 +182,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/trview.graphics/trview.graphics.vcxproj
+++ b/trview.graphics/trview.graphics.vcxproj
@@ -184,6 +184,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -204,6 +205,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -226,6 +228,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -250,6 +253,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trview.input.tests/trview.input.tests.vcxproj
+++ b/trview.input.tests/trview.input.tests.vcxproj
@@ -77,6 +77,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -95,6 +96,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -115,6 +117,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -137,6 +140,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/trview.input/trview.input.vcxproj
+++ b/trview.input/trview.input.vcxproj
@@ -122,6 +122,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -146,6 +147,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -172,6 +174,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -200,6 +203,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trview.lau/trview.lau.vcxproj
+++ b/trview.lau/trview.lau.vcxproj
@@ -93,6 +93,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -112,6 +113,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -131,6 +133,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -150,6 +153,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/trview.lua.imgui/trview.lua.imgui.vcxproj
+++ b/trview.lua.imgui/trview.lua.imgui.vcxproj
@@ -81,6 +81,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -101,6 +102,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -121,6 +123,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -141,6 +144,7 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>

--- a/trview.shaders/level_vertex_shader.hlsl
+++ b/trview.shaders/level_vertex_shader.hlsl
@@ -5,6 +5,8 @@ cbuffer cb : register (b0)
     float4 light_dir;
     float light_intensity;
     int light_enable;
+    int use_colour_override;
+    float4 colour_override;
 }
 
 struct VertexInput
@@ -27,7 +29,16 @@ VertexOutput main( VertexInput input )
     VertexOutput output;
     output.position = mul(scale, input.position);
     output.uv = input.uv;
-    output.colour = input.colour * colour;
+    output.colour = colour;
+
+    if (use_colour_override)
+    {
+         output.colour *= colour_override;
+    }
+    else
+    {
+        output.colour *= input.colour;
+    }
 
     if (light_enable != 0)
     {

--- a/trview.tests.common/trview.tests.common.vcxproj
+++ b/trview.tests.common/trview.tests.common.vcxproj
@@ -105,6 +105,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -126,6 +127,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -145,6 +147,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -166,6 +169,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/trview/trview.vcxproj
+++ b/trview/trview.vcxproj
@@ -94,6 +94,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -116,6 +117,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -140,6 +142,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -166,6 +169,7 @@
       <ForcedIncludeFiles>stdafx.h</ForcedIncludeFiles>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <BuildStlModules>false</BuildStlModules>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
Use Room vertex lighting and colours when rendering rooms. On by default but can be turned off in the view options menu to go back to the current full brightness mode.
Also has an update to the projects to work around a VS modules bug.
Closes #1144 