### PR TITLE
Add selected trigger property to Level (Lua)

### DIFF
--- a/doc/lua/level.md
+++ b/doc/lua/level.md
@@ -14,6 +14,7 @@ The Level library provides information about the currently loaded Level in trvie
 | rooms | [Room](room.md)[] | R | All rooms |
 | selected_item | [Item](item.md) | RW | Currently selected item |
 | selected_room | [Room](room.md) | RW | Currently selected room |
+| selected_trigger | [Trigger](trigger.md) | RW | Currently selected trigger |
 | static_meshes | [StaticMesh](staticmesh.md)[] | R | All static meshes |
 | triggers | [Trigger](trigger.md)[] | R | All triggers |
 | version | number | R | The game number for which this level was made |

--- a/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Lua/Elements/Level/Lua_Level.h>
 #include <trview.app/Lua/Elements/Room/Lua_Room.h>
+#include <trview.app/Lua/Elements/Trigger/Lua_Trigger.h>
 #include <trview.app/Mocks/Elements/ILevel.h>
 #include <trview.app/Mocks/Elements/ICameraSink.h>
 #include <trview.app/Mocks/Elements/ILight.h>
@@ -193,6 +194,39 @@ TEST(Lua_Level, SetSelectedRoom)
     lua_setglobal(L, "r");
 
     ASSERT_EQ(0, luaL_dostring(L, "l.selected_room = r"));
+}
+
+TEST(Lua_Level, SelectedTrigger)
+{
+    auto trigger = mock_shared<MockTrigger>()->with_number(200);
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, trigger(200)).WillRepeatedly(Return(trigger));
+    EXPECT_CALL(*level, selected_trigger).WillRepeatedly(Return(200));
+
+    lua_State* L = luaL_newstate();
+    lua::create_level(L, level);
+    lua_setglobal(L, "l");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return l.selected_trigger"));
+    ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return l.selected_trigger.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(200, lua_tonumber(L, -1));
+}
+
+TEST(Lua_Level, SetSelectedTrigger)
+{
+    auto trigger = mock_shared<MockTrigger>()->with_number(200);
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, set_selected_trigger(200));
+
+    lua_State* L = luaL_newstate();
+    lua::create_level(L, level);
+    lua_setglobal(L, "l");
+    lua::create_trigger(L, trigger);
+    lua_setglobal(L, "t");
+
+    ASSERT_EQ(0, luaL_dostring(L, "l.selected_trigger = t"));
 }
 
 TEST(Lua_Level, Triggers)

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -991,3 +991,67 @@ TEST(Viewer, SetShowLighting)
     ui.on_toggle_changed(IViewer::Options::lighting, true);
 }
 
+TEST(Viewer, RoomSelectedForwarded)
+{
+    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto viewer = register_test_module().build();
+
+    std::optional<uint32_t> raised;
+    auto token = viewer->on_room_selected += [&](auto r) { raised = r; };
+
+    viewer->open(&level, ILevel::OpenMode::Full);
+    level.on_room_selected(123);
+
+    ASSERT_TRUE(raised);
+    ASSERT_EQ(*raised, 123);
+
+    raised.reset();
+    auto [new_level_ptr, new_level] = create_mock<MockLevel>();
+    viewer->open(&new_level, ILevel::OpenMode::Full);
+    level.on_room_selected(456);
+    ASSERT_FALSE(raised);
+}
+
+TEST(Viewer, ItemSelectedForwarded)
+{
+    auto item = mock_shared<MockItem>();
+
+    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto viewer = register_test_module().build();
+
+    std::shared_ptr<IItem> raised;
+    auto token = viewer->on_item_selected += [&](auto i) { raised = i.lock(); };
+
+    viewer->open(&level, ILevel::OpenMode::Full);
+    level.on_item_selected(item);
+
+    ASSERT_EQ(raised, item);
+
+    raised.reset();
+    auto [new_level_ptr, new_level] = create_mock<MockLevel>();
+    viewer->open(&new_level, ILevel::OpenMode::Full);
+    level.on_item_selected(item);
+    ASSERT_EQ(raised, nullptr);
+}
+
+TEST(Viewer, TriggerSelectedForwarded)
+{
+    auto trigger = mock_shared<MockTrigger>();
+
+    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto viewer = register_test_module().build();
+
+    std::shared_ptr<ITrigger> raised;
+    auto token = viewer->on_trigger_selected += [&](auto t) { raised = t.lock(); };
+
+    viewer->open(&level, ILevel::OpenMode::Full);
+    level.on_trigger_selected(trigger);
+
+    ASSERT_EQ(raised, trigger);
+
+    raised.reset();
+    auto [new_level_ptr, new_level] = create_mock<MockLevel>();
+    viewer->open(&new_level, ILevel::OpenMode::Full);
+    level.on_trigger_selected(trigger);
+    ASSERT_EQ(raised, nullptr);
+}

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -1005,9 +1005,10 @@ TEST(Viewer, RoomSelectedForwarded)
     ASSERT_TRUE(raised);
     ASSERT_EQ(*raised, 123);
 
-    raised.reset();
     auto [new_level_ptr, new_level] = create_mock<MockLevel>();
     viewer->open(&new_level, ILevel::OpenMode::Full);
+
+    raised.reset();
     level.on_room_selected(456);
     ASSERT_FALSE(raised);
 }

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -147,5 +147,6 @@ namespace trview
         /// items that are contained within.
         Event<> on_level_changed;
         mutable Event<> on_geometry_colours_changed;
+        Event<std::weak_ptr<ITrigger>> on_trigger_selected;
     };
 }

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -875,8 +875,13 @@ namespace trview
 
     void Level::set_selected_trigger(uint32_t number)
     {
-        _selected_trigger = _triggers[number];
-        on_level_changed();
+        const auto selected_trigger = _triggers[number];
+        if (_selected_trigger.lock() != selected_trigger)
+        {
+            _selected_trigger = selected_trigger;
+            on_level_changed();
+            on_trigger_selected(_selected_trigger);
+        }
     }
 
     void Level::set_selected_light(uint32_t number)

--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -67,6 +67,16 @@ namespace trview
                 {
                     return create_room(L, level->room(level->selected_room()).lock());
                 }
+                else if (key == "selected_trigger")
+                {
+                    auto trigger = level->selected_trigger();
+                    if (trigger)
+                    {
+                        return create_trigger(L, level->trigger(trigger.value()).lock());
+                    }
+                    lua_pushnil(L);
+                    return 1;
+                }
                 else if (key == "static_meshes")
                 {
                     return push_list_p(L, level->static_meshes(), create_static_mesh);
@@ -106,6 +116,13 @@ namespace trview
                     if (auto room = to_room(L, -1))
                     {
                         level->set_selected_room(static_cast<uint16_t>(room->number()));
+                    }
+                }
+                else if (key == "selected_trigger")
+                {
+                    if (auto trigger = to_trigger(L, -1))
+                    {
+                        level->set_selected_trigger(trigger->number());
                     }
                 }
 

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -587,6 +587,7 @@ namespace trview
         {
             old_level->on_room_selected -= on_room_selected;
             old_level->on_item_selected -= on_item_selected;
+            old_level->on_trigger_selected -= on_trigger_selected;
         }
 
         _level_token_store += _level->on_alternate_mode_selected += [&](bool enabled) { set_alternate_mode(enabled); };
@@ -594,6 +595,7 @@ namespace trview
         _level_token_store += _level->on_level_changed += [&]() { _scene_changed = true; };
         _level->on_room_selected += on_room_selected;
         _level->on_item_selected += on_item_selected;
+        _level->on_trigger_selected += on_trigger_selected;
 
         _level->set_show_triggers(_ui->toggle(Options::triggers));
         _level->set_show_geometry(_ui->toggle(Options::geometry));


### PR DESCRIPTION
Add a `selected_trigger` to the `Level` bindings. This is read/write and will select the trigger as normal. 
Also update tests for item/room/trigger selection to make sure they forward the events and that the viewer unregisters correctly when it loads another level.
Closes #1161