### PR TITLE
Add zero size check for window size

### DIFF
--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -952,6 +952,11 @@ namespace trview
     void Viewer::resize_elements()
     {
         const auto size = window().size();
+        if (size == Size())
+        {
+            return;
+        }
+
         // Inform elements that need to know that the device has been resized.
         _camera.set_view_size(size);
         _free_camera.set_view_size(size);


### PR DESCRIPTION
Don't attempt to resize elements to be zero sized if the window is zero sized (for example when the window is minimised). This prevents an error in the render target creation.
Closes #1179