### PR TITLE
Add option to toggle route line rendering in route window

### DIFF
--- a/doc/lua/route.md
+++ b/doc/lua/route.md
@@ -8,6 +8,7 @@ The Route library lets you create and edit routes. Routes need to be bound to a 
 | colour | [Colour](colour.md) | RW | The route line colour |
 | filename | string | R | The file to read and write from/to |
 | level | [Level](level.md) | RW | The level all targets will reference |
+| show_route_line | boolean | RW | Whether to show the route line in the viewer |
 | waypoints | [Waypoint](waypoint.md)[] | RW | The route waypoints |
 | waypoint_colour | [Colour](colour.md) | RW | The default waypoint colour |
 | is_randomizer | boolean | R | Whether this is a randomizer route |

--- a/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
+++ b/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
@@ -321,6 +321,32 @@ TEST(Lua_Route, SetWaypoints)
     ASSERT_EQ(0, luaL_dostring(L, "r.waypoints = { w1, w2 }"));
 }
 
+TEST(Lua_Route, SetShowRouteLine)
+{
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, set_show_route_line(true));
+
+    lua_State* L = luaL_newstate();
+    lua::create_route(L, route);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "r.show_route_line = true"));
+}
+
+TEST(Lua_Route, ShowRouteLine)
+{
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, show_route_line).WillOnce(Return(true));
+
+    lua_State* L = luaL_newstate();
+    lua::create_route(L, route);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return r.show_route_line"));
+    ASSERT_EQ(LUA_TBOOLEAN, lua_type(L, -1));
+    ASSERT_TRUE(lua_toboolean(L, -1));
+}
+
 TEST(Lua_Route, WaypointColour)
 {
     auto route = mock_shared<MockRoute>();

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -327,7 +327,7 @@ TEST(Route, Render)
     route->render(camera, texture_storage, true);
 }
 
-TEST(Route, RenderDoesNotJoinWhenRandoEnabled)
+TEST(Route, RenderDoesNotJoinWhenRouteLineDisabled)
 {
     auto [selection_renderer_ptr, selection_renderer] = create_mock<MockSelectionRenderer>();
     EXPECT_CALL(selection_renderer, render).Times(1);
@@ -354,7 +354,7 @@ TEST(Route, RenderDoesNotJoinWhenRandoEnabled)
     };
 
     auto route = register_test_module().with_selection_renderer(std::move(selection_renderer_ptr)).with_waypoint_source(source).build();
-    route->set_randomizer_enabled(true);
+    route->set_show_route_line(false);
     route->add(Vector3::Zero, Vector3::Down, 0);
     route->add(Vector3::Zero, Vector3::Down, 0);
     route->add(Vector3::Zero, Vector3::Down, 0);

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -514,3 +514,16 @@ TEST(Route, SetWaypointColourUpdatesWaypoints)
     route->add(Vector3::Zero, Vector3::Zero, 0);
     route->set_waypoint_colour(Colour::Cyan);
 }
+
+TEST(Route, SetShowRouteLine)
+{
+    auto route = register_test_module().build();
+
+    bool raised = false;
+    auto token = route->on_changed += [&]() { raised = true; };
+
+    route->set_show_route_line(false);
+
+    ASSERT_TRUE(raised);
+    ASSERT_FALSE(route->show_route_line());
+}

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -272,7 +272,6 @@ namespace trview
             _settings = settings;
             _viewer->set_settings(_settings);
             _route_window->set_randomizer_enabled(settings.randomizer_tools);
-            _route->set_randomizer_enabled(settings.randomizer_tools);
             _rooms_windows->set_map_colours(settings.map_colours);
             lua::set_settings(settings);
             if (_level)
@@ -387,7 +386,6 @@ namespace trview
             _viewer->set_scene_changed();
         };
         _route_window->set_randomizer_enabled(_settings.randomizer_tools);
-        _route->set_randomizer_enabled(_settings.randomizer_tools);
         _route_window->set_randomizer_settings(_settings.randomizer);
         _token_store += _route_window->on_window_created += [&]() { open_recent_route(); };
         _token_store += _route_window->on_level_switch += [&](const auto& level) { _file_menu->switch_to(level); };
@@ -1033,7 +1031,6 @@ namespace trview
         _route = route;
         _token_store += _route->on_changed += [&]() { if (_viewer) { _viewer->set_scene_changed(); } };
         _route_window->set_route(_route);
-        _route->set_randomizer_enabled(_settings.randomizer_tools);
         _route->set_level(_level);
         _viewer->set_route(_route);
     }

--- a/trview.app/Lua/Route/Lua_Route.cpp
+++ b/trview.app/Lua/Route/Lua_Route.cpp
@@ -223,6 +223,11 @@ namespace trview
                     lua_pushcfunction(L, route_save_as);
                     return 1;
                 }
+                else if (key == "show_route_line")
+                {
+                    lua_pushboolean(L, route->show_route_line());
+                    return 1;
+                }
                 else if (key == "waypoint_colour")
                 {
                     return create_colour(L, route->waypoint_colour());
@@ -252,6 +257,10 @@ namespace trview
                 else if (key == "level")
                 {
                     route->set_level(to_level(L, 3));
+                }
+                else if (key == "show_route_line")
+                {
+                    route->set_show_route_line(lua_toboolean(L, 3));
                 }
                 else if (key == "waypoint_colour")
                 {

--- a/trview.app/Mocks/Routing/IRandomizerRoute.h
+++ b/trview.app/Mocks/Routing/IRandomizerRoute.h
@@ -37,9 +37,10 @@ namespace trview
             MOCK_METHOD(void, set_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_filename, (const std::string&), (override));
             MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
-            MOCK_METHOD(void, set_randomizer_enabled, (bool), (override));
             MOCK_METHOD(void, set_unsaved, (bool), (override));
             MOCK_METHOD(void, set_waypoint_colour, (const Colour&), (override));
+            MOCK_METHOD(void, set_show_route_line, (bool), (override));
+            MOCK_METHOD(bool, show_route_line, (), (const, override));
             MOCK_METHOD(Colour, waypoint_colour, (), (const, override));
             MOCK_METHOD(std::weak_ptr<IWaypoint>, waypoint, (uint32_t), (const, override));
             MOCK_METHOD(uint32_t, waypoints, (), (const, override));

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -35,9 +35,10 @@ namespace trview
             MOCK_METHOD(void, set_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_filename, (const std::string&), (override));
             MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
-            MOCK_METHOD(void, set_randomizer_enabled, (bool), (override));
+            MOCK_METHOD(void, set_show_route_line, (bool), (override));
             MOCK_METHOD(void, set_unsaved, (bool), (override));
             MOCK_METHOD(void, set_waypoint_colour, (const Colour&), (override));
+            MOCK_METHOD(bool, show_route_line, (), (const, override));
             MOCK_METHOD(Colour, waypoint_colour, (), (const, override));
             MOCK_METHOD(std::weak_ptr<IWaypoint>, waypoint, (uint32_t), (const, override));
             MOCK_METHOD(uint32_t, waypoints, (), (const, override));

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -9,7 +9,6 @@
 #include <trview.app/Geometry/PickResult.h>
 #include <trview.common/Event.h>
 #include <trview.common/IFiles.h>
-#include "../Settings/RandomizerSettings.h"
 
 namespace trview
 {
@@ -145,12 +144,8 @@ namespace trview
         /// <param name="colour">The colour to use.</param>
         virtual void set_colour(const Colour& colour) = 0;
         virtual void set_filename(const std::string& filename) = 0;
+        virtual void set_show_route_line(bool show) = 0;
         virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
-        /// <summary>
-        /// Set whether randomizer tools are enabled.
-        /// </summary>
-        /// <param name="enabled">Whether randomizer tools are enabled.</param>
-        virtual void set_randomizer_enabled(bool enabled) = 0;
         /// <summary>
         /// Set the colour for the stick.
         /// </summary>
@@ -161,6 +156,7 @@ namespace trview
         /// </summary>
         /// <param name="value">Whether the route has unsaved changes.</param>
         virtual void set_unsaved(bool value) = 0;
+        virtual bool show_route_line() const = 0;
         /// <summary>
         /// Get the colour to use for the stick.
         /// </summary>

--- a/trview.app/Routing/RandomizerRoute.cpp
+++ b/trview.app/Routing/RandomizerRoute.cpp
@@ -131,6 +131,8 @@ namespace trview
     RandomizerRoute::RandomizerRoute(const std::shared_ptr<IRoute>& inner_route, const IWaypoint::Source& waypoint_source)
         : _route(inner_route), _waypoint_source(waypoint_source)
     {
+        _route->set_show_route_line(false);
+        _route->on_changed += on_changed;
     }
 
     std::shared_ptr<IWaypoint> RandomizerRoute::add(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room)
@@ -339,11 +341,6 @@ namespace trview
         _route->set_unsaved(false);
     }
 
-    void RandomizerRoute::set_randomizer_enabled(bool enabled)
-    {
-        return _route->set_randomizer_enabled(enabled);
-    }
-
     void RandomizerRoute::set_waypoint_colour(const Colour& colour)
     {
         return _route->set_waypoint_colour(colour);
@@ -352,6 +349,16 @@ namespace trview
     void RandomizerRoute::set_unsaved(bool value)
     {
         return _route->set_unsaved(value);
+    }
+
+    void RandomizerRoute::set_show_route_line(bool show)
+    {
+        _route->set_show_route_line(show);
+    }
+
+    bool RandomizerRoute::show_route_line() const
+    {
+        return _route->show_route_line();
     }
 
     Colour RandomizerRoute::waypoint_colour() const

--- a/trview.app/Routing/RandomizerRoute.h
+++ b/trview.app/Routing/RandomizerRoute.h
@@ -44,9 +44,10 @@ namespace trview
         void set_colour(const Colour& colour) override;
         void set_filename(const std::string& filename) override;
         void set_level(const std::weak_ptr<ILevel>& level) override;
-        void set_randomizer_enabled(bool enabled) override;
         void set_waypoint_colour(const Colour& colour) override;
         void set_unsaved(bool value) override;
+        void set_show_route_line(bool show) override;
+        bool show_route_line() const override;
         Colour waypoint_colour() const override;
         std::weak_ptr<IWaypoint> waypoint(uint32_t index) const override;
         uint32_t waypoints() const override;

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -270,7 +270,7 @@ namespace trview
         {
             auto& waypoint = _waypoints[i];
             waypoint->render(camera, texture_storage, _waypoint_colour);
-            if (!_randomizer_enabled && i < _waypoints.size() - 1)
+            if (_show_route_line && i < _waypoints.size() - 1)
             {
                 waypoint->render_join(*_waypoints[i + 1], camera, texture_storage, _colour);
             }
@@ -385,11 +385,6 @@ namespace trview
         bind_waypoint_targets();
     }
 
-    void Route::set_randomizer_enabled(bool enabled)
-    {
-        _randomizer_enabled = enabled;
-    }
-
     void Route::set_waypoint_colour(const Colour& colour)
     {
         _waypoint_colour = colour;
@@ -404,6 +399,17 @@ namespace trview
     {
         _is_unsaved = value;
         on_changed();
+    }
+
+    void Route::set_show_route_line(bool show)
+    {
+        _show_route_line = show;
+        on_changed();
+    }
+
+    bool Route::show_route_line() const
+    {
+        return _show_route_line;
     }
 
     Colour Route::waypoint_colour() const 

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -5,7 +5,6 @@
 #include <trview.app/Routing/IRoute.h>
 #include <trview.app/Camera/ICamera.h>
 #include <trview.common/IFiles.h>
-#include <trview.app/Settings/RandomizerSettings.h>
 #include "../Settings/UserSettings.h"
 
 namespace trview
@@ -44,9 +43,10 @@ namespace trview
         virtual void set_colour(const Colour& colour) override;
         void set_filename(const std::string& filename) override;
         void set_level(const std::weak_ptr<ILevel>& level) override;
-        virtual void set_randomizer_enabled(bool enabled) override;
         virtual void set_waypoint_colour(const Colour& colour) override;
         virtual void set_unsaved(bool value) override;
+        void set_show_route_line(bool show) override;
+        bool show_route_line() const override;
         virtual Colour waypoint_colour() const override;
         virtual std::weak_ptr<IWaypoint> waypoint(uint32_t index) const override;
         virtual uint32_t waypoints() const override;
@@ -65,8 +65,8 @@ namespace trview
         Colour _colour{ Colour::Green };
         Colour _waypoint_colour{ Colour::White };
         bool _is_unsaved{ false };
-        bool _randomizer_enabled{ false };
         std::weak_ptr<ILevel> _level;
         std::optional<std::string> _filename;
+        bool _show_route_line{ true };
     };
 }

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -630,6 +630,11 @@ namespace trview
                 {
                     on_waypoint_colour_changed(waypoint_colour);
                 }
+                bool route_line = route->show_route_line();;
+                if (ImGui::Checkbox("Route Line", &route_line))
+                {
+                    route->set_show_route_line(route_line);
+                }
                 ImGui::EndPopup();
             }
             else


### PR DESCRIPTION
Add an option to the route window to control whether a route renders the route line between waypoints. This is `true` by default for regular routes and `false` for randomizer routes.
Added Lua property for this as well.
Closes #1156 