### PR TITLE
Remove pointer lists from Lua integration

### DIFF
--- a/trview.app.tests/Lua/Elements/Lua_CameraSinkTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_CameraSinkTests.cpp
@@ -4,6 +4,7 @@
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
+#include "../Lua.h"
 
 using namespace trview;
 using namespace trview::mocks;
@@ -16,7 +17,7 @@ TEST(Lua_CameraSink, BoxIndex)
     auto cs = mock_shared<MockCameraSink>();
     EXPECT_CALL(*cs, box_index).WillOnce(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_camera_sink(L, cs);
     lua_setglobal(L, "c");
 
@@ -30,7 +31,7 @@ TEST(Lua_CameraSink, Flag)
     auto cs = mock_shared<MockCameraSink>();
     EXPECT_CALL(*cs, flag).WillOnce(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_camera_sink(L, cs);
     lua_setglobal(L, "c");
 
@@ -46,7 +47,7 @@ TEST(Lua_CameraSink, InferredRooms)
     auto cs = mock_shared<MockCameraSink>();
     EXPECT_CALL(*cs, inferred_rooms).WillRepeatedly(Return(std::vector<std::weak_ptr<IRoom>>{ room1, room2 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_camera_sink(L, cs);
     lua_setglobal(L, "c");
 
@@ -68,7 +69,7 @@ TEST(Lua_CameraSink, Number)
     auto cs = mock_shared<MockCameraSink>();
     EXPECT_CALL(*cs, number).WillOnce(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_camera_sink(L, cs);
     lua_setglobal(L, "c");
 
@@ -82,7 +83,7 @@ TEST(Lua_CameraSink, Persistent)
     auto cs = mock_shared<MockCameraSink>();
     EXPECT_CALL(*cs, persistent).WillOnce(Return(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_camera_sink(L, cs);
     lua_setglobal(L, "c");
 
@@ -96,7 +97,7 @@ TEST(Lua_CameraSink, Position)
     auto cs = mock_shared<MockCameraSink>();
     EXPECT_CALL(*cs, position).WillRepeatedly(Return(Vector3(1, 2, 3)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_camera_sink(L, cs);
     lua_setglobal(L, "c");
 
@@ -119,7 +120,7 @@ TEST(Lua_CameraSink, Room)
     auto cs = mock_shared<MockCameraSink>();
     EXPECT_CALL(*cs, room).WillRepeatedly(Return(room));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_camera_sink(L, cs);
     lua_setglobal(L, "c");
 
@@ -135,7 +136,7 @@ TEST(Lua_CameraSink, Strength)
     auto cs = mock_shared<MockCameraSink>();
     EXPECT_CALL(*cs, strength).WillOnce(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_camera_sink(L, cs);
     lua_setglobal(L, "c");
 
@@ -149,7 +150,7 @@ TEST(Lua_CameraSink, Type)
     auto cs = mock_shared<MockCameraSink>();
     EXPECT_CALL(*cs, type).WillOnce(Return(ICameraSink::Type::Camera));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_camera_sink(L, cs);
     lua_setglobal(L, "c");
 
@@ -171,7 +172,7 @@ TEST(Lua_CameraSink, TriggeredBy)
     auto cs = mock_shared<MockCameraSink>();
     EXPECT_CALL(*cs, triggers).WillRepeatedly(Return(std::vector<std::weak_ptr<ITrigger>>{ trigger1, trigger2 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_camera_sink(L, cs);
     lua_setglobal(L, "c");
 
@@ -193,7 +194,7 @@ TEST(Lua_CameraSink, Visible)
     auto cs = mock_shared<MockCameraSink>();
     EXPECT_CALL(*cs, visible).WillOnce(Return(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_camera_sink(L, cs);
     lua_setglobal(L, "c");
 
@@ -217,7 +218,7 @@ TEST(Lua_CameraSink, SetType)
     EXPECT_CALL(*cs, level).WillRepeatedly(Return(level));
     EXPECT_CALL(*cs, set_type(ICameraSink::Type::Sink)).Times(1);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_camera_sink(L, cs);
     lua_setglobal(L, "c");
 
@@ -237,7 +238,7 @@ TEST(Lua_CameraSink, SetVisible)
     auto cs = mock_shared<MockCameraSink>()->with_number(100);
     EXPECT_CALL(*cs, level).WillRepeatedly(Return(level));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_camera_sink(L, cs);
     lua_setglobal(L, "c");
 

--- a/trview.app.tests/Lua/Elements/Lua_CameraSinkTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_CameraSinkTests.cpp
@@ -214,7 +214,6 @@ TEST(Lua_CameraSink, SetType)
     };
 
     auto cs = mock_shared<MockCameraSink>();
-    EXPECT_CALL(*cs, visible).WillOnce(Return(true));
     EXPECT_CALL(*cs, level).WillRepeatedly(Return(level));
     EXPECT_CALL(*cs, set_type(ICameraSink::Type::Sink)).Times(1);
 

--- a/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
@@ -4,6 +4,7 @@
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
+#include "../Lua.h"
 
 using namespace trview;
 using namespace trview::mocks;
@@ -16,7 +17,7 @@ TEST(Lua_Item, ActivationFlags)
     auto item = mock_shared<MockItem>();
     EXPECT_CALL(*item, activation_flags).WillOnce(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 
@@ -30,7 +31,7 @@ TEST(Lua_Item, Angle)
     auto item = mock_shared<MockItem>();
     EXPECT_CALL(*item, angle).WillOnce(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 
@@ -44,7 +45,7 @@ TEST(Lua_Item, ClearBody)
     auto item = mock_shared<MockItem>();
     EXPECT_CALL(*item, clear_body_flag).WillOnce(Return(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 
@@ -58,7 +59,7 @@ TEST(Lua_Item, Invisible)
     auto item = mock_shared<MockItem>();
     EXPECT_CALL(*item, invisible_flag).WillOnce(Return(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 
@@ -71,7 +72,7 @@ TEST(Lua_Item, Number)
 {
     auto item = mock_shared<MockItem>()->with_number(123);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 
@@ -85,7 +86,7 @@ TEST(Lua_Item, Ocb)
     auto item = mock_shared<MockItem>();
     EXPECT_CALL(*item, ocb).WillOnce(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 
@@ -99,7 +100,7 @@ TEST(Lua_Item, Position)
     auto item = mock_shared<MockItem>();
     EXPECT_CALL(*item, position).WillRepeatedly(Return(Vector3(1, 2, 3)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 
@@ -122,7 +123,7 @@ TEST(Lua_Item, Room)
     auto item = mock_shared<MockItem>()->with_number(100);
     EXPECT_CALL(*item, room).WillRepeatedly(Return(room));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 
@@ -141,7 +142,7 @@ TEST(Lua_Item, TriggeredBy)
     auto item = mock_shared<MockItem>();
     EXPECT_CALL(*item, triggers).WillRepeatedly(Return(std::vector<std::weak_ptr<ITrigger>>{ trigger1, trigger2 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 
@@ -163,7 +164,7 @@ TEST(Lua_Item, Type)
     auto item = mock_shared<MockItem>();
     EXPECT_CALL(*item, type).WillOnce(Return("Lara"));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 
@@ -177,7 +178,7 @@ TEST(Lua_Item, TypeId)
     auto item = mock_shared<MockItem>();
     EXPECT_CALL(*item, type_id).WillOnce(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 
@@ -191,7 +192,7 @@ TEST(Lua_Item, Visible)
     auto item = mock_shared<MockItem>();
     EXPECT_CALL(*item, visible).WillOnce(Return(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 
@@ -208,7 +209,7 @@ TEST(Lua_Item, SetVisible)
     auto item = mock_shared<MockItem>()->with_number(100);
     EXPECT_CALL(*item, level).WillRepeatedly(Return(level));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 

--- a/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
@@ -8,6 +8,7 @@
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
+#include "../Lua.h"
 
 using namespace trview;
 using namespace trview::tests;
@@ -19,7 +20,7 @@ TEST(Lua_Level, AlternateMode)
     auto level = mock_shared<MockLevel>();
     EXPECT_CALL(*level, alternate_mode).WillRepeatedly(Return(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l");
 
@@ -33,7 +34,7 @@ TEST(Lua_Level, SetAlternateMode)
     auto level = mock_shared<MockLevel>();
     EXPECT_CALL(*level, set_alternate_mode(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l");
 
@@ -48,7 +49,7 @@ TEST(Lua_Level, CamerasAndSinks)
     auto level = mock_shared<MockLevel>();
     EXPECT_CALL(*level, camera_sinks).WillRepeatedly(Return(std::vector<std::weak_ptr<ICameraSink>>{ cs1, cs2 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l");
 
@@ -70,7 +71,7 @@ TEST(Lua_Level, Filename)
     auto level = mock_shared<MockLevel>();
     ON_CALL(*level, filename).WillByDefault(testing::Return("test filename"));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l"); 
 
@@ -83,7 +84,7 @@ TEST(Lua_Level, Floordata)
 {
     auto level = mock_shared<MockLevel>();
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l");
 
@@ -98,7 +99,7 @@ TEST(Lua_Level, Items)
     auto level = mock_shared<MockLevel>();
     EXPECT_CALL(*level, items).WillRepeatedly(Return(std::vector<std::weak_ptr<IItem>>{ item1, item2 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l");
 
@@ -122,7 +123,7 @@ TEST(Lua_Level, Lights)
     auto level = mock_shared<MockLevel>();
     EXPECT_CALL(*level, lights).WillRepeatedly(Return(std::vector<std::weak_ptr<ILight>>{ light1, light2 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l");
 
@@ -146,7 +147,7 @@ TEST(Lua_Level, Rooms)
     auto level = mock_shared<MockLevel>();
     EXPECT_CALL(*level, rooms).WillRepeatedly(Return(std::vector<std::weak_ptr<IRoom>>{ room1, room2 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l");
 
@@ -170,7 +171,7 @@ TEST(Lua_Level, SelectedRoom)
     EXPECT_CALL(*level, room(200)).WillRepeatedly(Return(room));
     EXPECT_CALL(*level, selected_room).WillRepeatedly(Return(200));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l");
 
@@ -187,7 +188,7 @@ TEST(Lua_Level, SetSelectedRoom)
     auto level = mock_shared<MockLevel>();
     EXPECT_CALL(*level, set_selected_room(200));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l");
     lua::create_room(L, room);
@@ -203,7 +204,7 @@ TEST(Lua_Level, SelectedTrigger)
     EXPECT_CALL(*level, trigger(200)).WillRepeatedly(Return(trigger));
     EXPECT_CALL(*level, selected_trigger).WillRepeatedly(Return(200));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l");
 
@@ -220,7 +221,7 @@ TEST(Lua_Level, SetSelectedTrigger)
     auto level = mock_shared<MockLevel>();
     EXPECT_CALL(*level, set_selected_trigger(200));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l");
     lua::create_trigger(L, trigger);
@@ -236,7 +237,7 @@ TEST(Lua_Level, Triggers)
     auto level = mock_shared<MockLevel>();
     EXPECT_CALL(*level, triggers).WillRepeatedly(Return(std::vector<std::weak_ptr<ITrigger>>{ trigger1, trigger2 }));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l");
 
@@ -258,7 +259,7 @@ TEST(Lua_Level, Version)
     auto level = mock_shared<MockLevel>();
     ON_CALL(*level, version).WillByDefault(testing::Return(trlevel::LevelVersion::Tomb4));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_level(L, level);
     lua_setglobal(L, "l");
 

--- a/trview.app.tests/Lua/Elements/Lua_LightTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_LightTests.cpp
@@ -4,6 +4,7 @@
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
+#include "../Lua.h"
 
 using namespace trview;
 using namespace trview::mocks;
@@ -16,7 +17,7 @@ TEST(Lua_Light, Colour)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, colour).WillRepeatedly(Return(Color(1, 2, 3, 4)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -41,7 +42,7 @@ TEST(Lua_Light, Cutoff)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, cutoff).WillOnce(Return(123.0f));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -55,7 +56,7 @@ TEST(Lua_Light, Density)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, density).WillOnce(Return(123.0f));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -69,7 +70,7 @@ TEST(Lua_Light, Direction)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, direction).WillRepeatedly(Return(Vector3(1, 2, 3)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -91,7 +92,7 @@ TEST(Lua_Light, Fade)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, fade).WillOnce(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -105,7 +106,7 @@ TEST(Lua_Light, Falloff)
     auto light = mock_shared<MockLight>();
     ON_CALL(*light, out).WillByDefault(Return(123.0f));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -130,7 +131,7 @@ TEST(Lua_Light, FalloffAngle)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, out).WillOnce(Return(1.0f));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -150,7 +151,7 @@ TEST(Lua_Light, Hotspot)
     auto light = mock_shared<MockLight>();
     ON_CALL(*light, in).WillByDefault(Return(1.0f));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -180,7 +181,7 @@ TEST(Lua_Light, Intensity)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, intensity).WillOnce(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -194,7 +195,7 @@ TEST(Lua_Light, Length)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, length).WillOnce(Return(123.0f));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -208,7 +209,7 @@ TEST(Lua_Light, Number)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, number).WillOnce(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -222,7 +223,7 @@ TEST(Lua_Light, Position)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, position).WillRepeatedly(Return(Vector3(1, 2, 3)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -244,7 +245,7 @@ TEST(Lua_Light, Radius)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, cutoff).WillOnce(Return(123.0f));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -258,7 +259,7 @@ TEST(Lua_Light, RadIn)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, rad_in).WillOnce(Return(1.0f));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -272,7 +273,7 @@ TEST(Lua_Light, RadOut)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, rad_out).WillOnce(Return(1.0f));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -286,7 +287,7 @@ TEST(Lua_Light, Range)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, range).WillOnce(Return(123.0f));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -301,7 +302,7 @@ TEST(Lua_Light, Room)
     auto light = mock_shared<MockLight>()->with_number(100);
     EXPECT_CALL(*light, room).WillRepeatedly(Return(room));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -317,7 +318,7 @@ TEST(Lua_Light, Type)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, type).WillOnce(Return(trlevel::LightType::Point));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -331,7 +332,7 @@ TEST(Lua_Light, Visible)
     auto light = mock_shared<MockLight>();
     EXPECT_CALL(*light, visible).WillOnce(Return(true));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 
@@ -349,7 +350,7 @@ TEST(Lua_Light, SetVisible)
     auto light = mock_shared<MockLight>()->with_number(100);
     EXPECT_CALL(*light, level).WillRepeatedly(Return(level));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_light(L, light);
     lua_setglobal(L, "l");
 

--- a/trview.app.tests/Lua/Elements/Lua_StaticMeshTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_StaticMeshTests.cpp
@@ -4,6 +4,7 @@
 #include <trview.tests.common/Mocks.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
+#include "../Lua.h"
 
 using namespace trview;
 using namespace trview::mocks;
@@ -21,7 +22,7 @@ TEST(Lua_StaticMesh, Collision)
         Vector3(1024.0f, 2048.0f, 3072.0f));
     EXPECT_CALL(*static_mesh, collision).WillRepeatedly(Return(box));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_static_mesh(L, static_mesh);
     lua_setglobal(L, "s");
 
@@ -52,7 +53,7 @@ TEST(Lua_StaticMesh, Id)
     auto static_mesh = mock_shared<MockStaticMesh>();
     EXPECT_CALL(*static_mesh, id).WillRepeatedly(Return(123));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_static_mesh(L, static_mesh);
     lua_setglobal(L, "s");
 
@@ -66,7 +67,7 @@ TEST(Lua_StaticMesh, Position)
     auto static_mesh = mock_shared<MockStaticMesh>();
     EXPECT_CALL(*static_mesh, position).WillRepeatedly(Return(Vector3(1, 2, 3)));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_static_mesh(L, static_mesh);
     lua_setglobal(L, "s");
 
@@ -89,7 +90,7 @@ TEST(Lua_StaticMesh, Room)
     auto static_mesh = mock_shared<MockStaticMesh>();
     EXPECT_CALL(*static_mesh, room).WillRepeatedly(Return(room));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_static_mesh(L, static_mesh);
     lua_setglobal(L, "s");
 
@@ -105,7 +106,7 @@ TEST(Lua_StaticMesh, Rotation)
     auto static_mesh = mock_shared<MockStaticMesh>();
     EXPECT_CALL(*static_mesh, rotation).WillRepeatedly(Return(123.0f));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_static_mesh(L, static_mesh);
     lua_setglobal(L, "s");
 
@@ -119,7 +120,7 @@ TEST(Lua_StaticMesh, Type)
     auto static_mesh = mock_shared<MockStaticMesh>();
     ON_CALL(*static_mesh, type).WillByDefault(Return(IStaticMesh::Type::Mesh));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_static_mesh(L, static_mesh);
     lua_setglobal(L, "s");
 
@@ -143,7 +144,7 @@ TEST(Lua_StaticMesh, Visibility)
         Vector3(1024.0f, 2048.0f, 3072.0f));
     EXPECT_CALL(*static_mesh, visibility).WillRepeatedly(Return(box));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::create_static_mesh(L, static_mesh);
     lua_setglobal(L, "s");
 

--- a/trview.app.tests/Lua/Lua_ColourTests.cpp
+++ b/trview.app.tests/Lua/Lua_ColourTests.cpp
@@ -1,12 +1,14 @@
 #include <trview.app/Lua/Colour.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
+#include "Lua.h"
 
 using namespace trview;
+using namespace trview::tests;
 
 TEST(Lua_Colour, New)
 {
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::colour_register(L);
 
     ASSERT_EQ(0, luaL_dostring(L, "x = Colour.new(1, 0.5, 0.25) return x"));

--- a/trview.app.tests/Lua/Lua_Vector3Tests.cpp
+++ b/trview.app.tests/Lua/Lua_Vector3Tests.cpp
@@ -1,6 +1,7 @@
 #include <trview.app/Lua/Vector3.h>
 #include <external/lua/src/lua.h>
 #include <external/lua/src/lauxlib.h>
+#include "Lua.h"
 
 using namespace trview;
 using namespace trview::tests;
@@ -8,7 +9,7 @@ using namespace testing;
 
 TEST(Lua_Vector3, New)
 {
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::vector3_register(L);
 
     ASSERT_EQ(0, luaL_dostring(L, "x = Vector3.new() return x"));
@@ -26,7 +27,7 @@ TEST(Lua_Vector3, New)
 
 TEST(Lua_Vector3, NewXYZ)
 {
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::vector3_register(L);
 
     ASSERT_EQ(0, luaL_dostring(L, "x = Vector3.new(1, 0.5, 0.25) return x"));

--- a/trview.app.tests/Lua/Lua_trviewTests.cpp
+++ b/trview.app.tests/Lua/Lua_trviewTests.cpp
@@ -6,6 +6,7 @@
 #include <external/lua/src/lauxlib.h>
 #include <trview.app/Mocks/Routing/IRoute.h>
 #include <trview.app/Mocks/Routing/IRandomizerRoute.h>
+#include "Lua.h"
 
 using namespace trview;
 using namespace trview::mocks;
@@ -20,7 +21,7 @@ TEST(Lua_trview, Level)
     auto application = mock_shared<MockApplication>();
     EXPECT_CALL(*application, current_level).WillRepeatedly(Return(level));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::trview_register(L, application.get(), 
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
@@ -43,7 +44,7 @@ TEST(Lua_trview, RecentFiles)
     auto application = mock_shared<MockApplication>();
     EXPECT_CALL(*application, settings).WillRepeatedly(Return(settings));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::trview_register(L, application.get(),
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
@@ -66,7 +67,7 @@ TEST(Lua_trview, SetLevel)
     auto application = mock_shared<MockApplication>();
     EXPECT_CALL(*application, set_current_level).Times(1);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::trview_register(L, application.get(),
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
@@ -87,7 +88,7 @@ TEST(Lua_trview, Route)
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*application, route).Times(1).WillRepeatedly(Return(route));
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::trview_register(L, application.get(),
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
@@ -104,7 +105,7 @@ TEST(Lua_trview, SetRoute)
     auto application = mock_shared<MockApplication>();
     EXPECT_CALL(*application, set_route).Times(1);
 
-    lua_State* L = luaL_newstate();
+    LuaState L;
     lua::trview_register(L, application.get(),
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },

--- a/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.cpp
+++ b/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.cpp
@@ -11,8 +11,6 @@ namespace trview
     {
         namespace
         {
-            std::unordered_map<ICameraSink**, std::shared_ptr<ICameraSink>> camera_sinks;
-
             int camera_sink_index(lua_State* L)
             {
                 auto camera_sink = lua::get_self<ICameraSink>(L);
@@ -116,36 +114,11 @@ namespace trview
 
                 return 0;
             }
-
-            int camera_sink_gc(lua_State* L)
-            {
-                luaL_checktype(L, 1, LUA_TUSERDATA);
-                ICameraSink** userdata = static_cast<ICameraSink**>(lua_touserdata(L, 1));
-                camera_sinks.erase(userdata);
-                return 0;
-            }
         }
 
-        void create_camera_sink(lua_State* L, std::shared_ptr<ICameraSink> camera_sink)
+        int create_camera_sink(lua_State* L, std::shared_ptr<ICameraSink> camera_sink)
         {
-            if (!camera_sink)
-            {
-                lua_pushnil(L);
-                return;
-            }
-
-            ICameraSink** userdata = static_cast<ICameraSink**>(lua_newuserdata(L, sizeof(camera_sink.get())));
-            *userdata = camera_sink.get();
-            camera_sinks[userdata] = camera_sink;
-
-            lua_newtable(L);
-            lua_pushcfunction(L, camera_sink_index);
-            lua_setfield(L, -2, "__index");
-            lua_pushcfunction(L, camera_sink_newindex);
-            lua_setfield(L, -2, "__newindex");
-            lua_pushcfunction(L, camera_sink_gc);
-            lua_setfield(L, -2, "__gc");
-            lua_setmetatable(L, -2);
+            return create(L, camera_sink, camera_sink_index, camera_sink_newindex);
         }
     }
 }

--- a/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.h
+++ b/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.h
@@ -8,6 +8,6 @@ namespace trview
 {
     namespace lua
     {
-        void create_camera_sink(lua_State* L, std::shared_ptr<ICameraSink> camera_sink);
+        int create_camera_sink(lua_State* L, std::shared_ptr<ICameraSink> camera_sink);
     }
 }

--- a/trview.app/Lua/Elements/Light/Lua_Light.cpp
+++ b/trview.app/Lua/Elements/Light/Lua_Light.cpp
@@ -12,8 +12,6 @@ namespace trview
     {
         namespace
         {
-            std::unordered_map<ILight**, std::shared_ptr<ILight>> lights;
-
             int light_index(lua_State* L)
             {
                 auto light = lua::get_self<ILight>(L);
@@ -130,36 +128,11 @@ namespace trview
 
                 return 0;
             }
-
-            int light_gc(lua_State* L)
-            {
-                luaL_checktype(L, 1, LUA_TUSERDATA);
-                ILight** userdata = static_cast<ILight**>(lua_touserdata(L, 1));
-                lights.erase(userdata);
-                return 0;
-            }
         }
 
-        void create_light(lua_State* L, const std::shared_ptr<ILight>& light)
+        int create_light(lua_State* L, const std::shared_ptr<ILight>& light)
         {
-            if (!light)
-            {
-                lua_pushnil(L);
-                return;
-            }
-
-            ILight** userdata = static_cast<ILight**>(lua_newuserdata(L, sizeof(light.get())));
-            *userdata = light.get();
-            lights[userdata] = light;
-
-            lua_newtable(L);
-            lua_pushcfunction(L, light_index);
-            lua_setfield(L, -2, "__index");
-            lua_pushcfunction(L, light_newindex);
-            lua_setfield(L, -2, "__newindex");
-            lua_pushcfunction(L, light_gc);
-            lua_setfield(L, -2, "__gc");
-            lua_setmetatable(L, -2);
+            return create(L, light, light_index, light_newindex);
         }
     }
 }

--- a/trview.app/Lua/Elements/Light/Lua_Light.h
+++ b/trview.app/Lua/Elements/Light/Lua_Light.h
@@ -8,6 +8,6 @@ namespace trview
 {
     namespace lua
     {
-        void create_light(lua_State* L, const std::shared_ptr<ILight>& light);
+        int create_light(lua_State* L, const std::shared_ptr<ILight>& light);
     }
 }

--- a/trview.app/Lua/Elements/StaticMesh/Lua_StaticMesh.cpp
+++ b/trview.app/Lua/Elements/StaticMesh/Lua_StaticMesh.cpp
@@ -10,8 +10,6 @@ namespace trview
     {
         namespace
         {
-            std::unordered_map<IStaticMesh**, std::shared_ptr<IStaticMesh>> static_meshes;
-
             int static_mesh_index(lua_State* L)
             {
                 auto static_mesh = lua::get_self<IStaticMesh>(L);
@@ -58,36 +56,11 @@ namespace trview
                 static_mesh;
                 return 0;
             }
-
-            int static_mesh_gc(lua_State* L)
-            {
-                luaL_checktype(L, 1, LUA_TUSERDATA);
-                IStaticMesh** userdata = static_cast<IStaticMesh**>(lua_touserdata(L, 1));
-                static_meshes.erase(userdata);
-                return 0;
-            }
         }
 
-        void create_static_mesh(lua_State* L, const std::shared_ptr<IStaticMesh>& mesh)
+        int create_static_mesh(lua_State* L, const std::shared_ptr<IStaticMesh>& mesh)
         {
-            if (!mesh)
-            {
-                lua_pushnil(L);
-                return;
-            }
-
-            IStaticMesh** userdata = static_cast<IStaticMesh**>(lua_newuserdata(L, sizeof(mesh.get())));
-            *userdata = mesh.get();
-            static_meshes[userdata] = mesh;
-
-            lua_newtable(L);
-            lua_pushcfunction(L, static_mesh_index);
-            lua_setfield(L, -2, "__index");
-            lua_pushcfunction(L, static_mesh_newindex);
-            lua_setfield(L, -2, "__newindex");
-            lua_pushcfunction(L, static_mesh_gc);
-            lua_setfield(L, -2, "__gc");
-            lua_setmetatable(L, -2);
+            return create(L, mesh, static_mesh_index, static_mesh_newindex);
         }
     }
 }

--- a/trview.app/Lua/Elements/StaticMesh/Lua_StaticMesh.h
+++ b/trview.app/Lua/Elements/StaticMesh/Lua_StaticMesh.h
@@ -8,6 +8,6 @@ namespace trview
 {
     namespace lua
     {
-        void create_static_mesh(lua_State* L, const std::shared_ptr<IStaticMesh>& mesh);
+        int create_static_mesh(lua_State* L, const std::shared_ptr<IStaticMesh>& mesh);
     }
 }

--- a/trview.app/Lua/Elements/Trigger/Lua_Trigger.cpp
+++ b/trview.app/Lua/Elements/Trigger/Lua_Trigger.cpp
@@ -13,8 +13,6 @@ namespace trview
     {
         namespace
         {
-            std::unordered_map<ITrigger**, std::shared_ptr<ITrigger>> triggers;
-
             void create_command(lua_State* L, const Command& command)
             {
                 lua_newtable(L);
@@ -118,49 +116,16 @@ namespace trview
 
                 return 0;
             }
-
-            int trigger_gc(lua_State* L)
-            {
-                luaL_checktype(L, 1, LUA_TUSERDATA);
-                ITrigger** userdata = static_cast<ITrigger**>(lua_touserdata(L, 1));
-                triggers.erase(userdata);
-                return 0;
-            }
         }
 
         int create_trigger(lua_State* L, const std::shared_ptr<ITrigger>& trigger)
         {
-            if (!trigger)
-            {
-                lua_pushnil(L);
-                return 1;
-            }
-
-            ITrigger** userdata = static_cast<ITrigger**>(lua_newuserdata(L, sizeof(trigger.get())));
-            *userdata = trigger.get();
-            triggers[userdata] = trigger;
-
-            lua_newtable(L);
-            lua_pushcfunction(L, trigger_index);
-            lua_setfield(L, -2, "__index");
-            lua_pushcfunction(L, trigger_newindex);
-            lua_setfield(L, -2, "__newindex");
-            lua_pushcfunction(L, trigger_gc);
-            lua_setfield(L, -2, "__gc");
-            lua_setmetatable(L, -2);
-            return 1;
+            return create(L, trigger, trigger_index, trigger_newindex);
         }
 
         std::shared_ptr<ITrigger> to_trigger(lua_State* L, int index)
         {
-            luaL_checktype(L, index, LUA_TUSERDATA);
-            ITrigger** userdata = static_cast<ITrigger**>(lua_touserdata(L, index));
-            auto found = triggers.find(userdata);
-            if (found == triggers.end())
-            {
-                return {};
-            }
-            return found->second;
+            return get_self<ITrigger>(L, index);
         }
     }
 }

--- a/trview.app/Lua/Lua.h
+++ b/trview.app/Lua/Lua.h
@@ -66,6 +66,9 @@ namespace trview
         std::shared_ptr<T> get_self(lua_State* L, int index = 1);
 
         template <typename T>
+        T* get_self_raw(lua_State* L, int index = 1);
+
+        template <typename T>
         void set_self(lua_State* L, const std::shared_ptr<T>& self);
 
         /// <summary>

--- a/trview.app/Lua/Lua.h
+++ b/trview.app/Lua/Lua.h
@@ -47,9 +47,6 @@ namespace trview
         int push_list(lua_State* L, std::ranges::input_range auto&& range, Func&& func);
 
         template <typename T>
-        T* get_self(lua_State* L);
-
-        template <typename T>
         struct EnumValue
         {
             std::string name;
@@ -61,6 +58,24 @@ namespace trview
         
         template <typename T>
         void create_enum(lua_State* L, const std::string& name, const std::vector<EnumValue<T>>& values);
+
+        template <typename T>
+        int create(lua_State* L, const std::shared_ptr<T>& self, lua_CFunction index, lua_CFunction new_index);
+
+        template <typename T>
+        std::shared_ptr<T> get_self(lua_State* L, int index = 1);
+
+        template <typename T>
+        void set_self(lua_State* L, const std::shared_ptr<T>& self);
+
+        /// <summary>
+        /// GC function for cleaning up a shared_ptr.
+        /// </summary>
+        /// <typeparam name="T">Pointed to type</typeparam>
+        /// <param name="L">Lua state</param>
+        /// <returns>Stack change.</returns>
+        template <typename T>
+        int gc(lua_State* L);
     }
 }
 

--- a/trview.app/Lua/Lua.inl
+++ b/trview.app/Lua/Lua.inl
@@ -35,13 +35,6 @@ namespace trview
         }
 
         template <typename T>
-        T* get_self(lua_State* L)
-        {
-            luaL_checktype(L, 1, LUA_TUSERDATA);
-            return *static_cast<T**>(lua_touserdata(L, 1));
-        }
-
-        template <typename T>
         void set_enum_value(lua_State* L, const EnumValue<T>& value)
         {
             lua_pushinteger(L, static_cast<int>(value.value));
@@ -57,6 +50,52 @@ namespace trview
                 set_enum_value(L, v);
             }
             lua_setfield(L, -2, name.c_str());
+        }
+
+        template <typename T>
+        int create(lua_State* L, const std::shared_ptr<T>& self, lua_CFunction index, lua_CFunction new_index)
+        {
+            if (!self)
+            {
+                lua_pushnil(L);
+                return 1;
+            }
+
+            set_self(L, self);
+
+            lua_newtable(L);
+            lua_pushcfunction(L, index);
+            lua_setfield(L, -2, "__index");
+            lua_pushcfunction(L, new_index);
+            lua_setfield(L, -2, "__newindex");
+            lua_pushcfunction(L, gc<T>);
+            lua_setfield(L, -2, "__gc");
+            lua_setmetatable(L, -2);
+            return 1;
+        }
+
+        template <typename T>
+        std::shared_ptr<T> get_self(lua_State* L, int index)
+        {
+            luaL_checktype(L, index, LUA_TUSERDATA);
+            return *static_cast<std::shared_ptr<T>*>(lua_touserdata(L, index));
+        }
+
+        template <typename T>
+        void set_self(lua_State* L, const std::shared_ptr<T>& self)
+        {
+            using Ptr = std::shared_ptr<T>;
+            auto userdata = static_cast<Ptr*>(lua_newuserdata(L, sizeof(Ptr)));
+            new (userdata) Ptr(self);
+        }
+
+        template <typename T>
+        int gc(lua_State* L)
+        {
+            luaL_checktype(L, 1, LUA_TUSERDATA);
+            auto userdata = static_cast<std::shared_ptr<T>*>(lua_touserdata(L, 1));
+            userdata->~shared_ptr<T>();
+            return 0;
         }
     }
 }

--- a/trview.app/Lua/Lua.inl
+++ b/trview.app/Lua/Lua.inl
@@ -82,6 +82,13 @@ namespace trview
         }
 
         template <typename T>
+        T* get_self_raw(lua_State* L, int index)
+        {
+            luaL_checktype(L, index, LUA_TUSERDATA);
+            return *static_cast<T**>(lua_touserdata(L, index));
+        }
+
+        template <typename T>
         void set_self(lua_State* L, const std::shared_ptr<T>& self)
         {
             using Ptr = std::shared_ptr<T>;

--- a/trview.app/Lua/trview/trview.cpp
+++ b/trview.app/Lua/trview/trview.cpp
@@ -42,7 +42,7 @@ namespace trview
 
             int trview_load(lua_State* L)
             {
-                auto application = lua::get_self<IApplication>(L);
+                auto application = lua::get_self_raw<IApplication>(L);
 
                 luaL_checktype(L, -1, LUA_TSTRING);
                 const char* filename = lua_tostring(L, -1);
@@ -71,7 +71,7 @@ namespace trview
 
             int trview_index(lua_State* L)
             {
-                auto application = lua::get_self<IApplication>(L);
+                auto application = lua::get_self_raw<IApplication>(L);
 
                 const std::string key = lua_tostring(L, 2);
                 if (key == "level")
@@ -100,7 +100,7 @@ namespace trview
 
             int trview_newindex(lua_State* L)
             {
-                auto application = lua::get_self<IApplication>(L);
+                auto application = lua::get_self_raw<IApplication>(L);
 
                 const std::string key = lua_tostring(L, 2);
                 if (key == "level")


### PR DESCRIPTION
Just create a shared_ptr in the userdata instead of keeping them alive via maps. Reuse creation code for assigning `__index`, `__newindex`, `__gc` in most cases too.
Closes https://github.com/chreden/trview/issues/1168