### PR TITLE
Add room property to waypoints

### DIFF
--- a/doc/lua/waypoint.md
+++ b/doc/lua/waypoint.md
@@ -11,6 +11,7 @@ The Waypoint library lets you create and edit route waypoints.
 | notes | string | RW | Notes for this waypoint |
 | position | [Vector3](vector3.md) | RW | The position that is the target of the waypoint |
 | randomizer_settings | Table | RW | The randomizer settings for this waypoint (map of `string` to (`boolean`, `number` or `string`)) |
+| room | [Room](room.md) | RW | The room that the waypoint is in |
 | room_number | number | RW | The room number that the waypoint is in |
 | trigger | [Trigger](trigger.md) | RW | The trigger that is the target of the waypoint |
 | type | string | R | One of `Item`, `Trigger`, `Position`. Can be changed by setting `item`, `trigger` or `position`.  |

--- a/trview.app.tests/Lua/Route/Lua_WaypointTests.cpp
+++ b/trview.app.tests/Lua/Route/Lua_WaypointTests.cpp
@@ -230,6 +230,30 @@ TEST(Lua_Waypoint, RandomizerSettings)
     ASSERT_EQ(123, lua_tonumber(L, -1));
 }
 
+TEST(Lua_Waypoint, Room)
+{
+    auto room = mock_shared<MockRoom>();
+    EXPECT_CALL(*room, number).WillRepeatedly(Return(123));
+    
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, room(123)).WillRepeatedly(Return(room));
+
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, level).WillOnce(Return(level));
+
+    auto waypoint = mock_shared<MockWaypoint>();
+    EXPECT_CALL(*waypoint, route).WillOnce(Return(route));
+    EXPECT_CALL(*waypoint, room).WillOnce(Return(123));
+
+    LuaState L;
+    lua::create_waypoint(L, waypoint);
+    lua_setglobal(L, "w");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return w.room.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
 TEST(Lua_Waypoint, RoomNumber)
 {
     auto waypoint = mock_shared<MockWaypoint>();
@@ -337,6 +361,23 @@ TEST(Lua_Waypoint, SetRandomizerSettings)
 
     ASSERT_EQ("Test string", std::get<std::string>(called_settings["test"]));
     ASSERT_EQ(150.0f, std::get<float>(called_settings["test2"]));
+}
+
+TEST(Lua_Waypoint, SetRoom)
+{
+    auto room = mock_shared<MockRoom>();
+    EXPECT_CALL(*room, number).WillRepeatedly(Return(123));
+
+    auto waypoint = mock_shared<MockWaypoint>();
+    EXPECT_CALL(*waypoint, set_room_number(123)).Times(1);
+
+    LuaState L;
+    lua::create_waypoint(L, waypoint);
+    lua_setglobal(L, "w");
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "w.room = r"));
 }
 
 TEST(Lua_Waypoint, SetRoomNumber)

--- a/trview.app/Lua/Route/Lua_Waypoint.cpp
+++ b/trview.app/Lua/Route/Lua_Waypoint.cpp
@@ -94,6 +94,18 @@ namespace trview
                     }
                     return 1;
                 }
+                else if (key == "room")
+                {
+                    if (auto route = waypoint->route().lock())
+                    {
+                        if (auto level = route->level().lock())
+                        {
+                            return create_room(L, level->room(waypoint->room()).lock());
+                        }
+                    }
+                    lua_pushnil(L);
+                    return 1;
+                }
                 else if (key == "room_number")
                 {
                     lua_pushinteger(L, waypoint->room());
@@ -232,6 +244,14 @@ namespace trview
                     }
 
                     waypoint->set_randomizer_settings(new_settings);
+                }
+                else if (key == "room")
+                {
+                    if (auto room = to_room(L, 3))
+                    {
+                        waypoint->set_room_number(room->number());
+                    }
+                    return 0;
                 }
                 else if (key == "room_number")
                 {


### PR DESCRIPTION
Return room when available.
Only available when bound to a level and when the room number is valid.
Closes #1148