### PR TITLE
Add static mesh list to Rooms window

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -1283,3 +1283,20 @@ TEST(Application, RouteNewRandomizerRoute)
     route_window_manager.on_new_randomizer_route();
     ASSERT_EQ(application->route(), route);
 }
+
+TEST(Application, OnStaticMeshSelected)
+{
+    auto level = mock_shared<trview::mocks::MockLevel>();
+    auto static_mesh = mock_shared<MockStaticMesh>();
+    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
+    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
+    auto application = register_test_module()
+        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
+        .with_viewer(std::move(viewer_ptr))
+        .build();
+
+    application->set_current_level(level, ILevel::OpenMode::Full, false);
+
+    EXPECT_CALL(viewer, select_static_mesh).Times(1);
+    rooms_window_manager.on_static_mesh_selected(static_mesh);
+}

--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -6,6 +6,7 @@
 #include <trview.app/Mocks/Elements/ITrigger.h>
 #include <trview.app/Mocks/Elements/ISector.h>
 #include <trview.app/Mocks/Elements/IRoom.h>
+#include <trview.app/Mocks/Elements/IStaticMesh.h>
 
 using namespace trview;
 using namespace trview::mocks;
@@ -148,4 +149,22 @@ TEST(RoomsWindowManager, OnSectorHoverRaised)
 
     window->on_sector_hover(sector);
     ASSERT_EQ(raised.lock(), sector);
+}
+
+TEST(RoomsWindowManager, OnStaticMeshSelectedForwarded)
+{
+    auto manager = register_test_module().build();
+    auto static_mesh = mock_shared<MockStaticMesh>();
+
+    std::shared_ptr<IStaticMesh> raised;
+    auto token = manager->on_static_mesh_selected += [&](auto&& value)
+    {
+        raised = value.lock();
+    };
+
+    auto window = manager->create_window().lock();
+    ASSERT_NE(window, nullptr);
+
+    window->on_static_mesh_selected(static_mesh);
+    ASSERT_EQ(raised, static_mesh);
 }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -354,6 +354,7 @@ namespace trview
         _token_store += _rooms_windows->on_sector_hover += [this](const auto& sector) { select_sector(sector); };
         _token_store += _rooms_windows->on_camera_sink_selected += [this](const auto& camera_sink) { select_camera_sink(camera_sink); };
         _token_store += _rooms_windows->on_light_selected += [this](const auto& light) { select_light(light); };
+        _token_store += _rooms_windows->on_static_mesh_selected += [this](const auto& static_mesh) { select_static_mesh(static_mesh); };
     }
 
     void Application::setup_route_window()
@@ -1032,5 +1033,22 @@ namespace trview
         _route_window->set_route(_route);
         _route->set_level(_level);
         _viewer->set_route(_route);
+    }
+
+    void Application::select_static_mesh(const std::weak_ptr<IStaticMesh>& static_mesh)
+    {
+        if (!_level)
+        {
+            return;
+        }
+
+        auto static_mesh_ptr = static_mesh.lock();
+        if (!static_mesh_ptr)
+        {
+            return;
+        }
+
+        select_room(static_mesh_room(static_mesh_ptr));
+        _viewer->select_static_mesh(static_mesh_ptr);
     }
 }

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -132,6 +132,7 @@ namespace trview
         void save_route_as();
         void open_recent_route();
         void save_window_placement();
+        void select_static_mesh(const std::weak_ptr<IStaticMesh>& static_mesh);
 
         TokenStore _token_store;
 

--- a/trview.app/Elements/IStaticMesh.h
+++ b/trview.app/Elements/IStaticMesh.h
@@ -39,6 +39,9 @@ namespace trview
     };
 
     constexpr std::string to_string(IStaticMesh::Type type) noexcept;
+
+    uint32_t static_mesh_room(const std::shared_ptr<IStaticMesh>& static_mesh);
+    uint32_t static_mesh_room(const IStaticMesh& static_mesh);
 }
 
 #include "IStaticMesh.inl"

--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -1,6 +1,7 @@
 #include "StaticMesh.h"
 #include <trview.app/Geometry/Matrix.h>
 #include <trview.app/Geometry/ITransparencyBuffer.h>
+#include "IRoom.h"
 
 namespace trview
 {
@@ -131,5 +132,23 @@ namespace trview
     uint16_t StaticMesh::id() const
     {
         return _mesh_texture_id;
+    }
+
+    uint32_t static_mesh_room(const std::shared_ptr<IStaticMesh>& static_mesh)
+    {
+        if (!static_mesh)
+        {
+            return 0u;
+        }
+        return static_mesh_room(*static_mesh);
+    }
+
+    uint32_t static_mesh_room(const IStaticMesh& static_mesh)
+    {
+        if (auto room = static_mesh.room().lock())
+        {
+            return room->number();
+        }
+        return 0u;
     }
 }

--- a/trview.app/Mocks/Windows/IViewer.h
+++ b/trview.app/Mocks/Windows/IViewer.h
@@ -21,6 +21,7 @@ namespace trview
             MOCK_METHOD(void, select_trigger, (const std::weak_ptr<ITrigger>&), (override));
             MOCK_METHOD(void, select_waypoint, (const std::weak_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, select_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
+            MOCK_METHOD(void, select_static_mesh, (const std::weak_ptr<IStaticMesh>&), (override));
             MOCK_METHOD(void, set_camera_mode, (CameraMode), (override));
             MOCK_METHOD(void, set_route, (const std::shared_ptr<IRoute>&), (override));
             MOCK_METHOD(void, set_show_compass, (bool), (override));

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -35,6 +35,7 @@ namespace trview
 
         Event<std::weak_ptr<ILight>> on_light_selected;
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
+        Event<std::weak_ptr<IStaticMesh>> on_static_mesh_selected;
 
         /// Clear the selected trigger.
         virtual void clear_selected_trigger() = 0;

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -22,6 +22,7 @@ namespace trview
         Event<std::weak_ptr<ISector>> on_sector_hover;
         Event<std::weak_ptr<ILight>> on_light_selected;
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
+        Event<std::weak_ptr<IStaticMesh>> on_static_mesh_selected;
 
         /// Render all of the rooms windows.
         virtual void render() = 0;

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -151,5 +151,6 @@ namespace trview
         virtual void set_scene_changed() = 0;
 
         virtual void select_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
+        virtual void select_static_mesh(const std::weak_ptr<IStaticMesh>& static_mesh) = 0;
     };
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -294,11 +294,12 @@ namespace trview
                 set_sync_room(sync_room);
             }
 
-            if (ImGui::BeginTable(Names::rooms_list.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedSame, ImVec2(-1, -1)))
+            if (ImGui::BeginTable(Names::rooms_list.c_str(), 5, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -1)))
             {
                 ImGui::TableSetupColumn("#");
                 ImGui::TableSetupColumn("Items");
                 ImGui::TableSetupColumn("Triggers");
+                ImGui::TableSetupColumn("Statics");
                 ImGui::TableSetupColumn("Hide");
                 ImGui::TableSetupScrollFreeze(1, 1);
                 ImGui::TableHeadersRow();
@@ -320,11 +321,14 @@ namespace trview
                     return room.triggers().size();
                 };
 
+                auto static_mesh_count = [](const IRoom& room) { return room.static_meshes().size(); };
+
                 imgui_sort_weak(_all_rooms,
                     {
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
                         [&](auto&& l, auto&& r) { return item_count(l) < item_count(r); },
                         [&](auto&& l, auto&& r) { return trigger_count(l) < trigger_count(r); },
+                        [&](auto&& l, auto&& r) { return static_mesh_count(l) < static_mesh_count(r); },
                         [&](auto&& l, auto&& r) { return l.visible() < r.visible(); }
                     }, _force_sort);
 
@@ -364,6 +368,8 @@ namespace trview
                     ImGui::Text(std::to_string(item_count(*room_ptr)).c_str());
                     ImGui::TableNextColumn();
                     ImGui::Text(std::to_string(trigger_count(*room_ptr)).c_str());
+                    ImGui::TableNextColumn();
+                    ImGui::Text(std::to_string(static_mesh_count(*room_ptr)).c_str());
                     ImGui::TableNextColumn();
                     bool hidden = !room_ptr->visible();
                     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
@@ -521,7 +527,7 @@ namespace trview
                             _in_floordata_mode = false;
                         }
 
-                        if (ImGui::BeginTabItem("Statics"))
+                        if (ImGui::BeginTabItem("Statics##Statics Tab"))
                         {
                             render_statics_tab();
                             ImGui::EndTabItem();

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -66,12 +66,15 @@ namespace trview
         void set_lights(const std::vector<std::weak_ptr<ILight>>& lights);
         void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks);
         void select_room(uint32_t room);
+        void render_statics_tab();
+        void set_static_meshes(const std::vector<std::weak_ptr<IStaticMesh>>& static_meshes);
 
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<std::weak_ptr<IItem>> _all_items;
         std::vector<std::weak_ptr<ITrigger>> _triggers;
         std::vector<std::weak_ptr<ILight>> _lights;
         std::vector<std::weak_ptr<ICameraSink>> _camera_sinks;
+        std::vector<std::weak_ptr<IStaticMesh>> _static_meshes;
 
         bool _sync_room{ true };
 
@@ -90,6 +93,9 @@ namespace trview
         std::weak_ptr<ICameraSink> _global_selected_camera_sink;
         std::weak_ptr<ICameraSink> _local_selected_camera_sink;
         bool _scroll_to_camera_sink{ false };
+
+        std::weak_ptr<IStaticMesh> _local_selected_static_mesh;
+        bool _scroll_to_static_mesh{ false };
 
         uint32_t _current_room{ 0u };
         uint32_t _selected_room{ 0u };

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -106,6 +106,7 @@ namespace trview
         rooms_window->on_sector_hover += on_sector_hover;
         rooms_window->on_light_selected += on_light_selected;
         rooms_window->on_camera_sink_selected += on_camera_sink_selected;
+        rooms_window->on_static_mesh_selected += on_static_mesh_selected;
         rooms_window->set_level_version(_level_version);
         rooms_window->set_items(_all_items);
         rooms_window->set_rooms(_all_rooms);

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1404,4 +1404,17 @@ namespace trview
             set_show_lighting(!_level->show_lighting());
         }
     }
+
+    void Viewer::select_static_mesh(const std::weak_ptr<IStaticMesh>& static_mesh)
+    {
+        if (auto static_mesh_ptr = static_mesh.lock())
+        {
+            _target = static_mesh_ptr->position();
+            if (_settings.auto_orbit)
+            {
+                set_camera_mode(CameraMode::Orbit);
+            }
+            _scene_changed = true;
+        }
+    }
 }

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -92,6 +92,7 @@ namespace trview
         virtual void select_sector(const std::weak_ptr<ISector>& sector) override;
         virtual void set_scene_changed() override;
         virtual void select_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
+        void select_static_mesh(const std::weak_ptr<IStaticMesh>& static_mesh) override;
     private:
         void initialise_input();
         void toggle_highlight();


### PR DESCRIPTION
Add a list to show static meshes to the Rooms window. User can click on the the entries to focus the camera on the static mesh. There static mesh is not selected as that isn't really a concept yet.
Part of #912 