### PR TITLE
Add floordata bindings to Sector and Level

### DIFF
--- a/doc/lua/level.md
+++ b/doc/lua/level.md
@@ -8,7 +8,7 @@ The Level library provides information about the currently loaded Level in trvie
 | alternate_mode | boolean | RW | Whether the level flipmap is enabled (TR1-3) |
 | cameras_and_sinks | [CameraSink](camera_sink.md)[] | R | All cameras/sinks in the level |
 | filename | string | R | The path of the level file |
-| floordata | Table | R | All floordata |
+| floordata | Table of number  | R | All floordata |
 | items | [Item](item.md)[] | R | All items |
 | lights | [Light](light.md)[] | R | All lights |
 | rooms | [Room](room.md)[] | R | All rooms |

--- a/doc/lua/sector.md
+++ b/doc/lua/sector.md
@@ -11,6 +11,7 @@ The Sector library provides information about a sector in a [Level](level.md)/[R
 | ceiling_triangulation | string | R | Ceiling triangulation direction (`None`/`NWSE`/`NESW`) |
 | corners | number[] | R | Height of corners in clicks above room floor |
 | flags | [Flags](#flags)| R | Sector flags |
+| floordata | Table of number | R | Raw floordata values for the sector |
 | number | number | R | Sector number |
 | portal | [Room](room.md) | R | Destination room for portal or `nil` |
 | room | [Room](room.md) | R | Room that the sector is in |

--- a/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
@@ -82,7 +82,9 @@ TEST(Lua_Level, Filename)
 
 TEST(Lua_Level, Floordata)
 {
+    std::vector<uint16_t> data { 0, 0x8004, 0x3e00, 0x0005, 0x0001, 0x0002, 0x8003 };
     auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, floor_data).WillRepeatedly(Return(data));
 
     LuaState L;
     lua::create_level(L, level);
@@ -90,6 +92,13 @@ TEST(Lua_Level, Floordata)
 
     ASSERT_EQ(0, luaL_dostring(L, "return l.floordata"));
     ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+
+    for (std::size_t i = 0; i < data.size(); ++i)
+    {
+        lua_rawgeti(L, -1, i + 1);
+        ASSERT_EQ(lua_tointeger(L, -1), data[i]);
+        lua_pop(L, 1);
+    }
 }
 
 TEST(Lua_Level, Items)

--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -35,8 +35,13 @@ namespace trview
                 }
                 else if (key == "floordata")
                 {
-                    lua_newtable(L);
-                    // TODO: Floordata
+                    const auto data = level->floor_data();
+                    lua_createtable(L, static_cast<int>(data.size()), 0);
+                    for (auto i = 0u; i < data.size(); ++i)
+                    {
+                        lua_pushinteger(L, data[i]);
+                        lua_rawseti(L, -2, i + 1);
+                    }
                     return 1;
                 }
                 else if (key == "items")


### PR DESCRIPTION
Add raw floordata bindings for `Sector` and for `Level`.
Closes #1116 