### PR TITLE
TR1 PlayStation support

### DIFF
--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -13,7 +13,7 @@ namespace trlevel
     // Interface that defines a level.
     struct ILevel
     {
-        using Source = std::function<std::unique_ptr<ILevel>(const std::string&)>;
+        using Source = std::function<std::shared_ptr<ILevel>(const std::string&)>;
 
         virtual ~ILevel() = 0;
 
@@ -71,10 +71,6 @@ namespace trlevel
         // index: The index of the texture to get.
         // Returns: The object texture.
         virtual tr_object_texture get_object_texture(uint32_t index) const = 0;
-
-        virtual std::vector<tr_object_texture_psx> get_object_textures_psx() const = 0;
-        virtual std::vector<tr_clut> get_clut() const = 0;
-        virtual std::vector<tr_textile4> get_textile4s() const = 0;
 
         /// Get the number of floordata values in the level.
         /// @returns The number of floordata values.
@@ -181,5 +177,7 @@ namespace trlevel
 
         virtual uint32_t num_cameras() const = 0;
         virtual tr_camera get_camera(uint32_t index) const = 0;
+
+        virtual Platform platform() const = 0;
     };
 }

--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -72,6 +72,10 @@ namespace trlevel
         // Returns: The object texture.
         virtual tr_object_texture get_object_texture(uint32_t index) const = 0;
 
+        virtual std::vector<tr_object_texture_psx> get_object_textures_psx() const = 0;
+        virtual std::vector<tr_clut> get_clut() const = 0;
+        virtual std::vector<tr_textile4> get_textile4s() const = 0;
+
         /// Get the number of floordata values in the level.
         /// @returns The number of floordata values.
         virtual uint32_t num_floor_data() const = 0;

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -549,8 +549,8 @@ namespace trlevel
                     }
                 }
 
-                auto rectangles = read_vector<int16_t, tr_face4>(stream);
-                auto triangles = read_vector<int16_t, tr_face3>(stream);
+                const auto rectangles = read_vector<int16_t, tr_face4>(stream);
+                const auto triangles = read_vector<int16_t, tr_face3>(stream);
 
                 mesh.textured_rectangles = rectangles
                     | std::views::filter([](const auto& rect) { return rect.texture > 255; })

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -1111,37 +1111,6 @@ namespace trlevel
             _static_meshes.insert({ mesh.ID, mesh });
         }
 
-        auto convert_textile4 = [this](uint16_t tile, uint16_t clut_id) -> uint16_t
-        {
-            // Check if we've already converted this tile + clut
-            for (auto i = _converted_t16.begin(); i < _converted_t16.end(); ++i)
-            {
-                if (i->first == tile && i->second == clut_id)
-                {
-                    return static_cast<uint16_t>(std::distance(_converted_t16.begin(), i));
-                }
-            }
-            // If not, create new conversion
-            _converted_t16.push_back(std::make_pair(tile, clut_id));
-
-            const tr_textile4 tile4 = get_textile4(tile);
-            const tr_clut clut = get_clut(clut_id);
-            tr_textile16 tile16;
-            for (int x = 0; x < 256; ++x)
-            {
-                for (int y = 0; y < 256; ++y)
-                {
-                    const std::size_t pixel = (y * 256 + x);
-                    const tr_colorindex4& index = tile4.Tile[pixel / 2];
-                    const tr_rgba5551& colour = clut.Colour[(x % 2) ? index.b : index.a];
-                    tile16.Tile[pixel] = (colour.Alpha << 15) | (colour.Red << 10) | (colour.Green << 5) | colour.Blue;
-                }
-            }
-            _textile16.push_back(tile16);
-            _num_textiles = static_cast<uint32_t>(_textile16.size());
-            return static_cast<uint16_t>(_textile16.size() - 1);
-        };
-
         if (get_version() < LevelVersion::Tomb3)
         {
             activity.log("Reading object textures");
@@ -1484,4 +1453,35 @@ namespace trlevel
             .Blue = static_cast<uint8_t>(std::min(1.0f, b) * 255)
         };
     }
+
+    uint16_t Level::convert_textile4(uint16_t tile, uint16_t clut_id)
+    {
+        // Check if we've already converted this tile + clut
+        for (auto i = _converted_t16.begin(); i < _converted_t16.end(); ++i)
+        {
+            if (i->first == tile && i->second == clut_id)
+            {
+                return static_cast<uint16_t>(std::distance(_converted_t16.begin(), i));
+            }
+        }
+        // If not, create new conversion
+        _converted_t16.push_back(std::make_pair(tile, clut_id));
+
+        const tr_textile4 tile4 = get_textile4(tile);
+        const tr_clut clut = get_clut(clut_id);
+        tr_textile16 tile16;
+        for (int x = 0; x < 256; ++x)
+        {
+            for (int y = 0; y < 256; ++y)
+            {
+                const std::size_t pixel = (y * 256 + x);
+                const tr_colorindex4& index = tile4.Tile[pixel / 2];
+                const tr_rgba5551& colour = clut.Colour[(x % 2) ? index.b : index.a];
+                tile16.Tile[pixel] = (colour.Alpha << 15) | (colour.Red << 10) | (colour.Green << 5) | colour.Blue;
+            }
+        }
+        _textile16.push_back(tile16);
+        _num_textiles = static_cast<uint32_t>(_textile16.size());
+        return static_cast<uint16_t>(_textile16.size() - 1);
+    };
 }

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -1467,9 +1467,10 @@ namespace trlevel
         // If not, create new conversion
         _converted_t16.push_back(std::make_pair(tile, clut_id));
 
-        const tr_textile4 tile4 = get_textile4(tile);
-        const tr_clut clut = get_clut(clut_id);
-        tr_textile16 tile16;
+        const tr_textile4& tile4 = _textile4[tile];
+        const tr_clut& clut = _clut[clut_id];
+
+        tr_textile16& tile16 = _textile16.emplace_back();
         for (int x = 0; x < 256; ++x)
         {
             for (int y = 0; y < 256; ++y)
@@ -1480,7 +1481,6 @@ namespace trlevel
                 tile16.Tile[pixel] = (colour.Alpha << 15) | (colour.Red << 10) | (colour.Green << 5) | colour.Blue;
             }
         }
-        _textile16.push_back(tile16);
         _num_textiles = static_cast<uint32_t>(_textile16.size());
         return static_cast<uint16_t>(_textile16.size() - 1);
     };

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -1177,19 +1177,6 @@ namespace trlevel
                             };
                         })
                     | std::ranges::to<std::vector>();
-                        /*
-
-                for (auto& texture : textures)
-                {
-                    texture.Tile = convert_textile4(texture.Tile, texture.Clut);
-                    texture.Clut = 0U; // Unneeded after conversion
-                    if (texture.x3 || texture.y3)
-                    {
-                        std::swap(texture.x2, texture.x3);
-                        std::swap(texture.y2, texture.y3);
-                    }
-                }
-                _level->_object_textures = convert_object_textures(textures);*/
             }
             else
             {
@@ -1341,9 +1328,9 @@ namespace trlevel
             activity.log("Read light map");
         }
 
-        if (_platform_and_version.platform == Platform::PSX)
+        if (_platform_and_version.platform == Platform::PSX &&
+            get_version() == LevelVersion::Tomb1)
         {
-            _palette.resize(256);
             return;
         }
 

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -415,6 +415,10 @@ namespace trlevel
             _platform_and_version = convert_level_version(raw_version);
 
             activity.log(std::format("Version number is {:X} ({}), Platform is {}", raw_version, to_string(get_version()), to_string(platform())));
+            if (_platform_and_version.version == LevelVersion::Unknown)
+            {
+                throw LevelLoadException(std::format("Unknown level version ({})", raw_version));
+            }
 
             if (raw_version == 0x63345254)
             {
@@ -491,7 +495,7 @@ namespace trlevel
         catch (const std::exception& e)
         {
             activity.log(trview::Message::Status::Error, std::format("Level failed to load: {}", e.what()));
-            throw LevelLoadException();
+            throw LevelLoadException(e.what());
         }
     }
 

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -2,6 +2,7 @@
 #include "LevelLoadException.h"
 #include "LevelEncryptedException.h"
 #include <format>
+#include <ranges>
 
 namespace trlevel
 {
@@ -105,7 +106,7 @@ namespace trlevel
             skip(file, 4);
         }
 
-        void load_tr1_4_room(trview::Activity& activity, std::istream& file, tr3_room& room, LevelVersion version)
+        void load_tr1_4_room(trview::Activity& activity, std::istream& file, tr3_room& room, PlatformAndVersion platform_and_version)
         {
             activity.log("Reading room info");
             room.info = convert_room_info(read<tr1_4_room_info>(file));
@@ -115,15 +116,21 @@ namespace trlevel
             uint32_t NumDataWords = read<uint32_t>(file);
             activity.log(std::format("{} data words to process", NumDataWords));
 
+            if (platform_and_version.platform == Platform::PSX &&
+                platform_and_version.version == LevelVersion::Tomb1)
+            {
+                skip(file, 2);
+            }
+
             // Read actual room data.
             if (NumDataWords > 0)
             {
                 activity.log("Reading vertices");
-                if (version == LevelVersion::Tomb1)
+                if (platform_and_version.version == LevelVersion::Tomb1)
                 {
                     room.data.vertices = convert_vertices(read_vector<int16_t, tr_room_vertex>(file));
                 }
-                else if (version == LevelVersion::Tomb2)
+                else if (platform_and_version.version == LevelVersion::Tomb2)
                 {
                     room.data.vertices = convert_vertices(read_vector<int16_t, tr2_room_vertex>(file));
                 }
@@ -158,7 +165,7 @@ namespace trlevel
             room.sector_list = read_vector<tr_room_sector>(file, room.num_z_sectors * room.num_x_sectors);
             activity.log(std::format("Read {} sectors", room.sector_list.size()));
 
-            if (version == LevelVersion::Tomb4)
+            if (platform_and_version.version == LevelVersion::Tomb4)
             {
                 activity.log("Reading room colour");
                 room.colour = read<uint32_t>(file);
@@ -170,7 +177,7 @@ namespace trlevel
                 room.ambient_intensity_1 = read<int16_t>(file);
                 activity.log(std::format("Read ambient intensity 1: {}", room.ambient_intensity_1));
 
-                if (version == LevelVersion::Tomb2)
+                if (platform_and_version.version == LevelVersion::Tomb2)
                 {
                     activity.log("Reading ambient intensity 2");
                     room.ambient_intensity_2 = read<int16_t>(file);
@@ -178,8 +185,8 @@ namespace trlevel
                 }
             }
 
-            if (version == LevelVersion::Tomb2 ||
-                version == LevelVersion::Tomb3)
+            if (platform_and_version.version == LevelVersion::Tomb2 ||
+                platform_and_version.version == LevelVersion::Tomb3)
             {
                 activity.log("Reading light mode");
                 room.light_mode = read<int16_t>(file);
@@ -187,11 +194,18 @@ namespace trlevel
             }
 
             activity.log("Reading lights");
-            switch (version)
+            switch (platform_and_version.version)
             {
             case LevelVersion::Tomb1:
             {
-                room.lights = convert_lights(read_vector<uint16_t, tr_room_light>(file));
+                if (platform_and_version.platform == Platform::PSX)
+                {
+                    room.lights = convert_lights(read_vector<uint16_t, tr_room_light_psx>(file));
+                }
+                else
+                {
+                    room.lights = convert_lights(read_vector<uint16_t, tr_room_light>(file));
+                }
                 break;
             }
             case LevelVersion::Tomb2:
@@ -213,9 +227,16 @@ namespace trlevel
             activity.log(std::format("Read {} lights", room.lights.size()));
 
             activity.log("Reading static meshes");
-            if (version == LevelVersion::Tomb1)
+            if (platform_and_version.version == LevelVersion::Tomb1)
             {
-                room.static_meshes = convert_room_static_meshes(read_vector<uint16_t, tr_room_staticmesh>(file));
+                if (platform_and_version.platform == Platform::PSX)
+                {
+                    room.static_meshes = convert_room_static_meshes(read_vector<uint16_t, tr_room_staticmesh_psx>(file));
+                }
+                else
+                {
+                    room.static_meshes = convert_room_static_meshes(read_vector<uint16_t, tr_room_staticmesh>(file));
+                }
             }
             else
             {
@@ -230,7 +251,7 @@ namespace trlevel
             room.flags = read<int16_t>(file);
             activity.log(std::format("Read flags: {:X}", room.flags));
 
-            if (version >= LevelVersion::Tomb3)
+            if (platform_and_version.version >= LevelVersion::Tomb3)
             {
                 activity.log("Reading water scheme");
                 room.water_scheme = read<uint8_t>(file);
@@ -383,8 +404,9 @@ namespace trlevel
 
             activity.log("Reading version number from file");
             uint32_t raw_version = read<uint32_t>(file);
-            _version = convert_level_version(raw_version);
-            activity.log(std::format("Version number is {:X} ({})", raw_version, to_string(_version)));
+            _platform_and_version = convert_level_version(raw_version);
+
+            activity.log(std::format("Version number is {:X} ({}), Platform is {}", raw_version, to_string(get_version()), to_string(platform())));
 
             if (raw_version == 0x63345254)
             {
@@ -393,23 +415,23 @@ namespace trlevel
 
                 file = std::stringstream(std::string(bytes.value().begin(), bytes.value().end()), std::ios::in | std::ios::binary);
                 raw_version = read<uint32_t>(file);
-                _version = convert_level_version(raw_version);
-                activity.log(std::format("Version number is {:X} ({})", raw_version, to_string(_version)));
+                _platform_and_version = convert_level_version(raw_version);
+                activity.log(std::format("Version number is {:X} ({})", raw_version, to_string(get_version())));
             }
 
-            if (is_tr5(activity, _version, converted))
+            if (is_tr5(activity, get_version(), converted))
             {
-                _version = LevelVersion::Tomb5;
-                activity.log(std::format("Version number is {:X} ({})", raw_version, to_string(_version)));
+                _platform_and_version.version = LevelVersion::Tomb5;
+                activity.log(std::format("Version number is {:X} ({})", raw_version, to_string(get_version())));
             }
 
-            if (_version >= LevelVersion::Tomb4)
+            if (get_version() >= LevelVersion::Tomb4)
             {
                 load_tr4(activity, file);
                 return;
             }
 
-            if (_version > LevelVersion::Tomb1)
+            if (get_version() > LevelVersion::Tomb1)
             {
                 activity.log("Reading 8-bit palette");
                 _palette = read_vector<tr_colour>(file, 256);
@@ -417,17 +439,39 @@ namespace trlevel
                 _palette16 = read_vector<tr_colour4>(file, 256);
             }
 
-            activity.log("Reading textiles");
-            _num_textiles = read<uint32_t>(file);
-            activity.log(std::format("Reading {} 8-bit textiles", _num_textiles));
-            _textile8 = read_vector<tr_textile8>(file, _num_textiles);
+            if (_platform_and_version.platform == Platform::PSX)
+            {
+                if (_platform_and_version.version == LevelVersion::Tomb1)
+                {
+                    skip(file, 12);
+                    uint32_t textile_address = read<uint32_t>(file);
+                    file.seekg(textile_address + 8, std::ios::beg);
+                }
+            }
 
-            if (_version > LevelVersion::Tomb1)
+            activity.log("Reading textiles");
+            if (_platform_and_version.platform == Platform::PSX)
+            {
+                auto at = file.tellg();
+                _num_textiles = 13;
+                _textile4 = read_vector<tr_textile4>(file, 13);
+                _clut = read_vector<tr_clut>(file, 1024);
+                activity.log(std::format("Read {} textile4s and {} clut", _textile4.size(), _clut.size()));
+            }
+            else
+            {
+                _num_textiles = read<uint32_t>(file);
+                activity.log(std::format("Reading {} 8-bit textiles", _num_textiles));
+                _textile8 = read_vector<tr_textile8>(file, _num_textiles);
+            }
+
+            if (get_version() > LevelVersion::Tomb1)
             {
                 activity.log(std::format("Reading {} 16-bit textiles", _num_textiles));
                 _textile16 = read_vector<tr_textile16>(file, _num_textiles);
             }
 
+            auto at = file.tellg();
             load_level_data(activity, file);
             generate_meshes(_mesh_data);
         }
@@ -473,29 +517,84 @@ namespace trlevel
             tr_mesh mesh;
             mesh.centre = read<tr_vertex>(stream);
             mesh.coll_radius = read<int32_t>(stream);
-            mesh.vertices = read_vector<int16_t, tr_vertex>(stream);
 
-            int16_t normals = read<int16_t>(stream);
-            if (normals > 0)
+            if (_platform_and_version.platform == Platform::PSX)
             {
-                mesh.normals = read_vector<tr_vertex>(stream, normals);
-            }
-            else
-            {
-                mesh.lights = read_vector<int16_t>(stream, abs(normals));
-            }
+                int16_t vertices_count = read<int16_t>(stream);
+                int16_t normals_count = vertices_count;
+                vertices_count = static_cast<int16_t>(std::abs(vertices_count));
 
-            if (_version < LevelVersion::Tomb4)
-            {
+                mesh.vertices = convert_vertices(read_vector<tr_vertex_psx>(stream, vertices_count));
+
+                for (int i = 0; i < vertices_count; ++i)
+                {
+                    if (normals_count > 0)
+                    {
+                        tr_vertex_psx norm = read<tr_vertex_psx>(stream);
+                        norm.w = 1;
+                        mesh.normals.push_back({ norm.x, norm.y, norm.z });
+                    }
+                    else
+                    {
+                        mesh.lights.push_back(read<int16_t>(stream)); // intensity
+                        mesh.normals.push_back({ 0, 0, 0 });
+                    }
+                }
+
+                // if (_version == LevelVersion::Tomb2 && normals_count > 0)
+                // {
+                //     const uint16_t face4_count = read<uint16_t>(stream);
+                //     _data->seekg(12 * face4_count, SEEK_CUR);
+                //     const uint16_t face3_count = read<uint16_t>(stream);
+                //     _data->seekg(10 * face4_count, SEEK_CUR);
+                // }
+
                 mesh.textured_rectangles = convert_rectangles(read_vector<int16_t, tr_face4>(stream));
                 mesh.textured_triangles = convert_triangles(read_vector<int16_t, tr_face3>(stream));
-                mesh.coloured_rectangles = read_vector<int16_t, tr_face4>(stream);
-                mesh.coloured_triangles = read_vector<int16_t, tr_face3>(stream);
+                // if (_platform_and_version.version == LevelVersion::Tomb2)
+                // {
+                //     for (auto& mesh : mesh.textured_rectangles)
+                //     {
+                //         for (int i = 0; i < 4; ++i)
+                //         {
+                //             mesh.vertices[i] >>= 3;
+                //         }
+                //     }
+                //     for (auto& mesh : mesh.textured_triangles)
+                //     {
+                //         for (int i = 0; i < 3; ++i)
+                //         {
+                //             mesh.vertices[i] >>= 3;
+                //         }
+                //     }
+                // }
             }
             else
             {
-                mesh.textured_rectangles = read_vector<int16_t, tr4_mesh_face4>(stream);
-                mesh.textured_triangles = read_vector<int16_t, tr4_mesh_face3>(stream);
+                mesh.vertices = read_vector<int16_t, tr_vertex>(stream);
+
+                int16_t normals = read<int16_t>(stream);
+                if (normals > 0)
+                {
+                    mesh.normals = read_vector<tr_vertex>(stream, normals);
+                }
+                else
+                {
+                    mesh.lights = read_vector<int16_t>(stream, abs(normals));
+                }
+
+                if (get_version() < LevelVersion::Tomb4)
+                {
+                    mesh.textured_rectangles = convert_rectangles(read_vector<int16_t, tr_face4>(stream));
+                    mesh.textured_triangles = convert_triangles(read_vector<int16_t, tr_face3>(stream));
+                    mesh.coloured_rectangles = read_vector<int16_t, tr_face4>(stream);
+                    mesh.coloured_triangles = read_vector<int16_t, tr_face3>(stream);
+                }
+                else
+                {
+                    mesh.textured_rectangles = read_vector<int16_t, tr4_mesh_face4>(stream);
+                    mesh.textured_triangles = read_vector<int16_t, tr4_mesh_face3>(stream);
+                }
             }
 
             _meshes.insert({ pointer, mesh });
@@ -726,7 +825,7 @@ namespace trlevel
 
         // Tomb Raider I has the mesh count in the frame structure - all other tombs
         // already know based on the number of meshes.
-        if (_version == LevelVersion::Tomb1)
+        if (get_version() == LevelVersion::Tomb1)
         {
             mesh_count = _frames[offset++];
         }
@@ -740,7 +839,7 @@ namespace trlevel
             uint16_t mode = 0;
 
             // Tomb Raider I has reversed words and always uses the two word format.
-            if (_version == LevelVersion::Tomb1)
+            if (get_version() == LevelVersion::Tomb1)
             {
                 next = _frames[offset++];
                 data = _frames[offset++];
@@ -758,7 +857,7 @@ namespace trlevel
             if (mode)
             {
                 float angle = 0;
-                if (_version >= LevelVersion::Tomb4)
+                if (get_version() >= LevelVersion::Tomb4)
                 {
                     angle = (data & 0x0fff) * PiMul2 / 4096.0f;
                 }
@@ -793,7 +892,7 @@ namespace trlevel
 
     LevelVersion Level::get_version() const 
     {
-        return _version;
+        return _platform_and_version.version;
     }
 
     bool Level::get_sprite_sequence_by_id(int32_t sprite_sequence_id, tr_sprite_sequence& output) const
@@ -855,7 +954,7 @@ namespace trlevel
             _textile32.clear();
         }
 
-        if (_version == LevelVersion::Tomb5)
+        if (get_version() == LevelVersion::Tomb5)
         {
             activity.log("Reading Lara type");
             _lara_type = read<uint16_t>(file);
@@ -867,7 +966,7 @@ namespace trlevel
             file.seekg(28, std::ios::cur);
         }
 
-        if (_version == LevelVersion::Tomb4)
+        if (get_version() == LevelVersion::Tomb4)
         {
             activity.log("Reading and decompressing level data");
             std::vector<uint8_t> level_data = read_compressed(file);
@@ -901,7 +1000,7 @@ namespace trlevel
 
         activity.log("Reading number of rooms");
         uint32_t num_rooms = 0;
-        if (_version == LevelVersion::Tomb5)
+        if (get_version() == LevelVersion::Tomb5)
         {
             num_rooms = read<uint32_t>(file);
         }
@@ -916,13 +1015,13 @@ namespace trlevel
             trview::Activity room_activity(activity, std::format("Room {}", i));
             room_activity.log(std::format("Reading room {}", i));
             tr3_room room;
-            if (_version == LevelVersion::Tomb5)
+            if (get_version() == LevelVersion::Tomb5)
             {
                 load_tr5_room(room_activity, file, room);
             }
             else
             {
-                load_tr1_4_room(room_activity, file, room, _version);
+                load_tr1_4_room(room_activity, file, room, _platform_and_version);
             }
             room_activity.log(std::format("Read room {}", i));
             _rooms.push_back(room);
@@ -941,7 +1040,7 @@ namespace trlevel
         activity.log(std::format("Read {} mesh pointers", _mesh_pointers.size()));
 
         activity.log("Reading animations");
-        if (_version >= LevelVersion::Tomb4)
+        if (get_version() >= LevelVersion::Tomb4)
         {
             auto animations = read_vector<uint32_t, tr4_animation>(file);
         }
@@ -971,9 +1070,12 @@ namespace trlevel
         activity.log(std::format("Read {} frames", _frames.size()));
 
         activity.log("Reading models");
-        if (_version < LevelVersion::Tomb5)
+        if (get_version() < LevelVersion::Tomb5)
         {
-            _models = read_vector<uint32_t, tr_model>(file);
+            _models = 
+                _platform_and_version.platform == Platform::PSX ?
+                    convert_models(read_vector<uint32_t, tr_model_psx>(file)) :
+                    read_vector<uint32_t, tr_model>(file);
         }
         else
         {
@@ -989,19 +1091,99 @@ namespace trlevel
             _static_meshes.insert({ mesh.ID, mesh });
         }
 
+        auto convert_textile4 = [this](uint16_t tile, uint16_t clut_id) -> uint16_t
+        {
+            // Check if we've already converted this tile + clut
+            for (auto i = _converted_t16.begin(); i < _converted_t16.end(); ++i)
+            {
+                if (i->first == tile && i->second == clut_id)
+                {
+                    return static_cast<uint16_t>(std::distance(_converted_t16.begin(), i));
+                }
+            }
+            // If not, create new conversion
+            _converted_t16.push_back(std::make_pair(tile, clut_id));
+
+            const tr_textile4& tile4 = get_textile4(tile);
+            const tr_clut& clut = get_clut(clut_id);
+            tr_textile16 tile16;
+            for (int x = 0; x < 256; ++x)
+                for (int y = 0; y < 256; ++y)
+                {
+                    const std::size_t pixel = (y * 256 + x);
+                    const tr_colorindex4& index = tile4.Tile[pixel / 2];
+                    const tr_rgba5551& colour = clut.Colour[(x % 2) ? index.b : index.a];
+                    tile16.Tile[pixel] = (colour.Alpha << 15) | (colour.Red << 10) | (colour.Green << 5) | colour.Blue;
+                }
+            _textile16.push_back(tile16);
+            _num_textiles = static_cast<uint32_t>(_textile16.size());
+            return static_cast<uint16_t>(_textile16.size() - 1);
+        };
+
         if (get_version() < LevelVersion::Tomb3)
         {
             activity.log("Reading object textures");
-            _object_textures = read_vector<uint32_t, tr_object_texture>(file);
+            if (_platform_and_version.platform == Platform::PSX)
+            {
+                auto textures = read_vector<uint32_t, tr_object_texture_psx>(file);
+                _object_textures = textures
+                    | std::views::transform([&](const auto texture)
+                        {
+                            tr_object_texture_psx new_texture = texture;
+                            new_texture.Tile = convert_textile4(texture.Tile, texture.Clut);
+                            new_texture.Clut = 0U; // Unneeded after conversion
+                            if (texture.x3 || texture.y3)
+                            {
+                                std::swap(new_texture.x2, new_texture.x3);
+                                std::swap(new_texture.y2, new_texture.y3);
+                            }
+                            return texture;
+                        })
+                    | std::views::transform([&](const auto texture) -> tr_object_texture
+                        {
+                            return
+                            {
+                                .Attribute = texture.Attribute,
+                                .TileAndFlag = texture.Tile,//convert_textile4(texture.Tile, texture.Clut),
+                                .Vertices = 
+                                {
+                                    { 0, texture.x0, 0, texture.y0 },
+                                    { 0, texture.x1, 0, texture.y1 },
+                                    { 0, texture.x2, 0, texture.y2 },
+                                    { 0, texture.x3, 0, texture.y3 }
+                                }
+                            };
+                        })
+                    | std::ranges::to<std::vector>();
+                        /*
+
+                for (auto& texture : textures)
+                {
+                    texture.Tile = convert_textile4(texture.Tile, texture.Clut);
+                    texture.Clut = 0U; // Unneeded after conversion
+                    if (texture.x3 || texture.y3)
+                    {
+                        std::swap(texture.x2, texture.x3);
+                        std::swap(texture.y2, texture.y3);
+                    }
+                }
+                _level->_object_textures = convert_object_textures(textures);*/
+            }
+            else
+            {
+                _object_textures = read_vector<uint32_t, tr_object_texture>(file);
+            }
+            
+            
             activity.log(std::format("Read {} object textures", _object_textures.size()));
         }
 
-        if (_version >= LevelVersion::Tomb4)
+        if (get_version() >= LevelVersion::Tomb4)
         {
             activity.log("Skipping SPR marker");
             // Skip past the 'SPR' marker.
             file.seekg(3, std::ios::cur);
-            if (_version == LevelVersion::Tomb5)
+            if (get_version() == LevelVersion::Tomb5)
             {
                 activity.log("Skipping SPR null terminator");
                 skip(file, 1);
@@ -1009,7 +1191,23 @@ namespace trlevel
         }
 
         activity.log("Reading sprite textures");
-        _sprite_textures = read_vector<uint32_t, tr_sprite_texture>(file);
+        if (_platform_and_version.platform == Platform::PSX)
+        {
+            auto textures = read_vector<uint32_t, tr_sprite_texture_psx>(file);
+            _sprite_textures = textures
+                | std::views::transform([&](const auto texture) -> tr_sprite_texture
+                    {
+                        const uint16_t tile = convert_textile4(texture.Tile, texture.Clut);
+                        const uint16_t width = (texture.u1 - texture.u0) * 256 + 255;
+                        const uint16_t height = (texture.v1 - texture.v0) * 256 + 255;
+                        return { tile, texture.u0, texture.v0, width, height, texture.LeftSide, texture.TopSide, texture.RightSide, texture.BottomSide };
+                    })
+                | std::ranges::to<std::vector>();
+        }
+        else
+        {
+            _sprite_textures = read_vector<uint32_t, tr_sprite_texture>(file);
+        }
         activity.log(std::format("Read {} sprite textures", _sprite_textures.size()));
         activity.log("Reading sprite sequences");
         _sprite_sequences = read_vector<uint32_t, tr_sprite_sequence>(file);
@@ -1022,7 +1220,7 @@ namespace trlevel
         _cameras = read_vector<uint32_t, tr_camera>(file);
         activity.log(std::format("Read {} cameras", _cameras.size()));
 
-        if (_version >= LevelVersion::Tomb4)
+        if (get_version() >= LevelVersion::Tomb4)
         {
             activity.log("Reading flyby cameras");
             std::vector<tr4_flyby_camera> flyby_cameras = read_vector<uint32_t, tr4_flyby_camera>(file);
@@ -1035,7 +1233,7 @@ namespace trlevel
 
         uint32_t num_boxes = 0;
         activity.log("Reading boxes");
-        if (_version == LevelVersion::Tomb1)
+        if (get_version() == LevelVersion::Tomb1)
         {
             std::vector<tr_box> boxes = read_vector<uint32_t, tr_box>(file);
             num_boxes = static_cast<uint32_t>(boxes.size());
@@ -1052,7 +1250,7 @@ namespace trlevel
         activity.log(std::format("Read {} overlaps", overlaps.size()));
 
         activity.log("Reading zones");
-        if (_version == LevelVersion::Tomb1)
+        if (get_version() == LevelVersion::Tomb1)
         {
             std::vector<int16_t> zones = read_vector<int16_t>(file, num_boxes * 6);
             activity.log(std::format("Read {} zones", zones.size()));
@@ -1067,7 +1265,7 @@ namespace trlevel
         std::vector<uint16_t> animated_textures = read_vector<uint32_t, uint16_t>(file);
         activity.log(std::format("Read {} animated textures", animated_textures.size()));
 
-        if (_version >= LevelVersion::Tomb4)
+        if (get_version() >= LevelVersion::Tomb4)
         {
             // Animated textures uv count - not yet used:
             activity.log("Reading animated textures UV count");
@@ -1076,7 +1274,7 @@ namespace trlevel
 
             activity.log("Skipping TEX marker");
             file.seekg(3, std::ios::cur);
-            if (_version == LevelVersion::Tomb5)
+            if (get_version() == LevelVersion::Tomb5)
             {
                 activity.log("Skipping TEX null terminator");
                 skip(file, 1);
@@ -1103,7 +1301,7 @@ namespace trlevel
         }
 
         activity.log("Reading entities");
-        if (_version == LevelVersion::Tomb1)
+        if (get_version() == LevelVersion::Tomb1)
         {
             _entities = convert_entities(read_vector<uint32_t, tr_entity>(file));
         }
@@ -1114,28 +1312,34 @@ namespace trlevel
         }
         activity.log(std::format("Read {} entities", _entities.size()));
 
-        if (_version < LevelVersion::Tomb4)
+        if (get_version() < LevelVersion::Tomb4)
         {
             activity.log("Reading light map");
             std::vector<uint8_t> light_map = read_vector<uint8_t>(file, 32 * 256);
             activity.log("Read light map");
         }
 
-        if (_version == LevelVersion::Tomb1)
+        if (_platform_and_version.platform == Platform::PSX)
+        {
+            _palette.resize(256);
+            return;
+        }
+
+        if (get_version() == LevelVersion::Tomb1)
         {
             activity.log("Reading 8-bit palette");
             _palette = read_vector<tr_colour>(file, 256);
             activity.log("Read 8-bit palette");
         }
 
-        if (_version >= LevelVersion::Tomb4)
+        if (get_version() >= LevelVersion::Tomb4)
         {
             activity.log("Reading AI objects");
             _ai_objects = read_vector<uint32_t, tr4_ai_object>(file);
             activity.log(std::format("Read {} AI objects", _ai_objects.size()));
         }
 
-        if (_version < LevelVersion::Tomb4)
+        if (get_version() < LevelVersion::Tomb4)
         {
             activity.log("Reading cinematic frames");
             std::vector<tr_cinematic_frame> cinematic_frames = read_vector<uint16_t, tr_cinematic_frame>(file);
@@ -1147,15 +1351,15 @@ namespace trlevel
         activity.log(std::format("Read {} demo data", demo_data.size()));
 
         activity.log("Reading sound map");
-        if (_version == LevelVersion::Tomb1)
+        if (get_version() == LevelVersion::Tomb1)
         {
             std::vector<int16_t> sound_map = read_vector<int16_t>(file, 256);
         }
-        else if (_version < LevelVersion::Tomb4)
+        else if (get_version() < LevelVersion::Tomb4)
         {
             std::vector<int16_t> sound_map = read_vector<int16_t>(file, 370);
         }
-        else if (_version == LevelVersion::Tomb4)
+        else if (get_version() == LevelVersion::Tomb4)
         {
             if (demo_data.size() == 2048)
             {
@@ -1176,14 +1380,14 @@ namespace trlevel
         std::vector<tr3_sound_details> sound_details = read_vector<uint32_t, tr3_sound_details>(file);
         activity.log(std::format("Read {} sound details", sound_details.size()));
 
-        if (_version == LevelVersion::Tomb1)
+        if (get_version() == LevelVersion::Tomb1)
         {
             activity.log("Reading sound data");
             std::vector<uint8_t> sound_data = read_vector<int32_t, uint8_t>(file);
             activity.log(std::format("Read {} sound data", sound_data.size()));
         }
 
-        if (_version < LevelVersion::Tomb4)
+        if (get_version() < LevelVersion::Tomb4)
         {
             activity.log("Reading sample indices");
             std::vector<uint32_t> sample_indices = read_vector<uint32_t, uint32_t>(file);
@@ -1208,12 +1412,12 @@ namespace trlevel
 
     int16_t Level::get_mesh_from_type_id(int16_t type) const
     {
-        if (type != 0 || _version < LevelVersion::Tomb3)
+        if (type != 0 || get_version() < LevelVersion::Tomb3)
         {
             return type;
         }
 
-        if (_version > trlevel::LevelVersion::Tomb3)
+        if (get_version() > trlevel::LevelVersion::Tomb3)
         {
             return LaraSkinPostTR3;
         }
@@ -1233,5 +1437,20 @@ namespace trlevel
     tr_camera Level::get_camera(uint32_t index) const
     {
         return _cameras[index];
+    }
+
+    Platform Level::platform() const
+    {
+        return _platform_and_version.platform;
+    }
+
+    tr_textile4 Level::get_textile4(uint32_t index) const
+    {
+        return _textile4[index];
+    }
+
+    tr_clut Level::get_clut(uint32_t index) const
+    {
+        return _clut[index];
     }
 }

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -80,6 +80,10 @@ namespace trlevel
         // Returns: The object texture.
         virtual tr_object_texture get_object_texture(uint32_t index) const override;
 
+        std::vector<tr_object_texture_psx> get_object_textures_psx() const override;
+        std::vector<tr_clut> get_clut() const override;
+        std::vector<tr_textile4> get_textile4s() const override;
+
         /// Get the number of floordata values in the level.
         /// @returns The number of floordata values.
         virtual uint32_t num_floor_data() const override;
@@ -208,6 +212,7 @@ namespace trlevel
 
         std::vector<tr3_room>          _rooms;
         std::vector<tr_object_texture> _object_textures;
+        std::vector<tr_object_texture_psx> _object_textures_psx;
         std::vector<uint16_t>          _floor_data;
         std::vector<tr_model>          _models;
         std::vector<tr2_entity>        _entities;

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -188,8 +188,6 @@ namespace trlevel
 
         void load_level_data(trview::Activity& activity, std::istream& file);
 
-        tr_textile4 get_textile4(uint32_t index) const;
-        tr_clut get_clut(uint32_t index) const;
         tr_colour4 colour_from_object_texture(uint32_t texture) const;
 
         uint16_t convert_textile4(uint16_t tile, uint16_t clut_id);

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -192,6 +192,8 @@ namespace trlevel
         tr_clut get_clut(uint32_t index) const;
         tr_colour4 colour_from_object_texture(uint32_t texture) const;
 
+        uint16_t convert_textile4(uint16_t tile, uint16_t clut_id);
+
         std::shared_ptr<trview::ILog> _log;
 
         PlatformAndVersion _platform_and_version;

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -80,10 +80,6 @@ namespace trlevel
         // Returns: The object texture.
         virtual tr_object_texture get_object_texture(uint32_t index) const override;
 
-        std::vector<tr_object_texture_psx> get_object_textures_psx() const override;
-        std::vector<tr_clut> get_clut() const override;
-        std::vector<tr_textile4> get_textile4s() const override;
-
         /// Get the number of floordata values in the level.
         /// @returns The number of floordata values.
         virtual uint32_t num_floor_data() const override;
@@ -183,6 +179,7 @@ namespace trlevel
 
         virtual uint32_t num_cameras() const override;
         virtual tr_camera get_camera(uint32_t index) const override;
+        Platform platform() const override;
     private:
         void generate_meshes(const std::vector<uint16_t>& mesh_data);
 
@@ -191,9 +188,9 @@ namespace trlevel
 
         void load_level_data(trview::Activity& activity, std::istream& file);
 
-        Platform platform() const;
         tr_textile4 get_textile4(uint32_t index) const;
         tr_clut get_clut(uint32_t index) const;
+        tr_colour4 colour_from_object_texture(uint32_t texture) const;
 
         std::shared_ptr<trview::ILog> _log;
 

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -187,17 +187,24 @@ namespace trlevel
 
         void load_level_data(trview::Activity& activity, std::istream& file);
 
+        Platform platform() const;
+        tr_textile4 get_textile4(uint32_t index) const;
+        tr_clut get_clut(uint32_t index) const;
+
         std::shared_ptr<trview::ILog> _log;
 
-        LevelVersion _version;
+        PlatformAndVersion _platform_and_version;
 
         std::vector<tr_colour>  _palette;
         std::vector<tr_colour4> _palette16;
 
         uint32_t                  _num_textiles;
+        std::vector<tr_textile4>  _textile4;
         std::vector<tr_textile8>  _textile8;
         std::vector<tr_textile16> _textile16;
         std::vector<tr_textile32> _textile32;
+        std::vector<tr_clut> _clut;
+        std::vector<std::pair<uint16_t, uint16_t>> _converted_t16;
 
         std::vector<tr3_room>          _rooms;
         std::vector<tr_object_texture> _object_textures;

--- a/trlevel/LevelLoadException.h
+++ b/trlevel/LevelLoadException.h
@@ -1,10 +1,27 @@
 #pragma once
 
 #include <exception>
+#include <string>
 
 namespace trlevel
 {
     struct LevelLoadException final : public std::exception
     {
+        std::string message;
+
+        LevelLoadException()
+            : message("Unknown level load error")
+        {
+        }
+
+        LevelLoadException(const std::string& message)
+            : message(message)
+        {
+        }
+
+        const char* what() const override
+        {
+            return message.c_str();
+        }
     };
 }

--- a/trlevel/LevelVersion.cpp
+++ b/trlevel/LevelVersion.cpp
@@ -9,22 +9,18 @@ namespace trlevel
     // Returns: The level version.
     PlatformAndVersion convert_level_version(uint32_t version)
     {
-        switch (version)
+        switch (version & 0xff)
         {
         case 0x20:
-            return { .platform = Platform::PC, .version = LevelVersion::Tomb1 };
-        case 0xB020:
-            return { .platform = Platform::PSX, .version = LevelVersion::Tomb1 };
+            return { .platform = (version & 0xff00) ? Platform::PSX : Platform::PC, .version = LevelVersion::Tomb1 };
         case 0x2D:
             return { .platform = Platform::PC, .version = LevelVersion::Tomb2 };
-        case 0xFF180038:
-        case 0xFF080038:
-        case 0xFF180034:
+        case 0x34:
+        case 0x38:
             return { .platform = Platform::PC, .version = LevelVersion::Tomb3 }; 
-        case 0xffffffc8:
+        case 0xc8:
             return { .platform = Platform::PSX, .version = LevelVersion::Tomb3 };
-        case 0x00345254:
-        case 0x63345254:
+        case 0x54:
             return { .platform = Platform::PC, .version = LevelVersion::Tomb4 };
         }
         return { .platform = Platform::Unknown, .version = LevelVersion::Unknown };

--- a/trlevel/LevelVersion.cpp
+++ b/trlevel/LevelVersion.cpp
@@ -7,22 +7,26 @@ namespace trlevel
     // make that determination.
     // version: The version to convert.
     // Returns: The level version.
-    LevelVersion convert_level_version(uint32_t version)
+    PlatformAndVersion convert_level_version(uint32_t version)
     {
         switch (version)
         {
         case 0x20:
-            return LevelVersion::Tomb1;
+            return { .platform = Platform::PC, .version = LevelVersion::Tomb1 };
+        case 0xB020:
+            return { .platform = Platform::PSX, .version = LevelVersion::Tomb1 };
         case 0x2D:
-            return LevelVersion::Tomb2;
+            return { .platform = Platform::PC, .version = LevelVersion::Tomb2 };
         case 0xFF180038:
         case 0xFF080038:
         case 0xFF180034:
-            return LevelVersion::Tomb3;
+            return { .platform = Platform::PC, .version = LevelVersion::Tomb3 }; 
+        case 0xffffffc8:
+            return { .platform = Platform::PSX, .version = LevelVersion::Tomb3 };
         case 0x00345254:
         case 0x63345254:
-            return LevelVersion::Tomb4;
+            return { .platform = Platform::PC, .version = LevelVersion::Tomb4 };
         }
-        return LevelVersion::Unknown;
+        return { .platform = Platform::Unknown, .version = LevelVersion::Unknown };
     }
 }

--- a/trlevel/LevelVersion.h
+++ b/trlevel/LevelVersion.h
@@ -15,14 +15,28 @@ namespace trlevel
         Tomb5
     };
 
+    enum class Platform
+    {
+        Unknown,
+        PC,
+        PSX
+    };
+
+    struct PlatformAndVersion final
+    {
+        Platform platform{ Platform::Unknown };
+        LevelVersion version{ LevelVersion::Unknown };
+    };
+
     // Converts the level version number into a level version enumeration.
     // This will never return tomb5 as more information is required in order to 
     // make that determination.
     // version: The version to convert.
     // Returns: The level version.
-    LevelVersion convert_level_version(uint32_t version);
+    PlatformAndVersion convert_level_version(uint32_t version);
 
     constexpr std::string to_string(LevelVersion version) noexcept;
+    constexpr std::string to_string(Platform platform) noexcept;
 }
 
 #include "LevelVersion.hpp"

--- a/trlevel/LevelVersion.hpp
+++ b/trlevel/LevelVersion.hpp
@@ -19,4 +19,16 @@ namespace trlevel
         }
         return "Unknown";
     }
+
+    constexpr std::string to_string(Platform platform) noexcept
+    {
+        switch (platform)
+        {
+        case Platform::PC:
+            return "PC";
+        case Platform::PSX:
+            return "PSX";
+        }
+        return "Unknown";
+    }
 }

--- a/trlevel/Mocks/ILevel.h
+++ b/trlevel/Mocks/ILevel.h
@@ -47,6 +47,7 @@ namespace trlevel
             MOCK_METHOD(std::string, name, (), (const, override));
             MOCK_METHOD(uint32_t, num_cameras, (), (const, override));
             MOCK_METHOD(tr_camera, get_camera, (uint32_t), (const, override));
+            MOCK_METHOD(Platform, platform, (), (const, override));
         };
     }
 }

--- a/trlevel/tr_lights.cpp
+++ b/trlevel/tr_lights.cpp
@@ -292,6 +292,21 @@ namespace trlevel
         return new_lights;
     }
 
+    std::vector<tr_x_room_light> convert_lights(std::vector<tr_room_light_psx> lights)
+    {
+        std::vector<tr_x_room_light> new_lights;
+        new_lights.reserve(lights.size());
+        std::transform(lights.begin(), lights.end(),
+            std::back_inserter(new_lights), [](const auto& light)
+            {
+                tr_x_room_light new_light;
+                new_light.level_version = LevelVersion::Tomb1;
+                new_light.tr1 = { .x = light.x, .y = light.y, .z = light.z, .intensity = light.intensity, .fade = light.fade };
+                return new_light;
+            });
+        return new_lights;
+    }
+
     std::vector<tr_x_room_light> convert_lights(std::vector<tr2_room_light> lights)
     {
         std::vector<tr_x_room_light> new_lights;

--- a/trlevel/tr_lights.cpp
+++ b/trlevel/tr_lights.cpp
@@ -1,4 +1,5 @@
 #include "tr_lights.h"
+#include <ranges>
 
 namespace trlevel
 {
@@ -294,17 +295,15 @@ namespace trlevel
 
     std::vector<tr_x_room_light> convert_lights(std::vector<tr_room_light_psx> lights)
     {
-        std::vector<tr_x_room_light> new_lights;
-        new_lights.reserve(lights.size());
-        std::transform(lights.begin(), lights.end(),
-            std::back_inserter(new_lights), [](const auto& light)
-            {
-                tr_x_room_light new_light;
-                new_light.level_version = LevelVersion::Tomb1;
-                new_light.tr1 = { .x = light.x, .y = light.y, .z = light.z, .intensity = light.intensity, .fade = light.fade };
-                return new_light;
-            });
-        return new_lights;
+        return lights
+            | std::views::transform([](const auto& light)
+                {
+                    tr_x_room_light new_light;
+                    new_light.level_version = LevelVersion::Tomb1;
+                    new_light.tr1 = { .x = light.x, .y = light.y, .z = light.z, .intensity = light.intensity, .fade = light.fade };
+                    return new_light;
+                })
+            | std::ranges::to<std::vector>();
     }
 
     std::vector<tr_x_room_light> convert_lights(std::vector<tr2_room_light> lights)

--- a/trlevel/tr_lights.h
+++ b/trlevel/tr_lights.h
@@ -39,6 +39,7 @@ namespace trlevel
     std::string light_type_name(LightType type);
 
     std::vector<tr_x_room_light> convert_lights(std::vector<tr_room_light> lights);
+    std::vector<tr_x_room_light> convert_lights(std::vector<tr_room_light_psx> lights);
     std::vector<tr_x_room_light> convert_lights(std::vector<tr2_room_light> lights);
     std::vector<tr_x_room_light> convert_lights(std::vector<tr3_room_light> lights);
     std::vector<tr_x_room_light> convert_lights(std::vector<tr4_room_light> lights);

--- a/trlevel/trtypes.cpp
+++ b/trlevel/trtypes.cpp
@@ -57,6 +57,19 @@ namespace trlevel
         return new_meshes;
     }
 
+    std::vector<tr3_room_staticmesh> convert_room_static_meshes(std::vector<tr_room_staticmesh_psx> meshes)
+    {
+        std::vector<tr3_room_staticmesh> new_meshes;
+        new_meshes.reserve(meshes.size());
+        std::transform(meshes.begin(), meshes.end(),
+            std::back_inserter(new_meshes), [](const auto& mesh)
+            {
+                tr3_room_staticmesh new_mesh{ mesh.mesh.x, mesh.mesh.y, mesh.mesh.z, mesh.mesh.rotation, 0xffff, 0, mesh.mesh.mesh_id };
+                return new_mesh;
+            });
+        return new_meshes;
+    }
+
     // Convert a set of Tomb Raider I entities into a format compatible
     // with Tomb Raider III (what the viewer is currently using).
     std::vector<tr2_entity> convert_entities(std::vector<tr_entity> entities)
@@ -140,6 +153,15 @@ namespace trlevel
         return new_info;
     }
 
+    std::vector<tr_model> convert_models(std::vector<tr_model_psx> models)
+    {
+        std::vector<tr_model> new_models;
+        new_models.reserve(models.size());
+        std::transform(models.begin(), models.end(),
+            std::back_inserter(new_models), [](const auto& model) { return model.model; });
+        return new_models;
+    }
+
     std::vector<tr_model> convert_models(std::vector<tr5_model> models)
     {
         std::vector<tr_model> new_models;
@@ -147,5 +169,20 @@ namespace trlevel
         std::transform(models.begin(), models.end(),
             std::back_inserter(new_models), [](const auto& model) { return model.model; });
         return new_models;
+    }
+
+    std::vector<tr_vertex> convert_vertices(std::vector<tr_vertex_psx> vertices)
+    {
+        std::vector<tr_vertex> new_vertices;
+        new_vertices.reserve(vertices.size());
+        std::transform(
+            vertices.begin(),
+            vertices.end(),
+            std::back_inserter(new_vertices),
+            [](const auto& vert)
+            {
+                return tr_vertex{ vert.x, vert.y, vert.z };
+            });
+        return new_vertices;
     }
 }

--- a/trlevel/trtypes.cpp
+++ b/trlevel/trtypes.cpp
@@ -1,4 +1,5 @@
 #include "trtypes.h"
+#include <ranges>
 
 namespace trlevel
 {
@@ -59,15 +60,13 @@ namespace trlevel
 
     std::vector<tr3_room_staticmesh> convert_room_static_meshes(std::vector<tr_room_staticmesh_psx> meshes)
     {
-        std::vector<tr3_room_staticmesh> new_meshes;
-        new_meshes.reserve(meshes.size());
-        std::transform(meshes.begin(), meshes.end(),
-            std::back_inserter(new_meshes), [](const auto& mesh)
-            {
-                tr3_room_staticmesh new_mesh{ mesh.mesh.x, mesh.mesh.y, mesh.mesh.z, mesh.mesh.rotation, 0xffff, 0, mesh.mesh.mesh_id };
-                return new_mesh;
-            });
-        return new_meshes;
+        return meshes
+            | std::views::transform([](const auto& mesh)
+                {
+                    tr3_room_staticmesh new_mesh{ mesh.mesh.x, mesh.mesh.y, mesh.mesh.z, mesh.mesh.rotation, 0xffff, 0, mesh.mesh.mesh_id };
+                    return new_mesh;
+                })
+            | std::ranges::to<std::vector>();
     }
 
     // Convert a set of Tomb Raider I entities into a format compatible
@@ -173,16 +172,8 @@ namespace trlevel
 
     std::vector<tr_vertex> convert_vertices(std::vector<tr_vertex_psx> vertices)
     {
-        std::vector<tr_vertex> new_vertices;
-        new_vertices.reserve(vertices.size());
-        std::transform(
-            vertices.begin(),
-            vertices.end(),
-            std::back_inserter(new_vertices),
-            [](const auto& vert)
-            {
-                return tr_vertex{ vert.x, vert.y, vert.z };
-            });
-        return new_vertices;
+        return vertices
+            | std::views::transform([](const auto& vert) { return tr_vertex{ vert.x, vert.y, vert.z }; })
+            | std::ranges::to<std::vector>();
     }
 }

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -22,6 +22,19 @@ namespace trlevel
     constexpr float Scale_Y { 1024.0f };
     constexpr float Scale_Z { 1024.0f };
 
+    struct tr_rgba5551
+    {
+        uint16_t Red : 5,
+                 Green : 5,
+                 Blue : 5,
+                 Alpha : 1;
+    };
+
+    struct tr_clut
+    {
+        tr_rgba5551 Colour[16];
+    };
+
     struct tr_colour
     {
         uint8_t Red;
@@ -35,6 +48,16 @@ namespace trlevel
         uint8_t Green;
         uint8_t Blue;
         uint8_t Unused;
+    };
+
+    struct tr_colorindex4
+    {
+        uint8_t a : 4, b : 4;
+    };
+
+    struct tr_textile4
+    {
+        tr_colorindex4 Tile[256 * 256 / 2];
     };
 
     struct tr_textile8
@@ -74,6 +97,14 @@ namespace trlevel
         int16_t x;
         int16_t y;
         int16_t z;
+    };
+
+    struct tr_vertex_psx
+    {
+        int16_t x;
+        int16_t y;
+        int16_t z;
+        int16_t w;
     };
 
     struct tr5_vertex
@@ -228,6 +259,12 @@ namespace trlevel
         uint16_t Animation;    // Offset into Animations[]
     };
 
+    struct tr_model_psx
+    {
+        tr_model model;
+        uint16_t padding;
+    };
+
     struct tr5_model
     {
         tr_model model;
@@ -260,6 +297,20 @@ namespace trlevel
         int16_t TopSide;
         int16_t RightSide;
         int16_t BottomSide;
+    };
+
+    struct tr_sprite_texture_psx
+    {
+        int16_t LeftSide;
+        int16_t TopSide;
+        int16_t RightSide;
+        int16_t BottomSide;
+        uint16_t Clut;
+        uint16_t Tile;
+        uint8_t u0;
+        uint8_t v0;
+        uint8_t u1;
+        uint8_t v1;
     };
 
     struct tr_sprite_sequence  // 8 bytes
@@ -406,6 +457,22 @@ namespace trlevel
         tr_object_texture_vert Vertices[4]; // The four corners of the texture
     };
 
+    struct tr_object_texture_psx
+    {
+        uint8_t x0;
+        uint8_t y0;
+        uint16_t Clut;
+        uint8_t x1;
+        uint8_t y1;
+        uint16_t Tile : 14, : 2;
+        uint8_t x2;
+        uint8_t y2;
+        uint16_t Unknown;
+        uint8_t x3;
+        uint8_t y3;
+        uint16_t Attribute;
+    };
+
     struct tr4_object_texture // 38 bytes
     {
         uint16_t               Attribute;
@@ -490,6 +557,17 @@ namespace trlevel
         int32_t  y;
         int32_t  z;
         uint16_t intensity;
+        uint32_t fade;
+    };
+
+    // Version of the room_light structure used in Tomb Raider I PSX.
+    struct tr_room_light_psx
+    {
+        int32_t x;
+        int32_t y;
+        int32_t z;
+        uint16_t intensity;
+        uint16_t padding;
         uint32_t fade;
     };
 
@@ -585,6 +663,12 @@ namespace trlevel
         uint16_t rotation;
         uint16_t intensity;
         uint16_t mesh_id;
+    };
+
+    struct tr_room_staticmesh_psx
+    {
+        tr_room_staticmesh mesh;
+        uint16_t padding;
     };
 
     struct tr3_room_staticmesh 
@@ -709,6 +793,8 @@ namespace trlevel
     // with Tomb Raider III (what the viewer is currently using).
     std::vector<tr3_room_staticmesh> convert_room_static_meshes(std::vector<tr_room_staticmesh> meshes);
 
+    std::vector<tr3_room_staticmesh> convert_room_static_meshes(std::vector<tr_room_staticmesh_psx> meshes);
+
     // Convert a set of Tomb Raider I entities into a format compatible
     // with Tomb Raider III (what the viewer is currently using).
     std::vector<tr2_entity> convert_entities(std::vector<tr_entity> entities);
@@ -736,5 +822,8 @@ namespace trlevel
     /// @returns The converted room info.
     tr_room_info convert_room_info(const tr1_4_room_info& room_info);
 
+    std::vector<tr_model> convert_models(std::vector<tr_model_psx> models);
     std::vector<tr_model> convert_models(std::vector<tr5_model> models);
+
+    std::vector<tr_vertex> convert_vertices(std::vector<tr_vertex_psx> vertices);
 }

--- a/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
+++ b/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
@@ -19,41 +19,41 @@ using namespace trview::graphics::mocks;
 
 TEST(LevelTextureStorage, PaletteLoadedTomb1)
 {
-    NiceMock<trlevel::mocks::MockLevel> level;
-    EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb1));
-    EXPECT_CALL(level, get_palette_entry(_)).Times(AtLeast(1));
+    auto level = mock_shared<trlevel::mocks::MockLevel>();
+    EXPECT_CALL(*level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb1));
+    EXPECT_CALL(*level, get_palette_entry(_)).Times(AtLeast(1));
     LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
 }
 
 TEST(LevelTextureStorage, PaletteLoadedTomb2)
 {
-    NiceMock<trlevel::mocks::MockLevel> level;
-    EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb2));
-    EXPECT_CALL(level, get_palette_entry(_)).Times(AtLeast(1));
+    auto level = mock_shared<trlevel::mocks::MockLevel>();
+    EXPECT_CALL(*level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb2));
+    EXPECT_CALL(*level, get_palette_entry(_)).Times(AtLeast(1));
     LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
 }
 
 TEST(LevelTextureStorage, PaletteLoadedTomb3)
 {
-    NiceMock<trlevel::mocks::MockLevel> level;
-    EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb3));
-    EXPECT_CALL(level, get_palette_entry(_)).Times(AtLeast(1));
+    auto level = mock_shared<trlevel::mocks::MockLevel>();
+    EXPECT_CALL(*level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb3));
+    EXPECT_CALL(*level, get_palette_entry(_)).Times(AtLeast(1));
     LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
 }
 
 TEST(LevelTextureStorage, PaletteNotLoadedTomb4)
 {
-    NiceMock<trlevel::mocks::MockLevel> level;
-    EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb4));
-    EXPECT_CALL(level, get_palette_entry(_)).Times(Exactly(0));
+    auto level = mock_shared<trlevel::mocks::MockLevel>();
+    EXPECT_CALL(*level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb4));
+    EXPECT_CALL(*level, get_palette_entry(_)).Times(Exactly(0));
     LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
 }
 
 TEST(LevelTextureStorage, PaletteNotLoadedTomb5)
 {
-    NiceMock<trlevel::mocks::MockLevel> level;
-    EXPECT_CALL(level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb5));
-    EXPECT_CALL(level, get_palette_entry(_)).Times(Exactly(0));
+    auto level = mock_shared<trlevel::mocks::MockLevel>();
+    EXPECT_CALL(*level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb5));
+    EXPECT_CALL(*level, get_palette_entry(_)).Times(Exactly(0));
     LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
 }
 
@@ -62,9 +62,9 @@ TEST(LevelTextureStorage, TexturesGenerated)
     std::vector<uint32_t> data;
     data.resize(256 * 256, 0x000080ff);
 
-    NiceMock<trlevel::mocks::MockLevel> level;
-    ON_CALL(level, num_textiles).WillByDefault(Return(1));
-    EXPECT_CALL(level, get_textile(0)).Times(1).WillRepeatedly(Return(data));
+    auto level = mock_shared<trlevel::mocks::MockLevel>();
+    ON_CALL(*level, num_textiles).WillByDefault(Return(1));
+    EXPECT_CALL(*level, get_textile(0)).Times(1).WillRepeatedly(Return(data));
     auto device = mock_shared<MockDevice>();
 
     std::vector<std::vector<uint32_t>> saved_data;

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -908,8 +908,7 @@ namespace trview
 
     std::shared_ptr<ILevel> Application::load(const std::string& filename)
     {
-        std::unique_ptr<trlevel::ILevel> new_level = _trlevel_source(filename);
-        auto level = _level_source(std::move(new_level));
+        auto level = _level_source(_trlevel_source(filename));
         level->set_filename(filename);
         return level;
     }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -127,9 +127,9 @@ namespace trview
         {
             return;
         }
-        catch (...)
+        catch (std::exception& e)
         {
-            _dialogs->message_box(L"Failed to load level", L"Error", IDialogs::Buttons::OK);
+            _dialogs->message_box(to_utf16(std::format("Failed to load level : {}", e.what())), L"Error", IDialogs::Buttons::OK);
             return;
         }
     }

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -245,7 +245,7 @@ namespace trview
 
         auto level_source = [=](auto&& level)
         {
-            auto level_texture_storage = std::make_shared<LevelTextureStorage>(device, std::make_unique<TextureStorage>(device), *level);
+            auto level_texture_storage = std::make_shared<LevelTextureStorage>(device, std::make_unique<TextureStorage>(device), level);
             auto mesh_storage = std::make_unique<MeshStorage>(mesh_source, *level, *level_texture_storage);
             auto new_level = std::make_shared<Level>(
                 device, 
@@ -256,7 +256,7 @@ namespace trview
                 log,
                 buffer_source);
             new_level->initialise(
-                std::move(level),
+                level,
                 std::move(mesh_storage),
                 entity_source,
                 ai_source,
@@ -318,7 +318,7 @@ namespace trview
 
         auto decrypter = std::make_shared<trlevel::Decrypter>();
 
-        auto trlevel_source = [=](auto&& filename) { return std::make_unique<trlevel::Level>(filename, files, decrypter, log); };
+        auto trlevel_source = [=](auto&& filename) { return std::make_shared<trlevel::Level>(filename, files, decrypter, log); };
         auto textures_window_source = [=]() { return std::make_shared<TexturesWindow>(); };
         auto console_source = [=]() { return std::make_shared<Console>(dialogs, plugins); };
 

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -15,7 +15,7 @@ namespace trview
 {
     struct ILevel
     {
-        using Source = std::function<std::shared_ptr<ILevel>(std::unique_ptr<trlevel::ILevel>)>;
+        using Source = std::function<std::shared_ptr<ILevel>(std::shared_ptr<trlevel::ILevel>)>;
 
         enum class OpenMode
         {

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1232,7 +1232,7 @@ namespace trview
         return has_flag(_render_filters, RenderFilter::CameraSinks);
     }
 
-    void Level::initialise(std::unique_ptr<trlevel::ILevel> level,
+    void Level::initialise(std::shared_ptr<trlevel::ILevel> level,
         std::unique_ptr<IMeshStorage> mesh_storage,
         const IItem::EntitySource& entity_source,
         const IItem::AiSource& ai_source,

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -106,7 +106,7 @@ namespace trview
         virtual std::optional<uint32_t> selected_camera_sink() const override;
         virtual bool show_camera_sinks() const override;
         void initialise(
-            std::unique_ptr<trlevel::ILevel> level,
+            std::shared_ptr<trlevel::ILevel> level,
             std::unique_ptr<IMeshStorage> mesh_storage,
             const IItem::EntitySource& entity_source,
             const IItem::AiSource& ai_source,

--- a/trview.app/Graphics/LevelTextureStorage.cpp
+++ b/trview.app/Graphics/LevelTextureStorage.cpp
@@ -27,6 +27,10 @@ namespace trview
             _object_textures.push_back(level.get_object_texture(i));
         }
 
+        _object_textures_psx = level.get_object_textures_psx();
+        _clut = level.get_clut();
+        _textile4 = level.get_textile4s();
+
         if (_version < trlevel::LevelVersion::Tomb4)
         {
             using namespace DirectX::SimpleMath;
@@ -135,6 +139,24 @@ namespace trview
         {
             return _palette[texture >> 8];
         }
+
+        if (true)
+        {
+            const auto& object_texture = _object_textures_psx[texture];
+            const auto& tile = _textile4[object_texture.Tile];
+            const auto& clut = _clut[object_texture.Clut];
+
+            auto pixel = object_texture.x0 + object_texture.y0 * 256;
+            auto index = tile.Tile[pixel / 2];
+            auto colour = clut.Colour[object_texture.x0 % 2 ? index.b : index.a];
+            
+            float a = colour.Alpha;
+            float r = colour.Red / 31.0f;
+            float g = colour.Green / 31.0f;
+            float b = colour.Blue / 31.0f;
+            return Colour(a, r, g, b);
+        }
+
         return _palette[texture & 0xff];
     }
 

--- a/trview.app/Graphics/LevelTextureStorage.cpp
+++ b/trview.app/Graphics/LevelTextureStorage.cpp
@@ -27,10 +27,6 @@ namespace trview
             _object_textures.push_back(level->get_object_texture(i));
         }
 
-        // _object_textures_psx = level->get_object_textures_psx();
-        // _clut = level->get_clut();
-        // _textile4 = level->get_textile4s();
-
         if (_version < trlevel::LevelVersion::Tomb4)
         {
             using namespace DirectX::SimpleMath;
@@ -144,9 +140,10 @@ namespace trview
         {
             if (auto level = _level.lock())
             {
-                auto colour = level->get_palette_entry(texture);
+                const auto colour = level->get_palette_entry(texture);
                 return DirectX::SimpleMath::Color(colour.Red / 255.f, colour.Green / 255.f, colour.Blue / 255.f, 1.0f);
             }
+            return Colour::Black;
         }
 
         return _palette[texture & 0xff];

--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -14,7 +14,7 @@ namespace trview
     class LevelTextureStorage final : public ILevelTextureStorage
     {
     public:
-        explicit LevelTextureStorage(const std::shared_ptr<graphics::IDevice>& device, std::unique_ptr<ITextureStorage> texture_storage, const trlevel::ILevel& level);
+        explicit LevelTextureStorage(const std::shared_ptr<graphics::IDevice>& device, std::unique_ptr<ITextureStorage> texture_storage, const std::shared_ptr<trlevel::ILevel>& level);
         virtual ~LevelTextureStorage() = default;
         virtual graphics::Texture texture(uint32_t tile_index) const override;
         virtual graphics::Texture opaque_texture(uint32_t texture_index) const override;
@@ -32,6 +32,8 @@ namespace trview
     private:
         void determine_texture_mode();
 
+        std::weak_ptr<trlevel::ILevel> _level;
+
         std::vector<graphics::Texture> _tiles;
         std::vector<graphics::Texture> _opaque_tiles;
         std::vector<trlevel::tr_object_texture> _object_textures;
@@ -39,10 +41,7 @@ namespace trview
         mutable graphics::Texture _untextured_texture;
         std::array<DirectX::SimpleMath::Color, 256> _palette;
         trlevel::LevelVersion _version;
-
-        std::vector<trlevel::tr_object_texture_psx> _object_textures_psx;
-        std::vector<trlevel::tr_clut> _clut;
-        std::vector<trlevel::tr_textile4> _textile4;
+        trlevel::Platform _platform;
 
         enum class TextureMode
         {

--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -40,6 +40,10 @@ namespace trview
         std::array<DirectX::SimpleMath::Color, 256> _palette;
         trlevel::LevelVersion _version;
 
+        std::vector<trlevel::tr_object_texture_psx> _object_textures_psx;
+        std::vector<trlevel::tr_clut> _clut;
+        std::vector<trlevel::tr_textile4> _textile4;
+
         enum class TextureMode
         {
             Official,

--- a/trview.app/Menus/FileMenu.cpp
+++ b/trview.app/Menus/FileMenu.cpp
@@ -160,7 +160,7 @@ namespace trview
 
     void FileMenu::choose_file()
     {
-        const auto filename = _dialogs->open_file(L"Open level", { { L"All Tomb Raider Files", { L"*.tr*", L"*.phd" } } }, OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST);
+        const auto filename = _dialogs->open_file(L"Open level", { { L"All Tomb Raider Files", { L"*.tr*", L"*.phd", L"*.psx" } } }, OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST);
         if (filename.has_value())
         {
             on_file_open(filename.value().filename);

--- a/trview.app/Menus/FileMenu.h
+++ b/trview.app/Menus/FileMenu.h
@@ -10,7 +10,7 @@ namespace trview
     class FileMenu final : public IFileMenu, public MessageHandler
     {
     public:
-        static const inline std::string default_file_pattern{ "\\*.TR*,\\*.PHD" };
+        static const inline std::string default_file_pattern{ "\\*.TR*,\\*.PHD,\\*.PSX" };
 
         explicit FileMenu(
             const Window& window,


### PR DESCRIPTION
Add support for PS1 TR1 levels.
Load .PSX level in filters .
Change level versions detection to check first byte and then remaining bytes for more information.
Change `trlevel::ILevel` to be `shared_ptr` so that the `LevelTextureStorage` can call it for TR1 coloured rectangles/triangles lookup.
Part of #174 