### PR TITLE
Replace room index on ICameraSink 

### DIFF
--- a/trview.app.tests/CameraSinkWindowTests.cpp
+++ b/trview.app.tests/CameraSinkWindowTests.cpp
@@ -2,6 +2,7 @@
 #include <trview.app/Mocks/Elements/ICameraSink.h>
 #include <trview.common/Mocks/Windows/IClipboard.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 #include "TestImgui.h"
 
 using namespace trview;
@@ -141,8 +142,8 @@ TEST(CameraSinkWindow, TriggerSelectedRaised)
 TEST(CameraSinkWindow, CameraSinkListFilteredWhenRoomSetAndTrackRoomEnabled)
 {
     auto window = register_test_module().build();
-    auto camera_sink1 = mock_shared<MockCameraSink>()->with_number(0)->with_room(56);
-    auto camera_sink2 = mock_shared<MockCameraSink>()->with_number(1)->with_room(78);
+    auto camera_sink1 = mock_shared<MockCameraSink>()->with_number(0)->with_room(mock_shared<MockRoom>()->with_number(56));
+    auto camera_sink2 = mock_shared<MockCameraSink>()->with_number(1)->with_room(mock_shared<MockRoom>()->with_number(78));
     window->set_camera_sinks({ camera_sink1, camera_sink2 });
     window->set_current_room(78);
 

--- a/trview.app.tests/Lua/Elements/Lua_CameraSinkTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_CameraSinkTests.cpp
@@ -43,14 +43,8 @@ TEST(Lua_CameraSink, InferredRooms)
 {
     auto room1 = mock_shared<MockRoom>()->with_number(100);
     auto room2 = mock_shared<MockRoom>()->with_number(200);
-
-    auto level = mock_shared<MockLevel>();
-    EXPECT_CALL(*level, room(100)).WillRepeatedly(Return(room1));
-    EXPECT_CALL(*level, room(200)).WillRepeatedly(Return(room2));
-
     auto cs = mock_shared<MockCameraSink>();
-    EXPECT_CALL(*cs, level).WillRepeatedly(Return(level));
-    EXPECT_CALL(*cs, inferred_rooms).WillRepeatedly(Return(std::vector<uint16_t>{ 100, 200 }));
+    EXPECT_CALL(*cs, inferred_rooms).WillRepeatedly(Return(std::vector<std::weak_ptr<IRoom>>{ room1, room2 }));
 
     lua_State* L = luaL_newstate();
     lua::create_camera_sink(L, cs);
@@ -122,12 +116,8 @@ TEST(Lua_CameraSink, Position)
 TEST(Lua_CameraSink, Room)
 {
     auto room = mock_shared<MockRoom>()->with_number(100);
-    auto level = mock_shared<MockLevel>();
-    EXPECT_CALL(*level, room(100)).WillRepeatedly(Return(room));
-
     auto cs = mock_shared<MockCameraSink>();
-    EXPECT_CALL(*cs, level).WillRepeatedly(Return(level));
-    EXPECT_CALL(*cs, room).WillRepeatedly(Return(100));
+    EXPECT_CALL(*cs, room).WillRepeatedly(Return(room));
 
     lua_State* L = luaL_newstate();
     lua::create_camera_sink(L, cs);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -807,7 +807,8 @@ namespace trview
             return;
         }
 
-        select_room(actual_room(*camera_sink_ptr));
+        auto actual = actual_room(*camera_sink_ptr).lock();
+        select_room(actual ? actual->number() : 0u);
         _level->set_selected_camera_sink(camera_sink_ptr->number());
         _viewer->select_camera_sink(camera_sink);
         _camera_sink_windows->set_selected_camera_sink(camera_sink);

--- a/trview.app/Elements/CameraSink/CameraSink.h
+++ b/trview.app/Elements/CameraSink/CameraSink.h
@@ -9,7 +9,7 @@ namespace trview
     {
     public:
         explicit CameraSink(const std::shared_ptr<IMesh>& mesh, const std::shared_ptr<ITextureStorage>& texture_storage,
-            uint32_t number, const trlevel::tr_camera& camera, Type type, const std::vector<uint16_t>& inferred_rooms, const std::vector<std::weak_ptr<ITrigger>>& triggers,
+            uint32_t number, const trlevel::tr_camera& camera, Type type, const std::vector<std::weak_ptr<IRoom>>& inferred_rooms, const std::vector<std::weak_ptr<ITrigger>>& triggers,
             const std::weak_ptr<ILevel>& level);
         virtual ~CameraSink() = default;
         virtual DirectX::BoundingBox bounding_box() const override;
@@ -17,13 +17,13 @@ namespace trview
         virtual uint16_t flag() const override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         std::weak_ptr<ILevel> level() const override;
-        virtual std::vector<uint16_t> inferred_rooms() const override;
+        virtual std::vector<std::weak_ptr<IRoom>> inferred_rooms() const override;
         virtual uint32_t number() const override;
         virtual bool persistent() const override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
         virtual DirectX::SimpleMath::Vector3 position() const override;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
-        virtual uint16_t room() const override;
+        virtual std::weak_ptr<IRoom> room() const override;
         virtual void set_type(Type type) override;
         virtual void set_visible(bool value) override;
         virtual uint16_t strength() const override;
@@ -33,9 +33,10 @@ namespace trview
     private:
         uint32_t _number{ 0 };
         DirectX::SimpleMath::Vector3 _position;
-        uint16_t _room{ 0 };
+        std::weak_ptr<IRoom> _room;
+        uint16_t _strength{ 0u };
         uint16_t _flag{ 0 };
-        std::vector<uint16_t> _inferred_rooms{ 0 };
+        std::vector<std::weak_ptr<IRoom>> _inferred_rooms;
         bool _visible{ true };
         Type _type{ Type::Camera };
         std::shared_ptr<IMesh> _mesh;

--- a/trview.app/Elements/CameraSink/ICameraSink.h
+++ b/trview.app/Elements/CameraSink/ICameraSink.h
@@ -16,25 +16,25 @@ namespace trview
             Sink
         };
 
-        using Source = std::function<std::shared_ptr<ICameraSink>(uint32_t, const trlevel::tr_camera&, Type, const std::vector<uint16_t>& inferred_rooms, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<ILevel>&)>;
+        using Source = std::function<std::shared_ptr<ICameraSink>(uint32_t, const trlevel::tr_camera&, Type, const std::vector<std::weak_ptr<IRoom>>& inferred_rooms, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<ILevel>&)>;
 
         virtual ~ICameraSink() = 0;
         virtual DirectX::BoundingBox bounding_box() const = 0;
         virtual uint16_t box_index() const = 0;
         virtual uint16_t flag() const = 0;
-        virtual std::vector<uint16_t> inferred_rooms() const = 0;
+        virtual std::vector<std::weak_ptr<IRoom>> inferred_rooms() const = 0;
         virtual std::weak_ptr<ILevel> level() const = 0;
         virtual uint32_t number() const = 0;
         virtual bool persistent() const = 0;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
-        virtual uint16_t room() const = 0;
+        virtual std::weak_ptr<IRoom> room() const = 0;
         virtual uint16_t strength() const = 0;
         virtual Type type() const = 0;
         virtual void set_type(Type type) = 0;
         virtual std::vector<std::weak_ptr<ITrigger>> triggers() const = 0;
     };
 
-    uint16_t actual_room(const ICameraSink& camera_sink);
+    std::weak_ptr<IRoom> actual_room(const ICameraSink& camera_sink);
     std::string to_string(ICameraSink::Type type);
 }

--- a/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.cpp
+++ b/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.cpp
@@ -29,14 +29,7 @@ namespace trview
                 }
                 else if (key == "inferred_rooms")
                 {
-                    if (auto level = camera_sink->level().lock())
-                    {
-                        std::vector<std::weak_ptr<IRoom>> inferred_rooms;
-                        std::ranges::transform(camera_sink->inferred_rooms(),
-                            std::back_inserter(inferred_rooms),
-                            [&level](const auto& r) { return level->room(r); });
-                        return push_list_p(L, inferred_rooms, create_room);
-                    }
+                    return push_list_p(L, camera_sink->inferred_rooms(), create_room);
                 }
                 else if (key == "number")
                 {
@@ -55,10 +48,7 @@ namespace trview
                 }
                 else if (key == "room")
                 {
-                    if (auto level = camera_sink->level().lock())
-                    {
-                        return create_room(L, level->room(camera_sink->room()).lock());
-                    }
+                    return create_room(L, camera_sink->room().lock());
                 }
                 else if (key == "strength")
                 {

--- a/trview.app/Mocks/Elements/ICameraSink.h
+++ b/trview.app/Mocks/Elements/ICameraSink.h
@@ -4,6 +4,8 @@
 
 namespace trview
 {
+    struct IRoom;
+
     namespace mocks
     {
         struct MockCameraSink : public ICameraSink, public std::enable_shared_from_this<MockCameraSink>
@@ -13,14 +15,14 @@ namespace trview
             MOCK_METHOD(uint16_t, box_index, (), (const, override));
             MOCK_METHOD(uint16_t, flag, (), (const, override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
-            MOCK_METHOD(std::vector<uint16_t>, inferred_rooms, (), (const, override));
+            MOCK_METHOD(std::vector<std::weak_ptr<IRoom>>, inferred_rooms, (), (const, override));
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
             MOCK_METHOD(uint32_t, number, (), (const, override));
             MOCK_METHOD(bool, persistent, (), (const, override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
-            MOCK_METHOD(uint16_t, room, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<IRoom>, room, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(void, set_type, (Type), (override));
             MOCK_METHOD(uint16_t, strength, (), (const, override));
@@ -46,7 +48,7 @@ namespace trview
                 return shared_from_this();
             }
 
-            std::shared_ptr<MockCameraSink> with_room(uint16_t room)
+            std::shared_ptr<MockCameraSink> with_room(std::shared_ptr<IRoom> room)
             {
                 ON_CALL(*this, room).WillByDefault(testing::Return(room));
                 return shared_from_this();

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -57,6 +57,23 @@ namespace trview
         {
             return camera_sink.type() == ICameraSink::Type::Sink;
         }
+
+        std::string inferred_rooms_text(const std::vector<std::weak_ptr<IRoom>>& rooms)
+        {
+            std::string inferred_rooms;
+            for (auto i = 0u; i < rooms.size(); ++i)
+            {
+                if (const auto room = rooms[i].lock())
+                {
+                    inferred_rooms += std::to_string(room->number());
+                    if (i != rooms.size() - 1)
+                    {
+                        inferred_rooms += ",";
+                    }
+                }
+            }
+            return inferred_rooms;
+        }
     }
 
     ICameraSinkWindow::~ICameraSinkWindow()
@@ -201,20 +218,7 @@ namespace trview
                     }
                     else
                     {
-                        std::string inferred_rooms;
-                        const auto rooms = camera_sink->inferred_rooms();
-                        for (auto i = 0u; i < rooms.size(); ++i)
-                        {
-                            if (const auto room = rooms[i].lock())
-                            {
-                                inferred_rooms += std::to_string(room->number());
-                                if (i != rooms.size() - 1)
-                                {
-                                    inferred_rooms += ",";
-                                }
-                            }
-                        }
-                        ImGui::Text(inferred_rooms.c_str());
+                        ImGui::Text(inferred_rooms_text(camera_sink->inferred_rooms()).c_str());
                     }
 
                     ImGui::TableNextColumn();
@@ -302,20 +306,7 @@ namespace trview
                 {
                     add_stat("Strength", selected->strength());
                     add_stat("Box Index", selected->box_index());
-                    std::string inferred_rooms;
-                    auto rooms = selected->inferred_rooms();
-                    for (auto i = 0u; i < rooms.size(); ++i)
-                    {
-                        if (const auto room = rooms[i].lock())
-                        {
-                            inferred_rooms += std::to_string(room->number());
-                            if (i != rooms.size() - 1)
-                            {
-                                inferred_rooms += ",";
-                            }
-                        }
-                    }
-                    add_stat("Inferred Room", inferred_rooms.c_str());
+                    add_stat("Inferred Room", inferred_rooms_text(selected->inferred_rooms()));
                 }
 
                 ImGui::EndTable();

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -1,5 +1,6 @@
 #include "CameraSinkWindow.h"
 #include "../../trview_imgui.h"
+#include "../../Elements/IRoom.h"
 
 namespace trview
 {
@@ -9,19 +10,42 @@ namespace trview
         {
             if (camera_sink.type() == ICameraSink::Type::Camera)
             {
-                return camera_sink.room() == room;
+                if (auto camera_room = camera_sink.room().lock())
+                {
+                    return camera_room->number() == room;
+                }
+                return false;
             }
-            return std::ranges::contains(camera_sink.inferred_rooms(), static_cast<uint16_t>(room));
+
+            const auto inferred = camera_sink.inferred_rooms();
+            return std::ranges::find_if(inferred, [=](auto&& r)
+                {
+                    if (auto inferred_room = r.lock())
+                    {
+                        return inferred_room->number() == room;
+                    }
+                    return false;
+                }) != inferred.end();
         }
 
         uint32_t primary_room(const ICameraSink& camera_sink)
         {
             if (camera_sink.type() == ICameraSink::Type::Camera)
             {
-                return camera_sink.room();
+                if (auto room = camera_sink.room().lock())
+                {
+                    return room->number();
+                }
+                return 0u;
             }
-            const auto inferred_rooms = camera_sink.inferred_rooms();
-            return inferred_rooms.empty() ? 0u : std::ranges::min(camera_sink.inferred_rooms());
+            
+            const auto inferred = camera_sink.inferred_rooms();
+            if (inferred.empty())
+            {
+                return 0u;
+            }
+            const auto view = inferred | std::views::transform([](auto&& r) { if (auto room = r.lock()) { return room->number(); } return 0u; });
+            return *std::ranges::min_element(view);
         }
 
         bool is_camera(const ICameraSink& camera_sink)
@@ -173,21 +197,24 @@ namespace trview
                     ImGui::TableNextColumn();
                     if (camera_sink->type() == ICameraSink::Type::Camera)
                     {
-                        ImGui::Text(std::format("{}", camera_sink->room()).c_str());
+                        ImGui::Text(std::format("{}", primary_room(*camera_sink)).c_str());
                     }
                     else
                     {
-                        auto rooms = camera_sink->inferred_rooms();
-                        std::stringstream stream;
-                        if (!rooms.empty())
+                        std::string inferred_rooms;
+                        const auto rooms = camera_sink->inferred_rooms();
+                        for (auto i = 0u; i < rooms.size(); ++i)
                         {
-                            stream << rooms[0];
+                            if (const auto room = rooms[i].lock())
+                            {
+                                inferred_rooms += std::to_string(room->number());
+                                if (i != rooms.size() - 1)
+                                {
+                                    inferred_rooms += ",";
+                                }
+                            }
                         }
-                        for (std::size_t i = 1; i < rooms.size(); ++i)
-                        {
-                            stream << "," << rooms[i];
-                        }
-                        ImGui::Text(stream.str().c_str());
+                        ImGui::Text(inferred_rooms.c_str());
                     }
 
                     ImGui::TableNextColumn();
@@ -268,7 +295,7 @@ namespace trview
                 if (selected->type() == ICameraSink::Type::Camera)
                 {
                     add_stat("Flag", selected->flag());
-                    add_stat("Room", selected->room());
+                    add_stat("Room", primary_room(*selected));
                     add_stat("Persistent", selected->persistent());
                 }
                 else
@@ -279,10 +306,13 @@ namespace trview
                     auto rooms = selected->inferred_rooms();
                     for (auto i = 0u; i < rooms.size(); ++i)
                     {
-                        inferred_rooms += std::to_string(rooms[i]);
-                        if (i != rooms.size() - 1)
+                        if (const auto room = rooms[i].lock())
                         {
-                            inferred_rooms += ",";
+                            inferred_rooms += std::to_string(room->number());
+                            if (i != rooms.size() - 1)
+                            {
+                                inferred_rooms += ",";
+                            }
                         }
                     }
                     add_stat("Inferred Room", inferred_rooms.c_str());
@@ -368,11 +398,11 @@ namespace trview
             {
                 if (camera_sink.type() == ICameraSink::Type::Camera)
                 {
-                    return { static_cast<float>(camera_sink.room()) };
+                    return { static_cast<float>(primary_room(camera_sink)) };
                 }
                 return std::views::transform(
                     camera_sink.inferred_rooms(),
-                    [](const auto& r) { return static_cast<float>(r); }) |
+                    [](const auto& r) { if (auto room = r.lock()) { return static_cast<float>(room->number()); } return 0.0f; }) |
                     std::ranges::to<std::vector>();
             });
         _filters.add_multi_getter<float>("Triggered By", [&](auto&& camera_sink)
@@ -391,7 +421,7 @@ namespace trview
         _filters.add_getter<bool>("Persistent", [](auto&& camera_sink) { return (camera_sink.flag() & 0x1) == 1; }, is_camera);
         
         // Sink:
-        _filters.add_getter<float>("Strength", [](auto&& camera_sink) { return static_cast<float>(camera_sink.room()); }, is_sink);
+        _filters.add_getter<float>("Strength", [](auto&& camera_sink) { return static_cast<float>(camera_sink.strength()); }, is_sink);
         _filters.add_getter<float>("Box Index", [](auto&& camera_sink) { return static_cast<float>(camera_sink.flag()); }, is_sink);
     }
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -1002,9 +1002,11 @@ namespace trview
             {
                 if (_selected_room != _current_room)
                 {
-                    select_room(actual_room(*camera_sink_ptr));
+                    const auto actual = actual_room(*camera_sink_ptr).lock();
+                    const uint32_t actual_number = actual ? actual->number() : 0u;
+                    select_room(actual_number);
                     _scroll_to_room = true;
-                    load_room_details(actual_room(*camera_sink_ptr));
+                    load_room_details(actual_number);
                 }
 
                 _local_selected_camera_sink = camera_sink;


### PR DESCRIPTION
Replace the room index with a weak pointer to an `IRoom`.
Part of #1091