### PR TITLE
Rework Route I/O and Route Window for Randomizer

### DIFF
--- a/doc/lua/route.md
+++ b/doc/lua/route.md
@@ -6,16 +6,18 @@ The Route library lets you create and edit routes. Routes need to be bound to a 
 | Name | Type | Mode | Description |
 | ---- | ---- | ---- | ---- |
 | colour | [Colour](colour.md) | RW | The route line colour |
+| filename | string | R | The file to read and write from/to |
 | level | [Level](level.md) | RW | The level all targets will reference |
 | waypoints | [Waypoint](waypoint.md)[] | RW | The route waypoints |
 | waypoint_colour | [Colour](colour.md) | RW | The default waypoint colour |
+| is_randomizer | boolean | R | Whether this is a randomizer route |
 
 # Non-Instance Functions
 
 | Name | Returns | Parameters | Description |
 | ---- | ------- | ---------- | ----------- |
-| new | Route | - | Creates a new route |
-| import | Route | [optional] { [optional] string filename, [optional] boolean is_randomizer, [Level](level.md) level } | Imports a route. If no paramters are supplied or the `filename` property is empty the user will be prompted to choose a file to import. If `is_randomizer` is true then the import will default to Randomizer json files. The `level` parameter is required as the user may attempt to load a Randomizer json which will use the level to adjust some coordinates. If the filename is provided the user will only be prompted if they wish to allow the import. |
+| new | Route | ```[optional] { boolean is_randomizer }``` | Creates a new route. Is `is_randomizer` is true the route will be a randomizer route. |
+| open | Route | [optional] { [optional] string filename, [optional] boolean is_randomizer, [Level](level.md) level } | Imports a route. If no paramters are supplied or the `filename` property is empty the user will be prompted to choose a file to import. If `is_randomizer` is true then the import will default to Randomizer json files. The `level` parameter is required as the user may attempt to load a Randomizer json which will use the level to adjust some coordinates. If the filename is provided the user will only be prompted if they wish to allow the import. |
 
 # Functions
 
@@ -23,5 +25,7 @@ The Route library lets you create and edit routes. Routes need to be bound to a 
 | ---- | ------- | ---------- | ----------- |
 | add | [Waypoint](waypoint.md) | [Waypoint](waypoint.md) | Add the specified waypoint to the end of the route |
 | clear | - | - | Removes all waypoints in the route |
-| export | - | `[optional] { [optional] string filename, [optional] boolean is_randomizer }` | Export the route. If no parameters table is specified or the `filename` property is not set on the table the user will be prompted to choose a filename. If the `is_randomizer` setting is set to true in the parameters table then the file type will default to Randomizer locations. The option to export Randomizer settings will be available to the user if the Randomizer integration is enabled or if the `is_randomizer` parameter is true. |
+| save | - | `[optional] { [optional] string filename }` | Export the route. If no parameters table is specified or the `filename` property is not set on the table the user will be prompted to choose a filename. If route is a randomizer route then it will be saved as such. |
+| save_as | - | `[optional] { [optional] string filename }` | Export the route. If no parameters table is specified or the `filename` property is not set on the table the user will be prompted to choose a filename. If route is a randomizer route then it will be saved as such. |
+| reload | - | - | Reload the file from the stored filename |
 | remove | - | [Waypoint](waypoint.md) | Remove the specified waypoint from the route |

--- a/doc/lua/route.md
+++ b/doc/lua/route.md
@@ -16,7 +16,7 @@ The Route library lets you create and edit routes. Routes need to be bound to a 
 
 | Name | Returns | Parameters | Description |
 | ---- | ------- | ---------- | ----------- |
-| new | Route | ```[optional] { boolean is_randomizer }``` | Creates a new route. Is `is_randomizer` is true the route will be a randomizer route. |
+| new | Route | ```[optional] { boolean is_randomizer }``` | Creates a new route. If `is_randomizer` is true the route will be a randomizer route. |
 | open | Route | [optional] { [optional] string filename, [optional] boolean is_randomizer, [Level](level.md) level } | Imports a route. If no paramters are supplied or the `filename` property is empty the user will be prompted to choose a file to import. If `is_randomizer` is true then the import will default to Randomizer json files. The `level` parameter is required as the user may attempt to load a Randomizer json which will use the level to adjust some coordinates. If the filename is provided the user will only be prompted if they wish to allow the import. |
 
 # Functions

--- a/doc/lua/route.md
+++ b/doc/lua/route.md
@@ -15,6 +15,7 @@ The Route library lets you create and edit routes. Routes need to be bound to a 
 | Name | Returns | Parameters | Description |
 | ---- | ------- | ---------- | ----------- |
 | new | Route | - | Creates a new route |
+| import | Route | [optional] { [optional] string filename, [optional] boolean is_randomizer, [Level](level.md) level } | Imports a route. If no paramters are supplied or the `filename` property is empty the user will be prompted to choose a file to import. If `is_randomizer` is true then the import will default to Randomizer json files. The `level` parameter is required as the user may attempt to load a Randomizer json which will use the level to adjust some coordinates. If the filename is provided the user will only be prompted if they wish to allow the import. |
 
 # Functions
 

--- a/doc/lua/route.md
+++ b/doc/lua/route.md
@@ -21,5 +21,6 @@ The Route library lets you create and edit routes. Routes need to be bound to a 
 | Name | Returns | Parameters | Description |
 | ---- | ------- | ---------- | ----------- |
 | add | [Waypoint](waypoint.md) | [Waypoint](waypoint.md) | Add the specified waypoint to the end of the route |
-| remove | - | [Waypoint](waypoint.md) | Remove the specified waypoint from the route |
 | clear | - | - | Removes all waypoints in the route |
+| export | - | `[optional] { [optional] string filename, [optional] boolean is_randomizer }` | Export the route. If no parameters table is specified or the `filename` property is not set on the table the user will be prompted to choose a filename. If the `is_randomizer` setting is set to true in the parameters table then the file type will default to Randomizer locations. The option to export Randomizer settings will be available to the user if the Randomizer integration is enabled or if the `is_randomizer` parameter is true. |
+| remove | - | [Waypoint](waypoint.md) | Remove the specified waypoint from the route |

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -491,12 +491,9 @@ TEST(Application, OpenRouteLoadsFile)
     EXPECT_CALL(route_window_manager, set_route).Times(2);
     auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, load_file(A<const std::string&>())).Times(1).WillRepeatedly(Return<std::vector<uint8_t>>({ 0x7b, 0x7d }));;
-    auto route = mock_shared<MockRoute>();
-    EXPECT_CALL(*route, set_unsaved(false)).Times(1);
 
     auto application = register_test_module()
         .with_route_window_manager(std::move(route_window_manager_ptr))
-        .with_route_source([&](auto&&...) {return route; })
         .with_viewer(std::move(viewer_ptr))
         .with_files(files)
         .with_dialogs(dialogs)

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -465,15 +465,13 @@ TEST(Application, ExportRouteSavesFile)
     EXPECT_CALL(*dialogs, save_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename", 0 }));
 
     auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    auto files = mock_shared<MockFiles>();
-    EXPECT_CALL(*files, save_file(An<const std::string&>(), An<const std::string&>())).Times(1);
     auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, save_as).Times(1);
     EXPECT_CALL(*route, set_unsaved(false)).Times(1);
 
     auto application = register_test_module()
         .with_route_window_manager(std::move(route_window_manager_ptr))
         .with_route_source([&](auto&&...) {return route; })
-        .with_files(files)
         .with_dialogs(dialogs)
         .build();
 

--- a/trview.app.tests/FileMenuTests.cpp
+++ b/trview.app.tests/FileMenuTests.cpp
@@ -216,3 +216,23 @@ TEST(FileMenu, NextFile)
     ASSERT_TRUE(raised);
     ASSERT_EQ(raised.value(), "file2");
 }
+
+TEST(FileMenu, SwitchTo)
+{
+    auto files = mock_shared<MockFiles>();
+    std::vector<IFiles::File> filenames{ { "file1", "file1", 0 }, { "file2", "file2", 0 } };
+    EXPECT_CALL(*files, get_files).Times(1).WillOnce(Return(filenames));
+
+    auto menu = register_test_module().with_files(files).build();
+
+    std::optional<std::string> raised;
+    auto token = menu->on_file_open += [&](const auto& f)
+    {
+        raised = f;
+    };
+
+    menu->open_file("file1");
+    menu->switch_to("c:\\dir\\file2");
+    ASSERT_TRUE(raised);
+    ASSERT_EQ(raised.value(), "file2");
+}

--- a/trview.app.tests/Lua/Lua_trviewTests.cpp
+++ b/trview.app.tests/Lua/Lua_trviewTests.cpp
@@ -22,8 +22,8 @@ TEST(Lua_trview, Level)
 
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(), 
-        []() { return mock_shared<MockRoute>(); },
-        []() { return mock_shared<MockRandomizerRoute>(); },
+        [](auto&&) { return mock_shared<MockRoute>(); },
+        [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());
@@ -45,8 +45,8 @@ TEST(Lua_trview, RecentFiles)
 
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(),
-        []() { return mock_shared<MockRoute>(); },
-        []() { return mock_shared<MockRandomizerRoute>(); },
+        [](auto&&) { return mock_shared<MockRoute>(); },
+        [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());
@@ -68,8 +68,8 @@ TEST(Lua_trview, SetLevel)
 
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(),
-        []() { return mock_shared<MockRoute>(); },
-        []() { return mock_shared<MockRandomizerRoute>(); },
+        [](auto&&) { return mock_shared<MockRoute>(); },
+        [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());
@@ -89,8 +89,8 @@ TEST(Lua_trview, Route)
 
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(),
-        []() { return mock_shared<MockRoute>(); },
-        []() { return mock_shared<MockRandomizerRoute>(); },
+        [](auto&&) { return mock_shared<MockRoute>(); },
+        [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());
@@ -106,8 +106,8 @@ TEST(Lua_trview, SetRoute)
 
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(),
-        []() { return mock_shared<MockRoute>(); },
-        []() { return mock_shared<MockRandomizerRoute>(); },
+        [](auto&&) { return mock_shared<MockRoute>(); },
+        [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());

--- a/trview.app.tests/Lua/Lua_trviewTests.cpp
+++ b/trview.app.tests/Lua/Lua_trviewTests.cpp
@@ -22,7 +22,9 @@ TEST(Lua_trview, Level)
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(), 
         []() { return mock_shared<MockRoute>(); },
-        [](auto&&...) { return mock_shared<MockWaypoint>(); });
+        [](auto&&...) { return mock_shared<MockWaypoint>(); },
+        mock_shared<MockDialogs>(),
+        mock_shared<MockFiles>());
 
     ASSERT_EQ(0, luaL_dostring(L, "return trview.level"));
     ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
@@ -42,7 +44,9 @@ TEST(Lua_trview, RecentFiles)
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(),
         []() { return mock_shared<MockRoute>(); },
-        [](auto&&...) { return mock_shared<MockWaypoint>(); });
+        [](auto&&...) { return mock_shared<MockWaypoint>(); },
+        mock_shared<MockDialogs>(),
+        mock_shared<MockFiles>());
 
     ASSERT_EQ(0, luaL_dostring(L, "return trview.recent_files"));
     ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
@@ -62,7 +66,9 @@ TEST(Lua_trview, SetLevel)
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(),
         []() { return mock_shared<MockRoute>(); },
-        [](auto&&...) { return mock_shared<MockWaypoint>(); });
+        [](auto&&...) { return mock_shared<MockWaypoint>(); },
+        mock_shared<MockDialogs>(),
+        mock_shared<MockFiles>());
 
     auto level = mock_shared<MockLevel>();
     lua::create_level(L, level);
@@ -80,7 +86,9 @@ TEST(Lua_trview, Route)
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(),
         []() { return mock_shared<MockRoute>(); },
-        [](auto&&...) { return mock_shared<MockWaypoint>(); });
+        [](auto&&...) { return mock_shared<MockWaypoint>(); },
+        mock_shared<MockDialogs>(),
+        mock_shared<MockFiles>());
 
     ASSERT_EQ(0, luaL_dostring(L, "return trview.route"));
     ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
@@ -94,7 +102,9 @@ TEST(Lua_trview, SetRoute)
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(),
         []() { return mock_shared<MockRoute>(); },
-        [](auto&&...) { return mock_shared<MockWaypoint>(); });
+        [](auto&&...) { return mock_shared<MockWaypoint>(); },
+        mock_shared<MockDialogs>(),
+        mock_shared<MockFiles>());
 
     ASSERT_EQ(0, luaL_dostring(L, "trview.route = Route.new()"));
 }

--- a/trview.app.tests/Lua/Lua_trviewTests.cpp
+++ b/trview.app.tests/Lua/Lua_trviewTests.cpp
@@ -5,6 +5,7 @@
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
 #include <trview.app/Mocks/Routing/IRoute.h>
+#include <trview.app/Mocks/Routing/IRandomizerRoute.h>
 
 using namespace trview;
 using namespace trview::mocks;
@@ -22,6 +23,7 @@ TEST(Lua_trview, Level)
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(), 
         []() { return mock_shared<MockRoute>(); },
+        []() { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());
@@ -44,6 +46,7 @@ TEST(Lua_trview, RecentFiles)
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(),
         []() { return mock_shared<MockRoute>(); },
+        []() { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());
@@ -66,6 +69,7 @@ TEST(Lua_trview, SetLevel)
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(),
         []() { return mock_shared<MockRoute>(); },
+        []() { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());
@@ -86,6 +90,7 @@ TEST(Lua_trview, Route)
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(),
         []() { return mock_shared<MockRoute>(); },
+        []() { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());
@@ -102,6 +107,7 @@ TEST(Lua_trview, SetRoute)
     lua_State* L = luaL_newstate();
     lua::trview_register(L, application.get(),
         []() { return mock_shared<MockRoute>(); },
+        []() { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());

--- a/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
+++ b/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
@@ -9,6 +9,7 @@
 #include <trview.app/Lua/Route/Lua_Waypoint.h>
 #include <trview.app/Mocks/Routing/IWaypoint.h>
 #include <trview.app/Lua/Elements/Level/Lua_Level.h>
+#include <trview.app/Mocks/Routing/IRandomizerRoute.h>
 
 using namespace trview;
 using namespace trview::mocks;
@@ -66,6 +67,28 @@ TEST(Lua_Route, Colour)
     ASSERT_EQ(4.0f, lua_tonumber(L, -1));
 }
 
+TEST(Lua_Route, IsRandomizer)
+{
+    auto rando_route = mock_shared<MockRandomizerRoute>();
+
+    lua_State* L = luaL_newstate();
+    lua::create_route(L, rando_route);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "x = r.is_randomizer return x"));
+    ASSERT_EQ(LUA_TBOOLEAN, lua_type(L, -1));
+    ASSERT_TRUE(lua_toboolean(L, -1));
+
+    auto route = mock_shared<MockRoute>();
+
+    lua::create_route(L, route);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "x = r.is_randomizer return x"));
+    ASSERT_EQ(LUA_TBOOLEAN, lua_type(L, -1));
+    ASSERT_FALSE(lua_toboolean(L, -1));
+}
+
 TEST(Lua_Route, Level)
 {
     auto level = mock_shared<MockLevel>();
@@ -93,6 +116,30 @@ TEST(Lua_Route, New)
     ASSERT_EQ(route.get(), *reinterpret_cast<void**>(lua_touserdata(L, -1)));
 }
 
+TEST(Lua_Route, NewRandoRoute)
+{
+    auto route = mock_shared<MockRandomizerRoute>();
+
+    lua_State* L = luaL_newstate();
+    lua::route_register(L, [](auto&&...) { return mock_shared<MockRoute>(); }, [=](auto&&...) { return route; }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+
+    ASSERT_EQ(0, luaL_dostring(L, "r = Route.new({is_randomizer = true}) return r"));
+    ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
+    ASSERT_EQ(route.get(), *reinterpret_cast<void**>(lua_touserdata(L, -1)));
+}
+
+TEST(Lua_Route, Reload)
+{
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, reload);
+
+    lua_State* L = luaL_newstate();
+    lua::create_route(L, route);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "r:reload()"));
+}
+
 TEST(Lua_Route, Remove)
 {
     auto route = mock_shared<MockRoute>();
@@ -105,6 +152,16 @@ TEST(Lua_Route, Remove)
     lua_setglobal(L, "r");
 
     ASSERT_EQ(0, luaL_dostring(L, "r:remove(w)"));
+}
+
+TEST(Lua_Route, Save)
+{
+    FAIL();
+}
+
+TEST(Lua_Route, SaveAs)
+{
+    FAIL();
 }
 
 TEST(Lua_Route, SetColour)

--- a/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
+++ b/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
@@ -156,12 +156,93 @@ TEST(Lua_Route, Remove)
 
 TEST(Lua_Route, Save)
 {
-    FAIL();
+    auto route = mock_shared<MockRoute>();
+    ON_CALL(*route, filename).WillByDefault(Return("test"));
+    EXPECT_CALL(*route, save).Times(1);
+
+    lua_State* L = luaL_newstate();
+    lua::create_route(L, route);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "r:save()"));
 }
 
-TEST(Lua_Route, SaveAs)
+TEST(Lua_Route, SaveNoFilename)
 {
-    FAIL();
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, save).Times(0);
+    EXPECT_CALL(*route, set_filename).Times(0);
+
+    lua_State* L = luaL_newstate();
+    lua::create_route(L, route);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "r:save()"));
+}
+
+TEST(Lua_Route, SaveChooseFile)
+{
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, save).Times(1);
+    EXPECT_CALL(*route, set_filename).Times(1);
+
+    auto dialogs = mock_shared<MockDialogs>();
+    EXPECT_CALL(*dialogs, save_file).WillRepeatedly(Return(IDialogs::FileResult{ .filename = "test", .filter_index = 1 }));
+
+    lua_State* L = luaL_newstate();
+    lua::create_route(L, route);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "r:save()"));
+}
+
+TEST(Lua_Route, SaveAsWithFileAllowed)
+{
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, save_as).Times(1);
+    EXPECT_CALL(*route, set_filename).Times(1);
+
+    auto dialogs = mock_shared<MockDialogs>();
+    EXPECT_CALL(*dialogs, message_box).WillRepeatedly(Return(true));
+    EXPECT_CALL(*dialogs, save_file).WillRepeatedly(Return(IDialogs::FileResult{.filename = "test", .filter_index = 1 }));
+
+    lua_State* L = luaL_newstate();
+    lua::create_route(L, route);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "r:save_as()"));
+}
+
+TEST(Lua_Route, SaveAsWithFileRejected)
+{
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, save_as).Times(0);
+    EXPECT_CALL(*route, set_filename).Times(0);
+
+    auto dialogs = mock_shared<MockDialogs>();
+    EXPECT_CALL(*dialogs, save_file).WillRepeatedly(Return(IDialogs::FileResult{.filename = "test", .filter_index = 1 }));
+
+    lua_State* L = luaL_newstate();
+    lua::create_route(L, route);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "r:save_as()"));
+}
+
+TEST(Lua_Route, SaveAsChoosesFile)
+{
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, save_as).Times(1);
+    EXPECT_CALL(*route, set_filename).Times(1);
+
+    auto dialogs = mock_shared<MockDialogs>();
+    EXPECT_CALL(*dialogs, save_file).WillRepeatedly(Return(IDialogs::FileResult{.filename = "test", .filter_index = 1 }));
+
+    lua_State* L = luaL_newstate();
+    lua::create_route(L, route);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "r:save_as()"));
 }
 
 TEST(Lua_Route, SetColour)

--- a/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
+++ b/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
@@ -4,6 +4,7 @@
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
 #include <trview.app/Mocks/Routing/IRoute.h>
+#include <trview.app/Mocks/Routing/IRandomizerRoute.h>
 #include <trview.app/Mocks/Elements/ILevel.h>
 #include <trview.app/Lua/Route/Lua_Waypoint.h>
 #include <trview.app/Mocks/Routing/IWaypoint.h>
@@ -85,7 +86,7 @@ TEST(Lua_Route, New)
     auto route = mock_shared<MockRoute>();
 
     lua_State* L = luaL_newstate();
-    lua::route_register(L, [=](auto&&...) { return route; }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
 
     ASSERT_EQ(0, luaL_dostring(L, "r = Route.new() return r"));
     ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));

--- a/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
+++ b/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
@@ -85,7 +85,7 @@ TEST(Lua_Route, New)
     auto route = mock_shared<MockRoute>();
 
     lua_State* L = luaL_newstate();
-    lua::route_register(L, [=](auto&&...) { return route; });
+    lua::route_register(L, [=](auto&&...) { return route; }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
 
     ASSERT_EQ(0, luaL_dostring(L, "r = Route.new() return r"));
     ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -153,20 +153,6 @@ TEST(RouteWindow, ClearSaveMarksRouteUnsaved)
         .id(RouteWindow::Names::clear_save));
 }
 
-TEST(RouteWindow, ExportRouteButtonRaisesEvent)
-{
-    bool file_raised = false;
-    auto window = register_test_module().build();
-    auto token = window->on_route_save_as += [&]() { file_raised = true; };
-
-    TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
-        .push_child(RouteWindow::Names::waypoint_list_panel)
-        .id(RouteWindow::Names::export_button));
-
-    ASSERT_TRUE(file_raised);
-}
-
 TEST(RouteWindow, ExportRouteButtonDoesNotRaiseEventWhenCancelled)
 {
     bool file_raised = false;
@@ -179,20 +165,6 @@ TEST(RouteWindow, ExportRouteButtonDoesNotRaiseEventWhenCancelled)
         .id(RouteWindow::Names::export_button));
 
     ASSERT_FALSE(file_raised);
-}
-
-TEST(RouteWindow, ImportRouteButtonRaisesEvent)
-{
-    bool raised = false;
-    auto window = register_test_module().build();
-    auto token = window->on_route_open += [&]() { raised = true; };
-
-    TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
-        .push_child(RouteWindow::Names::waypoint_list_panel)
-        .id(RouteWindow::Names::import_button));
-
-    ASSERT_TRUE(raised);
 }
 
 TEST(RouteWindow, ImportRouteButtonDoesNotRaiseEventWhenCancelled)

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -558,35 +558,161 @@ TEST(RouteWindow, DeleteWaypointRaisesEvent)
 
 TEST(RouteWindow, FileOpenRaisesEvent)
 {
-    FAIL();
+    auto window = register_test_module().build();
+
+    bool raised = false;
+    auto token = window->on_route_open += [&]()
+    {
+        raised = true;
+    };
+
+    TestImgui imgui([&]() { window->render(); });
+    imgui.render();
+
+    imgui.hover_element(imgui.id("Route###Route").push("##menubar").id("File"));
+    imgui.click_element(imgui.id("Route###Route").push("##menubar").id("File"));
+    imgui.hover_element(imgui.id("##Menu_00").id("Open"));
+    imgui.click_element_with_release(imgui.id("##Menu_00").id("Open"));
+
+    ASSERT_TRUE(raised);
 }
 
 TEST(RouteWindow, ReloadRaisesEvent)
 {
-    FAIL();
+    auto route = mock_shared<MockRoute>();
+    ON_CALL(*route, filename).WillByDefault(Return("test"));
+
+    auto window = register_test_module().build();
+    window->set_route(route);
+
+    bool raised = false;
+    auto token = window->on_route_reload += [&]()
+    {
+        raised = true;
+    };
+
+    TestImgui imgui([&]() { window->render(); });
+    imgui.render();
+
+    imgui.hover_element(imgui.id("Route###Route").push("##menubar").id("File"));
+    imgui.click_element(imgui.id("Route###Route").push("##menubar").id("File"));
+    imgui.hover_element(imgui.id("##Menu_00").id("Reload"));
+    imgui.click_element_with_release(imgui.id("##Menu_00").id("Reload"));
+
+    ASSERT_TRUE(raised);
 }
 
 TEST(RouteWindow, SaveRaisesEvent)
 {
-    FAIL();
+    auto window = register_test_module().build();
+
+    bool raised = false;
+    auto token = window->on_route_save += [&]()
+    {
+        raised = true;
+    };
+
+    TestImgui imgui([&]() { window->render(); });
+    imgui.render();
+
+    imgui.hover_element(imgui.id("Route###Route").push("##menubar").id("File"));
+    imgui.click_element(imgui.id("Route###Route").push("##menubar").id("File"));
+    imgui.hover_element(imgui.id("##Menu_00").id("Save"));
+    imgui.click_element_with_release(imgui.id("##Menu_00").id("Save"));
+
+    ASSERT_TRUE(raised);
 }
 
 TEST(RouteWindow, SaveAsRaisesEvent)
 {
-    FAIL();
+    auto window = register_test_module().build();
+
+    bool raised = false;
+    auto token = window->on_route_save_as += [&]()
+    {
+        raised = true;
+    };
+
+    TestImgui imgui([&]() { window->render(); });
+    imgui.render();
+
+    imgui.hover_element(imgui.id("Route###Route").push("##menubar").id("File"));
+    imgui.click_element(imgui.id("Route###Route").push("##menubar").id("File"));
+    imgui.hover_element(imgui.id("##Menu_00").id("Save"));
+    imgui.click_element_with_release(imgui.id("##Menu_00").id("Save As"));
+
+    ASSERT_TRUE(raised);
 }
 
 TEST(RouteWindow, LevelSwitchRaisesEvent)
 {
-    FAIL();
+    auto route = mock_shared<MockRandomizerRoute>();
+    ON_CALL(*route, filenames).WillByDefault(Return(std::vector<std::string>{ "test1", "test2" }));
+
+    auto window = register_test_module().build();
+    window->set_route(route);
+
+    std::optional<std::string> raised;
+    auto token = window->on_level_switch += [&](const auto& value)
+    {
+        raised = value;
+    };
+
+    TestImgui imgui([&]() { window->render(); });
+    imgui.render();
+
+    imgui.click_element_with_hover(imgui.id("Route###Route")
+        .push_child(RouteWindow::Names::waypoint_list_panel)
+        .push("##levellist").id("test2"));
+
+    ASSERT_TRUE(raised);
+    ASSERT_EQ(raised.value(), "test2");
 }
 
 TEST(RouteWindow, NewRouteRaisesEvent)
 {
-    FAIL();
+    auto window = register_test_module().build();
+
+    bool raised = false;
+    auto token = window->on_new_route += [&]()
+    {
+        raised = true;
+    };
+
+    TestImgui imgui([&]() { window->render(); });
+    imgui.render();
+
+    imgui.hover_element(imgui.id("Route###Route").push("##menubar").id("File"));
+    imgui.click_element(imgui.id("Route###Route").push("##menubar").id("File"));
+    imgui.hover_element(imgui.id("##Menu_00").id("New"));
+    imgui.click_element_with_release(imgui.id("##Menu_00").id("New"));
+    imgui.hover_element(imgui.id("##Menu_01").id("Route"));
+    imgui.click_element_with_release(imgui.id("##Menu_01").id("Route"));
+
+    ASSERT_TRUE(raised);
 }
 
 TEST(RouteWindow, NewRandomizerRouteRaisesEvent)
 {
-    FAIL();
+    auto window = register_test_module().build();
+
+    bool raised = false;
+    auto token = window->on_new_randomizer_route += [&]()
+    {
+        raised = true;
+    };
+
+    window->set_randomizer_enabled(true);
+
+    TestImgui imgui([&]() { window->render(); });
+    imgui.render();
+
+    imgui.hover_element(imgui.id("Route###Route").push("##menubar").id("File"));
+    imgui.click_element(imgui.id("Route###Route").push("##menubar").id("File"));
+    imgui.hover_element(imgui.id("##Menu_00").id("New"));
+    imgui.click_element_with_release(imgui.id("##Menu_00").id("New"));
+    imgui.hover_element(imgui.id("##Menu_01").id("Randomizer Route"));
+    imgui.click_element_with_release(imgui.id("##Menu_01").id("Randomizer Route"));
+
+    ASSERT_TRUE(raised);
 }

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -78,7 +78,7 @@ TEST(RouteWindow, WaypointRoomPositionCalculatedCorrectly)
     window->select_waypoint(0);
 
     TestImgui imgui([&]() { window->render(); });
-    auto rendered = imgui.rendered_text(imgui.id("Route")
+    auto rendered = imgui.rendered_text(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id(RouteWindow::Names::waypoint_stats));
 
@@ -104,7 +104,7 @@ TEST(RouteWindow, RoomPositionValuesCopiedToClipboard)
     window->select_waypoint(0);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .push(RouteWindow::Names::waypoint_stats)
         .id("Room Position"));
@@ -127,7 +127,7 @@ TEST(RouteWindow, AddingWaypointNotesMarksRouteUnsaved)
     window->select_waypoint(0);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element_with_hover(imgui.id("Route")
+    imgui.click_element_with_hover(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .push(RouteWindow::Names::notes).id(""));
     imgui.enter_text("Test");
@@ -148,7 +148,7 @@ TEST(RouteWindow, ClearSaveMarksRouteUnsaved)
     window->set_route(route);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id(RouteWindow::Names::clear_save));
 }
@@ -160,7 +160,7 @@ TEST(RouteWindow, ExportRouteButtonDoesNotRaiseEventWhenCancelled)
     auto token = window->on_route_save_as += [&]() { file_raised = true; };
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_list_panel)
         .id(RouteWindow::Names::export_button));
 
@@ -174,7 +174,7 @@ TEST(RouteWindow, ImportRouteButtonDoesNotRaiseEventWhenCancelled)
     auto token = window->on_route_save_as += [&]() { file_raised = true; };
     
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_list_panel)
         .id(RouteWindow::Names::import_button));
 
@@ -201,7 +201,7 @@ TEST(RouteWindow, ExportSaveButtonSavesFile)
     window->set_route(route);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id("SAVEGAME.0"));
 }
@@ -226,7 +226,7 @@ TEST(RouteWindow, ExportSaveButtonShowsErrorOnFailure)
     window->set_route(route);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id("SAVEGAME.0"));
 }
@@ -250,7 +250,7 @@ TEST(RouteWindow, ExportSaveButtonDoesNotSaveFileWhenCancelled)
     window->set_route(route);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id("SAVEGAME.0"));
 }
@@ -275,7 +275,7 @@ TEST(RouteWindow, AttachSaveButtonLoadsSave)
     window->set_route(route);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id(RouteWindow::Names::attach_save));
 }
@@ -299,7 +299,7 @@ TEST(RouteWindow, AttachSaveButtonShowsMessageOnError)
     window->set_route(route);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id(RouteWindow::Names::attach_save));
 
@@ -324,7 +324,7 @@ TEST(RouteWindow, AttachSaveButtonDoesNotLoadFileWhenCancelled)
     window->set_route(route);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id(RouteWindow::Names::attach_save));
     ASSERT_FALSE(waypoint->has_save());
@@ -342,7 +342,7 @@ TEST(RouteWindow, ClickStatShowsBubble)
     window->select_waypoint(0);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .push(RouteWindow::Names::waypoint_stats)
         .id("Room Position"));
@@ -365,13 +365,13 @@ TEST(RouteWindow, RandomizerPanelVisibleBasedOnSetting)
     window->select_waypoint(0);
 
     TestImgui imgui([&]() { window->render(); });
-    ASSERT_FALSE(imgui.element_present(imgui.id("Route")
+    ASSERT_FALSE(imgui.element_present(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .push(RouteWindow::Names::randomizer_flags)
         .id("Test")));
     window->set_randomizer_enabled(true);
     imgui.render();
-    ASSERT_TRUE(imgui.element_present(imgui.id("Route")
+    ASSERT_TRUE(imgui.element_present(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .push(RouteWindow::Names::randomizer_flags)
         .id("Test")));
@@ -397,14 +397,14 @@ TEST(RouteWindow, RandomizerPanelCreatesUIFromSettings)
 
     TestImgui imgui([&]() { window->render(); });
 
-    ASSERT_TRUE(imgui.element_present(imgui.id("Route")
+    ASSERT_TRUE(imgui.element_present(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .push(RouteWindow::Names::randomizer_flags)
         .id("Test 1")));
-    ASSERT_TRUE(imgui.element_present(imgui.id("Route")
+    ASSERT_TRUE(imgui.element_present(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id("Test 2")));
-    ASSERT_TRUE(imgui.element_present(imgui.id("Route")
+    ASSERT_TRUE(imgui.element_present(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id("Test 3")));
 }
@@ -429,7 +429,7 @@ TEST(RouteWindow, ToggleRandomizerBoolUpdatesWaypoint)
     window->select_waypoint(0);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .push(RouteWindow::Names::randomizer_flags)
         .id("Test 1"));
@@ -458,7 +458,7 @@ TEST(RouteWindow, ChooseRandomizerDropDownUpdatesWaypoint)
     window->select_waypoint(0);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id("Test 1"));
     imgui.click_element(imgui.id("##Combo_00").id("Two"));
@@ -487,7 +487,7 @@ TEST(RouteWindow, SetRandomizerTextUpdatesWaypoint)
     window->select_waypoint(0);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id("Test 1"));
     imgui.enter_text("Two");
@@ -516,7 +516,7 @@ TEST(RouteWindow, SetRandomizerNumberUpdatesWaypoint)
     window->select_waypoint(0);
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id("Test 1"));
     imgui.enter_text("2");
@@ -542,7 +542,7 @@ TEST(RouteWindow, DeleteWaypointRaisesEvent)
     };
 
     TestImgui imgui([&]() { window->render(); });
-    imgui.click_element(imgui.id("Route")
+    imgui.click_element(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .id(RouteWindow::Names::delete_waypoint));
 

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Windows/RouteWindow.h>
 #include <trview.app/Mocks/Routing/IRoute.h>
+#include <trview.app/Mocks/Routing/IRandomizerRoute.h>
 #include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.common/Mocks/Windows/IClipboard.h>
 #include <trview.common/Mocks/Windows/IDialogs.h>
@@ -349,7 +350,7 @@ TEST(RouteWindow, ClickStatShowsBubble)
     ASSERT_NE(imgui.find_window("##Tooltip_00"), nullptr);
 }
 
-TEST(RouteWindow, RandomizerPanelVisibleBasedOnSetting)
+TEST(RouteWindow, RandomizerPanelVisibleBasedOnRouteType)
 {
     auto window = register_test_module().build();
 
@@ -369,7 +370,12 @@ TEST(RouteWindow, RandomizerPanelVisibleBasedOnSetting)
         .push_child(RouteWindow::Names::waypoint_details_panel)
         .push(RouteWindow::Names::randomizer_flags)
         .id("Test")));
-    window->set_randomizer_enabled(true);
+
+    auto rando_route = mock_shared<MockRandomizerRoute>();
+    EXPECT_CALL(*rando_route, waypoints).WillRepeatedly(Return(1));
+    EXPECT_CALL(*rando_route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
+    window->set_route(rando_route);
+
     imgui.render();
     ASSERT_TRUE(imgui.element_present(imgui.id("Route###Route")
         .push_child(RouteWindow::Names::waypoint_details_panel)
@@ -382,7 +388,7 @@ TEST(RouteWindow, RandomizerPanelCreatesUIFromSettings)
     auto window = register_test_module().build();
 
     auto waypoint = mock_shared<MockWaypoint>();
-    auto route = mock_shared<MockRoute>();
+    auto route = mock_shared<MockRandomizerRoute>();
     EXPECT_CALL(*route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(*route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
     window->set_route(route);
@@ -421,7 +427,7 @@ TEST(RouteWindow, ToggleRandomizerBoolUpdatesWaypoint)
     IWaypoint::WaypointRandomizerSettings new_settings;
 
     auto waypoint = mock_shared<MockWaypoint>();
-    auto route = mock_shared<MockRoute>();
+    auto route = mock_shared<MockRandomizerRoute>();
     EXPECT_CALL(*route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(*route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
     EXPECT_CALL(*waypoint, set_randomizer_settings(An<const IWaypoint::WaypointRandomizerSettings&>())).WillRepeatedly(SaveArg<0>(&new_settings));
@@ -450,7 +456,7 @@ TEST(RouteWindow, ChooseRandomizerDropDownUpdatesWaypoint)
     IWaypoint::WaypointRandomizerSettings new_settings;
 
     auto waypoint = mock_shared<MockWaypoint>();
-    auto route = mock_shared<MockRoute>();
+    auto route = mock_shared<MockRandomizerRoute>();
     EXPECT_CALL(*route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(*route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
     EXPECT_CALL(*waypoint, set_randomizer_settings(An<const IWaypoint::WaypointRandomizerSettings&>())).WillRepeatedly(SaveArg<0>(&new_settings));
@@ -479,7 +485,7 @@ TEST(RouteWindow, SetRandomizerTextUpdatesWaypoint)
     IWaypoint::WaypointRandomizerSettings new_settings;
 
     auto waypoint = mock_shared<MockWaypoint>();
-    auto route = mock_shared<MockRoute>();
+    auto route = mock_shared<MockRandomizerRoute>();
     EXPECT_CALL(*route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(*route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
     EXPECT_CALL(*waypoint, set_randomizer_settings(An<const IWaypoint::WaypointRandomizerSettings&>())).WillRepeatedly(SaveArg<0>(&new_settings));
@@ -508,7 +514,7 @@ TEST(RouteWindow, SetRandomizerNumberUpdatesWaypoint)
     IWaypoint::WaypointRandomizerSettings new_settings;
 
     auto waypoint = mock_shared<MockWaypoint>();
-    auto route = mock_shared<MockRoute>();
+    auto route = mock_shared<MockRandomizerRoute>();
     EXPECT_CALL(*route, waypoints).WillRepeatedly(Return(1));
     EXPECT_CALL(*route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
     EXPECT_CALL(*waypoint, set_randomizer_settings(An<const IWaypoint::WaypointRandomizerSettings&>())).WillRepeatedly(SaveArg<0>(&new_settings));

--- a/trview.app.tests/RouteWindowTests.cpp
+++ b/trview.app.tests/RouteWindowTests.cpp
@@ -555,3 +555,38 @@ TEST(RouteWindow, DeleteWaypointRaisesEvent)
     ASSERT_TRUE(raised.has_value());
     ASSERT_EQ(raised, 0);
 }
+
+TEST(RouteWindow, FileOpenRaisesEvent)
+{
+    FAIL();
+}
+
+TEST(RouteWindow, ReloadRaisesEvent)
+{
+    FAIL();
+}
+
+TEST(RouteWindow, SaveRaisesEvent)
+{
+    FAIL();
+}
+
+TEST(RouteWindow, SaveAsRaisesEvent)
+{
+    FAIL();
+}
+
+TEST(RouteWindow, LevelSwitchRaisesEvent)
+{
+    FAIL();
+}
+
+TEST(RouteWindow, NewRouteRaisesEvent)
+{
+    FAIL();
+}
+
+TEST(RouteWindow, NewRandomizerRouteRaisesEvent)
+{
+    FAIL();
+}

--- a/trview.app.tests/Routing/RandomizerRouteTests.cpp
+++ b/trview.app.tests/Routing/RandomizerRouteTests.cpp
@@ -2,6 +2,7 @@
 #include <trview.app/Mocks/Routing/IRoute.h>
 #include <trview.app/Mocks/Routing/IWaypoint.h>
 #include <trview.tests.common/Mocks.h>
+#include <ranges>
 
 using namespace trview;
 using namespace trview::mocks;
@@ -9,6 +10,8 @@ using namespace trview::tests;
 using namespace DirectX::SimpleMath;
 using testing::Return;
 using testing::NiceMock;
+using testing::A;
+using testing::SaveArg;
 
 namespace
 {
@@ -40,47 +43,133 @@ namespace
     }
 }
 
-TEST(RandomizerRoute, AddUpdatesLevels)
-{
-    FAIL();
-}
-
 TEST(RandomizerRoute, AddForwardsToRoute)
 {
-    FAIL();
+    auto inner_route = mock_shared<MockRoute>();
+    EXPECT_CALL(*inner_route, add(Vector3::Zero, Vector3::Down, 15));
+    auto route = register_test_module()
+        .with_route(inner_route)
+        .build();
+    route->add(Vector3::Zero, Vector3::Down, 15);
 }
 
 TEST(RandomizerRoute, ClearForwardsToRoute)
 {
-    FAIL();
+    auto inner_route = mock_shared<MockRoute>();
+    EXPECT_CALL(*inner_route, clear);
+    auto route = register_test_module()
+        .with_route(inner_route)
+        .build();
+    route->clear();
 }
 
 TEST(RandomizerRoute, InsertForwardsToRoute)
 {
-    FAIL();
+    auto inner_route = mock_shared<MockRoute>();
+    EXPECT_CALL(*inner_route, insert(Vector3::Zero, Vector3::Down, 15));
+    auto route = register_test_module()
+        .with_route(inner_route)
+        .build();
+    route->insert(Vector3::Zero, Vector3::Down, 15);
 }
 
 TEST(RandomizerRoute, Reload)
 {
-    FAIL();
+    const std::string contents = "{\n  \"level1\": [\n    {\n      \"X\": 0,\n      \"Y\": 0,\n      \"Z\": 0,\n      \"Room\": 0\n    }\n  ],\n  \"level2\": [\n    {\n      \"X\": 0,\n      \"Y\": 0,\n      \"Z\": 0,\n      \"Room\": 0\n    }\n  ]\n}";
+    std::vector<uint8_t> bytes = contents 
+        | std::views::transform([](const auto v) { return static_cast<uint8_t>(v); }) 
+        | std::ranges::to<std::vector>();
+    UserSettings settings{};
+    auto files = mock_shared<MockFiles>();
+    EXPECT_CALL(*files, load_file(A<const std::string&>())).WillRepeatedly(Return(bytes));
+
+    auto route = register_test_module().build();
+    
+    route->set_filename("test.json");
+    route->reload(files, settings);
+
+    const std::vector<std::string> expected { "level1", "level2" };
+    ASSERT_EQ(route->filenames(), expected);
 }
 
 TEST(RandomizerRoute, RemoveForwardsToRoute)
 {
-    FAIL();
+    std::shared_ptr<IWaypoint> waypoint = mock_shared<MockWaypoint>();
+    auto inner_route = mock_shared<MockRoute>();
+    EXPECT_CALL(*inner_route, remove(15));
+    EXPECT_CALL(*inner_route, remove(waypoint));
+    auto route = register_test_module()
+        .with_route(inner_route)
+        .build();
+    route->remove(15);
+    route->remove(waypoint);
 }
 
 TEST(RandomizerRoute, Save)
 {
-    FAIL();
+    auto route = register_test_module().build();
+    auto files = mock_shared<MockFiles>();
+
+    std::string contents;
+    EXPECT_CALL(*files, save_file("test.json", A<const std::string&>()))
+        .WillOnce(SaveArg<1>(&contents));
+
+    UserSettings settings{};
+
+    route->set_filename("test.json");
+    route->add("level1", Vector3::Zero, Vector3::Down, 0);
+    route->add("level2", Vector3::Zero, Vector3::Down, 0);
+    route->save(files, settings);
+
+    ASSERT_EQ(contents, "{\n  \"level1\": [\n    {\n      \"X\": 0,\n      \"Y\": 0,\n      \"Z\": 0,\n      \"Room\": 0\n    }\n  ],\n  \"level2\": [\n    {\n      \"X\": 0,\n      \"Y\": 0,\n      \"Z\": 0,\n      \"Room\": 0\n    }\n  ]\n}");
+}
+
+TEST(RandomizerRoute, SaveNoFileName)
+{
+    auto route = register_test_module().build();
+    auto files = mock_shared<MockFiles>();
+
+    EXPECT_CALL(*files, save_file(A<const std::string&>(), A<const std::string&>())).Times(0);
+
+    UserSettings settings{};
+    route->save(files, settings);
 }
 
 TEST(RandomizerRoute, SaveAs)
 {
-    FAIL();
+    auto route = register_test_module().build();
+    auto files = mock_shared<MockFiles>();
+
+    std::string contents;
+    EXPECT_CALL(*files, save_file("test.json", A<const std::string&>()))
+        .WillOnce(SaveArg<1>(&contents));
+
+    UserSettings settings{};
+    route->add("level1", Vector3::Zero, Vector3::Down, 0);
+    route->add("level2", Vector3::Zero, Vector3::Down, 0);
+    route->save_as(files, "test.json", settings);
+
+    ASSERT_EQ(contents, "{\n  \"level1\": [\n    {\n      \"X\": 0,\n      \"Y\": 0,\n      \"Z\": 0,\n      \"Room\": 0\n    }\n  ],\n  \"level2\": [\n    {\n      \"X\": 0,\n      \"Y\": 0,\n      \"Z\": 0,\n      \"Room\": 0\n    }\n  ]\n}");
 }
 
 TEST(RandomizerRoute, SetLevelSwitchesWaypoints)
 {
-    FAIL();
+    std::shared_ptr<IWaypoint> waypoint = mock_shared<MockWaypoint>();
+    const auto source = [=](auto&&...) { return waypoint; };
+
+    auto level = mock_shared<MockLevel>();
+    ON_CALL(*level, filename).WillByDefault(Return("C:\\Temp\\test.tr2"));
+
+    auto inner_route = mock_shared<MockRoute>();
+    EXPECT_CALL(*inner_route, clear);
+    EXPECT_CALL(*inner_route, add(waypoint));
+    EXPECT_CALL(*inner_route, set_level);
+    EXPECT_CALL(*inner_route, set_unsaved(false));
+    auto route = register_test_module()
+        .with_route(inner_route)
+        .with_waypoint_source(source)
+        .build();
+
+    route->add("test.tr2", Vector3::Zero, Vector3::Down, 15);
+    route->set_level(level);
 }

--- a/trview.app.tests/Routing/RandomizerRouteTests.cpp
+++ b/trview.app.tests/Routing/RandomizerRouteTests.cpp
@@ -1,0 +1,86 @@
+#include <trview.app/Routing/RandomizerRoute.h>
+#include <trview.app/Mocks/Routing/IRoute.h>
+#include <trview.app/Mocks/Routing/IWaypoint.h>
+#include <trview.tests.common/Mocks.h>
+
+using namespace trview;
+using namespace trview::mocks;
+using namespace trview::tests;
+using namespace DirectX::SimpleMath;
+using testing::Return;
+using testing::NiceMock;
+
+namespace
+{
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            IWaypoint::Source waypoint_source = [](auto&&...) { return mock_unique<MockWaypoint>(); };
+            std::shared_ptr<IRoute> route { mock_shared<MockRoute>() };
+
+            test_module& with_route(const std::shared_ptr<IRoute>& route)
+            {
+                this->route = route;
+                return *this;
+            }
+
+            test_module& with_waypoint_source(IWaypoint::Source waypoint_source)
+            {
+                this->waypoint_source = waypoint_source;
+                return *this;
+            }
+
+            std::shared_ptr<RandomizerRoute> build()
+            {
+                return std::make_shared<RandomizerRoute>(route, waypoint_source);
+            }
+        };
+        return test_module{};
+    }
+}
+
+TEST(RandomizerRoute, AddUpdatesLevels)
+{
+    FAIL();
+}
+
+TEST(RandomizerRoute, AddForwardsToRoute)
+{
+    FAIL();
+}
+
+TEST(RandomizerRoute, ClearForwardsToRoute)
+{
+    FAIL();
+}
+
+TEST(RandomizerRoute, InsertForwardsToRoute)
+{
+    FAIL();
+}
+
+TEST(RandomizerRoute, Reload)
+{
+    FAIL();
+}
+
+TEST(RandomizerRoute, RemoveForwardsToRoute)
+{
+    FAIL();
+}
+
+TEST(RandomizerRoute, Save)
+{
+    FAIL();
+}
+
+TEST(RandomizerRoute, SaveAs)
+{
+    FAIL();
+}
+
+TEST(RandomizerRoute, SetLevelSwitchesWaypoints)
+{
+    FAIL();
+}

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -409,6 +409,11 @@ TEST(Route, AddWaypointUsesColours)
     ASSERT_EQ(waypoint_values.value().waypoint_colour, Colour::Green);
 }
 
+TEST(Route, Reload)
+{
+    FAIL();
+}
+
 TEST(Route, RouteUsesDefaultColours)
 {
     UserSettings settings;
@@ -417,6 +422,16 @@ TEST(Route, RouteUsesDefaultColours)
     auto route = register_test_module().with_settings(settings).build();
     ASSERT_EQ(route->colour(), settings.route_colour);
     ASSERT_EQ(route->waypoint_colour(), settings.waypoint_colour);
+}
+
+TEST(Route, Save)
+{
+    FAIL();
+}
+
+TEST(Route, SaveAs)
+{
+    FAIL();
 }
 
 TEST(Route, SetColourUpdatesWaypoints)

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -413,7 +413,20 @@ TEST(Route, AddWaypointUsesColours)
 
 TEST(Route, Reload)
 {
-    FAIL();
+    const std::string contents = "{\"colour\":\"4278255360\",\"waypoint_colour\":\"4294967295\",\"waypoints\":[{\"index\":0,\"normal\":\"0,0,0\",\"notes\":\"\",\"position\":\"0,0,0\",\"room\":0,\"type\":\"Position\"},{\"index\":0,\"normal\":\"0,0,0\",\"notes\":\"\",\"position\":\"0,0,0\",\"room\":0,\"type\":\"Position\"}]}";
+    std::vector<uint8_t> bytes = contents
+        | std::views::transform([](const auto v) { return static_cast<uint8_t>(v); })
+        | std::ranges::to<std::vector>();
+    UserSettings settings{};
+    auto files = mock_shared<MockFiles>();
+    EXPECT_CALL(*files, load_file(A<const std::string&>())).WillRepeatedly(Return(bytes));
+
+    auto route = register_test_module().build();
+
+    route->set_filename("test.tvr");
+    route->reload(files, settings);
+
+    ASSERT_EQ(route->waypoints(), 2);
 }
 
 TEST(Route, RouteUsesDefaultColours)

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -11,6 +11,8 @@ using namespace trview::tests;
 using namespace DirectX::SimpleMath;
 using testing::Return;
 using testing::NiceMock;
+using testing::A;
+using testing::SaveArg;
 
 namespace
 {
@@ -426,12 +428,50 @@ TEST(Route, RouteUsesDefaultColours)
 
 TEST(Route, Save)
 {
-    FAIL();
+    auto route = register_test_module().build();
+    auto files = mock_shared<MockFiles>();
+
+    std::string contents;
+    EXPECT_CALL(*files, save_file("test.tvr", A<const std::string&>()))
+        .WillOnce(SaveArg<1>(&contents));
+
+    UserSettings settings{};
+
+    route->set_filename("test.tvr");
+    route->add(Vector3::Zero, Vector3::Down, 0);
+    route->add(Vector3::Zero, Vector3::Down, 1);
+    route->save(files, settings);
+
+    ASSERT_EQ(contents, "{\"colour\":\"4278255360\",\"waypoint_colour\":\"4294967295\",\"waypoints\":[{\"index\":0,\"normal\":\"0,0,0\",\"notes\":\"\",\"position\":\"0,0,0\",\"room\":0,\"type\":\"Position\"},{\"index\":0,\"normal\":\"0,0,0\",\"notes\":\"\",\"position\":\"0,0,0\",\"room\":0,\"type\":\"Position\"}]}");
+}
+
+TEST(Route, SaveNoFileName)
+{
+    auto route = register_test_module().build();
+    auto files = mock_shared<MockFiles>();
+
+    EXPECT_CALL(*files, save_file(A<const std::string&>(), A<const std::string&>())).Times(0);
+
+    UserSettings settings{};
+    route->save(files, settings);
 }
 
 TEST(Route, SaveAs)
 {
-    FAIL();
+    auto route = register_test_module().build();
+    auto files = mock_shared<MockFiles>();
+
+    std::string contents;
+    EXPECT_CALL(*files, save_file("test.tvr", A<const std::string&>()))
+        .WillOnce(SaveArg<1>(&contents));
+
+    UserSettings settings{};
+
+    route->add(Vector3::Zero, Vector3::Down, 0);
+    route->add(Vector3::Zero, Vector3::Down, 1);
+    route->save_as(files, "test.tvr", settings);
+
+    ASSERT_EQ(contents, "{\"colour\":\"4278255360\",\"waypoint_colour\":\"4294967295\",\"waypoints\":[{\"index\":0,\"normal\":\"0,0,0\",\"notes\":\"\",\"position\":\"0,0,0\",\"room\":0,\"type\":\"Position\"},{\"index\":0,\"normal\":\"0,0,0\",\"notes\":\"\",\"position\":\"0,0,0\",\"room\":0,\"type\":\"Position\"}]}");
 }
 
 TEST(Route, SetColourUpdatesWaypoints)

--- a/trview.app.tests/Windows/RouteWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/RouteWindowManagerTests.cpp
@@ -185,3 +185,103 @@ TEST(RouteWindowManager, WaypointChangedRaised)
     mock_window->on_waypoint_changed();
     ASSERT_TRUE(raised);
 }
+
+TEST(RouteWindowManager, OnRouteOpenRaised)
+{
+    auto mock_window = mock_shared<MockRouteWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+
+    bool raised = false;
+    auto token = manager->on_route_open += [&]() { raised = true; };
+
+    manager->create_window();
+    mock_window->on_route_open();
+
+    ASSERT_TRUE(raised);
+}
+
+TEST(RouteWindowManager, OnRouteReloadRaised)
+{
+    auto mock_window = mock_shared<MockRouteWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+
+    bool raised = false;
+    auto token = manager->on_route_reload += [&]() { raised = true; };
+
+    manager->create_window();
+    mock_window->on_route_reload();
+
+    ASSERT_TRUE(raised);
+}
+
+TEST(RouteWindowManager, OnRouteSaveRaised)
+{
+    auto mock_window = mock_shared<MockRouteWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+
+    bool raised = false;
+    auto token = manager->on_route_save += [&]() { raised = true; };
+
+    manager->create_window();
+    mock_window->on_route_save();
+
+    ASSERT_TRUE(raised);
+}
+
+TEST(RouteWindowManager, OnRouteSaveAsRaised)
+{
+    auto mock_window = mock_shared<MockRouteWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+
+    bool raised = false;
+    auto token = manager->on_route_save_as += [&]() { raised = true; };
+
+    manager->create_window();
+    mock_window->on_route_save_as();
+
+    ASSERT_TRUE(raised);
+}
+
+TEST(RouteWindowManager, OnLevelSwitchRaised)
+{
+    auto mock_window = mock_shared<MockRouteWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+
+    std::optional<std::string> filename;
+    auto token = manager->on_level_switch += [&](const auto& f) { filename = f; };
+
+    manager->create_window();
+    mock_window->on_level_switch("test1");
+
+    ASSERT_TRUE(filename);
+    ASSERT_EQ(filename.value(), "test1");
+}
+
+
+TEST(RouteWindowManager, OnNewRouteRaised)
+{
+    auto mock_window = mock_shared<MockRouteWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+
+    bool raised = false;
+    auto token = manager->on_new_route += [&]() { raised = true; };
+
+    manager->create_window();
+    mock_window->on_new_route();
+
+    ASSERT_TRUE(raised);
+}
+
+TEST(RouteWindowManager, OnNewRandomizerRouteRaised)
+{
+    auto mock_window = mock_shared<MockRouteWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+
+    bool raised = false;
+    auto token = manager->on_new_randomizer_route += [&]() { raised = true; };
+
+    manager->create_window();
+    mock_window->on_new_randomizer_route();
+
+    ASSERT_TRUE(raised);
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -67,6 +67,7 @@
     <ClCompile Include="RouteWindowTests.cpp" />
     <ClCompile Include="Routing\ActionsTests.cpp" />
     <ClCompile Include="Routing\ActionTests.cpp" />
+    <ClCompile Include="Routing\RandomizerRouteTests.cpp" />
     <ClCompile Include="Routing\RouteTests.cpp" />
     <ClCompile Include="Routing\WaypointTests.cpp" />
     <ClCompile Include="SettingsWindowTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -227,6 +227,9 @@
     <ClCompile Include="Lua\Lua_Vector3Tests.cpp">
       <Filter>Lua</Filter>
     </ClCompile>
+    <ClCompile Include="Routing\RandomizerRouteTests.cpp">
+      <Filter>Routing</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -73,7 +73,7 @@ namespace trview
         _settings = _settings_loader->load_user_settings();
         lua::set_settings(_settings);
 
-        set_route(route_source());
+        set_route(_settings.randomizer_tools ? randomizer_route_source() : route_source());
 
         _file_menu->set_recent_files(_settings.recent_files);
         _token_store += _file_menu->on_file_open += [=](const auto& file) { open(file, ILevel::OpenMode::Full); };

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -772,7 +772,7 @@ namespace trview
     {
         auto route = is_rando ?
             trview::import_randomizer_route(_randomizer_route_source, _files, path, _settings.randomizer) :
-            trview::import_route(_route_source, _files, path, _settings.randomizer);
+            trview::import_route(_route_source, _files, path);
         if (route)
         {
             route->set_filename(path);
@@ -799,7 +799,7 @@ namespace trview
             filters.push_back({ L"trview route", { L"*.tvr" } });
         }
 
-        const auto filename = _dialogs->save_file(L"Export route", filters, 1);
+        const auto filename = _dialogs->save_file(L"Save route", filters, 1);
         if (filename.has_value())
         {
             _route->save_as(_files, filename->filename, _settings);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -390,6 +390,7 @@ namespace trview
         _route->set_randomizer_enabled(_settings.randomizer_tools);
         _route_window->set_randomizer_settings(_settings.randomizer);
         _token_store += _route_window->on_window_created += [&]() { open_recent_route(); };
+        _token_store += _route_window->on_level_switch += [&](const auto& level) { _file_menu->switch_to(level); };
 
         if (_settings.route_startup)
         {

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -391,6 +391,8 @@ namespace trview
         _route_window->set_randomizer_settings(_settings.randomizer);
         _token_store += _route_window->on_window_created += [&]() { open_recent_route(); };
         _token_store += _route_window->on_level_switch += [&](const auto& level) { _file_menu->switch_to(level); };
+        _token_store += _route_window->on_new_route += [&]() { if (should_discard_changes()) { set_route(_route_source()); } };
+        _token_store += _route_window->on_new_randomizer_route += [&]() { if (should_discard_changes()) { set_route(_randomizer_route_source()); } };
 
         if (_settings.route_startup)
         {

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -753,7 +753,7 @@ namespace trview
 
     void Application::reload_route()
     {
-        _route->reload();
+        _route->reload(_files, _settings);
     }
 
     void Application::save_route()

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -57,14 +57,15 @@ namespace trview
         std::unique_ptr<ICameraSinkWindowManager> camera_sink_window_manager,
         std::unique_ptr<IConsoleManager> console_manager,
         std::shared_ptr<IPlugins> plugins,
-        std::unique_ptr<IPluginsWindowManager> plugins_window_manager)
+        std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
+        const IRandomizerRoute::Source& randomizer_route_source)
         : MessageHandler(application_window), _instance(GetModuleHandle(nullptr)),
         _file_menu(std::move(file_menu)), _update_checker(std::move(update_checker)), _view_menu(window()), _settings_loader(settings_loader), _trlevel_source(trlevel_source),
         _viewer(std::move(viewer)), _route_source(route_source), _shortcuts(shortcuts), _items_windows(std::move(items_window_manager)),
         _triggers_windows(std::move(triggers_window_manager)), _route_window(std::move(route_window_manager)), _rooms_windows(std::move(rooms_window_manager)), _level_source(level_source),
         _dialogs(dialogs), _files(files), _timer(default_time_source()), _imgui_backend(std::move(imgui_backend)), _lights_windows(std::move(lights_window_manager)), _log_windows(std::move(log_window_manager)),
         _textures_windows(std::move(textures_window_manager)), _camera_sink_windows(std::move(camera_sink_window_manager)), _console_manager(std::move(console_manager)),
-        _plugins(plugins), _plugins_windows(std::move(plugins_window_manager))
+        _plugins(plugins), _plugins_windows(std::move(plugins_window_manager)), _randomizer_route_source(randomizer_route_source)
     {
         SetWindowLongPtr(window(), GWLP_USERDATA, reinterpret_cast<LONG_PTR>(_imgui_backend.get()));
 
@@ -734,7 +735,9 @@ namespace trview
 
     void Application::import_route(const std::string& path, bool is_rando)
     {
-        auto route = trview::import_route(_route_source, _files, path, _level.get(), _settings.randomizer, is_rando);
+        auto route = is_rando ?
+            trview::import_randomizer_route(_randomizer_route_source, _files, path, _settings.randomizer) :
+            trview::import_route(_route_source, _files, path, _settings.randomizer);
         if (route)
         {
             set_route(route);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -776,6 +776,7 @@ namespace trview
         if (route)
         {
             route->set_filename(path);
+            route->set_unsaved(false);
             set_route(route);
             if (_level)
             {
@@ -812,7 +813,7 @@ namespace trview
 
     void Application::open_recent_route()
     {
-        if (!_level || _recent_route_prompted || !_route_window->is_window_open())
+        if (!_level || _recent_route_prompted || !_route_window->is_window_open() || std::dynamic_pointer_cast<IRandomizerRoute>(_route) != nullptr)
         {
             return;
         }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -737,7 +737,9 @@ namespace trview
         const auto filename = _dialogs->open_file(L"Import route", filters, OFN_FILEMUSTEXIST);
         if (filename)
         {
-            import_route(filename->filename, filename->filter_index == 2);
+            import_route(filename->filename,
+                filename->filter_index == 2 ||
+                filename->filename.ends_with(".json"));
         }
     }
 
@@ -748,7 +750,8 @@ namespace trview
 
     void Application::save_route()
     {
-        // TODO: Save the route in the current location.
+        // TODO: Prompt if the route didn't come from a file.
+        _route->save(_files, _settings);
     }
 
     void Application::import_route(const std::string& path, bool is_rando)
@@ -758,6 +761,7 @@ namespace trview
             trview::import_route(_route_source, _files, path, _settings.randomizer);
         if (route)
         {
+            route->set_filename(path);
             set_route(route);
             if (_level)
             {
@@ -783,6 +787,7 @@ namespace trview
             const bool is_rando = filename->filter_index == 2;
             export_route(*_route, _files, filename->filename, _level ? _level->filename() : "", _settings.randomizer, is_rando);
             _route->set_unsaved(false);
+            _route->set_filename(filename->filename);
             if (_level)
             {
                 _settings.recent_routes[_level->filename()] = { filename->filename, is_rando };

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -753,7 +753,7 @@ namespace trview
 
     void Application::reload_route()
     {
-        // TODO: Reload the route
+        _route->reload();
     }
 
     void Application::save_route()

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -784,7 +784,7 @@ namespace trview
         const auto filename = _dialogs->save_file(L"Export route", filters, filter_index);
         if (filename.has_value())
         {
-            const bool is_rando = filename->filter_index == 2;
+            const bool is_rando = filename->filter_index == 2 || filename->filename.ends_with(".json");
             export_route(*_route, _files, filename->filename, _level ? _level->filename() : "", _settings.randomizer, is_rando);
             _route->set_unsaved(false);
             _route->set_filename(filename->filename);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -393,6 +393,13 @@ namespace trview
         _token_store += _route_window->on_level_switch += [&](const auto& level) { _file_menu->switch_to(level); };
         _token_store += _route_window->on_new_route += [&]() { if (should_discard_changes()) { set_route(_route_source(std::nullopt)); } };
         _token_store += _route_window->on_new_randomizer_route += [&]() { if (should_discard_changes()) { set_route(_randomizer_route_source(std::nullopt)); } };
+        _token_store += _route_window->on_level_reordered += [&](const std::string& from, const std::string& to)
+        {
+            if (auto rando = std::dynamic_pointer_cast<IRandomizerRoute>(_route))
+            {
+                rando->move_level(from, to);
+            }
+        };
 
         if (_settings.route_startup)
         {

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -788,19 +788,21 @@ namespace trview
 
     void Application::save_route_as()
     {
-        std::vector<IDialogs::FileFilter> filters{ { L"trview route", { L"*.tvr" } } };
-        uint32_t filter_index = 1;
-        if (_settings.randomizer_tools)
+        const bool is_rando = std::dynamic_pointer_cast<IRandomizerRoute>(_route) != nullptr;
+        std::vector<IDialogs::FileFilter> filters;
+        if (is_rando)
         {
-            filters.push_back({ L"Randomizer Locations", { L"*.json" } });
-            filter_index = 2;
+            filters.push_back({ { L"Randomizer Locations", { L"*.json" } } });
+        }
+        else
+        {
+            filters.push_back({ { L"trview route", { L"*.tvr" } } });
         }
 
-        const auto filename = _dialogs->save_file(L"Export route", filters, filter_index);
+        const auto filename = _dialogs->save_file(L"Export route", filters, 1);
         if (filename.has_value())
         {
-            const bool is_rando = filename->filter_index == 2 || filename->filename.ends_with(".json");
-            export_route(*_route, _files, filename->filename, _level ? _level->filename() : "", _settings.randomizer, is_rando);
+            _route->save_as(_files, filename->filename, _settings);
             _route->set_unsaved(false);
             _route->set_filename(filename->filename);
             if (_level)

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -792,11 +792,11 @@ namespace trview
         std::vector<IDialogs::FileFilter> filters;
         if (is_rando)
         {
-            filters.push_back({ { L"Randomizer Locations", { L"*.json" } } });
+            filters.push_back({ L"Randomizer Locations", { L"*.json" }});
         }
         else
         {
-            filters.push_back({ { L"trview route", { L"*.tvr" } } });
+            filters.push_back({ L"trview route", { L"*.tvr" } });
         }
 
         const auto filename = _dialogs->save_file(L"Export route", filters, 1);

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -10,6 +10,7 @@
 #include <trview.app/Menus/IUpdateChecker.h>
 #include <trview.app/Menus/ViewMenu.h>
 #include <trview.app/Routing/Route.h>
+#include "Routing/IRandomizerRoute.h"
 #include <trview.app/Settings/ISettingsLoader.h>
 #include <trview.app/Settings/IStartupOptions.h>
 #include <trview.app/Windows/IItemsWindowManager.h>
@@ -73,7 +74,8 @@ namespace trview
             std::unique_ptr<ICameraSinkWindowManager> camera_sink_window_manager,
             std::unique_ptr<IConsoleManager> console_manager,
             std::shared_ptr<IPlugins> plugins,
-            std::unique_ptr<IPluginsWindowManager> plugins_window_manager);
+            std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
+            const IRandomizerRoute::Source& randomizer_route_source);
         virtual ~Application();
         /// Attempt to open the specified level file.
         /// @param filename The level file to open.
@@ -170,6 +172,8 @@ namespace trview
         std::unique_ptr<IConsoleManager> _console_manager;
         std::shared_ptr<IPlugins> _plugins;
         std::unique_ptr<IPluginsWindowManager> _plugins_windows;
+
+        IRandomizerRoute::Source _randomizer_route_source;
     };
 
     std::unique_ptr<IApplication> create_application(HINSTANCE hInstance, int command_show, const std::wstring& command_line);

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -122,6 +122,7 @@ namespace trview
         void set_room_visibility(const std::weak_ptr<IRoom>& room, bool visible);
         void set_camera_sink_visibility(const std::weak_ptr<ICameraSink>& camera_sink, bool visible);
         void select_sector(const std::weak_ptr<ISector>& sector);
+        bool is_rando_route() const;
         bool should_discard_changes();
         void reload();
         void open_route();

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -124,7 +124,11 @@ namespace trview
         void select_sector(const std::weak_ptr<ISector>& sector);
         bool should_discard_changes();
         void reload();
+        void open_route();
+        void reload_route();
+        void save_route();
         void import_route(const std::string& path, bool is_rando);
+        void save_route_as();
         void open_recent_route();
         void save_window_placement();
 

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -252,10 +252,10 @@ namespace trview
         auto dialogs = std::make_shared<Dialogs>(window);
         auto shell = std::make_shared<Shell>();
 
-        auto plugin_source = [=](auto&&... args) { return std::make_shared<Plugin>(files, std::make_unique<Lua>(route_source, waypoint_source), args...); };
+        auto plugin_source = [=](auto&&... args) { return std::make_shared<Plugin>(files, std::make_unique<Lua>(route_source, waypoint_source, dialogs, files), args...); };
         auto plugins = std::make_shared<Plugins>(
             files,
-            std::make_shared<Plugin>(std::make_unique<Lua>(route_source, waypoint_source), "Default", "trview", "Default Lua plugin for trview"),
+            std::make_shared<Plugin>(std::make_unique<Lua>(route_source, waypoint_source, dialogs, files), "Default", "trview", "Default Lua plugin for trview"),
             plugin_source,
             settings_loader->load_user_settings());
         auto plugins_window_source = [=]() { return std::make_shared<PluginsWindow>(plugins, shell); };

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -38,6 +38,7 @@
 #include "Menus/FileMenu.h"
 #include "Menus/UpdateChecker.h"
 #include "Routing/Waypoint.h"
+#include "Routing/RandomizerRoute.h"
 #include "Settings/SettingsLoader.h"
 #include "Settings/StartupOptions.h"
 #include "UI/CameraControls.h"
@@ -189,6 +190,13 @@ namespace trview
                 waypoint_source, settings_loader->load_user_settings());
         };
 
+        auto randomizer_route_source = [=]()
+        {
+            return std::make_shared<RandomizerRoute>(
+                route_source(),
+                waypoint_source);
+        };
+
         auto entity_source = [=](auto&& level, auto&& entity, auto&& index, auto&& triggers, auto&& mesh_storage, auto&& owning_level, auto&& room)
         {
             return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index,
@@ -252,10 +260,10 @@ namespace trview
         auto dialogs = std::make_shared<Dialogs>(window);
         auto shell = std::make_shared<Shell>();
 
-        auto plugin_source = [=](auto&&... args) { return std::make_shared<Plugin>(files, std::make_unique<Lua>(route_source, waypoint_source, dialogs, files), args...); };
+        auto plugin_source = [=](auto&&... args) { return std::make_shared<Plugin>(files, std::make_unique<Lua>(route_source, randomizer_route_source, waypoint_source, dialogs, files), args...); };
         auto plugins = std::make_shared<Plugins>(
             files,
-            std::make_shared<Plugin>(std::make_unique<Lua>(route_source, waypoint_source, dialogs, files), "Default", "trview", "Default Lua plugin for trview"),
+            std::make_shared<Plugin>(std::make_unique<Lua>(route_source, randomizer_route_source, waypoint_source, dialogs, files), "Default", "trview", "Default Lua plugin for trview"),
             plugin_source,
             settings_loader->load_user_settings());
         auto plugins_window_source = [=]() { return std::make_shared<PluginsWindow>(plugins, shell); };
@@ -328,6 +336,7 @@ namespace trview
             std::make_unique<CameraSinkWindowManager>(window, shortcuts, camera_sink_window_source),
             std::make_unique<ConsoleManager>(window, shortcuts, console_source, files),
             plugins,
-            std::make_unique<PluginsWindowManager>(window, shortcuts, plugins_window_source));
+            std::make_unique<PluginsWindowManager>(window, shortcuts, plugins_window_source),
+            randomizer_route_source);
     }
 }

--- a/trview.app/Lua/Lua.cpp
+++ b/trview.app/Lua/Lua.cpp
@@ -43,6 +43,17 @@ namespace trview
             self->on_print(oss.str());
             return 0;
         }
+
+        constexpr luaL_Reg loadedlibs[] = {
+          {LUA_GNAME, luaopen_base},
+          {LUA_LOADLIBNAME, luaopen_package},
+          {LUA_COLIBNAME, luaopen_coroutine},
+          {LUA_TABLIBNAME, luaopen_table},
+          {LUA_STRLIBNAME, luaopen_string},
+          {LUA_MATHLIBNAME, luaopen_math},
+          {LUA_UTF8LIBNAME, luaopen_utf8},
+          {LUA_DBLIBNAME, luaopen_debug}
+        };
     }
 
     ILua::~ILua()
@@ -53,7 +64,11 @@ namespace trview
         : _route_source(route_source), _waypoint_source(waypoint_source)
     {
         L = luaL_newstate();
-        luaL_openlibs(L);
+        for (const auto& lib : loadedlibs)
+        {
+            luaL_requiref(L, lib.name, lib.func, 1);
+            lua_pop(L, 1);
+        }
     }
 
     Lua::~Lua()

--- a/trview.app/Lua/Lua.cpp
+++ b/trview.app/Lua/Lua.cpp
@@ -60,8 +60,8 @@ namespace trview
     {
     }
 
-    Lua::Lua(const IRoute::Source& route_source, const IWaypoint::Source& waypoint_source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files)
-        : _route_source(route_source), _waypoint_source(waypoint_source), _dialogs(dialogs), _files(files)
+    Lua::Lua(const IRoute::Source& route_source, const IRandomizerRoute::Source& randomizer_route_source, const IWaypoint::Source& waypoint_source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files)
+        : _route_source(route_source), _randomizer_route_source(randomizer_route_source), _waypoint_source(waypoint_source), _dialogs(dialogs), _files(files)
     {
         L = luaL_newstate();
         for (const auto& lib : loadedlibs)
@@ -100,7 +100,7 @@ namespace trview
         *userdata = this;
         lua_pushcclosure(L, print, 1);
         lua_setglobal(L, "print");
-        lua::trview_register(L, application, _route_source, _waypoint_source, _dialogs, _files);
+        lua::trview_register(L, application, _route_source, _randomizer_route_source, _waypoint_source, _dialogs, _files);
         lua::imgui_register(L);
     }
 

--- a/trview.app/Lua/Lua.cpp
+++ b/trview.app/Lua/Lua.cpp
@@ -80,8 +80,14 @@ namespace trview
     {
         if (luaL_dofile(L, file.c_str()) != LUA_OK)
         {
-            std::string msg = lua_tostring(L, -1);
-            on_print(msg);
+            if (lua_type(L, -1) == LUA_TSTRING)
+            {
+                on_print(lua_tostring(L, -1));
+            }
+            else
+            {
+                on_print("An error occurred");
+            }
         }
     }
 
@@ -89,8 +95,14 @@ namespace trview
     {
         if (luaL_dostring(L, command.c_str()) != LUA_OK)
         {
-            std::string msg = lua_tostring(L, -1);
-            on_print(msg);
+            if (lua_type(L, -1) == LUA_TSTRING)
+            {
+                on_print(lua_tostring(L, -1));
+            }
+            else
+            {
+                on_print("An error occurred");
+            }
         }
     }
 

--- a/trview.app/Lua/Lua.cpp
+++ b/trview.app/Lua/Lua.cpp
@@ -60,8 +60,8 @@ namespace trview
     {
     }
 
-    Lua::Lua(const IRoute::Source& route_source, const IWaypoint::Source& waypoint_source)
-        : _route_source(route_source), _waypoint_source(waypoint_source)
+    Lua::Lua(const IRoute::Source& route_source, const IWaypoint::Source& waypoint_source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files)
+        : _route_source(route_source), _waypoint_source(waypoint_source), _dialogs(dialogs), _files(files)
     {
         L = luaL_newstate();
         for (const auto& lib : loadedlibs)
@@ -100,7 +100,7 @@ namespace trview
         *userdata = this;
         lua_pushcclosure(L, print, 1);
         lua_setglobal(L, "print");
-        lua::trview_register(L, application, _route_source, _waypoint_source);
+        lua::trview_register(L, application, _route_source, _waypoint_source, _dialogs, _files);
         lua::imgui_register(L);
     }
 

--- a/trview.app/Lua/Lua.h
+++ b/trview.app/Lua/Lua.h
@@ -3,6 +3,8 @@
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
 #include <string>
+#include <vector>
+#include <cstdint>
 #include <trview.common/Event.h>
 #include <functional>
 #include "ILua.h"

--- a/trview.app/Lua/Lua.h
+++ b/trview.app/Lua/Lua.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include "ILua.h"
 #include "../Routing/IRoute.h"
+#include "../Routing/IRandomizerRoute.h"
 #include "../Settings/UserSettings.h"
 
 #include <trview.common/Windows/IDialogs.h>
@@ -19,7 +20,7 @@ namespace trview
     class Lua final : public ILua
     {
     public:
-        explicit Lua(const IRoute::Source& route_source, const IWaypoint::Source& waypoint_source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
+        explicit Lua(const IRoute::Source& route_source, const IRandomizerRoute::Source& randomizer_route_source, const IWaypoint::Source& waypoint_source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
         ~Lua();
         void do_file(const std::string& file) override;
         void execute(const std::string& command) override;
@@ -27,6 +28,7 @@ namespace trview
     private:
         lua_State* L{ nullptr };
         IRoute::Source _route_source;
+        IRandomizerRoute::Source _randomizer_route_source;
         IWaypoint::Source _waypoint_source;
         std::shared_ptr<IDialogs> _dialogs;
         std::shared_ptr<IFiles> _files;

--- a/trview.app/Lua/Lua.h
+++ b/trview.app/Lua/Lua.h
@@ -9,6 +9,9 @@
 #include "../Routing/IRoute.h"
 #include "../Settings/UserSettings.h"
 
+#include <trview.common/Windows/IDialogs.h>
+#include <trview.common/IFiles.h>
+
 namespace trview
 {
     struct IApplication;
@@ -16,7 +19,7 @@ namespace trview
     class Lua final : public ILua
     {
     public:
-        explicit Lua(const IRoute::Source& route_source, const IWaypoint::Source& waypoint_source);
+        explicit Lua(const IRoute::Source& route_source, const IWaypoint::Source& waypoint_source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
         ~Lua();
         void do_file(const std::string& file) override;
         void execute(const std::string& command) override;
@@ -25,6 +28,8 @@ namespace trview
         lua_State* L{ nullptr };
         IRoute::Source _route_source;
         IWaypoint::Source _waypoint_source;
+        std::shared_ptr<IDialogs> _dialogs;
+        std::shared_ptr<IFiles> _files;
     };
 
     namespace lua

--- a/trview.app/Lua/Route/Lua_Route.cpp
+++ b/trview.app/Lua/Route/Lua_Route.cpp
@@ -92,6 +92,13 @@ namespace trview
                 return 0;
             }
 
+            int route_reload(lua_State* L)
+            {
+                auto route = get_self<IRoute>(L);
+                route->reload(files, user_settings);
+                return 0;
+            }
+
             int route_import(lua_State* L)
             {
                 std::string filename;
@@ -169,9 +176,19 @@ namespace trview
                     lua_pushcfunction(L, route_export);
                     return 1;
                 }
+                else if (key == "is_randomizer")
+                {
+                    lua_pushboolean(L, dynamic_cast<IRandomizerRoute*>(route) != nullptr);
+                    return 1;
+                }
                 else if (key == "level")
                 {
                     return create_level(L, route->level().lock());
+                }
+                else if (key == "reload")
+                {
+                    lua_pushcfunction(L, route_reload);
+                    return 1;
                 }
                 else if (key == "remove")
                 {
@@ -245,6 +262,16 @@ namespace trview
 
             int route_new(lua_State* L)
             {
+                if (lua_gettop(L) != 0 && lua_type(L, 1) == LUA_TTABLE)
+                {
+                    if (LUA_TBOOLEAN == lua_getfield(L, 1, "is_randomizer"))
+                    {
+                        if (lua_toboolean(L, -1))
+                        {
+                            return create_route(L, randomizer_route_source());
+                        }
+                    }
+                }
                 return create_route(L, route_source());
             }
         }

--- a/trview.app/Lua/Route/Lua_Route.cpp
+++ b/trview.app/Lua/Route/Lua_Route.cpp
@@ -41,6 +41,23 @@ namespace trview
                 return 0;
             }
 
+            int route_export(lua_State* L)
+            {
+                auto route = get_self<IRoute>(L);
+
+                if (LUA_TSTRING == lua_getfield(L, 1, "filename"))
+                {
+                    // TODO: Ask the user to confirm the export to the file specified.
+
+                }
+                else
+                {
+                    // TODO: Ask the user for a filename if none was provided.
+
+                }
+                return 0;
+            }
+
             int route_index(lua_State* L)
             {
                 auto route = get_self<IRoute>(L);
@@ -58,6 +75,11 @@ namespace trview
                 else if (key == "clear")
                 {
                     lua_pushcfunction(L, route_clear);
+                    return 1;
+                }
+                else if (key == "export")
+                {
+                    lua_pushcfunction(L, route_export);
                     return 1;
                 }
                 else if (key == "level")

--- a/trview.app/Lua/Route/Lua_Route.cpp
+++ b/trview.app/Lua/Route/Lua_Route.cpp
@@ -66,11 +66,11 @@ namespace trview
                     std::vector<IDialogs::FileFilter> filters;
                     if (is_rando)
                     {
-                        filters.push_back({ { L"Randomizer Locations", { L"*.json" } } });
+                        filters.push_back({ L"Randomizer Locations", { L"*.json" } });
                     }
                     else
                     {
-                        filters.push_back({ { L"trview route", { L"*.tvr" } } });
+                        filters.push_back({ L"trview route", { L"*.tvr" } });
                     }
 
                     if (const auto result = dialogs->save_file(L"Select location to save route as", filters, 1))

--- a/trview.app/Lua/Route/Lua_Route.cpp
+++ b/trview.app/Lua/Route/Lua_Route.cpp
@@ -80,7 +80,7 @@ namespace trview
                         L"Route export",
                         IDialogs::Buttons::Yes_No))
                     {
-                        export_route(*route, files, filename, level_filename, user_settings.randomizer, is_rando);
+                        export_route(*route, files, filename, level_filename, user_settings.randomizer, is_rando || filename.ends_with(".json"));
                     }
                 }
                 else
@@ -93,7 +93,7 @@ namespace trview
 
                     if (const auto result = dialogs->save_file(L"Select location for route export", filters, is_rando ? 2 : 1))
                     {
-                        export_route(*route, files, result.value().filename, level_filename, user_settings.randomizer, is_rando);
+                        export_route(*route, files, result.value().filename, level_filename, user_settings.randomizer, is_rando || result->filename.ends_with(".json"));
                     }
                 }
                 return 0;

--- a/trview.app/Lua/Route/Lua_Route.cpp
+++ b/trview.app/Lua/Route/Lua_Route.cpp
@@ -132,7 +132,7 @@ namespace trview
                     }
                     if (auto result = dialogs->open_file(L"Select route to import", filters, OFN_FILEMUSTEXIST))
                     {
-                        is_rando = result->filter_index == 2;
+                        is_rando = result->filter_index == 2 || result->filename.ends_with(".json");
                         filename = result->filename;
                     }
                     else

--- a/trview.app/Lua/Route/Lua_Route.cpp
+++ b/trview.app/Lua/Route/Lua_Route.cpp
@@ -296,11 +296,11 @@ namespace trview
                     {
                         if (lua_toboolean(L, -1))
                         {
-                            return create_route(L, randomizer_route_source());
+                            return create_route(L, randomizer_route_source(std::nullopt));
                         }
                     }
                 }
-                return create_route(L, route_source());
+                return create_route(L, route_source(std::nullopt));
             }
         }
 

--- a/trview.app/Lua/Route/Lua_Route.cpp
+++ b/trview.app/Lua/Route/Lua_Route.cpp
@@ -137,7 +137,7 @@ namespace trview
 
                 auto route = is_rando ?
                     import_randomizer_route(randomizer_route_source, files, filename, user_settings.randomizer) :
-                    import_route(route_source, files, filename, user_settings.randomizer);
+                    import_route(route_source, files, filename);
                 if (route)
                 {
                     route->set_level(level);

--- a/trview.app/Lua/Route/Lua_Route.h
+++ b/trview.app/Lua/Route/Lua_Route.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <trview.common/IFiles.h>
+#include <trview.common/Windows/IDialogs.h>
+
 #include "../../Routing/IRoute.h"
+#include "../../Settings/UserSettings.h"
 
 struct lua_State;
 
@@ -10,6 +14,7 @@ namespace trview
     {
         int create_route(lua_State* L, const std::shared_ptr<IRoute>& route);
         std::shared_ptr<IRoute> to_route(lua_State* L, int index);
-        void route_register(lua_State* L, const IRoute::Source& source);
+        void route_register(lua_State* L, const IRoute::Source& source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
+        void route_set_settings(const UserSettings& new_settings);
     }
 }

--- a/trview.app/Lua/Route/Lua_Route.h
+++ b/trview.app/Lua/Route/Lua_Route.h
@@ -4,6 +4,7 @@
 #include <trview.common/Windows/IDialogs.h>
 
 #include "../../Routing/IRoute.h"
+#include "../../Routing/IRandomizerRoute.h"
 #include "../../Settings/UserSettings.h"
 
 struct lua_State;
@@ -14,7 +15,7 @@ namespace trview
     {
         int create_route(lua_State* L, const std::shared_ptr<IRoute>& route);
         std::shared_ptr<IRoute> to_route(lua_State* L, int index);
-        void route_register(lua_State* L, const IRoute::Source& source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
+        void route_register(lua_State* L, const IRoute::Source& source, const IRandomizerRoute::Source& randomizer_source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
         void route_set_settings(const UserSettings& new_settings);
     }
 }

--- a/trview.app/Lua/trview/trview.cpp
+++ b/trview.app/Lua/trview/trview.cpp
@@ -131,7 +131,9 @@ namespace trview
 
         void trview_register(lua_State* L, IApplication* application,
             const IRoute::Source& route_source,
-            const IWaypoint::Source& waypoint_source)
+            const IWaypoint::Source& waypoint_source,
+            const std::shared_ptr<IDialogs>& dialogs,
+            const std::shared_ptr<IFiles>& files)
         {
             IApplication** userdata = static_cast<IApplication**>(lua_newuserdata(L, sizeof(application)));
             *userdata = application;
@@ -145,7 +147,7 @@ namespace trview
             lua_setglobal(L, "trview");
 
             sector_register(L);
-            route_register(L, route_source);
+            route_register(L, route_source, dialogs, files);
             waypoint_register(L, waypoint_source);
             colour_register(L);
             vector3_register(L);
@@ -154,6 +156,7 @@ namespace trview
         void set_settings(const UserSettings& settings)
         {
             waypoint_set_settings(settings);
+            route_set_settings(settings);
         }
     }
 }

--- a/trview.app/Lua/trview/trview.cpp
+++ b/trview.app/Lua/trview/trview.cpp
@@ -131,6 +131,7 @@ namespace trview
 
         void trview_register(lua_State* L, IApplication* application,
             const IRoute::Source& route_source,
+            const IRandomizerRoute::Source& randomizer_route_source,
             const IWaypoint::Source& waypoint_source,
             const std::shared_ptr<IDialogs>& dialogs,
             const std::shared_ptr<IFiles>& files)
@@ -147,7 +148,7 @@ namespace trview
             lua_setglobal(L, "trview");
 
             sector_register(L);
-            route_register(L, route_source, dialogs, files);
+            route_register(L, route_source, randomizer_route_source, dialogs, files);
             waypoint_register(L, waypoint_source);
             colour_register(L);
             vector3_register(L);

--- a/trview.app/Lua/trview/trview.h
+++ b/trview.app/Lua/trview/trview.h
@@ -2,6 +2,10 @@
 
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
+
+#include <trview.common/IFiles.h>
+#include <trview.common/Windows/IDialogs.h>
+
 #include "../../Elements/ILevel.h"
 #include "../../Routing/IRoute.h"
 #include "../../Settings/UserSettings.h"
@@ -12,7 +16,12 @@ namespace trview
 
     namespace lua
     {
-        void trview_register(lua_State* L, IApplication* application, const IRoute::Source& route_source, const IWaypoint::Source& waypoint_source);
+        void trview_register(lua_State* L,
+            IApplication* application,
+            const IRoute::Source& route_source,
+            const IWaypoint::Source& waypoint_source,
+            const std::shared_ptr<IDialogs>& dialogs,
+            const std::shared_ptr<IFiles>& files);
         void set_settings(const UserSettings& settings);
     }
 }

--- a/trview.app/Lua/trview/trview.h
+++ b/trview.app/Lua/trview/trview.h
@@ -8,6 +8,7 @@
 
 #include "../../Elements/ILevel.h"
 #include "../../Routing/IRoute.h"
+#include "../../Routing/IRandomizerRoute.h"
 #include "../../Settings/UserSettings.h"
 
 namespace trview
@@ -19,6 +20,7 @@ namespace trview
         void trview_register(lua_State* L,
             IApplication* application,
             const IRoute::Source& route_source,
+            const IRandomizerRoute::Source& randomizer_route_source,
             const IWaypoint::Source& waypoint_source,
             const std::shared_ptr<IDialogs>& dialogs,
             const std::shared_ptr<IFiles>& files);

--- a/trview.app/Menus/FileMenu.cpp
+++ b/trview.app/Menus/FileMenu.cpp
@@ -1,5 +1,6 @@
 #include "FileMenu.h"
 #include "../Resources/resource.h"
+#include <ranges>
 
 namespace trview
 {
@@ -64,6 +65,11 @@ namespace trview
 
             DrawMenuBar(window);
             return directory_listing_menu;
+        }
+
+        std::string trimmed_level_name(const std::string& input)
+        {
+            return input.substr(input.find_last_of("/\\") + 1);
         }
     }
 
@@ -195,5 +201,19 @@ namespace trview
             files.push_back(f.path);
         }
         return files;
+    }
+
+    void FileMenu::switch_to(const std::string& filename)
+    {
+        const auto found = std::ranges::find_if(
+            _file_switcher_list,
+            [&](const auto& x) -> bool
+            {
+                return trimmed_level_name(x.friendly_name) == trimmed_level_name(filename);
+            });
+        if (found != _file_switcher_list.end())
+        {
+            on_file_open(found->path);
+        }
     }
 }

--- a/trview.app/Menus/FileMenu.h
+++ b/trview.app/Menus/FileMenu.h
@@ -22,6 +22,7 @@ namespace trview
         virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         virtual void open_file(const std::string& filename) override;
         virtual void set_recent_files(const std::list<std::string>& files) override;
+        void switch_to(const std::string& filename) override;
     private:
         void choose_file();
         void next_directory_file();

--- a/trview.app/Menus/IFileMenu.h
+++ b/trview.app/Menus/IFileMenu.h
@@ -22,6 +22,7 @@ namespace trview
         /// </summary>
         /// <param name="files">The files to show.</param>
         virtual void set_recent_files(const std::list<std::string>& files) = 0;
+        virtual void switch_to(const std::string& filename) = 0;
         /// <summary>
         /// Event raised when the user opens a level. The opened level is passed as a parameter.
         /// </summary>

--- a/trview.app/Mocks/Menus/IFileMenu.h
+++ b/trview.app/Mocks/Menus/IFileMenu.h
@@ -13,6 +13,7 @@ namespace trview
             MOCK_METHOD(std::vector<std::string>, local_levels, (), (const, override));
             MOCK_METHOD(void, open_file, (const std::string&), (override));
             MOCK_METHOD(void, set_recent_files, (const std::list<std::string>&), (override));
+            MOCK_METHOD(void, switch_to, (const std::string&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Mocks.cpp
+++ b/trview.app/Mocks/Mocks.cpp
@@ -22,6 +22,7 @@
 #include "Menus/IUpdateChecker.h"
 #include "Routing/IRoute.h"
 #include "Routing/IWaypoint.h"
+#include "Routing/IRandomizerRoute.h"
 #include "Settings/ISettingsLoader.h"
 #include "Settings/IStartupOptions.h"
 #include "Tools/ICompass.h"
@@ -123,6 +124,9 @@ namespace trview
 
         MockRoute::MockRoute() {}
         MockRoute::~MockRoute() {}
+
+        MockRandomizerRoute::MockRandomizerRoute() {}
+        MockRandomizerRoute::~MockRandomizerRoute() {}
 
         MockWaypoint::MockWaypoint() {}
         MockWaypoint::~MockWaypoint() {}

--- a/trview.app/Mocks/Routing/IRandomizerRoute.h
+++ b/trview.app/Mocks/Routing/IRandomizerRoute.h
@@ -17,6 +17,7 @@ namespace trview
             MOCK_METHOD(void, clear, (), (override));
             MOCK_METHOD(Colour, colour, (), (const, override));
             MOCK_METHOD(std::optional<std::string>, filename, (), (const, override));
+            MOCK_METHOD(std::vector<std::string>, filenames, (), (const, override));
             MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t), (override));
             MOCK_METHOD(uint32_t, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t), (override));
             MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t, IWaypoint::Type, uint32_t), (override));

--- a/trview.app/Mocks/Routing/IRandomizerRoute.h
+++ b/trview.app/Mocks/Routing/IRandomizerRoute.h
@@ -28,9 +28,11 @@ namespace trview
             MOCK_METHOD(void, remove, (uint32_t), (override));
             MOCK_METHOD(void, remove, (const std::shared_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));
+            MOCK_METHOD(void, save, (const std::shared_ptr<IFiles>&, const UserSettings&), (override));
             MOCK_METHOD(uint32_t, selected_waypoint, (), (const, override));
             MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
             MOCK_METHOD(void, set_colour, (const Colour&), (override));
+            MOCK_METHOD(void, set_filename, (const std::string&), (override));
             MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
             MOCK_METHOD(void, set_randomizer_enabled, (bool), (override));
             MOCK_METHOD(void, set_unsaved, (bool), (override));

--- a/trview.app/Mocks/Routing/IRandomizerRoute.h
+++ b/trview.app/Mocks/Routing/IRandomizerRoute.h
@@ -26,7 +26,7 @@ namespace trview
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
             MOCK_METHOD(void, move, (int32_t, int32_t), (override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
-            MOCK_METHOD(void, reload, (), (override));
+            MOCK_METHOD(void, reload, (const std::shared_ptr<IFiles>&, const UserSettings&), (override));
             MOCK_METHOD(void, remove, (uint32_t), (override));
             MOCK_METHOD(void, remove, (const std::shared_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));

--- a/trview.app/Mocks/Routing/IRandomizerRoute.h
+++ b/trview.app/Mocks/Routing/IRandomizerRoute.h
@@ -30,6 +30,7 @@ namespace trview
             MOCK_METHOD(void, remove, (const std::shared_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));
             MOCK_METHOD(void, save, (const std::shared_ptr<IFiles>&, const UserSettings&), (override));
+            MOCK_METHOD(void, save_as, (const std::shared_ptr<IFiles>&, const std::string&, const UserSettings&), (override));
             MOCK_METHOD(uint32_t, selected_waypoint, (), (const, override));
             MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
             MOCK_METHOD(void, set_colour, (const Colour&), (override));

--- a/trview.app/Mocks/Routing/IRandomizerRoute.h
+++ b/trview.app/Mocks/Routing/IRandomizerRoute.h
@@ -16,6 +16,7 @@ namespace trview
             MOCK_METHOD(std::shared_ptr<IWaypoint>, add, (const std::string&, const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t), (override));
             MOCK_METHOD(void, clear, (), (override));
             MOCK_METHOD(Colour, colour, (), (const, override));
+            MOCK_METHOD(std::optional<std::string>, filename, (), (const, override));
             MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t), (override));
             MOCK_METHOD(uint32_t, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t), (override));
             MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t, IWaypoint::Type, uint32_t), (override));

--- a/trview.app/Mocks/Routing/IRandomizerRoute.h
+++ b/trview.app/Mocks/Routing/IRandomizerRoute.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "../../Routing/IRandomizerRoute.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockRandomizerRoute : public IRandomizerRoute
+        {
+            MockRandomizerRoute();
+            virtual ~MockRandomizerRoute();
+            MOCK_METHOD(std::shared_ptr<IWaypoint>, add, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t), (override));
+            MOCK_METHOD(std::shared_ptr<IWaypoint>, add, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, IWaypoint::Type, uint32_t), (override));
+            MOCK_METHOD(std::shared_ptr<IWaypoint>, add, (const std::shared_ptr<IWaypoint>&), (override));
+            MOCK_METHOD(std::shared_ptr<IWaypoint>, add, (const std::string&, const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t), (override));
+            MOCK_METHOD(void, clear, (), (override));
+            MOCK_METHOD(Colour, colour, (), (const, override));
+            MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t), (override));
+            MOCK_METHOD(uint32_t, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t), (override));
+            MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t, IWaypoint::Type, uint32_t), (override));
+            MOCK_METHOD(uint32_t, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, IWaypoint::Type, uint32_t), (override));
+            MOCK_METHOD(bool, is_unsaved, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
+            MOCK_METHOD(void, move, (int32_t, int32_t), (override));
+            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
+            MOCK_METHOD(void, remove, (uint32_t), (override));
+            MOCK_METHOD(void, remove, (const std::shared_ptr<IWaypoint>&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));
+            MOCK_METHOD(uint32_t, selected_waypoint, (), (const, override));
+            MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
+            MOCK_METHOD(void, set_colour, (const Colour&), (override));
+            MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
+            MOCK_METHOD(void, set_randomizer_enabled, (bool), (override));
+            MOCK_METHOD(void, set_unsaved, (bool), (override));
+            MOCK_METHOD(void, set_waypoint_colour, (const Colour&), (override));
+            MOCK_METHOD(Colour, waypoint_colour, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<IWaypoint>, waypoint, (uint32_t), (const, override));
+            MOCK_METHOD(uint32_t, waypoints, (), (const, override));
+        };
+    }
+}

--- a/trview.app/Mocks/Routing/IRandomizerRoute.h
+++ b/trview.app/Mocks/Routing/IRandomizerRoute.h
@@ -26,6 +26,7 @@ namespace trview
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
             MOCK_METHOD(void, move, (int32_t, int32_t), (override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
+            MOCK_METHOD(void, reload, (), (override));
             MOCK_METHOD(void, remove, (uint32_t), (override));
             MOCK_METHOD(void, remove, (const std::shared_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));

--- a/trview.app/Mocks/Routing/IRandomizerRoute.h
+++ b/trview.app/Mocks/Routing/IRandomizerRoute.h
@@ -43,6 +43,7 @@ namespace trview
             MOCK_METHOD(Colour, waypoint_colour, (), (const, override));
             MOCK_METHOD(std::weak_ptr<IWaypoint>, waypoint, (uint32_t), (const, override));
             MOCK_METHOD(uint32_t, waypoints, (), (const, override));
+            MOCK_METHOD(void, move_level, (const std::string&, const std::string&));
         };
     }
 }

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -15,6 +15,7 @@ namespace trview
             MOCK_METHOD(std::shared_ptr<IWaypoint>, add, (const std::shared_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, clear, (), (override));
             MOCK_METHOD(Colour, colour, (), (const, override));
+            MOCK_METHOD(std::optional<std::string>, filename, (), (const, override));
             MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t), (override));
             MOCK_METHOD(uint32_t, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t), (override));
             MOCK_METHOD(void, insert, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, uint32_t, uint32_t, IWaypoint::Type, uint32_t), (override));

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -27,9 +27,11 @@ namespace trview
             MOCK_METHOD(void, remove, (uint32_t), (override));
             MOCK_METHOD(void, remove, (const std::shared_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));
+            MOCK_METHOD(void, save, (const std::shared_ptr<IFiles>&, const UserSettings&), (override));
             MOCK_METHOD(uint32_t, selected_waypoint, (), (const, override));
             MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
             MOCK_METHOD(void, set_colour, (const Colour&), (override));
+            MOCK_METHOD(void, set_filename, (const std::string&), (override));
             MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
             MOCK_METHOD(void, set_randomizer_enabled, (bool), (override));
             MOCK_METHOD(void, set_unsaved, (bool), (override));

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -24,7 +24,7 @@ namespace trview
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
             MOCK_METHOD(void, move, (int32_t, int32_t), (override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
-            MOCK_METHOD(void, reload, (), (override));
+            MOCK_METHOD(void, reload, (const std::shared_ptr<IFiles>&, const UserSettings&), (override));
             MOCK_METHOD(void, remove, (uint32_t), (override));
             MOCK_METHOD(void, remove, (const std::shared_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -24,6 +24,7 @@ namespace trview
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
             MOCK_METHOD(void, move, (int32_t, int32_t), (override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
+            MOCK_METHOD(void, reload, (), (override));
             MOCK_METHOD(void, remove, (uint32_t), (override));
             MOCK_METHOD(void, remove, (const std::shared_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -28,6 +28,7 @@ namespace trview
             MOCK_METHOD(void, remove, (const std::shared_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));
             MOCK_METHOD(void, save, (const std::shared_ptr<IFiles>&, const UserSettings&), (override));
+            MOCK_METHOD(void, save_as, (const std::shared_ptr<IFiles>&, const std::string&, const UserSettings&), (override));
             MOCK_METHOD(uint32_t, selected_waypoint, (), (const, override));
             MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
             MOCK_METHOD(void, set_colour, (const Colour&), (override));

--- a/trview.app/Mocks/Windows/IRouteWindow.h
+++ b/trview.app/Mocks/Windows/IRouteWindow.h
@@ -11,7 +11,7 @@ namespace trview
             MockRouteWindow();
             virtual ~MockRouteWindow();
             MOCK_METHOD(void, render, (), (override));
-            MOCK_METHOD(void, set_route, (IRoute*), (override));
+            MOCK_METHOD(void, set_route, (const std::weak_ptr<IRoute>&), (override));
             MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
             MOCK_METHOD(void, set_items, (const std::vector<std::weak_ptr<IItem>>&), (override));
             MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&), (override));

--- a/trview.app/Mocks/Windows/IRouteWindowManager.h
+++ b/trview.app/Mocks/Windows/IRouteWindowManager.h
@@ -11,7 +11,7 @@ namespace trview
             MockRouteWindowManager();
             virtual ~MockRouteWindowManager();
             MOCK_METHOD(void, render, (), (override));
-            MOCK_METHOD(void, set_route, (IRoute*), (override));
+            MOCK_METHOD(void, set_route, (const std::weak_ptr<IRoute>&), (override));
             MOCK_METHOD(void, create_window, (), (override));
             MOCK_METHOD(void, set_items, (const std::vector<std::weak_ptr<IItem>>&), (override));
             MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&), (override));

--- a/trview.app/Routing/IRandomizerRoute.h
+++ b/trview.app/Routing/IRandomizerRoute.h
@@ -16,6 +16,7 @@ namespace trview
         using Source = std::function<std::shared_ptr<IRandomizerRoute>()>;
         virtual ~IRandomizerRoute() = 0;
         virtual std::shared_ptr<IWaypoint> add(const std::string& level_name, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room_number) = 0;
+        virtual std::vector<std::string> filenames() const = 0;
     };
 
     std::shared_ptr<IRoute> import_randomizer_route(const IRandomizerRoute::Source& route_source, const std::shared_ptr<IFiles>& files, const std::string& route_filename, const RandomizerSettings& randomizer_settings);

--- a/trview.app/Routing/IRandomizerRoute.h
+++ b/trview.app/Routing/IRandomizerRoute.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <memory>
+
+#include <trview.common/IFiles.h>
+#include "../Settings/RandomizerSettings.h"
+
+#include "IRoute.h"
+
+namespace trview
+{
+    struct IWaypoint;
+    struct IRandomizerRoute : public IRoute
+    {
+        using Source = std::function<std::shared_ptr<IRandomizerRoute>()>;
+        virtual ~IRandomizerRoute() = 0;
+        virtual std::shared_ptr<IWaypoint> add(const std::string& level_name, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room_number) = 0;
+    };
+
+    std::shared_ptr<IRoute> import_randomizer_route(const IRandomizerRoute::Source& route_source, const std::shared_ptr<IFiles>& files, const std::string& route_filename, const RandomizerSettings& randomizer_settings);
+}

--- a/trview.app/Routing/IRandomizerRoute.h
+++ b/trview.app/Routing/IRandomizerRoute.h
@@ -26,6 +26,7 @@ namespace trview
         virtual ~IRandomizerRoute() = 0;
         virtual std::shared_ptr<IWaypoint> add(const std::string& level_name, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room_number) = 0;
         virtual std::vector<std::string> filenames() const = 0;
+        virtual void move_level(const std::string& from, const std::string& to) = 0;
     };
 
     std::shared_ptr<IRoute> import_randomizer_route(const IRandomizerRoute::Source& route_source, const std::shared_ptr<IFiles>& files, const std::string& route_filename, const RandomizerSettings& randomizer_settings);

--- a/trview.app/Routing/IRandomizerRoute.h
+++ b/trview.app/Routing/IRandomizerRoute.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <memory>
+#include <vector>
 
 #include <trview.common/IFiles.h>
 #include "../Settings/RandomizerSettings.h"
@@ -13,7 +15,14 @@ namespace trview
     struct IWaypoint;
     struct IRandomizerRoute : public IRoute
     {
-        using Source = std::function<std::shared_ptr<IRandomizerRoute>()>;
+        struct FileData final
+        {
+            std::vector<uint8_t> data;
+            RandomizerSettings settings;
+        };
+
+        using Source = std::function<std::shared_ptr<IRandomizerRoute>(std::optional<FileData>)>;
+
         virtual ~IRandomizerRoute() = 0;
         virtual std::shared_ptr<IWaypoint> add(const std::string& level_name, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room_number) = 0;
         virtual std::vector<std::string> filenames() const = 0;

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -121,6 +121,7 @@ namespace trview
         /// <param name="show_selection">Whether to show the selection outline.</param>
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) = 0;
         virtual void save(const std::shared_ptr<IFiles>& files, const UserSettings& settings) = 0;
+        virtual void save_as(const std::shared_ptr<IFiles>& files, const std::string& filename, const UserSettings& settings) = 0;
         /// <summary>
         /// Get the index of the currently selected waypoint.
         /// </summary>
@@ -172,5 +173,4 @@ namespace trview
 
     std::shared_ptr<IRoute> import_route(const IRoute::Source& route_source, const std::shared_ptr<IFiles>& files, const std::string& route_filename, const RandomizerSettings& randomizer_settings);
     IWaypoint::WaypointRandomizerSettings import_randomizer_settings(const nlohmann::json& json, const RandomizerSettings& randomizer_settings);
-    void export_route(const IRoute& route, std::shared_ptr<IFiles>& files, const std::string& route_filename, const std::string& level_filename, const RandomizerSettings& randomizer_settings, bool rando_export);
 }

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -107,6 +107,7 @@ namespace trview
         /// <param name="direction">The direction of the ray.</param>
         /// <returns>The pcik result.</returns>
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
+        virtual void reload() = 0;
         /// <summary>
         /// Remove the waypoint at the specified index.
         /// </summary>

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include <trview.app/Routing/IWaypoint.h>
 #include <trview.app/Geometry/PickResult.h>
@@ -19,7 +20,12 @@ namespace trview
     /// </summary>
     struct IRoute
     {
-        using Source = std::function<std::shared_ptr<IRoute>()>;
+        struct FileData final
+        {
+            std::vector<uint8_t> data;
+        };
+
+        using Source = std::function<std::shared_ptr<IRoute>(std::optional<FileData>)>;
 
         Event<> on_changed;
 

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
+#include <string>
+
 #include <trview.app/Routing/IWaypoint.h>
 #include <trview.app/Geometry/PickResult.h>
 #include <trview.common/Event.h>
@@ -9,6 +12,8 @@
 
 namespace trview
 {
+    struct UserSettings;
+
     /// <summary>
     /// A route is a series of waypoints with notes.
     /// </summary>
@@ -46,6 +51,7 @@ namespace trview
         /// </summary>
         /// <returns>The colour of the route.</returns>
         virtual Colour colour() const = 0;
+        virtual std::optional<std::string> filename() const = 0;
         /// <summary>
         /// Insert the new waypoint into the route.
         /// </summary>
@@ -114,6 +120,7 @@ namespace trview
         /// <param name="texture_storage">Texture storage for the mesh.</param>
         /// <param name="show_selection">Whether to show the selection outline.</param>
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) = 0;
+        virtual void save(const std::shared_ptr<IFiles>& files, const UserSettings& settings) = 0;
         /// <summary>
         /// Get the index of the currently selected waypoint.
         /// </summary>
@@ -129,6 +136,7 @@ namespace trview
         /// </summary>
         /// <param name="colour">The colour to use.</param>
         virtual void set_colour(const Colour& colour) = 0;
+        virtual void set_filename(const std::string& filename) = 0;
         virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
         /// <summary>
         /// Set whether randomizer tools are enabled.

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -4,6 +4,8 @@
 #include <trview.app/Routing/IWaypoint.h>
 #include <trview.app/Geometry/PickResult.h>
 #include <trview.common/Event.h>
+#include <trview.common/IFiles.h>
+#include "../Settings/RandomizerSettings.h"
 
 namespace trview
 {
@@ -159,4 +161,8 @@ namespace trview
         /// <returns>The number of waypoints in the route.</returns>
         virtual uint32_t waypoints() const = 0;
     };
+
+    std::shared_ptr<IRoute> import_route(const IRoute::Source& route_source, const std::shared_ptr<IFiles>& files, const std::string& route_filename, const RandomizerSettings& randomizer_settings);
+    IWaypoint::WaypointRandomizerSettings import_randomizer_settings(const nlohmann::json& json, const RandomizerSettings& randomizer_settings);
+    void export_route(const IRoute& route, std::shared_ptr<IFiles>& files, const std::string& route_filename, const std::string& level_filename, const RandomizerSettings& randomizer_settings, bool rando_export);
 }

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -171,6 +171,5 @@ namespace trview
         virtual uint32_t waypoints() const = 0;
     };
 
-    std::shared_ptr<IRoute> import_route(const IRoute::Source& route_source, const std::shared_ptr<IFiles>& files, const std::string& route_filename, const RandomizerSettings& randomizer_settings);
-    IWaypoint::WaypointRandomizerSettings import_randomizer_settings(const nlohmann::json& json, const RandomizerSettings& randomizer_settings);
+    std::shared_ptr<IRoute> import_route(const IRoute::Source& route_source, const std::shared_ptr<IFiles>& files, const std::string& route_filename);
 }

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -107,7 +107,7 @@ namespace trview
         /// <param name="direction">The direction of the ray.</param>
         /// <returns>The pcik result.</returns>
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
-        virtual void reload() = 0;
+        virtual void reload(const std::shared_ptr<IFiles>& files, const UserSettings& settings) = 0;
         /// <summary>
         /// Remove the waypoint at the specified index.
         /// </summary>

--- a/trview.app/Routing/RandomizerRoute.cpp
+++ b/trview.app/Routing/RandomizerRoute.cpp
@@ -228,11 +228,14 @@ namespace trview
             return;
         }
 
-        // TODO: Standard route saving.
-        //. nlohmann::ordered_json json = try_load_route(files, route_filename);
+        save_as(files, _filename.value(), settings);
+        _route->set_unsaved(false);
+    }
+
+    void RandomizerRoute::save_as(const std::shared_ptr<IFiles>& files, const std::string& filename, const UserSettings& settings)
+    {
         nlohmann::ordered_json json;
 
-        // Sync the waypoints for the current route to the storage.
         update_waypoints();
 
         for (const auto& [level, waypoints] : _waypoints)
@@ -253,10 +256,8 @@ namespace trview
             }
 
             json[level] = waypoints_element;
-            files->save_file(_filename.value(), json.dump(2, ' '));
+            files->save_file(filename, json.dump(2, ' '));
         }
-
-        _route->set_unsaved(false);
     }
 
     uint32_t RandomizerRoute::selected_waypoint() const

--- a/trview.app/Routing/RandomizerRoute.cpp
+++ b/trview.app/Routing/RandomizerRoute.cpp
@@ -145,6 +145,11 @@ namespace trview
         return _filename;
     }
 
+    std::vector<std::string> RandomizerRoute::filenames() const
+    {
+        return _waypoints | std::views::keys | std::ranges::to<std::vector>();
+    }
+
     void RandomizerRoute::insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index)
     {
         return _route->insert(position, normal, room, index);

--- a/trview.app/Routing/RandomizerRoute.cpp
+++ b/trview.app/Routing/RandomizerRoute.cpp
@@ -290,7 +290,8 @@ namespace trview
                 std::ranges::for_each(found->second, [this](auto&& w) { _route->add(w); });
             }
         }
-        return _route->set_level(level);
+        _route->set_level(level);
+        _route->set_unsaved(false);
     }
 
     void RandomizerRoute::set_randomizer_enabled(bool enabled)

--- a/trview.app/Routing/RandomizerRoute.cpp
+++ b/trview.app/Routing/RandomizerRoute.cpp
@@ -289,7 +289,6 @@ namespace trview
             {
                 std::ranges::for_each(found->second, [this](auto&& w) { _route->add(w); });
             }
-            _route->set_unsaved(false);
         }
         return _route->set_level(level);
     }

--- a/trview.app/Routing/RandomizerRoute.cpp
+++ b/trview.app/Routing/RandomizerRoute.cpp
@@ -110,17 +110,23 @@ namespace trview
 
     std::shared_ptr<IWaypoint> RandomizerRoute::add(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room)
     {
-        return _route->add(position, normal, room);
+        auto result = _route->add(position, normal, room);
+        update_waypoints();
+        return result;
     }
 
     std::shared_ptr<IWaypoint> RandomizerRoute::add(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, IWaypoint::Type type, uint32_t type_index)
     {
-        return _route->add(position, normal, room, type, type_index);
+        auto result = _route->add(position, normal, room, type, type_index);
+        update_waypoints();
+        return result;
     }
 
     std::shared_ptr<IWaypoint> RandomizerRoute::add(const std::shared_ptr<IWaypoint>& waypoint)
     {
-        return _route->add(waypoint);
+        auto result = _route->add(waypoint);
+        update_waypoints();
+        return result;
     }
 
     std::shared_ptr<IWaypoint> RandomizerRoute::add(const std::string& level_name, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room_number)
@@ -132,7 +138,8 @@ namespace trview
 
     void RandomizerRoute::clear()
     {
-        return _route->clear();
+        _route->clear();
+        update_waypoints();
     }
 
     Colour RandomizerRoute::colour() const
@@ -152,22 +159,28 @@ namespace trview
 
     void RandomizerRoute::insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index)
     {
-        return _route->insert(position, normal, room, index);
+        _route->insert(position, normal, room, index);
+        update_waypoints();
     }
 
     uint32_t RandomizerRoute::insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room)
     {
-        return _route->insert(position, normal, room);
+        auto result = _route->insert(position, normal, room);
+        update_waypoints();
+        return result;
     }
 
     void RandomizerRoute::insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index, IWaypoint::Type type, uint32_t type_index)
     {
-        return _route->insert(position, normal, room, index, type, type_index);
+        _route->insert(position, normal, room, index, type, type_index);
+        update_waypoints();
     }
 
     uint32_t RandomizerRoute::insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, IWaypoint::Type type, uint32_t type_index)
     {
-        return _route->insert(position, normal, room, type, type_index);
+        auto result = _route->insert(position, normal, room, type, type_index);
+        update_waypoints();
+        return result;
     }
 
     bool RandomizerRoute::is_unsaved() const
@@ -182,7 +195,8 @@ namespace trview
 
     void RandomizerRoute::move(int32_t from, int32_t to)
     {
-        return _route->move(from, to);
+        _route->move(from, to);
+        update_waypoints();
     }
 
     PickResult RandomizerRoute::pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const
@@ -192,12 +206,14 @@ namespace trview
 
     void RandomizerRoute::remove(uint32_t index)
     {
-        return _route->remove(index);
+        _route->remove(index);
+        update_waypoints();
     }
 
     void RandomizerRoute::remove(const std::shared_ptr<IWaypoint>& waypoint)
     {
-        return _route->remove(waypoint);
+        _route->remove(waypoint);
+        update_waypoints();
     }
 
     void RandomizerRoute::render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection)
@@ -217,18 +233,7 @@ namespace trview
         nlohmann::ordered_json json;
 
         // Sync the waypoints for the current route to the storage.
-        if (auto current_level = _route->level().lock())
-        {
-            std::vector<std::shared_ptr<IWaypoint>> waypoints;
-            for (auto i = 0u; i < _route->waypoints(); ++i)
-            {
-                if (auto waypoint = _route->waypoint(i).lock())
-                {
-                    waypoints.push_back(waypoint);
-                }
-                _waypoints[trimmed_level_name(current_level->filename())] = waypoints;
-            }
-        }
+        update_waypoints();
 
         for (const auto& [level, waypoints] : _waypoints)
         {
@@ -317,6 +322,22 @@ namespace trview
     uint32_t RandomizerRoute::waypoints() const
     {
         return _route->waypoints();
+    }
+
+    void RandomizerRoute::update_waypoints()
+    {
+        if (auto current_level = _route->level().lock())
+        {
+            std::vector<std::shared_ptr<IWaypoint>> waypoints;
+            for (auto i = 0u; i < _route->waypoints(); ++i)
+            {
+                if (auto waypoint = _route->waypoint(i).lock())
+                {
+                    waypoints.push_back(waypoint);
+                }
+                _waypoints[trimmed_level_name(current_level->filename())] = waypoints;
+            }
+        }
     }
 
     std::shared_ptr<IRoute> import_randomizer_route(const IRandomizerRoute::Source& route_source, const std::shared_ptr<IFiles>& files, const std::string& route_filename, const RandomizerSettings& randomizer_settings)

--- a/trview.app/Routing/RandomizerRoute.cpp
+++ b/trview.app/Routing/RandomizerRoute.cpp
@@ -246,6 +246,11 @@ namespace trview
         return _route->pick(position, direction);
     }
 
+    void RandomizerRoute::reload()
+    {
+        // TODO
+    }
+
     void RandomizerRoute::remove(uint32_t index)
     {
         _route->remove(index);

--- a/trview.app/Routing/RandomizerRoute.h
+++ b/trview.app/Routing/RandomizerRoute.h
@@ -33,6 +33,7 @@ namespace trview
         std::weak_ptr<ILevel> level() const override;
         void move(int32_t from, int32_t to) override;
         PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
+        void reload() override;
         void remove(uint32_t index) override;
         void remove(const std::shared_ptr<IWaypoint>& waypoint) override;
         void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) override;

--- a/trview.app/Routing/RandomizerRoute.h
+++ b/trview.app/Routing/RandomizerRoute.h
@@ -23,6 +23,7 @@ namespace trview
         std::shared_ptr<IWaypoint> add(const std::string& level_name, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room_number) override;
         void clear() override;
         Colour colour() const override;
+        std::optional<std::string> filename() const override;
         void insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index) override;
         uint32_t insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room) override;
         void insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index, IWaypoint::Type type, uint32_t type_index) override;
@@ -34,9 +35,11 @@ namespace trview
         void remove(uint32_t index) override;
         void remove(const std::shared_ptr<IWaypoint>& waypoint) override;
         void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) override;
+        void save(const std::shared_ptr<IFiles>& files, const UserSettings& settings) override;
         uint32_t selected_waypoint() const override;
         void select_waypoint(uint32_t index) override;
         void set_colour(const Colour& colour) override;
+        void set_filename(const std::string& filename) override;
         void set_level(const std::weak_ptr<ILevel>& level) override;
         void set_randomizer_enabled(bool enabled) override;
         void set_waypoint_colour(const Colour& colour) override;
@@ -48,5 +51,6 @@ namespace trview
         std::shared_ptr<IRoute> _route;
         std::map<std::string, std::vector<std::shared_ptr<IWaypoint>>> _waypoints;
         IWaypoint::Source _waypoint_source;
+        std::optional<std::string> _filename;
     };
 }

--- a/trview.app/Routing/RandomizerRoute.h
+++ b/trview.app/Routing/RandomizerRoute.h
@@ -37,6 +37,7 @@ namespace trview
         void remove(const std::shared_ptr<IWaypoint>& waypoint) override;
         void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) override;
         void save(const std::shared_ptr<IFiles>& files, const UserSettings& settings) override;
+        void save_as(const std::shared_ptr<IFiles>& files, const std::string& filename, const UserSettings& settings) override;
         uint32_t selected_waypoint() const override;
         void select_waypoint(uint32_t index) override;
         void set_colour(const Colour& colour) override;

--- a/trview.app/Routing/RandomizerRoute.h
+++ b/trview.app/Routing/RandomizerRoute.h
@@ -24,6 +24,7 @@ namespace trview
         void clear() override;
         Colour colour() const override;
         std::optional<std::string> filename() const override;
+        std::vector<std::string> filenames() const override;
         void insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index) override;
         uint32_t insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room) override;
         void insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index, IWaypoint::Type type, uint32_t type_index) override;

--- a/trview.app/Routing/RandomizerRoute.h
+++ b/trview.app/Routing/RandomizerRoute.h
@@ -49,6 +49,8 @@ namespace trview
         std::weak_ptr<IWaypoint> waypoint(uint32_t index) const override;
         uint32_t waypoints() const override;
     private:
+        void update_waypoints();
+
         std::shared_ptr<IRoute> _route;
         std::map<std::string, std::vector<std::shared_ptr<IWaypoint>>> _waypoints;
         IWaypoint::Source _waypoint_source;

--- a/trview.app/Routing/RandomizerRoute.h
+++ b/trview.app/Routing/RandomizerRoute.h
@@ -50,13 +50,22 @@ namespace trview
         Colour waypoint_colour() const override;
         std::weak_ptr<IWaypoint> waypoint(uint32_t index) const override;
         uint32_t waypoints() const override;
+        void move_level(const std::string& from, const std::string& to) override;
 
         void import(const std::vector<uint8_t>& data, const RandomizerSettings& randomizer_settings);
     private:
         void update_waypoints();
 
+        struct Waypoints final
+        {
+            std::string level_name;
+            std::vector<std::shared_ptr<IWaypoint>> waypoints;
+        };
+
+        Waypoints& get_waypoints(const std::string& name);
+
         std::shared_ptr<IRoute> _route;
-        std::map<std::string, std::vector<std::shared_ptr<IWaypoint>>> _waypoints;
+        std::vector<Waypoints> _waypoints;
         IWaypoint::Source _waypoint_source;
         std::optional<std::string> _filename;
     };

--- a/trview.app/Routing/RandomizerRoute.h
+++ b/trview.app/Routing/RandomizerRoute.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "IRoute.h"
+#include "IRandomizerRoute.h"
+
+#include <map>
+#include <vector>
+
+namespace trview
+{
+    /// <summary>
+    /// Version of route that has a set of unbound waypoints that are eventually
+    /// converted to bound ones. It then exposes the route through the interface.
+    /// </summary>
+    class RandomizerRoute final : public IRandomizerRoute
+    {
+    public:
+        explicit RandomizerRoute(const std::shared_ptr<IRoute>& inner_route, const IWaypoint::Source& waypoint_source);
+        virtual ~RandomizerRoute() = default;
+        std::shared_ptr<IWaypoint> add(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room) override;
+        std::shared_ptr<IWaypoint> add(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, IWaypoint::Type type, uint32_t type_index) override;
+        std::shared_ptr<IWaypoint> add(const std::shared_ptr<IWaypoint>& waypoint) override;
+        std::shared_ptr<IWaypoint> add(const std::string& level_name, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room_number) override;
+        void clear() override;
+        Colour colour() const override;
+        void insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index) override;
+        uint32_t insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room) override;
+        void insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index, IWaypoint::Type type, uint32_t type_index) override;
+        uint32_t insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, IWaypoint::Type type, uint32_t type_index) override;
+        bool is_unsaved() const override;
+        std::weak_ptr<ILevel> level() const override;
+        void move(int32_t from, int32_t to) override;
+        PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
+        void remove(uint32_t index) override;
+        void remove(const std::shared_ptr<IWaypoint>& waypoint) override;
+        void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) override;
+        uint32_t selected_waypoint() const override;
+        void select_waypoint(uint32_t index) override;
+        void set_colour(const Colour& colour) override;
+        void set_level(const std::weak_ptr<ILevel>& level) override;
+        void set_randomizer_enabled(bool enabled) override;
+        void set_waypoint_colour(const Colour& colour) override;
+        void set_unsaved(bool value) override;
+        Colour waypoint_colour() const override;
+        std::weak_ptr<IWaypoint> waypoint(uint32_t index) const override;
+        uint32_t waypoints() const override;
+    private:
+        std::shared_ptr<IRoute> _route;
+        std::map<std::string, std::vector<std::shared_ptr<IWaypoint>>> _waypoints;
+        IWaypoint::Source _waypoint_source;
+    };
+}

--- a/trview.app/Routing/RandomizerRoute.h
+++ b/trview.app/Routing/RandomizerRoute.h
@@ -50,6 +50,8 @@ namespace trview
         Colour waypoint_colour() const override;
         std::weak_ptr<IWaypoint> waypoint(uint32_t index) const override;
         uint32_t waypoints() const override;
+
+        void import(const std::vector<uint8_t>& data, const RandomizerSettings& randomizer_settings);
     private:
         void update_waypoints();
 

--- a/trview.app/Routing/RandomizerRoute.h
+++ b/trview.app/Routing/RandomizerRoute.h
@@ -12,7 +12,7 @@ namespace trview
     /// Version of route that has a set of unbound waypoints that are eventually
     /// converted to bound ones. It then exposes the route through the interface.
     /// </summary>
-    class RandomizerRoute final : public IRandomizerRoute
+    class RandomizerRoute final : public IRandomizerRoute, public std::enable_shared_from_this<IRandomizerRoute>
     {
     public:
         explicit RandomizerRoute(const std::shared_ptr<IRoute>& inner_route, const IWaypoint::Source& waypoint_source);
@@ -33,7 +33,7 @@ namespace trview
         std::weak_ptr<ILevel> level() const override;
         void move(int32_t from, int32_t to) override;
         PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
-        void reload() override;
+        void reload(const std::shared_ptr<IFiles>& files, const UserSettings& settings) override;
         void remove(uint32_t index) override;
         void remove(const std::shared_ptr<IWaypoint>& waypoint) override;
         void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) override;

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -198,6 +198,11 @@ namespace trview
         return result;
     }
 
+    void Route::reload()
+    {
+        // TODO
+    }
+
     void Route::remove(uint32_t index)
     {
         if (index >= _waypoints.size())

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -61,7 +61,4 @@ namespace trview
         bool _randomizer_enabled{ false };
         std::weak_ptr<ILevel> _level;
     };
-
-    std::shared_ptr<IRoute> import_route(const IRoute::Source& route_source, const std::shared_ptr<IFiles>& files, const std::string& route_filename, const ILevel* const level, const RandomizerSettings& randomizer_settings, bool rando_import);
-    void export_route(const IRoute& route, std::shared_ptr<IFiles>& files, const std::string& route_filename, const std::string& level_filename, const RandomizerSettings& randomizer_settings, bool rando_export);
 }

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -33,6 +33,7 @@ namespace trview
         std::weak_ptr<ILevel> level() const override;
         virtual void move(int32_t left, int32_t right) override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
+        void reload() override;
         virtual void remove(uint32_t index) override;
         void remove(const std::shared_ptr<IWaypoint>& waypoint) override;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) override;

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -33,7 +33,7 @@ namespace trview
         std::weak_ptr<ILevel> level() const override;
         virtual void move(int32_t left, int32_t right) override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
-        void reload() override;
+        void reload(const std::shared_ptr<IFiles>& files, const UserSettings& settings) override;
         virtual void remove(uint32_t index) override;
         void remove(const std::shared_ptr<IWaypoint>& waypoint) override;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) override;

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -24,6 +24,7 @@ namespace trview
         std::shared_ptr<IWaypoint> add(const std::shared_ptr<IWaypoint>& waypoint) override;
         virtual void clear() override;
         virtual Colour colour() const override;
+        std::optional<std::string> filename() const;
         virtual void insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index) override;
         virtual uint32_t insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room) override;
         virtual void insert(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, uint32_t index, IWaypoint::Type type, uint32_t type_index) override;
@@ -35,9 +36,11 @@ namespace trview
         virtual void remove(uint32_t index) override;
         void remove(const std::shared_ptr<IWaypoint>& waypoint) override;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) override;
+        void save(const std::shared_ptr<IFiles>& files, const UserSettings& settings) override;
         virtual uint32_t selected_waypoint() const override;
         virtual void select_waypoint(uint32_t index) override;
         virtual void set_colour(const Colour& colour) override;
+        void set_filename(const std::string& filename) override;
         void set_level(const std::weak_ptr<ILevel>& level) override;
         virtual void set_randomizer_enabled(bool enabled) override;
         virtual void set_waypoint_colour(const Colour& colour) override;
@@ -60,5 +63,6 @@ namespace trview
         bool _is_unsaved{ false };
         bool _randomizer_enabled{ false };
         std::weak_ptr<ILevel> _level;
+        std::optional<std::string> _filename;
     };
 }

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -50,6 +50,8 @@ namespace trview
         virtual Colour waypoint_colour() const override;
         virtual std::weak_ptr<IWaypoint> waypoint(uint32_t index) const override;
         virtual uint32_t waypoints() const override;
+
+        void import(const std::vector<uint8_t>& data);
     private:
         uint32_t next_index() const;
         void bind_waypoint_targets();

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -37,6 +37,7 @@ namespace trview
         void remove(const std::shared_ptr<IWaypoint>& waypoint) override;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) override;
         void save(const std::shared_ptr<IFiles>& files, const UserSettings& settings) override;
+        void save_as(const std::shared_ptr<IFiles>& files, const std::string& filename, const UserSettings& settings) override;
         virtual uint32_t selected_waypoint() const override;
         virtual void select_waypoint(uint32_t index) override;
         virtual void set_colour(const Colour& colour) override;

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -58,6 +58,7 @@ namespace trview
 
         Event<> on_new_route;
         Event<> on_new_randomizer_route;
+        Event<std::string, std::string> on_level_reordered;
 
         /// Render the window.
         virtual void render() = 0;

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -56,6 +56,9 @@ namespace trview
 
         Event<std::string> on_level_switch;
 
+        Event<> on_new_route;
+        Event<> on_new_randomizer_route;
+
         /// Render the window.
         virtual void render() = 0;
 

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -54,6 +54,8 @@ namespace trview
         /// Event raised when the window is closed.
         Event<> on_window_closed;
 
+        Event<std::string> on_level_switch;
+
         /// Render the window.
         virtual void render() = 0;
 

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -40,10 +40,13 @@ namespace trview
         Event<int32_t, int32_t> on_waypoint_reordered;
 
         /// Event raised when a route file is opened.
-        Event<std::string, bool> on_route_import;
+        Event<> on_route_open;
+
+        Event<> on_route_reload;
+        Event<> on_route_save;
 
         /// Event raised when a route is exported.
-        Event<std::string, bool> on_route_export;
+        Event<> on_route_save_as;
 
         /// Event raised when a waypoint is deleted.
         Event<uint32_t> on_waypoint_deleted;
@@ -56,7 +59,7 @@ namespace trview
 
         /// Load the waypoints from the route.
         /// @param route The route to load from.
-        virtual void set_route(IRoute* route) = 0;
+        virtual void set_route(const std::weak_ptr<IRoute>& route) = 0;
 
         /// Select the specified waypoint.
         /// @param index The index of the waypoint to select.

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -50,6 +50,7 @@ namespace trview
         Event<std::string> on_level_switch;
         Event<> on_new_route;
         Event<> on_new_randomizer_route;
+        Event<std::string, std::string> on_level_reordered;
 
         /// Render all of the route windows.
         virtual void render() = 0;

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -48,6 +48,8 @@ namespace trview
         Event<> on_window_created;
 
         Event<std::string> on_level_switch;
+        Event<> on_new_route;
+        Event<> on_new_randomizer_route;
 
         /// Render all of the route windows.
         virtual void render() = 0;

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -47,6 +47,8 @@ namespace trview
 
         Event<> on_window_created;
 
+        Event<std::string> on_level_switch;
+
         /// Render all of the route windows.
         virtual void render() = 0;
 

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -13,10 +13,13 @@ namespace trview
         Event<Colour> on_colour_changed;
 
         /// Event raised when a route is imported.
-        Event<std::string, bool> on_route_import;
+        Event<> on_route_open;
+
+        Event<> on_route_reload;
+        Event<> on_route_save;
 
         /// Event raised when a route is exported.
-        Event<std::string, bool> on_route_export;
+        Event<> on_route_save_as;
 
         /// <summary>
         /// Event raised when the route stick colour has changed.
@@ -49,7 +52,7 @@ namespace trview
 
         /// Load the waypoints from the route.
         /// @param route The route to load from.
-        virtual void set_route(IRoute* route) = 0;
+        virtual void set_route(const std::weak_ptr<IRoute>& route) = 0;
 
         /// Create a new route window.
         virtual void create_window() = 0;

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -532,6 +532,27 @@ namespace trview
         {
             if (ImGui::BeginMenu("File"))
             {
+                if (_randomizer_enabled)
+                {
+                    if (ImGui::BeginMenu("New"))
+                    {
+                        if (ImGui::MenuItem("Route"))
+                        {
+                            on_new_route();
+                        }
+
+                        if (ImGui::MenuItem("Randomizer Route"))
+                        {
+                            on_new_randomizer_route();
+                        }
+                        ImGui::EndMenu();
+                    }
+                }
+                else if(ImGui::MenuItem("New"))
+                {
+                    on_new_route();
+                }
+
                 if (ImGui::MenuItem("Open"))
                 {
                     on_route_open();

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -272,7 +272,18 @@ namespace trview
     {
         bool stay_open = true;
         ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(420, 500));
-        if (ImGui::Begin("Route", &stay_open, ImGuiWindowFlags_MenuBar))
+
+        std::string window_title;
+        if (const auto route = _route.lock())
+        {
+            const auto filename = route->filename();
+            if (filename)
+            {
+                window_title = std::format(" - {}", filename.value());
+            }
+        }
+
+        if (ImGui::Begin(std::format("Route{}", window_title).c_str(), &stay_open, ImGuiWindowFlags_MenuBar))
         {
             render_menu_bar();
             render_waypoint_list();
@@ -483,7 +494,8 @@ namespace trview
                     on_route_open();
                 }
 
-                if (ImGui::MenuItem("Reload"))
+                const auto route = _route.lock();
+                if (ImGui::MenuItem("Reload", nullptr, nullptr, route && route->filename().has_value()))
                 {
                     on_route_reload();
                 }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -326,7 +326,7 @@ namespace trview
             }
         }
 
-        if (ImGui::Begin(std::format("Route{}", window_title).c_str(), &stay_open, ImGuiWindowFlags_MenuBar))
+        if (ImGui::Begin(std::format("Route{}###Route", window_title).c_str(), &stay_open, ImGuiWindowFlags_MenuBar))
         {
             render_menu_bar();
             render_waypoint_list();

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -228,7 +228,8 @@ namespace trview
                         ImGui::EndPopup();
                     }
 
-                    if (!_randomizer_enabled)
+                    const bool is_rando = std::dynamic_pointer_cast<IRandomizerRoute>(route) != nullptr;
+                    if (!is_rando)
                     {
                         const std::string save_text = waypoint->has_save() ? "SAVEGAME.0" : Names::attach_save.c_str();
                         if (ImGui::Button(save_text.c_str(), ImVec2(-24, 18)))
@@ -289,7 +290,7 @@ namespace trview
                     {
                         // Don't access the waypoint after it has been deleted - this is an issue with the window not
                         // having temporary ownership of the waypoint - if it was shared_ptr it would be fine.
-                        if (_randomizer_enabled)
+                        if (is_rando)
                         {
                             ImGui::Text("Randomizer");
                             load_randomiser_settings(*waypoint);

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -33,67 +33,6 @@ namespace trview
 
         if (ImGui::BeginChild(Names::waypoint_list_panel.c_str(), ImVec2(150, 0), true))
         {
-            if (ImGui::Button("Settings"))
-            {
-                if (!_show_settings)
-                {
-                    ImGui::OpenPopup("SettingsPopup");
-                }
-                _show_settings = !_show_settings;
-            }
-
-            if (_show_settings && ImGui::BeginPopup("SettingsPopup"))
-            {
-                auto colour = _route ? _route->colour() : Colour::Green;
-                if (ImGui::ColorEdit3("Route##colour", &colour.r, ImGuiColorEditFlags_NoInputs))
-                {
-                    on_colour_changed(colour);
-                }
-                auto waypoint_colour = _route ? _route->waypoint_colour() : Colour::White;
-                if (ImGui::ColorEdit3("Waypoint##colour", &waypoint_colour.r, ImGuiColorEditFlags_NoInputs))
-                {
-                    on_waypoint_colour_changed(waypoint_colour);
-                }
-                ImGui::EndPopup();
-            }
-            else
-            {
-                _show_settings = false;
-            }
-
-            ImGui::SameLine();
-            if (ImGui::Button(Names::import_button.c_str()))
-            {
-                std::vector<IDialogs::FileFilter> filters{ { L"trview route", { L"*.tvr" } } };
-                if (_randomizer_enabled)
-                {
-                    filters.push_back({ L"Randomizer Locations", { L"*.json" } });
-                }
-
-                const auto filename = _dialogs->open_file(L"Import route", filters, OFN_FILEMUSTEXIST);
-                if (filename.has_value())
-                {
-                    on_route_import(filename.value().filename, filename.value().filter_index == 2);
-                }
-            }
-            ImGui::SameLine();
-            if (ImGui::Button(Names::export_button.c_str()))
-            {
-                std::vector<IDialogs::FileFilter> filters{ { L"trview route", { L"*.tvr" } } };
-                uint32_t filter_index = 1;
-                if (_randomizer_enabled)
-                {
-                    filters.push_back({ L"Randomizer Locations", { L"*.json" } });
-                    filter_index = 2;
-                }
-
-                const auto filename = _dialogs->save_file(L"Export route", filters, filter_index);
-                if (filename.has_value())
-                {
-                    on_route_export(filename.value().filename, filename.value().filter_index == 2);
-                }
-            }
-
             std::optional<uint32_t> move_from;
             std::optional<uint32_t> move_to;
 
@@ -328,8 +267,9 @@ namespace trview
     {
         bool stay_open = true;
         ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(420, 500));
-        if (ImGui::Begin("Route", &stay_open))
+        if (ImGui::Begin("Route", &stay_open, ImGuiWindowFlags_MenuBar))
         {
+            render_menu_bar();
             render_waypoint_list();
             ImGui::SameLine();
             render_waypoint_details();
@@ -524,5 +464,87 @@ namespace trview
             }
         }
         return waypoint_type_to_string(waypoint.type());
+    }
+
+    void RouteWindow::render_menu_bar()
+    {
+        if (ImGui::BeginMenuBar())
+        {
+            if (ImGui::BeginMenu("File"))
+            {
+                if (ImGui::MenuItem("Open"))
+                {
+                    std::vector<IDialogs::FileFilter> filters{ { L"trview route", { L"*.tvr" } } };
+                    if (_randomizer_enabled)
+                    {
+                        filters.push_back({ L"Randomizer Locations", { L"*.json" } });
+                    }
+
+                    const auto filename = _dialogs->open_file(L"Import route", filters, OFN_FILEMUSTEXIST);
+                    if (filename.has_value())
+                    {
+                        on_route_import(filename.value().filename, filename.value().filter_index == 2);
+                    }
+                }
+
+                if (ImGui::MenuItem("Reload"))
+                {
+                    // TODO: Reload event
+                }
+
+                if (ImGui::MenuItem("Save"))
+                {
+                    // TODO: Save event
+                }
+
+                if (ImGui::MenuItem("Save As"))
+                {
+                    std::vector<IDialogs::FileFilter> filters{ { L"trview route", { L"*.tvr" } } };
+                    uint32_t filter_index = 1;
+                    if (_randomizer_enabled)
+                    {
+                        filters.push_back({ L"Randomizer Locations", { L"*.json" } });
+                        filter_index = 2;
+                    }
+
+                    const auto filename = _dialogs->save_file(L"Export route", filters, filter_index);
+                    if (filename.has_value())
+                    {
+                        on_route_export(filename.value().filename, filename.value().filter_index == 2);
+                    }
+                }
+                ImGui::EndMenu();
+            }
+
+            if (ImGui::MenuItem("Settings"))
+            {
+                if (!_show_settings)
+                {
+                    ImGui::OpenPopup("SettingsPopup");
+                }
+                _show_settings = !_show_settings;
+            }
+
+            if (_show_settings && ImGui::BeginPopup("SettingsPopup"))
+            {
+                auto colour = _route ? _route->colour() : Colour::Green;
+                if (ImGui::ColorEdit3("Route##colour", &colour.r, ImGuiColorEditFlags_NoInputs))
+                {
+                    on_colour_changed(colour);
+                }
+                auto waypoint_colour = _route ? _route->waypoint_colour() : Colour::White;
+                if (ImGui::ColorEdit3("Waypoint##colour", &waypoint_colour.r, ImGuiColorEditFlags_NoInputs))
+                {
+                    on_waypoint_colour_changed(waypoint_colour);
+                }
+                ImGui::EndPopup();
+            }
+            else
+            {
+                _show_settings = false;
+            }
+
+            ImGui::EndMenuBar();
+        }
     }
 }

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -51,6 +51,7 @@ namespace trview
         void render_waypoint_list();
         void render_waypoint_details();
         bool render_route_window();
+        void render_menu_bar();
         std::string waypoint_text(const IWaypoint& waypoint) const;
 
         IRoute* _route{ nullptr };

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -37,7 +37,7 @@ namespace trview
             const std::shared_ptr<IFiles>& files);
         virtual ~RouteWindow() = default;
         virtual void render() override;
-        virtual void set_route(IRoute* route) override;
+        virtual void set_route(const std::weak_ptr<IRoute>& route) override;
         virtual void select_waypoint(uint32_t index) override;
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) override;
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& rooms) override;
@@ -54,7 +54,7 @@ namespace trview
         void render_menu_bar();
         std::string waypoint_text(const IWaypoint& waypoint) const;
 
-        IRoute* _route{ nullptr };
+        std::weak_ptr<IRoute> _route;
         std::vector<std::weak_ptr<IItem>> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -45,6 +45,7 @@ namespace trview
         _route_window->on_waypoint_deleted += on_waypoint_deleted;
         _route_window->on_waypoint_reordered += on_waypoint_reordered;
         _route_window->on_waypoint_changed += on_waypoint_changed;
+        _route_window->on_level_switch += on_level_switch;
         _token_store += _route_window->on_window_closed += [&]() { _closing = true; };
 
         _route_window->set_randomizer_settings(_randomizer_settings);

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -48,6 +48,7 @@ namespace trview
         _route_window->on_level_switch += on_level_switch;
         _route_window->on_new_route += on_new_route;
         _route_window->on_new_randomizer_route += on_new_randomizer_route;
+        _route_window->on_level_reordered += on_level_reordered;
         _token_store += _route_window->on_window_closed += [&]() { _closing = true; };
 
         _route_window->set_randomizer_settings(_randomizer_settings);

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -46,6 +46,8 @@ namespace trview
         _route_window->on_waypoint_reordered += on_waypoint_reordered;
         _route_window->on_waypoint_changed += on_waypoint_changed;
         _route_window->on_level_switch += on_level_switch;
+        _route_window->on_new_route += on_new_route;
+        _route_window->on_new_randomizer_route += on_new_randomizer_route;
         _token_store += _route_window->on_window_closed += [&]() { _closing = true; };
 
         _route_window->set_randomizer_settings(_randomizer_settings);

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -34,8 +34,10 @@ namespace trview
         // Otherwise create the window.
         _route_window = _route_window_source();
         _route_window->on_colour_changed += on_colour_changed;
-        _route_window->on_route_import += on_route_import;
-        _route_window->on_route_export += on_route_export;
+        _route_window->on_route_open += on_route_open;
+        _route_window->on_route_reload += on_route_reload;
+        _route_window->on_route_save += on_route_save;
+        _route_window->on_route_save_as += on_route_save_as;
         _route_window->on_item_selected += on_item_selected;
         _route_window->on_waypoint_colour_changed += on_waypoint_colour_changed;
         _route_window->on_trigger_selected += on_trigger_selected;
@@ -50,10 +52,7 @@ namespace trview
         _route_window->set_items(_all_items);
         _route_window->set_rooms(_all_rooms);
         _route_window->set_triggers(_all_triggers);
-        if (_route)
-        {
-            _route_window->set_route(_route);
-        }
+        _route_window->set_route(_route);
         _route_window->select_waypoint(_selected_waypoint);
         on_window_created();
     }
@@ -72,7 +71,7 @@ namespace trview
         }
     }
 
-    void RouteWindowManager::set_route(IRoute* route)
+    void RouteWindowManager::set_route(const std::weak_ptr<IRoute>& route)
     {
         _route = route;
         if (_route_window)

--- a/trview.app/Windows/RouteWindowManager.h
+++ b/trview.app/Windows/RouteWindowManager.h
@@ -15,7 +15,7 @@ namespace trview
         virtual ~RouteWindowManager() = default;
         virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         virtual void render() override;
-        virtual void set_route(IRoute* route) override;
+        virtual void set_route(const std::weak_ptr<IRoute>& route) override;
         virtual void create_window() override;
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) override;
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& rooms) override;
@@ -29,7 +29,7 @@ namespace trview
         TokenStore _token_store;
         std::shared_ptr<IRouteWindow> _route_window;
         bool _closing{ false };
-        IRoute* _route{ nullptr };
+        std::weak_ptr<IRoute> _route;
         std::vector<std::weak_ptr<IItem>> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -132,6 +132,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\Lua\ILua.h" />
     <ClInclude Include="Mocks\Plugins\IPlugin.h" />
     <ClInclude Include="Mocks\Plugins\IPlugins.h" />
+    <ClInclude Include="Mocks\Routing\IRandomizerRoute.h" />
     <ClInclude Include="Mocks\Tools\IToolbar.h" />
     <ClInclude Include="Mocks\Windows\IConsole.h" />
     <ClInclude Include="Mocks\Windows\IConsoleManager.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -84,6 +84,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     </ClCompile>
     <ClCompile Include="Plugins\Plugin.cpp" />
     <ClCompile Include="Plugins\Plugins.cpp" />
+    <ClCompile Include="Routing\RandomizerRoute.cpp" />
     <ClCompile Include="trview_imgui.cpp" />
     <ClCompile Include="Lua\Lua.cpp" />
     <ClCompile Include="Menus\AlternateGroupToggler.cpp" />
@@ -140,6 +141,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Plugins\IPlugins.h" />
     <ClInclude Include="Plugins\Plugin.h" />
     <ClInclude Include="Plugins\Plugins.h" />
+    <ClInclude Include="Routing\IRandomizerRoute.h" />
+    <ClInclude Include="Routing\RandomizerRoute.h" />
     <ClInclude Include="Tools\IToolbar.h" />
     <ClInclude Include="Type.inl">
       <FileType>Document</FileType>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -317,6 +317,9 @@
     <ClCompile Include="Lua\Route\Lua_Waypoint.cpp">
       <Filter>Lua\Route</Filter>
     </ClCompile>
+    <ClCompile Include="Routing\RandomizerRoute.cpp">
+      <Filter>Routing</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -1020,6 +1023,12 @@
     </ClInclude>
     <ClInclude Include="Lua\Route\Lua_Waypoint.h">
       <Filter>Lua\Route</Filter>
+    </ClInclude>
+    <ClInclude Include="Routing\RandomizerRoute.h">
+      <Filter>Routing</Filter>
+    </ClInclude>
+    <ClInclude Include="Routing\IRandomizerRoute.h">
+      <Filter>Routing</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -1030,6 +1030,9 @@
     <ClInclude Include="Routing\IRandomizerRoute.h">
       <Filter>Routing</Filter>
     </ClInclude>
+    <ClInclude Include="Mocks\Routing\IRandomizerRoute.h">
+      <Filter>Mocks\Routing</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.common/Files.cpp
+++ b/trview.common/Files.cpp
@@ -91,6 +91,7 @@ namespace trview
     void Files::save_file(const std::string& filename, const std::vector<uint8_t>& bytes) const
     {
         std::ofstream outfile;
+        outfile.exceptions(std::ifstream::failbit | std::ifstream::badbit | std::ifstream::eofbit);
         outfile.open(to_utf16(filename), std::ios::out | std::ios::binary);
         outfile.write(reinterpret_cast<const char*>(&bytes[0]), bytes.size());
     }
@@ -98,6 +99,7 @@ namespace trview
     void Files::save_file(const std::string& filename, const std::string& text) const
     {
         std::ofstream outfile;
+        outfile.exceptions(std::ifstream::failbit | std::ifstream::badbit | std::ifstream::eofbit);
         outfile.open(to_utf16(filename), std::ios::out);
         outfile << text;
     }


### PR DESCRIPTION
This started off as adding the route I/O for the Lua bindings but grew to a larger rewrite of the Randomizer integration and the Route window in general. The import and export buttons are now gone, replaced with a menu bar. Routes now keep track of where they were saved and know what type they are so the user doesn't have to repeatedly specify the file to export to.

- Added `RandomizerRoute` type which is a collection of waypoints. It swaps the waypoints out when the user changes the opened level. This lets the user use one set of Randomizer locations without having to open it manually for each level.
- Added menu bar to Route Window
- Replaced `Import` with `Open`
- Replace `Export` with `Save` and `Save As`
- Added `Reload` command
- Added option to create a new `Route` or `RandomizerRoute` in the Route Window
- Randomizer settings are now only shown for `RandomizerRoute`
- Route Window now shows level selection for `RandomizerRoute`
- Default route type now depends on whether Randomizer tools are enabled
- Added Lua bindings for `open`, `save`, `save_as`

Closes #1149 
Closes #1155 