### PR TITLE
Don't reset Room when setting waypoint position

### DIFF
--- a/trview.app.tests/Routing/WaypointTests.cpp
+++ b/trview.app.tests/Routing/WaypointTests.cpp
@@ -105,3 +105,11 @@ TEST(Waypoint, Visibility)
     waypoint.set_visible(true);
     ASSERT_TRUE(waypoint.visible());
 }
+
+TEST(Waypoint, SetPositionPreservesRoom)
+{
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3::Zero, Vector3::Down, 110, IWaypoint::Type::Position, 0, Colour::Red, Colour::Green);
+    ASSERT_EQ(110, waypoint.room());
+    waypoint.set_position(Vector3(100, 200, 300));
+    ASSERT_EQ(110, waypoint.room());
+}

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -220,7 +220,7 @@ namespace trview
 
     void Waypoint::set_position(const DirectX::SimpleMath::Vector3& position)
     {
-        set_properties(Type::Position, 0, 0, position);
+        set_properties(Type::Position, 0, _room, position);
     }
 
     std::weak_ptr<ITrigger> Waypoint::trigger() const


### PR DESCRIPTION
Use the currently set room so that when the user adjusts the position it doesn't get reset to room 0.
Closes #1164