### PR TITLE
Replace room index property on IItem

### DIFF
--- a/trview.app.tests/Elements/ItemTests.cpp
+++ b/trview.app.tests/Elements/ItemTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Elements/Item.h>
 #include <trview.app/Mocks/Elements/IItem.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
 #include <trlevel/Mocks/ILevel.h>
@@ -25,10 +26,11 @@ namespace
             std::string type{ "Lara" };
             std::vector<std::weak_ptr<ITrigger>> triggers;
             std::shared_ptr<ILevel> owning_level{ mock_shared<MockLevel>() };
+            std::shared_ptr<IRoom> room { mock_shared<MockRoom>() };
 
             std::unique_ptr<Item> build()
             {
-                return std::make_unique<Item>(mesh_source, *level, entity, *mesh_storage, owning_level, index, type, triggers, is_pickup);
+                return std::make_unique<Item>(mesh_source, *level, entity, *mesh_storage, owning_level, index, type, triggers, is_pickup, room);
             }
 
             test_module& with_level(const std::shared_ptr<trlevel::ILevel>& level)

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -176,14 +176,16 @@ TEST(Level, OcbAdjustmentsPerformedWhenNeeded)
     EXPECT_CALL(mock_level, num_rooms()).WillRepeatedly(Return(1));
     EXPECT_CALL(mock_level, num_entities()).WillRepeatedly(Return(1));
     int entity_source_called = 0;
+
+    auto room = mock_shared<MockRoom>();
+    PickResult result{};
+    result.hit = true;
+    EXPECT_CALL(*room, pick).WillRepeatedly(Return(result));
+    
     auto level = register_test_module().with_level(std::move(mock_level_ptr))
         .with_room_source(
             [&](auto&&...)
             {
-                auto room = mock_shared<MockRoom>();
-                PickResult result{};
-                result.hit = true;
-                EXPECT_CALL(*room, pick).WillRepeatedly(Return(result));
                 return room;
             })
         .with_entity_source(
@@ -193,6 +195,7 @@ TEST(Level, OcbAdjustmentsPerformedWhenNeeded)
                 auto entity = mock_shared<MockItem>();
                 EXPECT_CALL(*entity, needs_ocb_adjustment).WillRepeatedly(Return(true));
                 EXPECT_CALL(*entity, adjust_y).Times(1);
+                EXPECT_CALL(*entity, room).WillRepeatedly(Return(room));
                 return entity;
             }).build();
 

--- a/trview.app.tests/ItemsWindowTests.cpp
+++ b/trview.app.tests/ItemsWindowTests.cpp
@@ -2,6 +2,7 @@
 #include <trview.app/Elements/Types.h>
 #include <trview.common/Mocks/Windows/IClipboard.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 #include "TestImgui.h"
 
 using namespace trview;
@@ -142,8 +143,8 @@ TEST(ItemsWindow, ItemsListNotFilteredWhenRoomSetAndTrackRoomDisabled)
 
     std::vector<std::shared_ptr<MockItem>> items
     {
-        mock_shared<MockItem>()->with_number(0)->with_room(55),
-        mock_shared<MockItem>()->with_number(1)->with_room(78)
+        mock_shared<MockItem>()->with_number(0)->with_room(mock_shared<MockRoom>()->with_number(55)),
+        mock_shared<MockItem>()->with_number(1)->with_room(mock_shared<MockRoom>()->with_number(78))
     };
     window->set_items({ std::from_range, items });
     window->set_current_room(78);
@@ -166,8 +167,8 @@ TEST(ItemsWindow, ItemsListFilteredWhenRoomSetAndTrackRoomEnabled)
 
     std::vector<std::shared_ptr<MockItem>> items
     {
-        mock_shared<MockItem>()->with_number(0)->with_room(55),
-        mock_shared<MockItem>()->with_number(1)->with_room(78)
+        mock_shared<MockItem>()->with_number(0)->with_room(mock_shared<MockRoom>()->with_number(55)),
+        mock_shared<MockItem>()->with_number(1)->with_room(mock_shared<MockRoom>()->with_number(78))
     };
     window->set_items({ std::from_range, items });
     window->set_current_room(78);
@@ -213,8 +214,8 @@ TEST(ItemsWindow, ItemsListUpdatedWhenFiltered)
 
     std::vector<std::shared_ptr<MockItem>> items
     {
-        mock_shared<MockItem>()->with_number(0)->with_room(55),
-        mock_shared<MockItem>()->with_number(1)->with_room(78)
+        mock_shared<MockItem>()->with_number(0)->with_room(mock_shared<MockRoom>()->with_number(55)),
+        mock_shared<MockItem>()->with_number(1)->with_room(mock_shared<MockRoom>()->with_number(78))
     };
     window->set_items({ std::from_range, items });
     window->set_current_room(78);
@@ -239,8 +240,8 @@ TEST(ItemsWindow, ItemsListUpdatedWhenNotFiltered)
 
     std::vector<std::shared_ptr<MockItem>> items
     {
-        mock_shared<MockItem>()->with_number(0)->with_room(55)->with_visible(true),
-        mock_shared<MockItem>()->with_number(1)->with_room(78)->with_visible(true)
+        mock_shared<MockItem>()->with_number(0)->with_room(mock_shared<MockRoom>()->with_number(55))->with_visible(true),
+        mock_shared<MockItem>()->with_number(1)->with_room(mock_shared<MockRoom>()->with_number(78))->with_visible(true)
     };
     window->set_items({ std::from_range, items });
     TestImgui imgui([&]() { window->render(); });

--- a/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
@@ -119,11 +119,8 @@ TEST(Lua_Item, Position)
 TEST(Lua_Item, Room)
 {
     auto room = mock_shared<MockRoom>()->with_number(100);
-    auto level = mock_shared<MockLevel>();
-    EXPECT_CALL(*level, room).WillRepeatedly(Return(room));
-
     auto item = mock_shared<MockItem>()->with_number(100);
-    EXPECT_CALL(*item, level).WillRepeatedly(Return(level));
+    EXPECT_CALL(*item, room).WillRepeatedly(Return(room));
 
     lua_State* L = luaL_newstate();
     lua::create_item(L, item);

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -335,7 +335,7 @@ TEST(Viewer, AddWaypointRaisedUsesItemPosition)
     TestImgui imgui;
 
     NiceMock<MockLevel> level;
-    auto item = mock_shared<MockItem>()->with_room(10)->with_number(50);
+    auto item = mock_shared<MockItem>()->with_room(mock_shared<MockRoom>()->with_number(10))->with_number(50);
 
     EXPECT_CALL(level, item(50)).WillRepeatedly(Return(item));
 

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -302,7 +302,7 @@ namespace trview
         {
             if (auto item_ptr = item.lock())
             {
-                add_waypoint(item_ptr->position(), Vector3::Down, item_ptr->room(), IWaypoint::Type::Entity, item_ptr->number());
+                add_waypoint(item_ptr->position(), Vector3::Down, item_room(item_ptr), IWaypoint::Type::Entity, item_ptr->number());
             }
         };
     }
@@ -456,7 +456,7 @@ namespace trview
             return;
         }
 
-        select_room(item_ptr->room());
+        select_room(item_room(item_ptr));
         _level->set_selected_item(item_ptr->number());
         _viewer->select_item(item);
         _items_windows->set_selected_item(item);

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -189,17 +189,18 @@ namespace trview
                 waypoint_source, settings_loader->load_user_settings());
         };
 
-        auto entity_source = [=](auto&& level, auto&& entity, auto&& index, auto&& triggers, auto&& mesh_storage, auto&& owning_level)
+        auto entity_source = [=](auto&& level, auto&& entity, auto&& index, auto&& triggers, auto&& mesh_storage, auto&& owning_level, auto&& room)
         {
             return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index,
                 type_name_lookup->lookup_type_name(level.get_version(), entity.TypeID, entity.Flags),
                 triggers,
-                type_name_lookup->is_pickup(level.get_version(), entity.TypeID));
+                type_name_lookup->is_pickup(level.get_version(), entity.TypeID),
+                room);
         };
 
-        auto ai_source = [=](auto&& level, auto&& entity, auto&& index, auto&& mesh_storage, auto&& owning_level)
+        auto ai_source = [=](auto&& level, auto&& entity, auto&& index, auto&& mesh_storage, auto&& owning_level, auto&& room)
         {
-            return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index, type_name_lookup->lookup_type_name(level.get_version(), entity.type_id, entity.flags), std::vector<std::weak_ptr<ITrigger>>{});
+            return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index, type_name_lookup->lookup_type_name(level.get_version(), entity.type_id, entity.flags), std::vector<std::weak_ptr<ITrigger>>{}, room);
         };
 
         auto log = std::make_shared<Log>();

--- a/trview.app/Elements/IItem.h
+++ b/trview.app/Elements/IItem.h
@@ -12,16 +12,18 @@
 namespace trview
 {
     struct ITrigger;
+    struct IRoom;
+
     struct IItem : public IRenderable
     {
         using EntitySource =
-            std::function<std::shared_ptr<IItem> (const trlevel::ILevel&, const trlevel::tr2_entity&, uint32_t, const std::vector<std::weak_ptr<ITrigger>>&, const IMeshStorage&, const std::weak_ptr<ILevel>&)>;
+            std::function<std::shared_ptr<IItem> (const trlevel::ILevel&, const trlevel::tr2_entity&, uint32_t, const std::vector<std::weak_ptr<ITrigger>>&, const IMeshStorage&, const std::weak_ptr<ILevel>&, const std::weak_ptr<IRoom>&)>;
         using AiSource =
-            std::function<std::shared_ptr<IItem>(const trlevel::ILevel&, const trlevel::tr4_ai_object&, uint32_t, const IMeshStorage&, const std::weak_ptr<ILevel>&)>;
+            std::function<std::shared_ptr<IItem>(const trlevel::ILevel&, const trlevel::tr4_ai_object&, uint32_t, const IMeshStorage&, const std::weak_ptr<ILevel>&, const std::weak_ptr<IRoom>&)>;
 
         virtual ~IItem() = 0;
         virtual uint32_t number() const = 0;
-        virtual uint16_t room() const = 0;
+        virtual std::weak_ptr<IRoom> room() const = 0;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
         virtual DirectX::BoundingBox bounding_box() const = 0;
         /// <summary>
@@ -50,4 +52,6 @@ namespace trview
     bool is_mutant_egg(uint32_t type_id);
     uint16_t mutant_egg_contents(const IItem& item);
     uint16_t mutant_egg_contents(uint16_t flags);
+    uint32_t item_room(const std::shared_ptr<IItem>& item);
+    uint32_t item_room(const IItem& item);
 }

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -1,14 +1,16 @@
 #include "Item.h"
 
-#include <trview.app/Graphics/ILevelTextureStorage.h>
-#include <trview.app/Graphics/IMeshStorage.h>
-#include <trview.app/Camera/ICamera.h>
-#include <trview.app/Geometry/Matrix.h>
-#include <trview.app/Geometry/IMesh.h>
-#include <trview.app/Geometry/TransparencyBuffer.h>
 #include <trview.common/Algorithms.h>
 #include <trlevel/ILevel.h>
 #include <trlevel/trtypes.h>
+
+#include "../Graphics/ILevelTextureStorage.h"
+#include "../Graphics/IMeshStorage.h"
+#include "../Camera/ICamera.h"
+#include "../Geometry/Matrix.h"
+#include "../Geometry/IMesh.h"
+#include "../Geometry/TransparencyBuffer.h"
+#include "IRoom.h"
 
 using namespace Microsoft::WRL;
 using namespace DirectX;
@@ -62,18 +64,18 @@ namespace trview
     {
     }
 
-    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, bool is_pickup)
-        : Item(mesh_source, mesh_storage, level, owning_level, entity.Room, number, entity.TypeID, entity.position(), entity.Angle, level.get_version() >= trlevel::LevelVersion::Tomb4 ? entity.Intensity2 : 0, type, triggers, entity.Flags, is_pickup)
+    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, bool is_pickup, const std::weak_ptr<IRoom>& room)
+        : Item(mesh_source, mesh_storage, level, owning_level, room, number, entity.TypeID, entity.position(), entity.Angle, level.get_version() >= trlevel::LevelVersion::Tomb4 ? entity.Intensity2 : 0, type, triggers, entity.Flags, is_pickup)
     {
         
     }
 
-    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers)
-        : Item(mesh_source, mesh_storage, level, owning_level, entity.room, number, entity.type_id, entity.position(), entity.angle, entity.ocb, type, triggers, entity.flags, false)
+    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room)
+        : Item(mesh_source, mesh_storage, level, owning_level, room, number, entity.type_id, entity.position(), entity.angle, entity.ocb, type, triggers, entity.flags, false)
     {
     }
 
-    Item::Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, uint16_t room, uint32_t number, uint16_t type_id,
+    Item::Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id,
         const Vector3& position, int32_t angle, int32_t ocb, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags, bool is_pickup)
         : _room(room), _number(number), _type(type), _triggers(triggers), _type_id(type_id), _ocb(ocb), _flags(flags), _level(owning_level), _angle(angle)
     {
@@ -202,7 +204,7 @@ namespace trview
         }
     }
 
-    uint16_t Item::room() const
+    std::weak_ptr<IRoom> Item::room() const
     {
         return _room;
     }
@@ -478,5 +480,23 @@ namespace trview
             return 22; // Mutant
         }
         return 20; // Winged
+    }
+
+    uint32_t item_room(const std::shared_ptr<IItem>& item)
+    {
+        if (!item)
+        {
+            return 0u;
+        }
+        return item_room(*item);
+    }
+
+    uint32_t item_room(const IItem& item)
+    {
+        if (auto room = item.room().lock())
+        {
+            return room->number();
+        }
+        return 0u;
     }
 }

--- a/trview.app/Elements/Item.h
+++ b/trview.app/Elements/Item.h
@@ -28,11 +28,11 @@ namespace trview
     class Item final : public IItem
     {
     public:
-        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, bool is_pickup);
-        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers);
+        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, bool is_pickup, const std::weak_ptr<IRoom>& room);
+        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room);
         virtual ~Item() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
-        virtual uint16_t room() const override;
+        std::weak_ptr<IRoom> room() const override;
         virtual uint32_t number() const override;
 
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
@@ -55,7 +55,7 @@ namespace trview
         std::weak_ptr<ILevel> level() const override;
         int32_t angle() const override;
     private:
-        Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, uint16_t room, uint32_t number, uint16_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags, bool is_pickup);
+        Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags, bool is_pickup);
 
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);
@@ -66,7 +66,7 @@ namespace trview
         std::vector<std::shared_ptr<IMesh>>       _meshes;
         std::shared_ptr<IMesh>                    _sprite_mesh;
         std::vector<DirectX::SimpleMath::Matrix>  _world_transforms;
-        uint16_t                                  _room;
+        std::weak_ptr<IRoom>                      _room;
         uint32_t                                  _number;
 
         // Bits for sprites.

--- a/trview.app/Lua/Elements/Item/Lua_Item.cpp
+++ b/trview.app/Lua/Elements/Item/Lua_Item.cpp
@@ -55,12 +55,7 @@ namespace trview
                 }
                 else if (key == "room")
                 {
-                    if (auto level = item->level().lock())
-                    {
-                        return create_room(L, level->room(item->room()).lock());
-                    }
-                    lua_pushnil(L);
-                    return 1;
+                    return create_room(L, item->room().lock());
                 }
                 else if (key == "triggered_by")
                 {

--- a/trview.app/Lua/Route/Lua_Waypoint.cpp
+++ b/trview.app/Lua/Route/Lua_Waypoint.cpp
@@ -270,7 +270,7 @@ namespace trview
                         auto waypoint = waypoint_source(
                                 item->position(),
                                 normal,
-                                item->room(),
+                                item_room(item),
                                 IWaypoint::Type::Entity,
                                 item->number(),
                                 Colour::White,

--- a/trview.app/Mocks/Elements/IItem.h
+++ b/trview.app/Mocks/Elements/IItem.h
@@ -16,7 +16,7 @@ namespace trview
             MOCK_METHOD(bool, visible, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(uint32_t, number, (), (const, override));
-            MOCK_METHOD(uint16_t, room, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<IRoom>, room, (), (const, override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
             MOCK_METHOD(DirectX::BoundingBox, bounding_box, (), (const, override));
             MOCK_METHOD(void, adjust_y, (float), (override));
@@ -38,9 +38,9 @@ namespace trview
                 return shared_from_this();
             }
 
-            std::shared_ptr<MockItem> with_room(uint16_t number)
+            std::shared_ptr<MockItem> with_room(std::shared_ptr<IRoom> room)
             {
-                ON_CALL(*this, room).WillByDefault(testing::Return(number));
+                ON_CALL(*this, room).WillByDefault(testing::Return(room));
                 return shared_from_this();
             }
 

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -155,7 +155,7 @@ namespace trview
         _item = item;
         if (auto new_item = _item.lock())
         {
-            set_properties(Type::Entity, new_item->number(), new_item->room(), new_item->position());
+            set_properties(Type::Entity, new_item->number(), item_room(new_item), new_item->position());
         }
     }
 

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -119,7 +119,7 @@ namespace trview
                 imgui_sort_weak(_all_items,
                     {
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
-                        [](auto&& l, auto&& r) { return std::tuple(l.room(), l.number()) < std::tuple(r.room(), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(item_room(l), l.number()) < std::tuple(item_room(r), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.type_id(), l.number()) < std::tuple(r.type_id(), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.type(), l.number()) < std::tuple(r.type(), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.visible(), l.number()) < std::tuple(r.visible(), r.number()); }
@@ -128,7 +128,7 @@ namespace trview
                 for (const auto& item : _all_items)
                 {
                     auto item_ptr = item.lock();
-                    if (!item_ptr || (_track.enabled<Type::Room>() && item_ptr->room() != _current_room || !_filters.match(*item_ptr)))
+                    if (!item_ptr || (_track.enabled<Type::Room>() && item_room(item_ptr) != _current_room || !_filters.match(*item_ptr)))
                     {
                         continue;
                     }
@@ -159,7 +159,7 @@ namespace trview
 
                     ImGui::SetItemAllowOverlap();
                     ImGui::TableNextColumn();
-                    ImGui::Text(std::to_string(item_ptr->room()).c_str());
+                    ImGui::Text(std::to_string(item_room(item_ptr)).c_str());
                     ImGui::TableNextColumn();
                     ImGui::Text(std::to_string(item_ptr->type_id()).c_str());
                     ImGui::TableNextColumn();
@@ -237,7 +237,7 @@ namespace trview
                     add_stat("Angle", bound_rotation(item->angle()));
                     add_stat("Angle Degrees", bound_rotation(item->angle()) / 182);
                     add_stat("Type ID", item->type_id());
-                    add_stat("Room", item->room());
+                    add_stat("Room", item_room(item));
                     add_stat("Clear Body", item->clear_body_flag());
                     add_stat("Invisible", item->invisible_flag());
                     add_stat("Flags", format_binary(item->activation_flags()));
@@ -373,7 +373,7 @@ namespace trview
         _filters.add_getter<float>("Angle", [](auto&& item) { return static_cast<float>(bound_rotation(item.angle())); });
         _filters.add_getter<float>("Angle Degrees", [](auto&& item) { return static_cast<float>(bound_rotation(item.angle()) / 182); });
         _filters.add_getter<float>("Type ID", [](auto&& item) { return static_cast<float>(item.type_id()); });
-        _filters.add_getter<float>("Room", [](auto&& item) { return static_cast<float>(item.room()); });
+        _filters.add_getter<float>("Room", [](auto&& item) { return static_cast<float>(item_room(item)); });
         _filters.add_getter<bool>("Clear Body", [](auto&& item) { return item.clear_body_flag(); });
         _filters.add_getter<bool>("Invisible", [](auto&& item) { return item.invisible_flag(); });
         _filters.add_getter<std::string>("Flags", [](auto&& item) { return format_binary(item.activation_flags()); });

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -190,9 +190,9 @@ namespace trview
             {
                 if (auto item_ptr = item.lock())
                 {
-                    select_room(item_ptr->room());
+                    select_room(item_room(item_ptr));
                     _scroll_to_room = true;
-                    load_room_details(item_ptr->room());
+                    load_room_details(item_room(item_ptr));
                 }
             }
 
@@ -309,7 +309,7 @@ namespace trview
                         {
                             if (auto i = item.lock())
                             {
-                                return i->room() == room.number();
+                                return item_room(i) == room.number();
                             }
                             return false;
                         });
@@ -612,7 +612,7 @@ namespace trview
                 {
                     if (const auto item_ptr = item.lock())
                     {
-                        if (item_ptr->room() == room.number())
+                        if (item_room(item_ptr) == room.number())
                         {
                             results.push_back(static_cast<float>(item_ptr->number()));
                         }
@@ -636,7 +636,7 @@ namespace trview
                 {
                     if (auto item_ptr = item.lock())
                     {
-                        if (item_ptr->room() == room.number())
+                        if (item_room(item_ptr) == room.number())
                         {
                             results.push_back(item_ptr->type());
                         }
@@ -813,7 +813,7 @@ namespace trview
             {
                 if (auto item_ptr = item.lock())
                 {
-                    if (item_ptr->room() == room->number())
+                    if (item_room(item_ptr) == room->number())
                     {
                         ImGui::TableNextRow();
                         ImGui::TableNextColumn();

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1180,7 +1180,7 @@ namespace trview
         {
             if (auto item = _level->item(pick.index).lock())
             {
-                return item->room();
+                return item_room(item);
             }
             break;
         }


### PR DESCRIPTION
Replace the room index with a weak pointer to an `IRoom`. Means there's less random indices around, eventually this should simplify some of the windows once everything is converted.
Part of #1091