### PR TITLE
Add position property to Room

### DIFF
--- a/doc/lua/room.md
+++ b/doc/lua/room.md
@@ -15,6 +15,7 @@ The Room library provides information about a room in a [level](level.md).
 | number | number | R | Room number |
 | num_x_sectors | number | R | Number of sectors in the x dimension |
 | num_z_sectors | number | R | Number of sectors in the z dimension |
+| position | [Vector3](vector3.md) | R | World position of the room |
 | sectors | [Sector](sector.md)[] | R | Sectors in the room
 | static_meshes | [StaticMesh](staticmesh.md)[] | R | Static meshes in the room |
 | triggers | [Trigger](trigger.md)[] | R | Triggers in the room |

--- a/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
@@ -201,6 +201,26 @@ TEST(Lua_Room, NumZSectors)
     ASSERT_EQ(123, lua_tointeger(L, -1));
 }
 
+TEST(Lua_Room, Position)
+{
+    constexpr RoomInfo info{ .x = 1000, .z = 3000, .yBottom = 2000 };
+    auto room = mock_shared<MockRoom>()->with_room_info(info);
+
+    lua_State* L = luaL_newstate();
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return r.position.x"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(1000, lua_tonumber(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return r.position.y"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(2000, lua_tonumber(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return r.position.z"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(3000, lua_tonumber(L, -1));
+}
+
 TEST(Lua_Room, Sector)
 {
     auto sector = mock_shared<MockSector>()->with_id(123);

--- a/trview.app/Lua/Elements/Room/Lua_Room.cpp
+++ b/trview.app/Lua/Elements/Room/Lua_Room.cpp
@@ -8,6 +8,7 @@
 #include "../../Lua.h"
 #include "../Level/Lua_Level.h"
 #include "../StaticMesh/Lua_StaticMesh.h"
+#include "../../Vector3.h"
 
 namespace trview
 {
@@ -79,6 +80,11 @@ namespace trview
                 {
                     lua_pushinteger(L, room->num_z_sectors());
                     return 1;
+                }
+                else if (key == "position")
+                {
+                    const auto info = room->info();
+                    return create_vector3(L, DirectX::SimpleMath::Vector3(static_cast<float>(info.x), static_cast<float>(info.yBottom), static_cast<float>(info.z)));
                 }
                 else if (key == "sector")
                 {

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -97,6 +97,12 @@ namespace trview
                 ON_CALL(*this, level).WillByDefault(testing::Return(level));
                 return shared_from_this();
             }
+
+            std::shared_ptr<MockRoom> with_room_info(const RoomInfo& info)
+            {
+                ON_CALL(*this, info).WillByDefault(testing::Return(info));
+                return shared_from_this();
+            }
         };
     }
 }


### PR DESCRIPTION
Add a binding to `Room` to get the world position as a `Vector3`.
Closes #1158