### PR TITLE
Allow Sector to be used to create Waypoint

### DIFF
--- a/doc/lua/waypoint.md
+++ b/doc/lua/waypoint.md
@@ -20,4 +20,4 @@ The Waypoint library lets you create and edit route waypoints.
 
 | Name | Returns | Parameters | Description |
 | ---- | ------- | ---------- | ----------- |
-| new | Waypoint | `{ Item item, Trigger trigger, Vector3 position, Vector3 normal, Room room }` | Creates an [Item](item.md), [Trigger](trigger.md) or [Position](vector3.md) waypoint, in that order of precedence. Only one needs to be provided. Normal is optional - if not provided the waypoint will be vertical. Room is required only if using Position. |
+| new | Waypoint | `{ Item item, Trigger trigger, Vector3 position, Vector3 normal, Room room, Sector sector }` | Creates an [Item](item.md), [Trigger](trigger.md) or [Position](vector3.md) waypoint, in that order of precedence. Only one needs to be provided. Normal is optional - if not provided the waypoint will be vertical. Room is required only if using Position. Sector can be used in place of Position to create a mid waypoint. |

--- a/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
@@ -6,6 +6,7 @@
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
+#include "../Lua.h"
 
 using namespace trview;
 using namespace trview::mocks;
@@ -17,7 +18,7 @@ TEST(Lua_Room, AlternateMode)
 {
     auto room = mock_shared<MockRoom>();
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -41,7 +42,7 @@ TEST(Lua_Room, AlternateGroup)
 {
     auto room = mock_shared<MockRoom>()->with_alternate_group(5);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -60,7 +61,7 @@ TEST(Lua_Room, AlternateRoom)
     auto room = mock_shared<MockRoom>()->with_alternate_room(5);
     ON_CALL(*room, level).WillByDefault(Return(level));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -79,7 +80,7 @@ TEST(Lua_Room, CamerasAndSinks)
     auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, camera_sinks).WillRepeatedly(Return(std::vector<std::weak_ptr<ICameraSink>>{ cs1, cs2 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -104,7 +105,7 @@ TEST(Lua_Room, Items)
     auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, items).WillRepeatedly(Return(std::vector<std::weak_ptr<IItem>>{ item1, item2 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -126,7 +127,7 @@ TEST(Lua_Room, Level)
     auto level = mock_shared<MockLevel>()->with_version(trlevel::LevelVersion::Tomb4);
     auto room = mock_shared<MockRoom>()->with_level(level);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -145,7 +146,7 @@ TEST(Lua_Room, Lights)
     auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, lights).WillRepeatedly(Return(std::vector<std::weak_ptr<ILight>>{ light1, light2 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -166,7 +167,7 @@ TEST(Lua_Room, Number)
 {
     auto room = mock_shared<MockRoom>()->with_number(123);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -179,7 +180,7 @@ TEST(Lua_Room, NumXSectors)
 {
     auto room = mock_shared<MockRoom>()->with_num_x_sectors(123);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -192,7 +193,7 @@ TEST(Lua_Room, NumZSectors)
 {
     auto room = mock_shared<MockRoom>()->with_num_z_sectors(123);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -206,7 +207,7 @@ TEST(Lua_Room, Position)
     constexpr RoomInfo info{ .x = 1000, .z = 3000, .yBottom = 2000 };
     auto room = mock_shared<MockRoom>()->with_room_info(info);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -227,7 +228,7 @@ TEST(Lua_Room, Sector)
     auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, sector(0, 1)).WillRepeatedly(Return(sector));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -245,7 +246,7 @@ TEST(Lua_Room, Sectors)
     auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, sectors).WillRepeatedly(Return(std::vector<std::shared_ptr<ISector>>{ sector1, sector2 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -270,7 +271,7 @@ TEST(Lua_Room, Triggers)
     auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, triggers).WillRepeatedly(Return(std::vector<std::weak_ptr<ITrigger>>{ trigger1, trigger2 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -292,7 +293,7 @@ TEST(Lua_Room, Visible)
     auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, visible).WillOnce(Return(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 
@@ -309,7 +310,7 @@ TEST(Lua_Room, SetVisible)
     auto room = mock_shared<MockRoom>()->with_number(100);
     EXPECT_CALL(*room, level).WillRepeatedly(Return(level));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_room(L, room);
     lua_setglobal(L, "r");
 

--- a/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
@@ -4,6 +4,7 @@
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
+#include "../Lua.h"
 
 using namespace trview;
 using namespace trview::mocks;
@@ -19,7 +20,7 @@ TEST(Lua_Sector, Above)
 
     auto sector = mock_shared<MockSector>()->with_room(room)->with_room_above(10);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
 
@@ -38,7 +39,7 @@ TEST(Lua_Sector, Below)
 
     auto sector = mock_shared<MockSector>()->with_room(room)->with_room_below(10);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
 
@@ -60,7 +61,7 @@ TEST(Lua_Sector, CeilingCorners)
     auto sector = mock_shared<MockSector>()->with_room(room);
     ON_CALL(*sector, ceiling_corners).WillByDefault(Return(corners));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
 
@@ -84,7 +85,7 @@ TEST(Lua_Sector, CeilingTriangulation)
 {
     auto sector = mock_shared<MockSector>()->with_ceiling_triangulation(ISector::TriangulationDirection::NeSw);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
 
@@ -104,7 +105,7 @@ TEST(Lua_Sector, Corners)
     auto sector = mock_shared<MockSector>()->with_room(room);
     ON_CALL(*sector, corners).WillByDefault(Return(corners));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
 
@@ -128,7 +129,7 @@ TEST(Lua_Sector, Flags)
 {
     auto sector = mock_shared<MockSector>()->with_flags(SectorFlag::Portal);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
 
@@ -141,7 +142,7 @@ TEST(Lua_Sector, HasFlag)
 {
     auto sector = mock_shared<MockSector>()->with_flags(SectorFlag::Portal);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
     lua::sector_register(L);
@@ -155,7 +156,7 @@ TEST(Lua_Sector, Number)
 {
     auto sector = mock_shared<MockSector>()->with_id(123);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
 
@@ -173,7 +174,7 @@ TEST(Lua_Sector, Portal)
     auto sector = mock_shared<MockSector>()->with_room(room)->with_portal(10);
     ON_CALL(*sector, is_portal).WillByDefault(Return(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
 
@@ -189,7 +190,7 @@ TEST(Lua_Sector, Room)
     auto room = mock_shared<MockRoom>()->with_number(10);
     auto sector = mock_shared<MockSector>()->with_room(room);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
 
@@ -205,7 +206,7 @@ TEST(Lua_Sector, Trigger)
     auto trigger = mock_shared<MockTrigger>()->with_number(10);
     auto sector = mock_shared<MockSector>()->with_trigger(trigger);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
 
@@ -220,7 +221,7 @@ TEST(Lua_Sector, X)
 {
     auto sector = mock_shared<MockSector>()->with_x(123);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
 
@@ -233,7 +234,7 @@ TEST(Lua_Sector, Z)
 {
     auto sector = mock_shared<MockSector>()->with_z(123);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
 
@@ -246,7 +247,7 @@ TEST(Lua_Sector, Triangulation)
 {
     auto sector = mock_shared<MockSector>()->with_triangulation(ISector::TriangulationDirection::NeSw);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
 

--- a/trview.app.tests/Lua/Elements/Lua_TriggerTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_TriggerTests.cpp
@@ -6,6 +6,7 @@
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
 #include <trview.app/Lua/Colour.h>
+#include "../Lua.h"
 
 using namespace trview;
 using namespace trview::mocks;
@@ -19,7 +20,7 @@ TEST(Lua_Trigger, Commands)
     auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, commands).WillRepeatedly(Return(std::vector<Command>{ command }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -44,7 +45,7 @@ TEST(Lua_Trigger, Flags)
     auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, flags).WillRepeatedly(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -57,7 +58,7 @@ TEST(Lua_Trigger, Number)
 {
     auto trigger = mock_shared<MockTrigger>()->with_number(123);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -71,7 +72,7 @@ TEST(Lua_Trigger, OnlyOnce)
     auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, only_once).WillRepeatedly(Return(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -85,7 +86,7 @@ TEST(Lua_Trigger, Position)
     auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, position).WillRepeatedly(Return(Vector3(1, 2, 3)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -108,7 +109,7 @@ TEST(Lua_Trigger, Room)
     auto trigger = mock_shared<MockTrigger>()->with_number(100);
     EXPECT_CALL(*trigger, room).WillRepeatedly(Return(room));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -129,7 +130,7 @@ TEST(Lua_Trigger, Sector)
     auto trigger = mock_shared<MockTrigger>()->with_number(100);
     EXPECT_CALL(*trigger, room).WillRepeatedly(Return(room));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -145,7 +146,7 @@ TEST(Lua_Trigger, Timer)
     auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, timer).WillRepeatedly(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -159,7 +160,7 @@ TEST(Lua_Trigger, Type)
     auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, type).WillRepeatedly(Return(TriggerType::HeavyTrigger));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -173,7 +174,7 @@ TEST(Lua_Trigger, Visible)
     auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, visible).WillRepeatedly(Return(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -190,7 +191,7 @@ TEST(Lua_Trigger, SetVisible)
     auto trigger = mock_shared<MockTrigger>()->with_number(100);
     EXPECT_CALL(*trigger, level).WillRepeatedly(Return(level));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -202,7 +203,7 @@ TEST(Lua_Trigger, Colour)
     auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, colour).WillRepeatedly(Return(trview::Colour(1,2,3,4)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -228,7 +229,7 @@ TEST(Lua_Trigger, SetColourDefault)
     auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, set_colour).WillOnce(SaveArg<0>(&arg));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -242,7 +243,7 @@ TEST(Lua_Trigger, SetColour)
     auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, set_colour).WillOnce(SaveArg<0>(&arg));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::colour_register(L);
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");

--- a/trview.app.tests/Lua/Lua.cpp
+++ b/trview.app.tests/Lua/Lua.cpp
@@ -1,0 +1,24 @@
+#include "Lua.h"
+#include <external/lua/src/lua.h>
+#include <external/lua/src/lauxlib.h>
+
+namespace trview
+{
+    namespace tests
+    {
+        LuaState::LuaState()
+        {
+            L = luaL_newstate();
+        }
+
+        LuaState::~LuaState()
+        {
+            lua_close(L);
+        }
+
+        LuaState::operator lua_State* ()
+        {
+            return L;
+        }
+    }
+}

--- a/trview.app.tests/Lua/Lua.h
+++ b/trview.app.tests/Lua/Lua.h
@@ -1,0 +1,18 @@
+#pragma once
+
+struct lua_State;
+
+namespace trview
+{
+    namespace tests
+    {
+        struct LuaState
+        {
+            LuaState();
+            ~LuaState();
+            operator lua_State* ();
+            lua_State* L;
+        };
+    }
+}
+

--- a/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
+++ b/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
@@ -16,12 +16,32 @@ using namespace trview::mocks;
 using namespace trview::tests;
 using namespace testing;
 
+struct LuaState
+{
+    LuaState()
+    {
+        L = luaL_newstate();
+    }
+
+    ~LuaState()
+    {
+        lua_close(L);
+    }
+
+    operator lua_State* () 
+    {
+        return L;
+    }
+
+    lua_State* L;
+};
+
 TEST(Lua_Route, Add)
 {
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, add(A<const std::shared_ptr<IWaypoint>&>())).Times(1);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, mock_shared<MockWaypoint>());
     lua_setglobal(L, "w");
     lua::create_route(L, route);
@@ -35,7 +55,7 @@ TEST(Lua_Route, Clear)
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, clear).Times(1);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -47,7 +67,7 @@ TEST(Lua_Route, Colour)
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, colour).Times(1).WillOnce(Return(Colour(1, 2, 3, 4)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -71,7 +91,7 @@ TEST(Lua_Route, IsRandomizer)
 {
     auto rando_route = mock_shared<MockRandomizerRoute>();
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, rando_route);
     lua_setglobal(L, "r");
 
@@ -95,7 +115,7 @@ TEST(Lua_Route, Level)
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, level).WillRepeatedly(Return(level));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -108,7 +128,7 @@ TEST(Lua_Route, New)
 {
     auto route = mock_shared<MockRoute>();
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
 
     ASSERT_EQ(0, luaL_dostring(L, "r = Route.new() return r"));
@@ -120,7 +140,7 @@ TEST(Lua_Route, NewRandoRoute)
 {
     auto route = mock_shared<MockRandomizerRoute>();
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::route_register(L, [](auto&&...) { return mock_shared<MockRoute>(); }, [=](auto&&...) { return route; }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
 
     ASSERT_EQ(0, luaL_dostring(L, "r = Route.new({is_randomizer = true}) return r"));
@@ -133,7 +153,7 @@ TEST(Lua_Route, Reload)
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, reload);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -145,7 +165,7 @@ TEST(Lua_Route, Remove)
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, remove(A<const std::shared_ptr<IWaypoint>&>())).Times(1);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, mock_shared<MockWaypoint>());
     lua_setglobal(L, "w");
     lua::create_route(L, route);
@@ -160,7 +180,7 @@ TEST(Lua_Route, Save)
     ON_CALL(*route, filename).WillByDefault(Return("test"));
     EXPECT_CALL(*route, save).Times(1);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -173,7 +193,7 @@ TEST(Lua_Route, SaveNoFilename)
     EXPECT_CALL(*route, save).Times(0);
     EXPECT_CALL(*route, set_filename).Times(0);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -189,7 +209,7 @@ TEST(Lua_Route, SaveChooseFile)
     auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, save_file).WillRepeatedly(Return(IDialogs::FileResult{ .filename = "test", .filter_index = 1 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -206,7 +226,7 @@ TEST(Lua_Route, SaveAsWithFileAllowed)
     EXPECT_CALL(*dialogs, message_box).WillRepeatedly(Return(true));
     EXPECT_CALL(*dialogs, save_file).WillRepeatedly(Return(IDialogs::FileResult{.filename = "test", .filter_index = 1 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -222,7 +242,7 @@ TEST(Lua_Route, SaveAsWithFileRejected)
     auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, save_file).WillRepeatedly(Return(IDialogs::FileResult{.filename = "test", .filter_index = 1 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -238,7 +258,7 @@ TEST(Lua_Route, SaveAsChoosesFile)
     auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, save_file).WillRepeatedly(Return(IDialogs::FileResult{.filename = "test", .filter_index = 1 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -251,7 +271,7 @@ TEST(Lua_Route, SetColour)
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, set_colour).Times(1).WillRepeatedly(SaveArg<0>(&called_colour));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::colour_register(L);
     lua::create_route(L, route);
     lua_setglobal(L, "r");
@@ -272,7 +292,7 @@ TEST(Lua_Route, SetLevel)
     std::weak_ptr<ILevel> value;
     EXPECT_CALL(*route, set_level).WillRepeatedly(SaveArg<0>(&value));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
     lua::create_level(L, level);
@@ -288,7 +308,7 @@ TEST(Lua_Route, SetWaypointColour)
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, set_waypoint_colour).Times(1).WillRepeatedly(SaveArg<0>(&called_colour));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::colour_register(L);
     lua::create_route(L, route);
     lua_setglobal(L, "r");
@@ -310,7 +330,7 @@ TEST(Lua_Route, SetWaypoints)
     EXPECT_CALL(*route, add(Eq(waypoint1)));
     EXPECT_CALL(*route, add(Eq(waypoint2)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
     lua::create_waypoint(L, waypoint1);
@@ -326,7 +346,7 @@ TEST(Lua_Route, SetShowRouteLine)
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, set_show_route_line(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -338,7 +358,7 @@ TEST(Lua_Route, ShowRouteLine)
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, show_route_line).WillOnce(Return(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -352,7 +372,7 @@ TEST(Lua_Route, WaypointColour)
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, waypoint_colour).Times(1).WillOnce(Return(Colour(1, 2, 3, 4)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -384,7 +404,7 @@ TEST(Lua_Route, Waypoints)
     ON_CALL(*route, waypoint(0)).WillByDefault(Return(waypoint1));
     ON_CALL(*route, waypoint(1)).WillByDefault(Return(waypoint2));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 

--- a/trview.app.tests/Lua/Route/Lua_WaypointTests.cpp
+++ b/trview.app.tests/Lua/Route/Lua_WaypointTests.cpp
@@ -13,6 +13,7 @@
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
+#include "../Lua.h"
 
 using namespace trview;
 using namespace trview::mocks;
@@ -25,7 +26,7 @@ TEST(Lua_Waypoint, Colour)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, route_colour).WillRepeatedly(Return(Colour(1, 0.5f, 0.25f)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -49,7 +50,7 @@ TEST(Lua_Waypoint, Item)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, item).WillOnce(Return(item));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -62,7 +63,7 @@ TEST(Lua_Waypoint, Normal)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, normal).WillRepeatedly(Return(Vector3(1, 2, 3)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -86,7 +87,7 @@ TEST(Lua_Waypoint, NewItem)
 
     auto item = mock_shared<MockItem>();
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::waypoint_register(L, [=](auto&&...) { return waypoint; });
     lua::create_item(L, item);
     lua_setglobal(L, "i");
@@ -104,7 +105,7 @@ TEST(Lua_Waypoint, NewPosition)
 
     std::optional<Vector3> position;
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::vector3_register(L);
     lua::create_room(L, room);
     lua_setglobal(L, "r");
@@ -129,7 +130,7 @@ TEST(Lua_Waypoint, NewSector)
 
     std::optional<Vector3> position;
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::vector3_register(L);
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
@@ -150,7 +151,7 @@ TEST(Lua_Waypoint, NewTrigger)
 
     auto trigger = mock_shared<MockTrigger>();
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::waypoint_register(L, [=](auto&&...) { return waypoint; });
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
@@ -165,7 +166,7 @@ TEST(Lua_Waypoint, Notes)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, notes).WillOnce(Return("These are the notes"));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -179,7 +180,7 @@ TEST(Lua_Waypoint, Position)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, position).WillRepeatedly(Return(Vector3(1, 2, 3)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -215,7 +216,7 @@ TEST(Lua_Waypoint, RandomizerSettings)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, randomizer_settings).WillRepeatedly(Return(waypoint_settings));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
     
@@ -234,7 +235,7 @@ TEST(Lua_Waypoint, RoomNumber)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, room).WillOnce(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -248,7 +249,7 @@ TEST(Lua_Waypoint, SetColour)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, set_route_colour(Colour(1, 2, 3)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::colour_register(L);
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
@@ -263,7 +264,7 @@ TEST(Lua_Waypoint, SetItem)
 
     EXPECT_CALL(*waypoint, set_item).Times(1);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
     lua::create_item(L, item);
@@ -277,7 +278,7 @@ TEST(Lua_Waypoint, SetNormal)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, set_normal(Vector3(1, 2, 3)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::vector3_register(L);
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
@@ -290,7 +291,7 @@ TEST(Lua_Waypoint, SetNotes)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, set_notes("New notes"));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -302,7 +303,7 @@ TEST(Lua_Waypoint, SetPosition)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, set_position(Vector3(1, 2, 3)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::vector3_register(L);
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
@@ -328,7 +329,7 @@ TEST(Lua_Waypoint, SetRandomizerSettings)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, set_randomizer_settings).Times(AtLeast(1)).WillRepeatedly(SaveArg<0>(&called_settings));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -343,7 +344,7 @@ TEST(Lua_Waypoint, SetRoomNumber)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, set_room_number(100));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -355,9 +356,9 @@ TEST(Lua_Waypoint, SetTrigger)
     auto waypoint = mock_shared<MockWaypoint>();
     auto trigger = mock_shared<MockTrigger>();
 
-    EXPECT_CALL(*waypoint, set_item).Times(1);
+    EXPECT_CALL(*waypoint, set_trigger).Times(1);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
     lua::create_trigger(L, trigger);
@@ -371,7 +372,7 @@ TEST(Lua_Waypoint, SetWaypointColour)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, set_waypoint_colour(Colour(1, 2, 3)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::colour_register(L);
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
@@ -386,7 +387,7 @@ TEST(Lua_Waypoint, Trigger)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, trigger).WillOnce(Return(trigger));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -399,7 +400,7 @@ TEST(Lua_Waypoint, Type)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, type).WillOnce(Return(IWaypoint::Type::Trigger));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -413,7 +414,7 @@ TEST(Lua_Waypoint, WaypointColour)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, waypoint_colour).WillRepeatedly(Return(Colour(1, 0.5f, 0.25f)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -49,6 +49,7 @@
     <ClCompile Include="Lua\Elements\Lua_SectorTests.cpp" />
     <ClCompile Include="Lua\Elements\Lua_StaticMeshTests.cpp" />
     <ClCompile Include="Lua\Elements\Lua_TriggerTests.cpp" />
+    <ClCompile Include="Lua\Lua.cpp" />
     <ClCompile Include="Lua\Lua_ColourTests.cpp" />
     <ClCompile Include="Lua\Lua_trviewTests.cpp" />
     <ClCompile Include="Lua\Lua_Vector3Tests.cpp" />
@@ -133,6 +134,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Lua\Lua.h" />
     <ClInclude Include="NullImGuiBackend.h" />
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="TestImgui.h" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -230,6 +230,9 @@
     <ClCompile Include="Routing\RandomizerRouteTests.cpp">
       <Filter>Routing</Filter>
     </ClCompile>
+    <ClCompile Include="Lua\Lua.cpp">
+      <Filter>Lua</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">
@@ -288,6 +291,9 @@
     </ClInclude>
     <ClInclude Include="TestImGuiId.h">
       <Filter>ImGui</Filter>
+    </ClInclude>
+    <ClInclude Include="Lua\Lua.h">
+      <Filter>Lua</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -253,6 +253,7 @@ namespace trview
         /// <param name="render_filter">What to render.</param>
         virtual void render_contained(const ICamera& camera, SelectionMode selected, RenderFilter render_filter) = 0;
         virtual std::weak_ptr<ISector> sector(int32_t x, int32_t z) const = 0;
+        virtual DirectX::SimpleMath::Vector3 sector_centroid(const std::weak_ptr<ISector>& sector) const = 0;
         /// <summary>
         /// Gets all sectors in the room.
         /// </summary>

--- a/trview.app/Elements/ISector.cpp
+++ b/trview.app/Elements/ISector.cpp
@@ -104,4 +104,18 @@ namespace trview
     {
         return !has_flag(flags, SectorFlag::Portal) && (has_flag(flags, SectorFlag::Wall) && has_flag(flags, SectorFlag::FloorSlant));
     }
+
+    uint32_t sector_room(const std::shared_ptr<ISector>& sector)
+    {
+        if (!sector)
+        {
+            return 0u;
+        }
+
+        if (auto room = sector->room().lock())
+        {
+            return room->number();
+        }
+        return 0u;
+    }
 }

--- a/trview.app/Elements/ISector.h
+++ b/trview.app/Elements/ISector.h
@@ -135,6 +135,7 @@ namespace trview
 
     bool is_no_space(SectorFlag flags);
     constexpr std::string to_string(ISector::TriangulationDirection direction);
+    uint32_t sector_room(const std::shared_ptr<ISector>& sector);
 }
 
 #include "ISector.hpp"

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -832,9 +832,9 @@ namespace trview
         {
             return Vector3::Zero;
         }
-        
+
         const auto corners = sector_ptr->corners();
-        Vector3 centroid =
+        const Vector3 centroid =
         {
             static_cast<float>(sector_ptr->x()) + 0.5f,
             std::accumulate(corners.begin(), corners.end(), 0.0f) / 4.0f,

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -825,6 +825,24 @@ namespace trview
         return {};
     }
 
+    Vector3 Room::sector_centroid(const std::weak_ptr<ISector>& sector) const
+    {
+        auto sector_ptr = sector.lock();
+        if (!sector_ptr)
+        {
+            return Vector3::Zero;
+        }
+        
+        const auto corners = sector_ptr->corners();
+        Vector3 centroid =
+        {
+            static_cast<float>(sector_ptr->x()) + 0.5f,
+            std::accumulate(corners.begin(), corners.end(), 0.0f) / 4.0f,
+            static_cast<float>(sector_ptr->z()) + 0.5f
+        };
+        return Vector3::Transform(centroid, _room_offset);
+    }
+
     const std::vector<std::shared_ptr<ISector>> Room::sectors() const
     {
         return _sectors; 

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -47,6 +47,7 @@ namespace trview
         virtual void add_light(const std::weak_ptr<ILight>& light) override;
         virtual void add_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
         std::weak_ptr<ISector> sector(int32_t x, int32_t z) const override;
+        DirectX::SimpleMath::Vector3 sector_centroid(const std::weak_ptr<ISector>& sector) const override;
         virtual const std::vector<std::shared_ptr<ISector>> sectors() const override;
         virtual void generate_sector_triangles() override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, SelectionMode selected, RenderFilter render_filter) override;

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -246,5 +246,17 @@ namespace trview
             });
             lua_setglobal(L, "Sector");
         }
+
+        std::shared_ptr<ISector> to_sector(lua_State* L, int index)
+        {
+            luaL_checktype(L, index, LUA_TUSERDATA);
+            ISector** userdata = static_cast<ISector**>(lua_touserdata(L, index));
+            auto found = sectors.find(userdata);
+            if (found == sectors.end())
+            {
+                return {};
+            }
+            return found->second;
+        }
     }
 }

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -12,8 +12,6 @@ namespace trview
     {
         namespace
         {
-            std::unordered_map<ISector**, std::shared_ptr<ISector>> sectors;
-
             std::array<int, 4> to_corner_clicks(ISector* sector, const std::array<float, 4>& corners)
             {
                 float base = 0;
@@ -191,8 +189,8 @@ namespace trview
             int sector_gc(lua_State* L)
             {
                 luaL_checktype(L, 1, LUA_TUSERDATA);
-                ISector** userdata = static_cast<ISector**>(lua_touserdata(L, 1));
-                sectors.erase(userdata);
+                std::shared_ptr<ISector>* userdata = static_cast<std::shared_ptr<ISector>*>(lua_touserdata(L, 1));
+                userdata->reset();
                 return 0;
             }
         }
@@ -205,9 +203,8 @@ namespace trview
                 return 1;
             }
 
-            ISector** userdata = static_cast<ISector**>(lua_newuserdata(L, sizeof(sector.get())));
-            *userdata = sector.get();
-            sectors[userdata] = sector;
+            std::shared_ptr<ISector>* userdata = static_cast<std::shared_ptr<ISector>*>(lua_newuserdata(L, sizeof(std::shared_ptr<ISector>)));
+            new (userdata) std::shared_ptr<ISector>(sector);
 
             lua_newtable(L);
             lua_pushcfunction(L, sector_index);
@@ -250,13 +247,8 @@ namespace trview
         std::shared_ptr<ISector> to_sector(lua_State* L, int index)
         {
             luaL_checktype(L, index, LUA_TUSERDATA);
-            ISector** userdata = static_cast<ISector**>(lua_touserdata(L, index));
-            auto found = sectors.find(userdata);
-            if (found == sectors.end())
-            {
-                return {};
-            }
-            return found->second;
+            std::shared_ptr<ISector>* userdata = static_cast<std::shared_ptr<ISector>*>(lua_touserdata(L, index));
+            return *userdata;
         }
     }
 }

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.h
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.h
@@ -10,5 +10,6 @@ namespace trview
     {
         int create_sector(lua_State* L, std::shared_ptr<ISector> sector);
         void sector_register(lua_State* L);
+        std::shared_ptr<ISector> to_sector(lua_State* L, int index);
     }
 }

--- a/trview.app/Lua/Route/Lua_Route.cpp
+++ b/trview.app/Lua/Route/Lua_Route.cpp
@@ -89,7 +89,7 @@ namespace trview
 
                 std::string filename;
 
-                if (lua_type(L, 1) == LUA_TTABLE)
+                if (lua_type(L, 2) == LUA_TTABLE)
                 {
                     if (LUA_TSTRING == lua_getfield(L, 2, "filename"))
                     {

--- a/trview.app/Lua/Route/Lua_Waypoint.cpp
+++ b/trview.app/Lua/Route/Lua_Waypoint.cpp
@@ -255,8 +255,8 @@ namespace trview
             int waypoint_gc(lua_State* L)
             {
                 luaL_checktype(L, 1, LUA_TUSERDATA);
-                IWaypoint** userdata = static_cast<IWaypoint**>(lua_touserdata(L, 1));
-                waypoints.erase(userdata);
+                std::shared_ptr<IWaypoint>* userdata = static_cast<std::shared_ptr<IWaypoint>*>(lua_touserdata(L, 1));
+                userdata->reset();
                 return 0;
             }
 
@@ -370,13 +370,8 @@ namespace trview
         std::shared_ptr<IWaypoint> to_waypoint(lua_State* L, int index)
         {
             luaL_checktype(L, index, LUA_TUSERDATA);
-            IWaypoint** userdata = static_cast<IWaypoint**>(lua_touserdata(L, index));
-            auto found = waypoints.find(userdata);
-            if (found == waypoints.end())
-            {
-                return {};
-            }
-            return found->second;
+            std::shared_ptr<IWaypoint>* userdata = static_cast<std::shared_ptr<IWaypoint>*>(lua_touserdata(L, index));
+            return *userdata;
         }
 
         int create_waypoint(lua_State* L, const std::shared_ptr<IWaypoint>& waypoint)
@@ -387,9 +382,8 @@ namespace trview
                 return 1;
             }
 
-            IWaypoint** userdata = static_cast<IWaypoint**>(lua_newuserdata(L, sizeof(waypoint.get())));
-            *userdata = waypoint.get();
-            waypoints[userdata] = waypoint;
+            std::shared_ptr<IWaypoint>* userdata = static_cast<std::shared_ptr<IWaypoint>*>(lua_newuserdata(L, sizeof(std::shared_ptr<IWaypoint>)));
+            new (userdata) std::shared_ptr<IWaypoint>(waypoint);
 
             lua_newtable(L);
             lua_pushcfunction(L, waypoint_index);

--- a/trview.app/Lua/Route/Lua_Waypoint.cpp
+++ b/trview.app/Lua/Route/Lua_Waypoint.cpp
@@ -8,6 +8,7 @@
 #include "../../Elements/ITrigger.h"
 #include "../../Elements/IRoom.h"
 #include "../../Elements/ILevel.h"
+#include "../Elements/Sector/Lua_Sector.h"
 
 using namespace DirectX::SimpleMath;
 
@@ -299,6 +300,30 @@ namespace trview
                                 Colour::White);
                         waypoint->set_trigger(trigger);
                         return create_waypoint(L, waypoint);
+                    }
+                    return 0;
+                }
+                else
+                {
+                    lua_pop(L, 1);
+                }
+
+                if (LUA_TUSERDATA == lua_getfield(L, 1, "sector"))
+                {
+                    if (auto sector = to_sector(L, -1))
+                    {
+                        if (const auto room = sector->room().lock())
+                        {
+                            auto waypoint = waypoint_source(
+                                room->sector_centroid(sector),
+                                normal,
+                                sector_room(sector),
+                                IWaypoint::Type::Position,
+                                0,
+                                Colour::White,
+                                Colour::White);
+                            return create_waypoint(L, waypoint);
+                        }
                     }
                     return 0;
                 }

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -41,6 +41,7 @@ namespace trview
             MOCK_METHOD(void, render_camera_sinks, (const ICamera&), (override));
             MOCK_METHOD(void, render_contained, (const ICamera&, SelectionMode, RenderFilter), (override));;
             MOCK_METHOD(std::weak_ptr<ISector>, sector, (int32_t, int32_t), (const, override));
+            MOCK_METHOD(DirectX::SimpleMath::Vector3, sector_centroid, (const std::weak_ptr<ISector>&), (const, override));
             MOCK_METHOD(const std::vector<std::shared_ptr<ISector>>, sectors, (), (const, override));
             MOCK_METHOD(void, set_is_alternate, (int16_t), (override));
             MOCK_METHOD(std::weak_ptr<ITrigger>, trigger_at, (int32_t, int32_t), (const, override));

--- a/trview.app/Routing/RandomizerRoute.cpp
+++ b/trview.app/Routing/RandomizerRoute.cpp
@@ -138,21 +138,30 @@ namespace trview
     std::shared_ptr<IWaypoint> RandomizerRoute::add(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room)
     {
         auto result = _route->add(position, normal, room);
-        update_waypoints();
+        if (auto current_level = _route->level().lock())
+        {
+            get_waypoints(trimmed_level_name(current_level->filename())).waypoints.push_back(result);
+        }
         return result;
     }
 
     std::shared_ptr<IWaypoint> RandomizerRoute::add(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, IWaypoint::Type type, uint32_t type_index)
     {
         auto result = _route->add(position, normal, room, type, type_index);
-        update_waypoints();
+        if (auto current_level = _route->level().lock())
+        {
+            get_waypoints(trimmed_level_name(current_level->filename())).waypoints.push_back(result);
+        }
         return result;
     }
 
     std::shared_ptr<IWaypoint> RandomizerRoute::add(const std::shared_ptr<IWaypoint>& waypoint)
     {
         auto result = _route->add(waypoint);
-        update_waypoints();
+        if (auto current_level = _route->level().lock())
+        {
+            get_waypoints(trimmed_level_name(current_level->filename())).waypoints.push_back(result);
+        }
         return result;
     }
 


### PR DESCRIPTION
Let user pass in a `Sector` when creating a `Waypoint` using `Waypoint.new`.
This will create a mid waypoint at the provided sector.
Also has a couple of performance adjustments; the randomizer route now just adds the waypoint to the list when a waypoint is added instead of regenerating the whole thing. `Waypoint` and `Sector` now no longer store instances in a map, they just create the shared_ptr in userdata directly. Other classes will need to do this too.
Closes #1159 