### PR TITLE
Add tilt_x and tilt_z properties to Sector

### DIFF
--- a/doc/lua/sector.md
+++ b/doc/lua/sector.md
@@ -14,6 +14,8 @@ The Sector library provides information about a sector in a [Level](level.md)/[R
 | number | number | R | Sector number |
 | portal | [Room](room.md) | R | Destination room for portal or `nil` |
 | room | [Room](room.md) | R | Room that the sector is in |
+| tilt_x | Number | R | X tilt value for the sector. Only check if `FloorSlant` flag is true |
+| tilt_z | Number | R | Z tilt value for the sector. Only check if `FloorSlant` flag is true |
 | triangulation | string | R | Triangulation direction (`None`/`NWSE`/`NESW`) |
 | trigger | [Trigger](trigger.md) | R | Trigger on this sector or `nil` |
 | x | number | R | Sector X location in room |

--- a/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
@@ -255,3 +255,31 @@ TEST(Lua_Sector, Triangulation)
     ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
     ASSERT_STREQ("NESW", lua_tostring(L, -1));
 }
+
+TEST(Lua_Sector, TiltX)
+{
+    auto sector = mock_shared<MockSector>();
+    EXPECT_CALL(*sector, tilt_x).WillRepeatedly(Return(-3));
+
+    LuaState L;
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.tilt_x"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(-3, lua_tonumber(L, -1));
+}
+
+TEST(Lua_Sector, TiltX)
+{
+    auto sector = mock_shared<MockSector>();
+    EXPECT_CALL(*sector, tilt_z).WillRepeatedly(Return(-3));
+
+    LuaState L;
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.tilt_z"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(-3, lua_tonumber(L, -1));
+}

--- a/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
@@ -270,7 +270,7 @@ TEST(Lua_Sector, TiltX)
     ASSERT_EQ(-3, lua_tonumber(L, -1));
 }
 
-TEST(Lua_Sector, TiltX)
+TEST(Lua_Sector, TiltZ)
 {
     auto sector = mock_shared<MockSector>();
     EXPECT_CALL(*sector, tilt_z).WillRepeatedly(Return(-3));

--- a/trview.app/Elements/ISector.h
+++ b/trview.app/Elements/ISector.h
@@ -114,6 +114,8 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 corner(Corner corner) const = 0;
         virtual DirectX::SimpleMath::Vector3 ceiling(Corner corner) const = 0;
         virtual std::weak_ptr<IRoom> room() const = 0;
+        virtual int8_t tilt_x() const = 0;
+        virtual int8_t tilt_z() const = 0;
         virtual TriangulationDirection triangulation() const = 0;
         virtual std::vector<Triangle> triangles() const = 0;
         virtual bool is_floor() const = 0;

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -226,8 +226,8 @@ namespace trview
 
     void Sector::parse_slope()
     {
-        const int8_t x_slope = _floor_slant & 0x00ff;
-        const int8_t z_slope = _floor_slant >> 8;
+        const int8_t x_slope = tilt_x();
+        const int8_t z_slope = tilt_z();
 
         if (x_slope > 0)
         {
@@ -329,6 +329,16 @@ namespace trview
     std::weak_ptr<IRoom> Sector::room() const
     {
         return _room_ptr;
+    }
+
+    int8_t Sector::tilt_x() const
+    {
+        return static_cast<int8_t>(_floor_slant & 0x00ff);
+    }
+
+    int8_t Sector::tilt_z() const
+    {
+        return static_cast<int8_t>(_floor_slant >> 8);
     }
 
     ISector::TriangulationDirection Sector::triangulation() const

--- a/trview.app/Elements/Sector.h
+++ b/trview.app/Elements/Sector.h
@@ -43,6 +43,8 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 corner(Corner corner) const override;
         virtual DirectX::SimpleMath::Vector3 ceiling(Corner corner) const override;
         std::weak_ptr<IRoom> room() const override;
+        int8_t tilt_x() const override;
+        int8_t tilt_z() const override;
         virtual TriangulationDirection triangulation() const override;
         virtual std::vector<Triangle> triangles() const override;
         virtual uint32_t floordata_index() const override;

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -156,6 +156,16 @@ namespace trview
                 {
                     return create_room(L, sector->room().lock());
                 }
+                else if (key == "tilt_x")
+                {
+                    lua_pushnumber(L, sector->tilt_x());
+                    return 1;
+                }
+                else if (key == "tilt_z")
+                {
+                    lua_pushnumber(L, sector->tilt_z());
+                    return 1;
+                }
                 else if (key == "triangulation")
                 {
                     lua_pushstring(L, to_string(sector->triangulation()).c_str());

--- a/trview.app/Mocks/Elements/ISector.h
+++ b/trview.app/Mocks/Elements/ISector.h
@@ -36,6 +36,8 @@ namespace trview
             MOCK_METHOD(void, add_triangle, (const ISector::Portal&, const Triangle&, std::unordered_set<uint32_t>), (override));
             MOCK_METHOD(void, add_flag, (SectorFlag), (override));
             MOCK_METHOD(void, set_trigger, (const std::weak_ptr<ITrigger>&), (override));
+            MOCK_METHOD(int8_t, tilt_x, (), (const, override));
+            MOCK_METHOD(int8_t, tilt_z, (), (const, override));
             MOCK_METHOD(std::weak_ptr<ITrigger>, trigger, (), (const, override));
             MOCK_METHOD(TriangulationDirection, ceiling_triangulation, (), (const, override));
 


### PR DESCRIPTION
Add `tilt_x` and `tilt_z` properties to the `Sector` object. Should only be read when the `FloorSlant` flag is true.
Closes #1169 