### PR TITLE
Add specific light type enum for TR3 lights

### DIFF
--- a/trlevel/tr_lights.cpp
+++ b/trlevel/tr_lights.cpp
@@ -53,7 +53,7 @@ namespace trlevel
         case LevelVersion::Tomb2:
             return LightType::Point;
         case LevelVersion::Tomb3:
-            return tr3.type;
+            return convert(tr3.type);
         case LevelVersion::Tomb4:
             return tr4.light_type;
         case LevelVersion::Tomb5:

--- a/trlevel/trlevel.vcxproj
+++ b/trlevel/trlevel.vcxproj
@@ -210,6 +210,9 @@
       <Project>{745dec58-ebb3-47a9-a9b8-4c6627c01bf8}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="trtypes.inl" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/trlevel/trlevel.vcxproj.filters
+++ b/trlevel/trlevel.vcxproj.filters
@@ -34,4 +34,7 @@
       <UniqueIdentifier>{761f107e-00af-4697-ba3e-3653c2e29391}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="trtypes.inl" />
+  </ItemGroup>
 </Project>

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -8,6 +8,12 @@ namespace trlevel
 {
 #pragma pack(push, 1)
 
+    enum class LightTypeTR3 : uint8_t
+    {
+        Point = 0,
+        Sun = 1
+    };
+
     enum class LightType : uint8_t
     {
         Sun = 0,
@@ -598,7 +604,7 @@ namespace trlevel
         int32_t y;
         int32_t z;
         tr_colour colour;
-        LightType type;
+        LightTypeTR3 type;
         union
         {
             tr3_room_sun sun;
@@ -826,4 +832,8 @@ namespace trlevel
     std::vector<tr_model> convert_models(std::vector<tr5_model> models);
 
     std::vector<tr_vertex> convert_vertices(std::vector<tr_vertex_psx> vertices);
+
+    constexpr LightType convert(LightTypeTR3 type);
 }
+
+#include "trtypes.inl"

--- a/trlevel/trtypes.inl
+++ b/trlevel/trtypes.inl
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace trlevel
+{
+    constexpr LightType convert(LightTypeTR3 type)
+    {
+        return type == LightTypeTR3::Point ? LightType::Point : LightType::Sun;
+    }
+}

--- a/trview.app.tests/Elements/LightTests.cpp
+++ b/trview.app.tests/Elements/LightTests.cpp
@@ -82,7 +82,7 @@ TEST(Light, PointTR3)
     level_light.tr3.y = 2048;
     level_light.tr3.z = 3072;
     level_light.tr3.colour = { 64, 128, 255 };
-    level_light.tr3.type = LightType::Point;
+    level_light.tr3.type = LightTypeTR3::Point;
     auto light = register_test_module().with_light(level_light).build();
 
     ASSERT_EQ(light.colour(), Colour(0.250980407f, 0.501960814f, 1.0f));
@@ -100,7 +100,7 @@ TEST(Light, SunTR3)
     level_light.tr3.sun.ny = 2048;
     level_light.tr3.sun.nz = 3072;
     level_light.tr3.colour = { 64, 128, 255 };
-    level_light.tr3.type = LightType::Sun;
+    level_light.tr3.type = LightTypeTR3::Sun;
     auto light = register_test_module().with_light(level_light).build();
 
     ASSERT_EQ(light.colour(), Colour(0.250980407f, 0.501960814f, 1.0f));


### PR DESCRIPTION
TR3 Lights were using the TR4+ light type enum - this meant that Sun and Point were the wrong way around.
Add a specific type for TR3 lights and convert it later.
Closes #1176