### PR TITLE
Replace room index on ILight

### DIFF
--- a/trview.app.tests/Elements/LightTests.cpp
+++ b/trview.app.tests/Elements/LightTests.cpp
@@ -1,4 +1,5 @@
 #include <trview.app/Elements/Light.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 
 using namespace trlevel;
 using namespace trview;
@@ -14,7 +15,7 @@ namespace
         {
             std::shared_ptr<IMesh> mesh{ mock_shared<MockMesh>() };
             uint32_t number{ 0u };
-            uint32_t room{ 0u };
+            std::shared_ptr<IRoom> room{ mock_shared<MockRoom>() };
             tr_x_room_light light{};
             std::shared_ptr<trview::ILevel> level{ mock_shared<MockLevel>() };
 

--- a/trview.app.tests/Lua/Elements/Lua_LightTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_LightTests.cpp
@@ -298,11 +298,8 @@ TEST(Lua_Light, Range)
 TEST(Lua_Light, Room)
 {
     auto room = mock_shared<MockRoom>()->with_number(100);
-    auto level = mock_shared<MockLevel>();
-    EXPECT_CALL(*level, room).WillRepeatedly(Return(room));
-
     auto light = mock_shared<MockLight>()->with_number(100);
-    EXPECT_CALL(*light, level).WillRepeatedly(Return(level));
+    EXPECT_CALL(*light, room).WillRepeatedly(Return(room));
 
     lua_State* L = luaL_newstate();
     lua::create_light(L, light);

--- a/trview.app.tests/Windows/LightsWindowTests.cpp
+++ b/trview.app.tests/Windows/LightsWindowTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Windows/LightsWindow.h>
 #include <trview.app/Mocks/Elements/ILight.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 #include "TestImgui.h"
 
 using namespace trview;
@@ -92,8 +93,8 @@ TEST(LightsWindow, OnLightVisibilityRaised)
 TEST(LightsWindow, LightListFilteredWhenRoomSetAndTrackRoomEnabled)
 {
     auto window = register_test_module().build();
-    auto light1 = mock_shared<MockLight>()->with_number(0)->with_room(56);
-    auto light2 = mock_shared<MockLight>()->with_number(1)->with_room(78);
+    auto light1 = mock_shared<MockLight>()->with_number(0)->with_room(mock_shared<MockRoom>()->with_number(56));
+    auto light2 = mock_shared<MockLight>()->with_number(1)->with_room(mock_shared<MockRoom>()->with_number(78));
     window->set_lights({ light1, light2 });
     window->set_current_room(78);
 
@@ -115,8 +116,8 @@ TEST(LightsWindow, LightListFilteredWhenRoomSetAndTrackRoomEnabled)
 TEST(LightsWindow, LightsListNotFilteredWhenRoomSetAndTrackRoomDisabled)
 {
     auto window = register_test_module().build();
-    auto light1 = mock_shared<MockLight>()->with_number(0)->with_room(56);
-    auto light2 = mock_shared<MockLight>()->with_number(1)->with_room(78);
+    auto light1 = mock_shared<MockLight>()->with_number(0)->with_room(mock_shared<MockRoom>()->with_number(56));
+    auto light2 = mock_shared<MockLight>()->with_number(1)->with_room(mock_shared<MockRoom>()->with_number(78));
     window->set_lights({ light1, light2 });
     window->set_current_room(78);
 

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -539,7 +539,7 @@ namespace trview
             return;
         }
 
-        select_room(light_ptr->room());
+        select_room(light_room(light_ptr));
         _level->set_selected_light(light_ptr->number());
         _viewer->select_light(light);
         _lights_windows->set_selected_light(light);

--- a/trview.app/Elements/ILight.cpp
+++ b/trview.app/Elements/ILight.cpp
@@ -1,4 +1,5 @@
 #include "ILight.h"
+#include "IRoom.h"
 
 namespace trview
 {
@@ -170,4 +171,21 @@ namespace trview
         return light.radius();
     }
 
+    uint32_t light_room(const std::shared_ptr<ILight>& light)
+    {
+        if (!light)
+        {
+            return 0u;
+        }
+        return light_room(*light);
+    }
+
+    uint32_t light_room(const ILight& light)
+    {
+        if (auto room = light.room().lock())
+        {
+            return room->number();
+        }
+        return 0u;
+    }
 }

--- a/trview.app/Elements/ILight.h
+++ b/trview.app/Elements/ILight.h
@@ -8,14 +8,16 @@
 
 namespace trview
 {
+    struct IRoom;
+
     struct ILight : public IRenderable
     {
-        using Source = std::function<std::shared_ptr<ILight>(uint32_t, uint32_t, const trlevel::tr_x_room_light&, const std::weak_ptr<ILevel>&)>;
+        using Source = std::function<std::shared_ptr<ILight>(uint32_t, const std::weak_ptr<IRoom>&, const trlevel::tr_x_room_light&, const std::weak_ptr<ILevel>&)>;
         virtual ~ILight() = 0;
         virtual uint32_t number() const = 0;
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
         virtual Colour colour() const = 0;
-        virtual uint32_t room() const = 0;
+        virtual std::weak_ptr<IRoom> room() const = 0;
         virtual trlevel::LightType type() const = 0;
         virtual int32_t intensity() const = 0;
         virtual int32_t fade() const = 0;
@@ -63,4 +65,7 @@ namespace trview
     float range(const ILight& light);
     float density(const ILight& light);
     float radius(const ILight& light);
+
+    uint32_t light_room(const std::shared_ptr<ILight>& light);
+    uint32_t light_room(const ILight& light);
 }

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -974,7 +974,7 @@ namespace trview
             auto room = level.get_room(i);
             for (const auto& light : room.lights)
             {
-                _lights.push_back(light_source(static_cast<uint32_t>(_lights.size()), i, light, shared_from_this()));
+                _lights.push_back(light_source(static_cast<uint32_t>(_lights.size()), _rooms[i], light, shared_from_this()));
                 _rooms[i]->add_light(_lights.back());
             }
         }

--- a/trview.app/Elements/Light.cpp
+++ b/trview.app/Elements/Light.cpp
@@ -5,7 +5,7 @@ namespace trview
     using namespace DirectX;
     using namespace DirectX::SimpleMath;
 
-    Light::Light(const std::shared_ptr<IMesh>& mesh, uint32_t number, uint32_t room, const trlevel::tr_x_room_light& light, const std::weak_ptr<ILevel>& level)
+    Light::Light(const std::shared_ptr<IMesh>& mesh, uint32_t number, const std::weak_ptr<IRoom>& room, const trlevel::tr_x_room_light& light, const std::weak_ptr<ILevel>& level)
         : _mesh(mesh), _number(number), _room(room), _position(light.position()), _colour(light.colour()), _type(light.type()),
         _intensity(light.intensity()), _fade(light.fade()), _direction(light.direction()), _in(light.in()), _out(light.out()),
         _rad_in(light.rad_in()), _rad_out(light.rad_out()), _length(light.length()), _cutoff(light.cutoff()), _range(light.range()),
@@ -23,7 +23,7 @@ namespace trview
         return _colour;
     }
 
-    uint32_t Light::room() const
+    std::weak_ptr<IRoom> Light::room() const
     {
         return _room;
     }

--- a/trview.app/Elements/Light.h
+++ b/trview.app/Elements/Light.h
@@ -8,12 +8,12 @@ namespace trview
     class Light final : public ILight
     {
     public:
-        explicit Light(const std::shared_ptr<IMesh>& mesh, uint32_t number, uint32_t room, const trlevel::tr_x_room_light& light, const std::weak_ptr<ILevel>& level);
+        explicit Light(const std::shared_ptr<IMesh>& mesh, uint32_t number, const std::weak_ptr<IRoom>& room, const trlevel::tr_x_room_light& light, const std::weak_ptr<ILevel>& level);
         virtual ~Light() = default;
         virtual uint32_t number() const override;
         virtual DirectX::SimpleMath::Vector3 position() const override;
         virtual Colour colour() const override;
-        virtual uint32_t room() const override;
+        std::weak_ptr<IRoom> room() const override;
         virtual trlevel::LightType type() const override;
         virtual int32_t intensity() const override;
         virtual int32_t fade() const override;
@@ -41,7 +41,7 @@ namespace trview
         std::weak_ptr<ILevel> _level;
 
         uint32_t _number;
-        uint32_t _room;
+        std::weak_ptr<IRoom> _room;
         bool _visible{ true };
         DirectX::SimpleMath::Vector3 _position;
         Colour _colour;

--- a/trview.app/Lua/Elements/Light/Lua_Light.cpp
+++ b/trview.app/Lua/Elements/Light/Lua_Light.cpp
@@ -98,12 +98,7 @@ namespace trview
                 }
                 else if (key == "room")
                 {
-                    if (auto level = light->level().lock())
-                    {
-                        return create_room(L, level->room(light->room()).lock());
-                    }
-                    lua_pushnil(L);
-                    return 1;
+                    return create_room(L, light->room().lock());
                 }
                 else if (key == "type")
                 {

--- a/trview.app/Mocks/Elements/ILight.h
+++ b/trview.app/Mocks/Elements/ILight.h
@@ -18,7 +18,7 @@ namespace trview
             MOCK_METHOD(uint32_t, number, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(Colour, colour, (), (const, override));
-            MOCK_METHOD(uint32_t, room, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<IRoom>, room, (), (const, override));
             MOCK_METHOD(trlevel::LightType, type, (), (const, override));
             MOCK_METHOD(int32_t, intensity, (), (const, override));
             MOCK_METHOD(int32_t, fade, (), (const, override));
@@ -43,9 +43,9 @@ namespace trview
                 return shared_from_this();
             }
 
-            std::shared_ptr<MockLight> with_room(uint32_t number)
+            std::shared_ptr<MockLight> with_room(std::shared_ptr<IRoom> room)
             {
-                ON_CALL(*this, room).WillByDefault(testing::Return(number));
+                ON_CALL(*this, room).WillByDefault(testing::Return(room));
                 return shared_from_this();
             }
 

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -103,7 +103,7 @@ namespace trview
                 imgui_sort_weak(_all_lights,
                     {
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
-                        [](auto&& l, auto&& r) { return std::tuple(l.room(), l.number()) < std::tuple(r.room(), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(light_room(l), l.number()) < std::tuple(light_room(r), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(light_type_name(l.type()), l.number()) < std::tuple(light_type_name(r.type()), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.visible(), l.number()) < std::tuple(r.visible(), r.number()); }
                     }, _force_sort);
@@ -111,7 +111,7 @@ namespace trview
                 for (const auto& light_ptr : _all_lights)
                 {
                     const auto& light = light_ptr.lock();
-                    if (_track.enabled<Type::Room>() && light->room() != _current_room || !_filters.match(*light))
+                    if (_track.enabled<Type::Room>() && light_room(light) != _current_room || !_filters.match(*light))
                     {
                         continue;
                     }
@@ -142,7 +142,7 @@ namespace trview
 
                     ImGui::SetItemAllowOverlap();
                     ImGui::TableNextColumn();
-                    ImGui::Text(std::to_string(light->room()).c_str());
+                    ImGui::Text(std::to_string(light_room(light)).c_str());
                     ImGui::TableNextColumn();
                     ImGui::Text(light_type_name(light->type()).c_str());
                     ImGui::TableNextColumn();
@@ -210,7 +210,7 @@ namespace trview
 
                     add_stat("Type", light_type_name(selected_light->type()));
                     add_stat("#", selected_light->number());
-                    add_stat("Room", selected_light->room());
+                    add_stat("Room", light_room(selected_light));
 
                     if (has_colour(*selected_light))
                     {
@@ -299,7 +299,7 @@ namespace trview
         }
         _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& light) { return light_type_name(light.type()); });
         _filters.add_getter<float>("#", [](auto&& light) { return static_cast<float>(light.number()); });
-        _filters.add_getter<float>("Room", [](auto&& light) { return static_cast<float>(light.room()); });
+        _filters.add_getter<float>("Room", [](auto&& light) { return static_cast<float>(light_room(light)); });
         _filters.add_getter<float>("X", [](auto&& light) { return light.position().x * trlevel::Scale_X; }, has_position);
         _filters.add_getter<float>("Y", [](auto&& light) { return light.position().y * trlevel::Scale_Y; }, has_position);
         _filters.add_getter<float>("Z", [](auto&& light) { return light.position().z * trlevel::Scale_Z; }, has_position);

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -982,9 +982,9 @@ namespace trview
             {
                 if (_selected_room != _current_room)
                 {
-                    select_room(light_ptr->room());
+                    select_room(light_room(light_ptr));
                     _scroll_to_room = true;
-                    load_room_details(light_ptr->room());
+                    load_room_details(light_room(light_ptr));
                 }
 
                 _local_selected_light = light;


### PR DESCRIPTION
Replace the room index with a weak pointer to an `IRoom`.
Part of #1091