### PR TITLE
Improve the "Go To" window

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -284,7 +284,7 @@ TEST(Application, FileOpenedInViewer)
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
     std::optional<std::string> called;
     auto trlevel_source = [&](auto&& filename) { called = filename; return mock_unique<trlevel::mocks::MockLevel>(); };
-    EXPECT_CALL(viewer, open(NotNull(), ILevel::OpenMode::Full)).Times(1);
+    EXPECT_CALL(viewer, open(A<const std::weak_ptr<ILevel>&>(), ILevel::OpenMode::Full)).Times(1);
     auto application = register_test_module().with_trlevel_source(trlevel_source).with_viewer(std::move(viewer_ptr)).build();
     application->open("test_path.tr2", ILevel::OpenMode::Full);
     ASSERT_TRUE(called.has_value());
@@ -326,7 +326,7 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
     EXPECT_CALL(*route, clear()).Times(1).WillOnce([&] { events.push_back("route_clear"); });
     EXPECT_CALL(*route, set_unsaved(false)).Times(1);
     EXPECT_CALL(textures_window_manager, set_texture_storage).Times(1).WillOnce([&](auto) { events.push_back("textures"); });
-    EXPECT_CALL(viewer, open(NotNull(), ILevel::OpenMode::Full)).Times(1).WillOnce([&](auto&&...) { events.push_back("viewer"); });
+    EXPECT_CALL(viewer, open(A<const std::weak_ptr<ILevel>&>(), ILevel::OpenMode::Full)).Times(1).WillOnce([&](auto&&...) { events.push_back("viewer"); });
 
     auto application = register_test_module()
         .with_trlevel_source(trlevel_source)

--- a/trview.app.tests/UI/GoToTests.cpp
+++ b/trview.app.tests/UI/GoToTests.cpp
@@ -17,53 +17,6 @@ TEST(GoTo, Name)
     ASSERT_NE(imgui.find_window(imgui.popup_id("Go To Item").name()), nullptr);
 }
 
-TEST(GoTo, OnSelectedWithPlusRaised)
-{
-    GoTo window;
-    window.toggle_visible();
-    window.set_name("Item");
-
-    std::optional<uint32_t> raised;
-    auto token = window.on_selected += [&](auto value)
-    {
-        raised = value;
-    };
-
-    TestImgui imgui([&]() { window.render(); });
-    imgui.click_element(
-        imgui.popup_id("Go To Item").push("##gotoentry").id("+"), 
-        false, 
-        imgui.popup_id("Go To Item").id("##gotoentry"));
-
-    ASSERT_TRUE(raised.has_value());
-    ASSERT_EQ(raised.value(), 1u);
-}
-
-TEST(GoTo, OnSelectedWithMinusRaised)
-{
-    GoTo window;
-    window.toggle_visible();
-    window.set_name("Item");
-
-    std::vector<uint32_t> raised;
-    auto token = window.on_selected += [&](auto value)
-    {
-        raised.push_back(value);
-    };
-
-    TestImgui imgui([&]() { window.render(); });
-    const auto goto_entry = imgui.popup_id("Go To Item").id("##gotoentry");
-    const auto plus = imgui.popup_id("Go To Item").push("##gotoentry").id("+");
-    const auto minus = imgui.popup_id("Go To Item").push("##gotoentry").id("-");
-
-    imgui.click_element(plus, false, goto_entry);
-    imgui.click_element(plus, false, goto_entry);
-    imgui.click_element(minus, false, goto_entry);
-
-    const std::vector<uint32_t> expected{ 1, 2, 1 };
-    ASSERT_EQ(raised, expected);
-}
-
 TEST(GoTo, OnSelectedNotRaisedWhenMinusPressedAtZero)
 {
     GoTo window;
@@ -85,12 +38,12 @@ TEST(GoTo, OnSelectedNotRaisedWhenMinusPressedAtZero)
     ASSERT_FALSE(raised.has_value());
 }
 
-TEST(GoTo, OnSelectedRaised)
+TEST(GoTo, OnSelectedRaisedNumber)
 {
     GoTo window;
     window.toggle_visible();
     window.set_name("Item");
-
+    window.set_items({ { .number = 10, .name = "Room Ten" } });
     std::optional<uint32_t> raised;
     auto token = window.on_selected += [&](auto value)
     {
@@ -100,8 +53,8 @@ TEST(GoTo, OnSelectedRaised)
     TestImgui imgui([&]() { window.render(); });
     imgui.click_element(imgui.popup_id("Go To Item").id("##gotoentry"));
     imgui.enter_text("10");
+    imgui.press_key(ImGuiKey_DownArrow);
     imgui.press_key(ImGuiKey_Enter);
-
     imgui.reset();
     imgui.render();
 
@@ -110,12 +63,12 @@ TEST(GoTo, OnSelectedRaised)
     ASSERT_FALSE(window.visible());
 }
 
-TEST(GoTo, OnZeroSelectedRaised)
+TEST(GoTo, OnSelectedRaisedText)
 {
     GoTo window;
     window.toggle_visible();
     window.set_name("Item");
-
+    window.set_items({ {.number = 10, .name = "Room Ten" } });
     std::optional<uint32_t> raised;
     auto token = window.on_selected += [&](auto value)
     {
@@ -124,14 +77,14 @@ TEST(GoTo, OnZeroSelectedRaised)
 
     TestImgui imgui([&]() { window.render(); });
     imgui.click_element(imgui.popup_id("Go To Item").id("##gotoentry"));
-    imgui.enter_text("0");
+    imgui.enter_text("Ten");
+    imgui.press_key(ImGuiKey_DownArrow);
     imgui.press_key(ImGuiKey_Enter);
-
     imgui.reset();
     imgui.render();
 
     ASSERT_TRUE(raised.has_value());
-    ASSERT_EQ(raised.value(), 0u);
+    ASSERT_EQ(raised.value(), 10u);
     ASSERT_FALSE(window.visible());
 }
 
@@ -150,30 +103,6 @@ TEST(GoTo, OnSelectedNotRaisedWhenCancelled)
     TestImgui imgui([&]() { window.render(); });
     imgui.click_element(imgui.popup_id("Go To Item").id("##gotoentry"));
     imgui.press_key(ImGuiKey_Escape);
-
-    ASSERT_FALSE(raised.has_value());
-    ASSERT_FALSE(window.visible());
-}
-
-TEST(GoTo, OnSelectedNotRaisedOnNegative)
-{
-    GoTo window;
-    window.toggle_visible();
-    window.set_name("Item");
-
-    std::optional<uint32_t> raised;
-    auto token = window.on_selected += [&](auto value)
-    {
-        raised = value;
-    };
-
-    TestImgui imgui([&]() { window.render(); });
-    imgui.click_element(imgui.popup_id("Go To Item").id("##gotoentry"));
-    imgui.enter_text("-10");
-    imgui.press_key(ImGuiKey_Enter);
-
-    imgui.reset();
-    imgui.render();
 
     ASSERT_FALSE(raised.has_value());
     ASSERT_FALSE(window.visible());

--- a/trview.app.tests/UI/GoToTests.cpp
+++ b/trview.app.tests/UI/GoToTests.cpp
@@ -7,7 +7,7 @@ using namespace trview::tests;
 TEST(GoTo, Name)
 {
     GoTo window;
-    window.toggle_visible(0);
+    window.toggle_visible();
 
     ASSERT_EQ(window.name(), "");
     window.set_name("Item");
@@ -20,7 +20,7 @@ TEST(GoTo, Name)
 TEST(GoTo, OnSelectedWithPlusRaised)
 {
     GoTo window;
-    window.toggle_visible(0);
+    window.toggle_visible();
     window.set_name("Item");
 
     std::optional<uint32_t> raised;
@@ -42,7 +42,7 @@ TEST(GoTo, OnSelectedWithPlusRaised)
 TEST(GoTo, OnSelectedWithMinusRaised)
 {
     GoTo window;
-    window.toggle_visible(0);
+    window.toggle_visible();
     window.set_name("Item");
 
     std::vector<uint32_t> raised;
@@ -67,7 +67,7 @@ TEST(GoTo, OnSelectedWithMinusRaised)
 TEST(GoTo, OnSelectedNotRaisedWhenMinusPressedAtZero)
 {
     GoTo window;
-    window.toggle_visible(0);
+    window.toggle_visible();
     window.set_name("Item");
 
     std::optional<uint32_t> raised;
@@ -88,7 +88,7 @@ TEST(GoTo, OnSelectedNotRaisedWhenMinusPressedAtZero)
 TEST(GoTo, OnSelectedRaised)
 {
     GoTo window;
-    window.toggle_visible(0);
+    window.toggle_visible();
     window.set_name("Item");
 
     std::optional<uint32_t> raised;
@@ -113,7 +113,7 @@ TEST(GoTo, OnSelectedRaised)
 TEST(GoTo, OnZeroSelectedRaised)
 {
     GoTo window;
-    window.toggle_visible(0);
+    window.toggle_visible();
     window.set_name("Item");
 
     std::optional<uint32_t> raised;
@@ -138,7 +138,7 @@ TEST(GoTo, OnZeroSelectedRaised)
 TEST(GoTo, OnSelectedNotRaisedWhenCancelled)
 {
     GoTo window;
-    window.toggle_visible(0);
+    window.toggle_visible();
     window.set_name("Item");
 
     std::optional<uint32_t> raised;
@@ -158,7 +158,7 @@ TEST(GoTo, OnSelectedNotRaisedWhenCancelled)
 TEST(GoTo, OnSelectedNotRaisedOnNegative)
 {
     GoTo window;
-    window.toggle_visible(0);
+    window.toggle_visible();
     window.set_name("Item");
 
     std::optional<uint32_t> raised;

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -118,11 +118,11 @@ TEST(Viewer, SelectItemRaisedForValidItem)
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
 
     auto item = mock_shared<MockItem>();
-    NiceMock<MockLevel> level;
-    EXPECT_CALL(level, item(123)).WillRepeatedly(Return(item));
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, item(123)).WillRepeatedly(Return(item));
 
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
 
     std::shared_ptr<IItem> raised_item;
     auto token = viewer->on_item_selected += [&raised_item](const auto& item) { raised_item = item.lock(); };
@@ -151,8 +151,8 @@ TEST(Viewer, SelectItemNotRaisedForInvalidItem)
 TEST(Viewer, ItemVisibilityRaisedForValidItem)
 {
     auto item = mock_shared<MockItem>();
-    NiceMock<MockLevel> level;
-    EXPECT_CALL(level, item(123)).WillRepeatedly(Return(item));
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, item(123)).WillRepeatedly(Return(item));
 
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
@@ -160,7 +160,7 @@ TEST(Viewer, ItemVisibilityRaisedForValidItem)
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
     TestImgui imgui;
 
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
 
     std::optional<std::tuple<std::shared_ptr<IItem>, bool>> raised_item;
     auto token = viewer->on_item_visibility += [&raised_item](const auto& item, auto visible) { raised_item = { item.lock(), visible }; };
@@ -214,12 +214,12 @@ TEST(Viewer, SelectTriggerRaised)
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
 
-    NiceMock<MockLevel> level;
+    auto level = mock_shared<MockLevel>();
     auto trigger = mock_shared<MockTrigger>();
-    EXPECT_CALL(level, trigger(100)).WillRepeatedly(Return(trigger));
+    EXPECT_CALL(*level, trigger(100)).WillRepeatedly(Return(trigger));
 
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
     TestImgui imgui;
 
     std::optional<std::weak_ptr<ITrigger>> selected_trigger;
@@ -240,12 +240,12 @@ TEST(Viewer, TriggerVisibilityRaised)
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     TestImgui imgui;
 
-    NiceMock<MockLevel> level;
+    auto level = mock_shared<MockLevel>();
     auto trigger = mock_shared<MockTrigger>();
-    EXPECT_CALL(level, trigger(100)).WillRepeatedly(Return(trigger));
+    EXPECT_CALL(*level, trigger(100)).WillRepeatedly(Return(trigger));
 
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
 
     std::optional<std::tuple<std::weak_ptr<ITrigger>, bool>> raised_trigger;
     auto token = viewer->on_trigger_visibility += [&raised_trigger](const auto& trigger, auto visible) { raised_trigger = { trigger, visible }; };
@@ -265,8 +265,11 @@ TEST(Viewer, SelectWaypointRaised)
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
     auto [picking_ptr, picking] = create_mock<MockPicking>();
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
+    auto level = mock_shared<MockLevel>();
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
     TestImgui imgui;
+
+    viewer->open(level, ILevel::OpenMode::Full);
 
     std::optional<uint32_t> selected_waypoint;
     auto token = viewer->on_waypoint_selected += [&selected_waypoint](const auto& waypoint) { selected_waypoint = waypoint; };
@@ -306,9 +309,9 @@ TEST(Viewer, AddWaypointRaised)
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     TestImgui imgui;
 
-    NiceMock<MockLevel> level;
+    auto level = mock_shared<MockLevel>();
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
 
     std::optional<std::tuple<Vector3, Vector3, uint32_t, IWaypoint::Type, uint32_t>> added_waypoint;
     auto token = viewer->on_waypoint_added += [&added_waypoint](const auto& position, const auto& normal, uint32_t room, IWaypoint::Type type, uint32_t index)
@@ -334,13 +337,13 @@ TEST(Viewer, AddWaypointRaisedUsesItemPosition)
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     TestImgui imgui;
 
-    NiceMock<MockLevel> level;
+    auto level = mock_shared<MockLevel>();
     auto item = mock_shared<MockItem>()->with_room(mock_shared<MockRoom>()->with_number(10))->with_number(50);
 
-    EXPECT_CALL(level, item(50)).WillRepeatedly(Return(item));
+    EXPECT_CALL(*level, item(50)).WillRepeatedly(Return(item));
 
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
 
     std::optional<std::tuple<Vector3, Vector3, uint32_t, IWaypoint::Type, uint32_t>> added_waypoint;
     auto token = viewer->on_waypoint_added += [&added_waypoint](const auto& position, const auto& normal, uint32_t room, IWaypoint::Type type, uint32_t index)
@@ -505,13 +508,13 @@ TEST(Viewer, OrbitEnabledWhenRoomSelectedAndAutoOrbitEnabled)
     settings.auto_orbit = true;
     viewer->set_settings(settings);
 
-    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto level = mock_shared<MockLevel>();
     auto room = mock_shared<MockRoom>();
 
-    EXPECT_CALL(level, number_of_rooms).WillRepeatedly(Return(1));
-    EXPECT_CALL(level, rooms).WillRepeatedly(Return(std::vector<std::weak_ptr<IRoom>>{ room }));
-    EXPECT_CALL(level, room).WillRepeatedly(Return(room));
-    viewer->open(&level, ILevel::OpenMode::Full);
+    EXPECT_CALL(*level, number_of_rooms).WillRepeatedly(Return(1));
+    EXPECT_CALL(*level, rooms).WillRepeatedly(Return(std::vector<std::weak_ptr<IRoom>>{ room }));
+    EXPECT_CALL(*level, room).WillRepeatedly(Return(room));
+    viewer->open(level, ILevel::OpenMode::Full);
 
     viewer->set_camera_mode(CameraMode::Free);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
@@ -532,13 +535,13 @@ TEST(Viewer, OrbitNotEnabledWhenRoomSelectedAndAutoOrbitDisabled)
     settings.auto_orbit = false;
     viewer->set_settings(settings);
 
-    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto level = mock_shared<MockLevel>();
     auto room = mock_shared<MockRoom>();
 
-    EXPECT_CALL(level, number_of_rooms).WillRepeatedly(Return(1));
-    EXPECT_CALL(level, rooms).WillRepeatedly(Return(std::vector<std::weak_ptr<IRoom>>{ room }));
-    EXPECT_CALL(level, room).WillRepeatedly(Return(room));
-    viewer->open(&level, ILevel::OpenMode::Full);
+    EXPECT_CALL(*level, number_of_rooms).WillRepeatedly(Return(1));
+    EXPECT_CALL(*level, rooms).WillRepeatedly(Return(std::vector<std::weak_ptr<IRoom>>{ room }));
+    EXPECT_CALL(*level, room).WillRepeatedly(Return(room));
+    viewer->open(level, ILevel::OpenMode::Full);
 
     viewer->set_camera_mode(CameraMode::Free);
     ASSERT_EQ(viewer->camera_mode(), CameraMode::Free);
@@ -575,15 +578,15 @@ TEST(Viewer, CameraRotationUpdated)
 TEST(Viewer, SetShowBoundingBox)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto level = mock_shared<MockLevel>();
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
 
-    EXPECT_CALL(level, set_show_bounding_boxes(false)).Times(1);
+    EXPECT_CALL(*level, set_show_bounding_boxes(false)).Times(1);
     EXPECT_CALL(ui, set_toggle(testing::A<const std::string&>(), testing::A<bool>())).Times(testing::AtLeast(0));
     EXPECT_CALL(ui, set_toggle(IViewer::Options::show_bounding_boxes, true)).Times(1);
-    EXPECT_CALL(level, set_show_bounding_boxes(true)).Times(1);
+    EXPECT_CALL(*level, set_show_bounding_boxes(true)).Times(1);
 
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
     ui.on_toggle_changed(IViewer::Options::show_bounding_boxes, true);
 }
 
@@ -662,25 +665,25 @@ TEST(Viewer, MidWaypointUsesCentroid)
 TEST(Viewer, DepthViewOptionUpdatesLevel)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    NiceMock<MockLevel> level;
-    EXPECT_CALL(level, set_neighbour_depth(6)).Times(1);
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, set_neighbour_depth(6)).Times(1);
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
     ui.on_scalar_changed(IViewer::Options::depth, 6);
 }
 
 TEST(Viewer, SetShowItems)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto level = mock_shared<MockLevel>();
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
 
-    EXPECT_CALL(level, set_show_items(false)).Times(1);
+    EXPECT_CALL(*level, set_show_items(false)).Times(1);
     EXPECT_CALL(ui, set_toggle(testing::A<const std::string&>(), testing::A<bool>())).Times(testing::AtLeast(0));
     EXPECT_CALL(ui, set_toggle(IViewer::Options::items, true)).Times(1);
-    EXPECT_CALL(level, set_show_items(true)).Times(1);
+    EXPECT_CALL(*level, set_show_items(true)).Times(1);
 
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
     ui.on_toggle_changed(IViewer::Options::items, true);
 }
 
@@ -693,13 +696,13 @@ TEST(Viewer, SelectionRendered)
     auto viewer = register_test_module().with_device(device).build();
 
     auto texture_storage = mock_shared<MockLevelTextureStorage>();
-    NiceMock<MockLevel> level;
-    ON_CALL(level, texture_storage).WillByDefault(testing::Return(texture_storage));
-    EXPECT_CALL(level, render(A<const ICamera&>(), true)).Times(1);
+    auto level = mock_shared<MockLevel>();
+    ON_CALL(*level, texture_storage).WillByDefault(testing::Return(texture_storage));
+    EXPECT_CALL(*level, render(A<const ICamera&>(), true)).Times(1);
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, render(A<const ICamera&>(), A<const ILevelTextureStorage&>(), true)).Times(1);
 
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
     viewer->set_route(route);
     viewer->render();
 }
@@ -713,14 +716,14 @@ TEST(Viewer, SelectionNotRendered)
     auto viewer = register_test_module().with_device(device).build();
 
     auto texture_storage = mock_shared<MockLevelTextureStorage>();
-    NiceMock<MockLevel> level;
-    ON_CALL(level, texture_storage).WillByDefault(testing::Return(texture_storage));
-    EXPECT_CALL(level, render(A<const ICamera&>(), false)).Times(1);
+    auto level = mock_shared<MockLevel>();
+    ON_CALL(*level, texture_storage).WillByDefault(testing::Return(texture_storage));
+    EXPECT_CALL(*level, render(A<const ICamera&>(), false)).Times(1);
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, render(A<const ICamera&>(), A<const ILevelTextureStorage&>(), false)).Times(1);
 
     viewer->set_show_selection(false);
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
     viewer->set_route(route);
     viewer->render();
 }
@@ -732,12 +735,12 @@ TEST(Viewer, LightVisibilityRaised)
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     TestImgui imgui;
 
-    NiceMock<MockLevel> level;
+    auto level = mock_shared<MockLevel>();
     auto light = mock_shared<MockLight>();
-    EXPECT_CALL(level, light(100)).WillRepeatedly(Return(light));
+    EXPECT_CALL(*level, light(100)).WillRepeatedly(Return(light));
 
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
 
     std::optional<std::tuple<std::weak_ptr<ILight>, bool>> raised_light;
     auto token = viewer->on_light_visibility += [&raised_light](const auto& light, auto visible) { raised_light = { light, visible }; };
@@ -758,12 +761,12 @@ TEST(Viewer, RoomVisibilityRaised)
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     TestImgui imgui;
 
-    NiceMock<MockLevel> level;
+    auto level = mock_shared<MockLevel>();
     auto room = mock_shared<MockRoom>();
-    EXPECT_CALL(level, room(100)).WillRepeatedly(Return(room));
+    EXPECT_CALL(*level, room(100)).WillRepeatedly(Return(room));
 
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
 
     std::optional<std::tuple<std::weak_ptr<IRoom>, bool>> raised_room;
     auto token = viewer->on_room_visibility += [&raised_room](const auto& room, auto visible) { raised_room = { room, visible }; };
@@ -800,29 +803,29 @@ TEST(Viewer, ReloadLevelSyncProperties)
 {
     std::set<uint32_t> groups{ 1, 2, 3 };
 
-    auto [original_ptr, original] = create_mock<MockLevel>();
-    EXPECT_CALL(original, alternate_mode).WillRepeatedly(Return(true));
-    EXPECT_CALL(original, neighbour_depth).WillRepeatedly(Return(6));
-    EXPECT_CALL(original, highlight_mode_enabled(ILevel::RoomHighlightMode::Highlight)).WillRepeatedly(Return(true));
-    EXPECT_CALL(original, highlight_mode_enabled(ILevel::RoomHighlightMode::Neighbours)).WillRepeatedly(Return(true));
-    EXPECT_CALL(original, alternate_group(1)).WillRepeatedly(Return(true));
-    EXPECT_CALL(original, alternate_group(2)).WillRepeatedly(Return(true));
-    EXPECT_CALL(original, alternate_group(3)).WillRepeatedly(Return(true));
+    auto original = mock_shared<MockLevel>();
+    EXPECT_CALL(*original, alternate_mode).WillRepeatedly(Return(true));
+    EXPECT_CALL(*original, neighbour_depth).WillRepeatedly(Return(6));
+    EXPECT_CALL(*original, highlight_mode_enabled(ILevel::RoomHighlightMode::Highlight)).WillRepeatedly(Return(true));
+    EXPECT_CALL(*original, highlight_mode_enabled(ILevel::RoomHighlightMode::Neighbours)).WillRepeatedly(Return(true));
+    EXPECT_CALL(*original, alternate_group(1)).WillRepeatedly(Return(true));
+    EXPECT_CALL(*original, alternate_group(2)).WillRepeatedly(Return(true));
+    EXPECT_CALL(*original, alternate_group(3)).WillRepeatedly(Return(true));
 
-    auto [reloaded_ptr, reloaded] = create_mock<MockLevel>();
-    EXPECT_CALL(reloaded, set_alternate_mode(true)).Times(1);
-    EXPECT_CALL(reloaded, set_neighbour_depth(6)).Times(1);
-    EXPECT_CALL(reloaded, set_highlight_mode(ILevel::RoomHighlightMode::Neighbours, true)).Times(1);
-    EXPECT_CALL(reloaded, set_highlight_mode(ILevel::RoomHighlightMode::Highlight, true)).Times(1);
-    EXPECT_CALL(reloaded, set_alternate_group(1, true)).Times(1);
-    EXPECT_CALL(reloaded, set_alternate_group(2, true)).Times(1);
-    EXPECT_CALL(reloaded, set_alternate_group(3, true)).Times(1);
-    EXPECT_CALL(reloaded, alternate_groups).WillRepeatedly(Return(groups));
+    auto reloaded = mock_shared<MockLevel>();
+    EXPECT_CALL(*reloaded, set_alternate_mode(true)).Times(1);
+    EXPECT_CALL(*reloaded, set_neighbour_depth(6)).Times(1);
+    EXPECT_CALL(*reloaded, set_highlight_mode(ILevel::RoomHighlightMode::Neighbours, true)).Times(1);
+    EXPECT_CALL(*reloaded, set_highlight_mode(ILevel::RoomHighlightMode::Highlight, true)).Times(1);
+    EXPECT_CALL(*reloaded, set_alternate_group(1, true)).Times(1);
+    EXPECT_CALL(*reloaded, set_alternate_group(2, true)).Times(1);
+    EXPECT_CALL(*reloaded, set_alternate_group(3, true)).Times(1);
+    EXPECT_CALL(*reloaded, alternate_groups).WillRepeatedly(Return(groups));
 
     auto viewer = register_test_module().build();
 
-    viewer->open(&original, ILevel::OpenMode::Full);
-    viewer->open(&reloaded, ILevel::OpenMode::Reload);
+    viewer->open(original, ILevel::OpenMode::Full);
+    viewer->open(reloaded, ILevel::OpenMode::Reload);
 }
 
 TEST(Viewer, CopyPosition)
@@ -872,7 +875,7 @@ TEST(Viewer, SetTriggeredBy)
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_clipboard(clipboard).with_mouse(std::move(mouse_ptr)).build();
 
     auto level = mock_shared<MockLevel>();
-    viewer->open(level.get(), ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
 
     activate_context_menu(picking, mouse, PickResult::Type::Entity, 14);
 }
@@ -881,26 +884,26 @@ TEST(Viewer, SetTriggeredBy)
 TEST(Viewer, SetShowRooms)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto level = mock_shared<MockLevel>();
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
 
-    EXPECT_CALL(level, set_show_rooms(false)).Times(1);
+    EXPECT_CALL(*level, set_show_rooms(false)).Times(1);
     EXPECT_CALL(ui, set_toggle(testing::A<const std::string&>(), testing::A<bool>())).Times(testing::AtLeast(0));
     EXPECT_CALL(ui, set_toggle(IViewer::Options::rooms, true)).Times(1);
-    EXPECT_CALL(level, set_show_rooms(true)).Times(1);
+    EXPECT_CALL(*level, set_show_rooms(true)).Times(1);
 
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
     ui.on_toggle_changed(IViewer::Options::rooms, true);
 }
 
 TEST(Viewer, GoToLaraSelectsLast)
 {
-    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto level = mock_shared<MockLevel>();
     auto viewer = register_test_module().build();
 
     auto item1 = mock_shared<MockItem>();
     auto item2 = mock_shared<MockItem>();
-    ON_CALL(level, items).WillByDefault(Return(std::vector<std::weak_ptr<IItem>>{ item1, item2 }));
+    ON_CALL(*level, items).WillByDefault(Return(std::vector<std::weak_ptr<IItem>>{ item1, item2 }));
 
     std::shared_ptr<IItem> selected;
     auto token = viewer->on_item_selected += [&](const auto& item)
@@ -908,7 +911,7 @@ TEST(Viewer, GoToLaraSelectsLast)
         selected = item.lock();
     };
 
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
 
     ASSERT_TRUE(selected);
     ASSERT_EQ(selected, item2);
@@ -917,8 +920,8 @@ TEST(Viewer, GoToLaraSelectsLast)
 TEST(Viewer, CameraSinkVisibilityRaisedForValidItem)
 {
     auto cs = mock_shared<MockCameraSink>();
-    NiceMock<MockLevel> level;
-    EXPECT_CALL(level, camera_sink(123)).WillRepeatedly(Return(cs));
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, camera_sink(123)).WillRepeatedly(Return(cs));
     TestImgui imgui;
 
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
@@ -926,7 +929,7 @@ TEST(Viewer, CameraSinkVisibilityRaisedForValidItem)
     auto [mouse_ptr, mouse] = create_mock<MockMouse>();
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_mouse(std::move(mouse_ptr)).build();
 
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
 
     std::optional<std::tuple<std::shared_ptr<ICameraSink>, bool>> raised;
     auto token = viewer->on_camera_sink_visibility += [&raised](const auto& camera_sink, auto visible)
@@ -946,15 +949,15 @@ TEST(Viewer, CameraSinkVisibilityRaisedForValidItem)
 TEST(Viewer, SetShowCameraSinks)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto level = mock_shared<MockLevel>();
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
 
-    EXPECT_CALL(level, set_show_camera_sinks(false)).Times(1);
+    EXPECT_CALL(*level, set_show_camera_sinks(false)).Times(1);
     EXPECT_CALL(ui, set_toggle(testing::A<const std::string&>(), testing::A<bool>())).Times(testing::AtLeast(0));
     EXPECT_CALL(ui, set_toggle(IViewer::Options::camera_sinks, true)).Times(1);
-    EXPECT_CALL(level, set_show_camera_sinks(true)).Times(1);
+    EXPECT_CALL(*level, set_show_camera_sinks(true)).Times(1);
 
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
     ui.on_toggle_changed(IViewer::Options::camera_sinks, true);
 }
 
@@ -971,7 +974,7 @@ TEST(Viewer, SetTriggeredByCameraSink)
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).with_picking(std::move(picking_ptr)).with_clipboard(clipboard).with_mouse(std::move(mouse_ptr)).build();
 
     auto level = mock_shared<MockLevel>();
-    viewer->open(level.get(), ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
 
     activate_context_menu(picking, mouse, PickResult::Type::CameraSink, 14);
 }
@@ -979,37 +982,37 @@ TEST(Viewer, SetTriggeredByCameraSink)
 TEST(Viewer, SetShowLighting)
 {
     auto [ui_ptr, ui] = create_mock<MockViewerUI>();
-    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto level = mock_shared<MockLevel>();
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
 
-    EXPECT_CALL(level, set_show_lighting(false)).Times(1);
+    EXPECT_CALL(*level, set_show_lighting(false)).Times(1);
     EXPECT_CALL(ui, set_toggle(testing::A<const std::string&>(), testing::A<bool>())).Times(testing::AtLeast(0));
     EXPECT_CALL(ui, set_toggle(IViewer::Options::lighting, true)).Times(1);
-    EXPECT_CALL(level, set_show_lighting(true)).Times(1);
+    EXPECT_CALL(*level, set_show_lighting(true)).Times(1);
 
-    viewer->open(&level, ILevel::OpenMode::Full);
+    viewer->open(level, ILevel::OpenMode::Full);
     ui.on_toggle_changed(IViewer::Options::lighting, true);
 }
 
 TEST(Viewer, RoomSelectedForwarded)
 {
-    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto level = mock_shared<MockLevel>();
     auto viewer = register_test_module().build();
 
     std::optional<uint32_t> raised;
     auto token = viewer->on_room_selected += [&](auto r) { raised = r; };
 
-    viewer->open(&level, ILevel::OpenMode::Full);
-    level.on_room_selected(123);
+    viewer->open(level, ILevel::OpenMode::Full);
+    level->on_room_selected(123);
 
     ASSERT_TRUE(raised);
     ASSERT_EQ(*raised, 123);
 
-    auto [new_level_ptr, new_level] = create_mock<MockLevel>();
-    viewer->open(&new_level, ILevel::OpenMode::Full);
+    auto new_level = mock_shared<MockLevel>();
+    viewer->open(new_level, ILevel::OpenMode::Full);
 
     raised.reset();
-    level.on_room_selected(456);
+    level->on_room_selected(456);
     ASSERT_FALSE(raised);
 }
 
@@ -1017,21 +1020,21 @@ TEST(Viewer, ItemSelectedForwarded)
 {
     auto item = mock_shared<MockItem>();
 
-    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto level = mock_shared<MockLevel>();
     auto viewer = register_test_module().build();
 
     std::shared_ptr<IItem> raised;
     auto token = viewer->on_item_selected += [&](auto i) { raised = i.lock(); };
 
-    viewer->open(&level, ILevel::OpenMode::Full);
-    level.on_item_selected(item);
+    viewer->open(level, ILevel::OpenMode::Full);
+    level->on_item_selected(item);
 
     ASSERT_EQ(raised, item);
 
     raised.reset();
-    auto [new_level_ptr, new_level] = create_mock<MockLevel>();
-    viewer->open(&new_level, ILevel::OpenMode::Full);
-    level.on_item_selected(item);
+    auto new_level = mock_shared<MockLevel>();
+    viewer->open(new_level, ILevel::OpenMode::Full);
+    level->on_item_selected(item);
     ASSERT_EQ(raised, nullptr);
 }
 
@@ -1039,21 +1042,21 @@ TEST(Viewer, TriggerSelectedForwarded)
 {
     auto trigger = mock_shared<MockTrigger>();
 
-    auto [level_ptr, level] = create_mock<MockLevel>();
+    auto level = mock_shared<MockLevel>();
     auto viewer = register_test_module().build();
 
     std::shared_ptr<ITrigger> raised;
     auto token = viewer->on_trigger_selected += [&](auto t) { raised = t.lock(); };
 
-    viewer->open(&level, ILevel::OpenMode::Full);
-    level.on_trigger_selected(trigger);
+    viewer->open(level, ILevel::OpenMode::Full);
+    level->on_trigger_selected(trigger);
 
     ASSERT_EQ(raised, trigger);
 
     raised.reset();
-    auto [new_level_ptr, new_level] = create_mock<MockLevel>();
-    viewer->open(&new_level, ILevel::OpenMode::Full);
-    level.on_trigger_selected(trigger);
+    auto new_level = mock_shared<MockLevel>();
+    viewer->open(new_level, ILevel::OpenMode::Full);
+    level->on_trigger_selected(trigger);
     ASSERT_EQ(raised, nullptr);
 }
 

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -962,7 +962,7 @@ namespace trview
         _textures_windows->set_texture_storage(_level->texture_storage());
 
         set_route(_route);
-        _viewer->open(_level.get(), open_mode);
+        _viewer->open(level, open_mode);
 
         if (old_level && open_mode == ILevel::OpenMode::Reload)
         {

--- a/trview.app/Mocks/UI/IViewerUI.h
+++ b/trview.app/Mocks/UI/IViewerUI.h
@@ -24,7 +24,8 @@ namespace trview
             MOCK_METHOD(void, set_flip_enabled, (bool), (override));
             MOCK_METHOD(void, set_hide_enabled, (bool), (override));
             MOCK_METHOD(void, set_host_size, (const Size&), (override));
-            MOCK_METHOD(void, set_level, (const std::string&, trlevel::LevelVersion), (override));
+            // MOCK_METHOD(void, set_level, (const std::string&, trlevel::LevelVersion), (override));
+            MOCK_METHOD(void, set_level, (const std::string&, ILevel*), (override));
             MOCK_METHOD(void, set_max_rooms, (uint32_t), (override));
             MOCK_METHOD(void, set_measure_distance, (float), (override));
             MOCK_METHOD(void, set_measure_position, (const Point&), (override));

--- a/trview.app/Mocks/UI/IViewerUI.h
+++ b/trview.app/Mocks/UI/IViewerUI.h
@@ -24,8 +24,7 @@ namespace trview
             MOCK_METHOD(void, set_flip_enabled, (bool), (override));
             MOCK_METHOD(void, set_hide_enabled, (bool), (override));
             MOCK_METHOD(void, set_host_size, (const Size&), (override));
-            // MOCK_METHOD(void, set_level, (const std::string&, trlevel::LevelVersion), (override));
-            MOCK_METHOD(void, set_level, (const std::string&, ILevel*), (override));
+            MOCK_METHOD(void, set_level, (const std::string&, const std::weak_ptr<ILevel>&), (override));
             MOCK_METHOD(void, set_max_rooms, (uint32_t), (override));
             MOCK_METHOD(void, set_measure_distance, (float), (override));
             MOCK_METHOD(void, set_measure_position, (const Point&), (override));

--- a/trview.app/Mocks/Windows/IViewer.h
+++ b/trview.app/Mocks/Windows/IViewer.h
@@ -12,7 +12,7 @@ namespace trview
             virtual ~MockViewer();
             MOCK_METHOD(CameraMode, camera_mode, (), (const, override));
             MOCK_METHOD(void, render, (), (override));
-            MOCK_METHOD(void, open, (ILevel*, ILevel::OpenMode), (override));
+            MOCK_METHOD(void, open, (const std::weak_ptr<ILevel>&, ILevel::OpenMode), (override));
             MOCK_METHOD(void, set_settings, (const UserSettings&), (override));
             MOCK_METHOD(void, select_item, (const std::weak_ptr<IItem>&), (override));
             MOCK_METHOD(void, select_room, (uint32_t), (override));

--- a/trview.app/UI/GoTo.cpp
+++ b/trview.app/UI/GoTo.cpp
@@ -8,10 +8,9 @@ namespace trview
         return _visible;
     }
 
-    void GoTo::toggle_visible(int32_t value)
+    void GoTo::toggle_visible()
     {
         _visible = !_visible;
-        _index = value;
         _shown = false;
         _current_input.clear();
     }
@@ -52,69 +51,44 @@ namespace trview
                     ImGui::SetKeyboardFocusHere();
                 }
 
-                if (!_items.empty())
+                std::string current_input = _current_input;
+                ImGui::InputText("##gotoentry", &current_input);
+                _current_input = current_input;
+
+                bool any_selected = false;
+                if (!_current_input.empty())
                 {
-                    std::string current_input = _current_input;
-                    ImGui::InputText("##gotoentry", &current_input);
-                    _current_input = current_input;
-
-                    bool any_selected = false;
-                    if (!_current_input.empty())
+                    const auto make_upper = std::views::transform([](auto&& c) { return static_cast<char>(std::toupper(c)); }) | std::ranges::to<std::string>();
+                    const auto upper_input = _current_input | make_upper;
+                    std::optional<uint32_t> numeric_input;
                     {
-                        const auto make_upper = std::views::transform([](auto&& c) { return static_cast<char>(std::toupper(c)); }) | std::ranges::to<std::string>();
-                        const auto upper_input = _current_input | make_upper;
-                        std::optional<uint32_t> numeric_input;
+                        uint32_t temp_numeric_input;
+                        if (std::from_chars(upper_input.data(), upper_input.data() + upper_input.size(), temp_numeric_input).ec == std::errc {})
                         {
-                            uint32_t temp_numeric_input;
-                            if (std::from_chars(upper_input.data(), upper_input.data() + upper_input.size(), temp_numeric_input).ec == std::errc {})
-                            {
-                                numeric_input = temp_numeric_input;
-                            }
-                        }
-                        const auto search_results = _items
-                            | std::views::filter([&](auto&& i) { return (numeric_input && i.number == numeric_input.value()) || (i.name | make_upper).contains(upper_input); })
-                            | std::ranges::to<std::vector>();
-
-                        for (const auto& item : search_results)
-                        {
-                            const auto item_id = std::format("{} - {}", item.number, item.name);
-                            if (ImGui::Selectable(item_id.c_str(), false, ImGuiSelectableFlags_DontClosePopups | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
-                            {
-                                on_selected(item.number);
-                            }
-                            any_selected |= ImGui::GetCurrentContext()->NavId == ImGui::GetCurrentWindow()->GetID(item_id.c_str());
+                            numeric_input = temp_numeric_input;
                         }
                     }
+                    const auto search_results = _items
+                        | std::views::filter([&](auto&& i) { return (numeric_input && i.number == numeric_input.value()) || (i.name | make_upper).contains(upper_input); })
+                        | std::ranges::to<std::vector>();
 
-                    ImGui::EndPopup();
-
-                    if (ImGui::IsKeyPressed(ImGuiKey_Escape) || (any_selected && (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter))))
+                    for (const auto& item : search_results)
                     {
-                        _visible = false;
-                        ImGui::FocusWindow(nullptr);
+                        const auto item_id = std::format("{} - {}", item.number, item.name);
+                        if (ImGui::Selectable(item_id.c_str(), false, ImGuiSelectableFlags_DontClosePopups | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
+                        {
+                            on_selected(item.number);
+                        }
+                        any_selected |= ImGui::GetCurrentContext()->NavId == ImGui::GetCurrentWindow()->GetID(item_id.c_str());
                     }
                 }
-                else
+
+                ImGui::EndPopup();
+
+                if (ImGui::IsKeyPressed(ImGuiKey_Escape) || (any_selected && (ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter))))
                 {
-                    if (ImGui::InputInt("##gotoentry", &_index, 1, 100, ImGuiInputTextFlags_EnterReturnsTrue))
-                    {
-                        if (_index >= 0)
-                        {
-                            on_selected(_index);
-                        }
-                    }
-
-                    ImGui::EndPopup();
-
-                    if (ImGui::IsKeyPressed(ImGuiKey_Escape) || ImGui::IsKeyPressed(ImGuiKey_Enter) || ImGui::IsKeyPressed(ImGuiKey_KeypadEnter))
-                    {
-                        if (!ImGui::IsKeyPressed(ImGuiKey_Escape) && _index >= 0)
-                        {
-                            on_selected(_index);
-                        }
-                        _visible = false;
-                        ImGui::FocusWindow(nullptr);
-                    }
+                    _visible = false;
+                    ImGui::FocusWindow(nullptr);
                 }
             }
             else

--- a/trview.app/UI/GoTo.cpp
+++ b/trview.app/UI/GoTo.cpp
@@ -51,7 +51,7 @@ namespace trview
                     ImGui::SetKeyboardFocusHere();
                 }
 
-                if (!_items.empty() && false)
+                if (!_items.empty())
                 {
                     std::string current_input = _current_input;
                     ImGui::InputText("##gotoentry", &current_input);

--- a/trview.app/UI/GoTo.h
+++ b/trview.app/UI/GoTo.h
@@ -17,6 +17,12 @@ namespace trview
     class GoTo final
     {
     public:
+        struct GoToItem final
+        {
+            uint32_t    number;
+            std::string name;
+        };
+
         /// Gets whether the window is currently visible.
         /// @returns True if the window is visible.
         bool visible() const;
@@ -35,10 +41,16 @@ namespace trview
 
         /// Set the name of the type of thing that is being gone to.
         void set_name(const std::string& name);
+
+        void set_items(const std::vector<GoToItem>& items);
     private:
         std::string  _name;
         bool _visible{ false };
         int _index{ 0 };
         bool _shown{ false };
+        std::vector<GoToItem> _items;
+
+        std::string _current_input;
+        std::optional<GoToItem> _current_item;
     };
 }

--- a/trview.app/UI/GoTo.h
+++ b/trview.app/UI/GoTo.h
@@ -49,5 +49,6 @@ namespace trview
         bool _shown{ false };
         std::vector<GoToItem> _items;
         std::string _current_input;
+        bool _need_focus{ false };
     };
 }

--- a/trview.app/UI/GoTo.h
+++ b/trview.app/UI/GoTo.h
@@ -28,7 +28,7 @@ namespace trview
         bool visible() const;
 
         /// Toggle whether the window is visible.
-        void toggle_visible(int32_t value);
+        void toggle_visible();
 
         /// Event raised when the user selects a new room. The newly selected room is passed as
         /// a parameter when the event is raised.
@@ -46,11 +46,8 @@ namespace trview
     private:
         std::string  _name;
         bool _visible{ false };
-        int _index{ 0 };
         bool _shown{ false };
         std::vector<GoToItem> _items;
-
         std::string _current_input;
-        std::optional<GoToItem> _current_item;
     };
 }

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -149,7 +149,8 @@ namespace trview
         /// Set the level name and version.
         /// @param name The file.
         /// @param version The version of the level.
-        virtual void set_level(const std::string& name, trlevel::LevelVersion version) = 0;
+        virtual void set_level(const std::string& name, ILevel* level) = 0;
+            // , const std::weak_ptr<ILevel>& level) = 0;
 
         /// Set the maximum number of rooms in the level.
         /// @param rooms The number of rooms that are in the level.

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -149,8 +149,7 @@ namespace trview
         /// Set the level name and version.
         /// @param name The file.
         /// @param version The version of the level.
-        virtual void set_level(const std::string& name, ILevel* level) = 0;
-            // , const std::weak_ptr<ILevel>& level) = 0;
+        virtual void set_level(const std::string& name, const std::weak_ptr<ILevel>& level) = 0;
 
         /// Set the maximum number of rooms in the level.
         /// @param rooms The number of rooms that are in the level.

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -46,7 +46,16 @@ namespace trview
             {
                 _go_to->set_name("Room");
                 _go_to->toggle_visible(_selected_room);
-                _go_to->set_items({});
+                // if (auto level = _level.lock())
+                if (auto level = _level)
+                {
+                    _go_to->set_items(
+                        level->rooms()
+                        | std::views::transform([](auto&& r) { return r.lock(); })
+                        | std::views::filter([](auto&& r) { return r != nullptr; })
+                        | std::views::transform([](auto&& r) -> GoTo::GoToItem { return { .number = r->number(), .name = std::format("Room {}", r->number()) }; })
+                        | std::ranges::to<std::vector>());
+                }
             }
         };
 

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -45,9 +45,8 @@ namespace trview
             if (!is_input_active())
             {
                 _go_to->set_name("Room");
-                _go_to->toggle_visible(_selected_room);
-                // if (auto level = _level.lock())
-                if (auto level = _level)
+                _go_to->toggle_visible();
+                if (auto level = _level.lock())
                 {
                     _go_to->set_items(
                         level->rooms()
@@ -64,9 +63,8 @@ namespace trview
             if (!is_input_active())
             {
                 _go_to->set_name("Item");
-                _go_to->toggle_visible(_selected_item);
-                // if (auto level = _level.lock())
-                if (auto level = _level)
+                _go_to->toggle_visible();
+                if (auto level = _level.lock())
                 {
                     _go_to->set_items(
                         level->items()
@@ -303,13 +301,11 @@ namespace trview
         _map_renderer->set_window_size(size);
     }
 
-    void ViewerUI::set_level(const std::string& name, ILevel* level)
-        // const std::weak_ptr<ILevel>& level)
+    void ViewerUI::set_level(const std::string& name, const std::weak_ptr<ILevel>& level)
     {
         _level = level;
         _level_info->set_level(name);
-        // if (auto new_level = _level.lock())
-        auto new_level = _level;
+        if (auto new_level = _level.lock())
         {
             _level_info->set_level_version(new_level->version());
         }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -46,6 +46,7 @@ namespace trview
             {
                 _go_to->set_name("Room");
                 _go_to->toggle_visible(_selected_room);
+                _go_to->set_items({});
             }
         };
 
@@ -73,6 +74,7 @@ namespace trview
         _go_to = std::make_unique<GoTo>();
         _token_store += _go_to->on_selected += [&](uint32_t index)
         {
+            _tooltip->set_visible(false);
             if (_go_to->name() == "Item")
             {
                 on_select_item(index);
@@ -217,7 +219,6 @@ namespace trview
             return;
         }
 
-        _tooltip->render();
         _map_tooltip->render();
         _map_renderer->render();
         _view_options->render();
@@ -229,6 +230,7 @@ namespace trview
         _go_to->render();
         _level_info->render();
         _toolbar->render();
+        _tooltip->render();
 
         if (_show_measure)
         {

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -55,6 +55,19 @@ namespace trview
             {
                 _go_to->set_name("Item");
                 _go_to->toggle_visible(_selected_item);
+                // if (auto level = _level.lock())
+                if (false)
+                {
+                    if (auto level = _level)
+                    {
+                        _go_to->set_items(
+                            level->items()
+                            | std::views::transform([](auto&& i) { return i.lock(); })
+                            | std::views::filter([](auto&& i) { return i != nullptr; })
+                            | std::views::transform([](auto&& i) -> GoTo::GoToItem { return { .number = i->number(), .name = i->type() }; })
+                            | std::ranges::to<std::vector>());
+                    }
+                }
             }
         };
 
@@ -282,10 +295,16 @@ namespace trview
         _map_renderer->set_window_size(size);
     }
 
-    void ViewerUI::set_level(const std::string& name, trlevel::LevelVersion version)
+    void ViewerUI::set_level(const std::string& name, ILevel* level)
+        // const std::weak_ptr<ILevel>& level)
     {
+        _level = level;
         _level_info->set_level(name);
-        _level_info->set_level_version(version);
+        // if (auto new_level = _level.lock())
+        auto new_level = _level;
+        {
+            _level_info->set_level_version(new_level->version());
+        }
     }
 
     void ViewerUI::set_max_rooms(uint32_t rooms)

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -56,17 +56,14 @@ namespace trview
                 _go_to->set_name("Item");
                 _go_to->toggle_visible(_selected_item);
                 // if (auto level = _level.lock())
-                if (false)
+                if (auto level = _level)
                 {
-                    if (auto level = _level)
-                    {
-                        _go_to->set_items(
-                            level->items()
-                            | std::views::transform([](auto&& i) { return i.lock(); })
-                            | std::views::filter([](auto&& i) { return i != nullptr; })
-                            | std::views::transform([](auto&& i) -> GoTo::GoToItem { return { .number = i->number(), .name = i->type() }; })
-                            | std::ranges::to<std::vector>());
-                    }
+                    _go_to->set_items(
+                        level->items()
+                        | std::views::transform([](auto&& i) { return i.lock(); })
+                        | std::views::filter([](auto&& i) { return i != nullptr; })
+                        | std::views::transform([](auto&& i) -> GoTo::GoToItem { return { .number = i->number(), .name = i->type() }; })
+                        | std::ranges::to<std::vector>());
                 }
             }
         };

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -44,6 +44,7 @@ namespace trview
         {
             if (!is_input_active())
             {
+                _tooltip->set_visible(false);
                 _go_to->set_name("Room");
                 _go_to->toggle_visible();
                 if (auto level = _level.lock())
@@ -62,6 +63,7 @@ namespace trview
         {
             if (!is_input_active())
             {
+                _tooltip->set_visible(false);
                 _go_to->set_name("Item");
                 _go_to->toggle_visible();
                 if (auto level = _level.lock())

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -46,8 +46,7 @@ namespace trview
 
         /// Set the size of the host window.
         void set_host_size(const Size& size) override;
-        void set_level(const std::string& name, ILevel* level) override;
-            // , const std::weak_ptr<ILevel>& level) override;
+        void set_level(const std::string& name, const std::weak_ptr<ILevel>& level) override;
         virtual void set_max_rooms(uint32_t rooms) override;
         virtual void set_measure_distance(float distance) override;
         virtual void set_measure_position(const Point& position) override;
@@ -99,7 +98,6 @@ namespace trview
         uint32_t _selected_room{ 0u };
         uint32_t _selected_item{ 0u };
         std::weak_ptr<IRoute> _route;
-        // std::weak_ptr<ILevel> _level;
-        ILevel* _level;
+        std::weak_ptr<ILevel> _level;
     };
 }

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -46,7 +46,8 @@ namespace trview
 
         /// Set the size of the host window.
         void set_host_size(const Size& size) override;
-        virtual void set_level(const std::string& name, trlevel::LevelVersion version) override;
+        void set_level(const std::string& name, ILevel* level) override;
+            // , const std::weak_ptr<ILevel>& level) override;
         virtual void set_max_rooms(uint32_t rooms) override;
         virtual void set_measure_distance(float distance) override;
         virtual void set_measure_position(const Point& position) override;
@@ -98,5 +99,7 @@ namespace trview
         uint32_t _selected_room{ 0u };
         uint32_t _selected_item{ 0u };
         std::weak_ptr<IRoute> _route;
+        // std::weak_ptr<ILevel> _level;
+        ILevel* _level;
     };
 }

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -89,7 +89,7 @@ namespace trview
 
         virtual void present(bool vsync) = 0;
 
-        virtual void open(ILevel* level, ILevel::OpenMode open_mode) = 0;
+        virtual void open(const std::weak_ptr<ILevel>& level, ILevel::OpenMode open_mode) = 0;
 
         virtual void set_settings(const UserSettings& settings) = 0;
 

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -691,11 +691,12 @@ namespace trview
         update_camera();
 
         const auto mouse_pos = client_cursor_position(window());
-        if (mouse_pos != _previous_mouse_pos)
+        if (mouse_pos != _previous_mouse_pos || (_camera_moved || _camera_input.movement().LengthSquared() > 0))
         {
             _picking->pick(current_camera());
         }
         _previous_mouse_pos = mouse_pos;
+        _camera_moved = false;
 
         _device->begin();
         _main_window->begin();
@@ -788,6 +789,7 @@ namespace trview
             return;
         }
 
+        _camera_moved = true;
         if (camera_mode == CameraMode::Free || camera_mode == CameraMode::Axis)
         {
             _free_camera.set_alignment(camera_mode_to_alignment(camera_mode));
@@ -1023,6 +1025,7 @@ namespace trview
                 return;
             }
 
+            _camera_moved = true;
             _ui->set_show_context_menu(false);
 
             ICamera& camera = current_camera();
@@ -1043,7 +1046,8 @@ namespace trview
             {
                 return;
             }
-
+            
+            _camera_moved = true;
             if (_camera_mode == CameraMode::Orbit)
             {
                 _camera.set_zoom(_camera.zoom() + zoom);
@@ -1069,6 +1073,7 @@ namespace trview
                 return;
             }
 
+            _camera_moved = true;
             _ui->set_show_context_menu(false);
 
             ICamera& camera = current_camera();

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -676,7 +676,13 @@ namespace trview
         _timer.update();
         update_camera();
 
-        _picking->pick(current_camera());
+        const auto mouse_pos = client_cursor_position(window());
+        if (mouse_pos != _previous_mouse_pos)
+        {
+            _picking->pick(current_camera());
+        }
+        _previous_mouse_pos = mouse_pos;
+
         _device->begin();
         _main_window->begin();
         _main_window->clear(Colour(_settings.background_colour));

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -62,7 +62,7 @@ namespace trview
         toggles[Options::triggers] = [this](bool value) { set_show_triggers(value); };
         toggles[Options::show_bounding_boxes] = [this](bool value) { set_show_bounding_boxes(value); };
         toggles[Options::flip] = [this](bool value) { set_alternate_mode(value); };
-        toggles[Options::depth_enabled] = [this](bool value) { if (_level) { _level->set_highlight_mode(ILevel::RoomHighlightMode::Neighbours, value); } };
+        toggles[Options::depth_enabled] = [this](bool value) { if (auto level = _level.lock()) { level->set_highlight_mode(ILevel::RoomHighlightMode::Neighbours, value); } };
         toggles[Options::lights] = [this](bool value) { set_show_lights(value); };
         toggles[Options::items] = [this](bool value) { set_show_items(value); };
         toggles[Options::rooms] = [this](bool value) { set_show_rooms(value); };
@@ -70,13 +70,13 @@ namespace trview
         toggles[Options::lighting] = [this](bool value) { set_show_lighting(value); };
 
         std::unordered_map<std::string, std::function<void(int32_t)>> scalars;
-        scalars[Options::depth] = [this](int32_t value) { if (_level) { _level->set_neighbour_depth(value); } };
+        scalars[Options::depth] = [this](int32_t value) { if (auto level = _level.lock()) { level->set_neighbour_depth(value); } };
 
         _token_store += _ui->on_select_item += [&](uint32_t index)
         {
-            if (_level)
+            if (auto level = _level.lock())
             {
-                if (const auto item = _level->item(index).lock())
+                if (const auto item = level->item(index).lock())
                 {
                     on_item_selected(item);
                 }
@@ -116,18 +116,21 @@ namespace trview
                 _context_pick.triangle.normal.Normalize();
             }
 
-            if (_context_pick.type == PickResult::Type::Entity)
+            if (auto level = _level.lock())
             {
-                if (const auto item = _level->item(_context_pick.index).lock())
+                if (_context_pick.type == PickResult::Type::Entity)
                 {
-                    _context_pick.position = item->position();
+                    if (const auto item = level->item(_context_pick.index).lock())
+                    {
+                        _context_pick.position = item->position();
+                    }
                 }
-            }
-            else if (_context_pick.type == PickResult::Type::Trigger)
-            {
-                if (const auto trigger = _level->trigger(_context_pick.index).lock())
+                else if (_context_pick.type == PickResult::Type::Trigger)
                 {
-                    _context_pick.position = trigger->position();
+                    if (const auto trigger = level->trigger(_context_pick.index).lock())
+                    {
+                        _context_pick.position = trigger->position();
+                    }
                 }
             }
             on_waypoint_added(_context_pick.position, _context_pick.triangle.normal, room_from_pick(_context_pick), type, _context_pick.index);
@@ -142,16 +145,22 @@ namespace trview
             }
             else if (_context_pick.type == PickResult::Type::Entity)
             {
-                if (const auto item = _level->item(_context_pick.index).lock())
+                if (const auto level = _level.lock())
                 {
-                    _context_pick.position = item->position();
+                    if (const auto item = level->item(_context_pick.index).lock())
+                    {
+                        _context_pick.position = item->position();
+                    }
                 }
             }
             else if (_context_pick.type == PickResult::Type::Trigger)
             {
-                if (const auto trigger = _level->trigger(_context_pick.index).lock())
+                if (const auto level = _level.lock())
                 {
-                    _context_pick.position = trigger->position();
+                    if (const auto trigger = level->trigger(_context_pick.index).lock())
+                    {
+                        _context_pick.position = trigger->position();
+                    }
                 }
             }
 
@@ -168,28 +177,28 @@ namespace trview
         _token_store += _ui->on_remove_waypoint += [&]() { on_waypoint_removed(_context_pick.index); };
         _token_store += _ui->on_hide += [&]()
         {
-            if (_context_pick.type == PickResult::Type::Entity)
+            if (auto level = _level.lock())
             {
-                if (const auto item = _level->item(_context_pick.index).lock())
+                if (_context_pick.type == PickResult::Type::Entity)
                 {
-                    on_item_visibility(item, false);
+                    on_item_visibility(level->item(_context_pick.index), false);
                 }
-            }
-            else if (_context_pick.type == PickResult::Type::Trigger)
-            {
-                on_trigger_visibility(_level->trigger(_context_pick.index), false);
-            }
-            else if (_context_pick.type == PickResult::Type::Light)
-            {
-                on_light_visibility(_level->light(_context_pick.index), false);
-            }
-            else if (_context_pick.type == PickResult::Type::Room)
-            {
-                on_room_visibility(_level->room(_context_pick.index), false);
-            }
-            else if (_context_pick.type == PickResult::Type::CameraSink)
-            {
-                on_camera_sink_visibility(_level->camera_sink(_context_pick.index), false);
+                else if (_context_pick.type == PickResult::Type::Trigger)
+                {
+                    on_trigger_visibility(level->trigger(_context_pick.index), false);
+                }
+                else if (_context_pick.type == PickResult::Type::Light)
+                {
+                    on_light_visibility(level->light(_context_pick.index), false);
+                }
+                else if (_context_pick.type == PickResult::Type::Room)
+                {
+                    on_room_visibility(level->room(_context_pick.index), false);
+                }
+                else if (_context_pick.type == PickResult::Type::CameraSink)
+                {
+                    on_camera_sink_visibility(level->camera_sink(_context_pick.index), false);
+                }
             }
         };
         _token_store += _ui->on_orbit += [&]()
@@ -280,11 +289,12 @@ namespace trview
         };
         _token_store += _picking->pick_sources += [&](PickInfo info, PickResult& result)
         {
-            if (result.stop || !_level)
+            const auto level = _level.lock();
+            if (result.stop || !level)
             {
                 return;
             }
-            result = nearest_result(result, _level->pick(current_camera(), info.position, info.direction));
+            result = nearest_result(result, level->pick(current_camera(), info.position, info.direction));
         };
         _token_store += _picking->pick_sources += [&](PickInfo info, PickResult& result)
         {
@@ -315,9 +325,10 @@ namespace trview
         {
             _current_pick = result;
 
-            if (_level && _route)
+            const auto level = _level.lock();
+            if (level && _route)
             {
-                result.text = generate_pick_message(result, *_level, *_route);
+                result.text = generate_pick_message(result, *level, *_route);
             }
             _ui->set_pick(result);
 
@@ -327,15 +338,15 @@ namespace trview
             }
 
             // Highlight sectors in the minimap.
-            if (_level)
+            if (level)
             {
                 std::optional<RoomInfo> info;
                 if (result.hit)
                 {
                     if (_current_pick.type == PickResult::Type::Room &&
-                        _current_pick.index == _level->selected_room())
+                        _current_pick.index == level->selected_room())
                     {
-                        const auto room = _level->room(_current_pick.index).lock();
+                        const auto room = level->room(_current_pick.index).lock();
                         if (room)
                         {
                             info = room->info();
@@ -343,8 +354,8 @@ namespace trview
                     }
                     else if (_current_pick.type == PickResult::Type::Trigger)
                     {
-                        const auto trigger = _level->trigger(_current_pick.index).lock();
-                        if (trigger && trigger_room(trigger) == _level->selected_room())
+                        const auto trigger = level->trigger(_current_pick.index).lock();
+                        if (trigger && trigger_room(trigger) == level->selected_room())
                         {
                             if (const auto room = trigger->room().lock())
                             {
@@ -479,11 +490,12 @@ namespace trview
                 }
                 else if (std::shared_ptr<ISector> sector = _ui->current_minimap_sector())
                 {
-                    if (!ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
+                    const auto level = _level.lock();
+                    if (level && !ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
                     {
                         uint32_t room = room_number(sector->room());
                         // Select the trigger (if it is a trigger).
-                        const auto triggers = _level->triggers();
+                        const auto triggers = level->triggers();
                         auto trigger = std::find_if(triggers.begin(), triggers.end(),
                             [&](auto t)
                             {
@@ -545,14 +557,15 @@ namespace trview
                 _ui->set_hide_enabled(equals_any(_current_pick.type, PickResult::Type::Entity, PickResult::Type::Trigger, PickResult::Type::Light, PickResult::Type::Room, PickResult::Type::CameraSink));
                 _ui->set_mid_waypoint_enabled(_current_pick.type == PickResult::Type::Room && _current_pick.triangle.normal.y < 0);
 
-                if (_current_pick.type == PickResult::Type::Entity)
+                const auto level = _level.lock();
+                if (_current_pick.type == PickResult::Type::Entity && level)
                 {
-                    const auto item = _level->item(_current_pick.index).lock();
+                    const auto item = level->item(_current_pick.index).lock();
                     _ui->set_triggered_by(item ? item->triggers() : std::vector<std::weak_ptr<ITrigger>>{});
                 }
-                else if (_current_pick.type == PickResult::Type::CameraSink)
+                else if (_current_pick.type == PickResult::Type::CameraSink && level)
                 {
-                    const auto camera_sink = _level->camera_sink(_current_pick.index).lock();
+                    const auto camera_sink = level->camera_sink(_current_pick.index).lock();
                     _ui->set_triggered_by(camera_sink ? camera_sink->triggers() : std::vector<std::weak_ptr<ITrigger>>{});
                 }
                 else 
@@ -570,18 +583,19 @@ namespace trview
             const float Speed = std::max(0.01f, _settings.camera_movement_speed) * _CAMERA_MOVEMENT_SPEED_MULTIPLIER;
             _free_camera.move(_camera_input.movement() * Speed, _timer.elapsed());
 
-            if (_level)
+            if (auto level = _level.lock())
             {
-                _level->on_camera_moved();
+                level->on_camera_moved();
             }
         }
 
         current_camera().update(_timer.elapsed());
     }
 
-    void Viewer::open(ILevel* level, ILevel::OpenMode open_mode)
+    void Viewer::open(const std::weak_ptr<ILevel>& level, ILevel::OpenMode open_mode)
     {
-        ILevel* old_level = _level;
+        auto old_level = _level.lock();
+        auto new_level = level.lock();
         _level = level;
 
         _level_token_store.clear();
@@ -592,26 +606,26 @@ namespace trview
             old_level->on_trigger_selected -= on_trigger_selected;
         }
 
-        _level_token_store += _level->on_alternate_mode_selected += [&](bool enabled) { set_alternate_mode(enabled); };
-        _level_token_store += _level->on_alternate_group_selected += [&](uint16_t group, bool enabled) { set_alternate_group(group, enabled); };
-        _level_token_store += _level->on_level_changed += [&]() { _scene_changed = true; };
-        _level->on_room_selected += on_room_selected;
-        _level->on_item_selected += on_item_selected;
-        _level->on_trigger_selected += on_trigger_selected;
+        _level_token_store += new_level->on_alternate_mode_selected += [&](bool enabled) { set_alternate_mode(enabled); };
+        _level_token_store += new_level->on_alternate_group_selected += [&](uint16_t group, bool enabled) { set_alternate_group(group, enabled); };
+        _level_token_store += new_level->on_level_changed += [&]() { _scene_changed = true; };
+        new_level->on_room_selected += on_room_selected;
+        new_level->on_item_selected += on_item_selected;
+        new_level->on_trigger_selected += on_trigger_selected;
 
-        _level->set_show_triggers(_ui->toggle(Options::triggers));
-        _level->set_show_geometry(_ui->toggle(Options::geometry));
-        _level->set_show_water(_ui->toggle(Options::water));
-        _level->set_show_wireframe(_ui->toggle(Options::wireframe)); 
-        _level->set_show_bounding_boxes(_ui->toggle(Options::show_bounding_boxes));
-        _level->set_show_lights(_ui->toggle( Options::lights));
-        _level->set_show_items(_ui->toggle(Options::items));
-        _level->set_show_rooms(_ui->toggle(Options::rooms));
-        _level->set_show_camera_sinks(_ui->toggle(Options::camera_sinks));
-        _level->set_show_lighting(_ui->toggle(Options::lighting));
+        new_level->set_show_triggers(_ui->toggle(Options::triggers));
+        new_level->set_show_geometry(_ui->toggle(Options::geometry));
+        new_level->set_show_water(_ui->toggle(Options::water));
+        new_level->set_show_wireframe(_ui->toggle(Options::wireframe));
+        new_level->set_show_bounding_boxes(_ui->toggle(Options::show_bounding_boxes));
+        new_level->set_show_lights(_ui->toggle(Options::lights));
+        new_level->set_show_items(_ui->toggle(Options::items));
+        new_level->set_show_rooms(_ui->toggle(Options::rooms));
+        new_level->set_show_camera_sinks(_ui->toggle(Options::camera_sinks));
+        new_level->set_show_lighting(_ui->toggle(Options::lighting));
 
         // Set up the views.
-        auto rooms = _level->rooms();
+        auto rooms = new_level->rooms();
 
         if (open_mode == ILevel::OpenMode::Full || !old_level)
         {
@@ -625,7 +639,7 @@ namespace trview
             _recent_orbit_index = 0u;
 
             std::weak_ptr<IItem> lara;
-            if (_settings.go_to_lara && find_last_item_by_type_id(*_level, 0u, lara))
+            if (_settings.go_to_lara && find_last_item_by_type_id(*new_level, 0u, lara))
             {
                 on_item_selected(lara);
             }
@@ -634,39 +648,39 @@ namespace trview
                 on_room_selected(0);
             }
 
-            if (level->selected_room() < rooms.size())
+            if (new_level->selected_room() < rooms.size())
             {
-                _ui->set_selected_room(rooms[level->selected_room()].lock());
+                _ui->set_selected_room(rooms[new_level->selected_room()].lock());
             }
             
-            auto selected_item = level->selected_item();
+            auto selected_item = new_level->selected_item();
             _ui->set_selected_item(selected_item.value_or(0));
 
             // Strip the last part of the path away.
-            const auto filename = _level->filename();
+            const auto filename = new_level->filename();
             auto last_index = std::min(filename.find_last_of('\\'), filename.find_last_of('/'));
             auto name = last_index == filename.npos ? filename : filename.substr(std::min(last_index + 1, filename.size()));
-            _ui->set_level(name, _level);
+            _ui->set_level(name, new_level);
             window().set_title("trview - " + name);
         }
         else if (open_mode == ILevel::OpenMode::Reload && old_level)
         {
-            _level->set_alternate_mode(old_level->alternate_mode());
-            _level->set_neighbour_depth(old_level->neighbour_depth());
-            _level->set_highlight_mode(ILevel::RoomHighlightMode::Highlight, old_level->highlight_mode_enabled(ILevel::RoomHighlightMode::Highlight));
-            _level->set_highlight_mode(ILevel::RoomHighlightMode::Neighbours, old_level->highlight_mode_enabled(ILevel::RoomHighlightMode::Neighbours));
+            new_level->set_alternate_mode(old_level->alternate_mode());
+            new_level->set_neighbour_depth(old_level->neighbour_depth());
+            new_level->set_highlight_mode(ILevel::RoomHighlightMode::Highlight, old_level->highlight_mode_enabled(ILevel::RoomHighlightMode::Highlight));
+            new_level->set_highlight_mode(ILevel::RoomHighlightMode::Neighbours, old_level->highlight_mode_enabled(ILevel::RoomHighlightMode::Neighbours));
 
-            for (const auto& group : _level->alternate_groups())
+            for (const auto& group : new_level->alternate_groups())
             {
-                _level->set_alternate_group(group, old_level->alternate_group(group));
+                new_level->set_alternate_group(group, old_level->alternate_group(group));
             }
         }
 
         // Reset UI buttons
         _ui->set_max_rooms(static_cast<uint32_t>(rooms.size()));
-        _ui->set_use_alternate_groups(_level->version() >= trlevel::LevelVersion::Tomb4);
-        _ui->set_alternate_groups(_level->alternate_groups());
-        _ui->set_flip_enabled(_level->any_alternates());
+        _ui->set_use_alternate_groups(new_level->version() >= trlevel::LevelVersion::Tomb4);
+        _ui->set_alternate_groups(new_level->alternate_groups());
+        _ui->set_flip_enabled(new_level->any_alternates());
 
         _scene_changed = true;
     }
@@ -717,23 +731,24 @@ namespace trview
     bool Viewer::should_pick() const
     {
         const auto window = this->window();
-        return _level && window_under_cursor() == window && !window_is_minimised(window) && !_ui->is_cursor_over() && !cursor_outside_window(window);
+        const auto level = _level.lock();
+        return level && window_under_cursor() == window && !window_is_minimised(window) && !_ui->is_cursor_over() && !cursor_outside_window(window);
     }
 
     void Viewer::render_scene()
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
             // Update the view matrix based on the room selected in the room window.
-            if (_level->number_of_rooms() > 0)
+            if (level->number_of_rooms() > 0)
             {
                 _camera.set_target(_target);
             }
             
             const auto& camera = current_camera();
 
-            _level->render(camera, _show_selection);
-            auto texture_storage = _level->texture_storage();
+            level->render(camera, _show_selection);
+            auto texture_storage = level->texture_storage();
 
             _sector_highlight->render(camera, *texture_storage);
             _measure->render(camera, *texture_storage);
@@ -743,7 +758,7 @@ namespace trview
                 _route->render(camera, *texture_storage, _show_selection);
             }
 
-            _level->render_transparency(camera);
+            level->render_transparency(camera);
             _compass->render(camera, *texture_storage);
         }
     }
@@ -799,22 +814,23 @@ namespace trview
 
     void Viewer::toggle_highlight()
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            bool new_value = !_level->highlight_mode_enabled(Level::RoomHighlightMode::Highlight);
-            _level->set_highlight_mode(Level::RoomHighlightMode::Highlight, new_value);
+            bool new_value = !level->highlight_mode_enabled(Level::RoomHighlightMode::Highlight);
+            level->set_highlight_mode(Level::RoomHighlightMode::Highlight, new_value);
             _ui->set_toggle(Options::highlight, new_value);
         }
     }
 
     void Viewer::select_room(uint32_t room_number)
     {
-        if (!_level || room_number >= _level->number_of_rooms())
+        const auto level = _level.lock();
+        if (!level || room_number >= level->number_of_rooms())
         {
             return;
         }
 
-        const auto room = _level->room(room_number).lock();
+        const auto room = level->room(room_number).lock();
         if (!room)
         {
             return;
@@ -923,37 +939,38 @@ namespace trview
 
     void Viewer::set_alternate_mode(bool enabled)
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
             _was_alternate_select = true;
-            _level->set_alternate_mode(enabled);
+            level->set_alternate_mode(enabled);
             _ui->set_toggle(Options::flip, enabled);
         }
     }
 
     void Viewer::toggle_alternate_mode()
     {
-        if (_level && _level->any_alternates())
+        const auto level = _level.lock();
+        if (level && level->any_alternates())
         {
-            set_alternate_mode(!_level->alternate_mode());
+            set_alternate_mode(!level->alternate_mode());
         }
     }
 
     void Viewer::set_alternate_group(uint32_t group, bool enabled)
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
             _was_alternate_select = true;
-            _level->set_alternate_group(group, enabled);
+            level->set_alternate_group(group, enabled);
             _ui->set_alternate_group(group, enabled);
         }
     }
 
     bool Viewer::alternate_group(uint32_t group) const
     {
-        if (_level)
+        if (const auto level = _level.lock())
         {
-            return _level->alternate_group(group);
+            return level->alternate_group(group);
         }
         return false;
     }
@@ -1014,9 +1031,9 @@ namespace trview
             const float sensitivity = low_sensitivity + (high_sensitivity - low_sensitivity) * _settings.camera_sensitivity;
             camera.set_rotation_yaw(camera.rotation_yaw() + x / sensitivity);
             camera.set_rotation_pitch(camera.rotation_pitch() - y / sensitivity);
-            if (_level)
+            if (auto level = _level.lock())
             {
-                _level->on_camera_moved();
+                level->on_camera_moved();
             }
         };
 
@@ -1030,17 +1047,17 @@ namespace trview
             if (_camera_mode == CameraMode::Orbit)
             {
                 _camera.set_zoom(_camera.zoom() + zoom);
-                if (_level)
+                if (auto level = _level.lock())
                 {
-                    _level->on_camera_moved();
+                    level->on_camera_moved();
                 }
             }
             else if (_free_camera.projection_mode() == ProjectionMode::Orthographic)
             {
                 _free_camera.set_zoom(_free_camera.zoom() + zoom);
-                if (_level)
+                if (auto level = _level.lock())
                 {
-                    _level->on_camera_moved();
+                    level->on_camera_moved();
                 }
             }
         };
@@ -1082,9 +1099,9 @@ namespace trview
                 _target += 0.05f * Vector3::Transform(Vector3(-x, y * (_settings.invert_vertical_pan ? -1.0f : 1.0f), 0), rotate);
             }
 
-            if (_level)
+            if (auto level = _level.lock())
             {
-                _level->on_camera_moved();
+                level->on_camera_moved();
             }
             _scene_changed = true;
         };
@@ -1094,117 +1111,124 @@ namespace trview
 
     void Viewer::set_show_triggers(bool show)
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            _level->set_show_triggers(show);
+            level->set_show_triggers(show);
             _ui->set_toggle(Options::triggers, show);
         }
     }
 
     void Viewer::toggle_show_triggers()
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            set_show_triggers(!_level->show_triggers());
+            set_show_triggers(!level->show_triggers());
         }
     }
 
     void Viewer::set_show_items(bool show)
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            _level->set_show_items(show);
+            level->set_show_items(show);
             _ui->set_toggle(Options::items, show);
         }
     }
 
     void Viewer::toggle_show_items()
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            set_show_items(!_level->show_items());
+            set_show_items(!level->show_items());
         }
     }
 
     void Viewer::set_show_geometry(bool show)
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            _level->set_show_geometry(show);
+            level->set_show_geometry(show);
             _ui->set_toggle(Options::geometry, show);
         }
     }
 
     void Viewer::toggle_show_geometry()
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            set_show_geometry(!_level->show_geometry());
+            set_show_geometry(!level->show_geometry());
         }
     }
 
     void Viewer::toggle_show_lights()
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            set_show_lights(!_level->show_lights());
+            set_show_lights(!level->show_lights());
         }
     }
 
     void Viewer::set_show_water(bool show)
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            _level->set_show_water(show);
+            level->set_show_water(show);
         }
     }
 
     void Viewer::set_show_wireframe(bool show)
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            _level->set_show_wireframe(show);
+            level->set_show_wireframe(show);
             _ui->set_toggle(Options::wireframe, show);
         }
     }
 
     void Viewer::set_show_bounding_boxes(bool show)
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            _level->set_show_bounding_boxes(show);
+            level->set_show_bounding_boxes(show);
             _ui->set_toggle(Options::show_bounding_boxes, show);
         }
     }
 
     void Viewer::set_show_lights(bool show)
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            _level->set_show_lights(show);
+            level->set_show_lights(show);
             _ui->set_toggle(Options::lights, show);
         }
     }
 
     uint32_t Viewer::room_from_pick(const PickResult& pick) const
     {
+        const auto level = _level.lock();
         switch (pick.type)
         {
         case PickResult::Type::Room:
             return pick.index;
         case PickResult::Type::Entity:
         {
-            if (auto item = _level->item(pick.index).lock())
+            if (level)
             {
-                return item_room(item);
+                if (auto item = level->item(pick.index).lock())
+                {
+                    return item_room(item);
+                }
             }
             break;
         }
         case PickResult::Type::Trigger:
         {
-            if (const auto trigger = _level->trigger(pick.index).lock())
+            if (level)
             {
-                return trigger_room(trigger);
+                if (const auto trigger = level->trigger(pick.index).lock())
+                {
+                    return trigger_room(trigger);
+                }
             }
             break;
         }
@@ -1217,7 +1241,8 @@ namespace trview
             break;
         }
         }
-        return _level->selected_room();
+
+        return level ? level->selected_room() : 0u;
     }
 
     void Viewer::add_recent_orbit(const PickResult& pick)
@@ -1256,6 +1281,7 @@ namespace trview
 
     void Viewer::select_pick(const PickResult& pick)
     {
+        const auto level = _level.lock();
         switch (pick.type)
         {
         case PickResult::Type::Room:
@@ -1267,24 +1293,44 @@ namespace trview
             break;
         case PickResult::Type::Entity:
         {
-            if (const auto item = _level->item(pick.index).lock())
+            if (level)
             {
-                on_item_selected(item);
+                on_item_selected(level->item(pick.index));
             }
             break;
         }
         case PickResult::Type::Trigger:
-            on_trigger_selected(_level->trigger(pick.index));
+        {
+            if (level)
+            {
+                on_trigger_selected(level->trigger(pick.index));
+            }
             break;
+        }
         case PickResult::Type::Waypoint:
-            on_waypoint_selected(pick.index);
+        {
+            if (level)
+            {
+                on_waypoint_selected(pick.index);
+            }
             break;
+        }
         case PickResult::Type::Light:
-            on_light_selected(_level->light(pick.index));
+        {
+            if (level)
+            {
+                on_light_selected(level->light(pick.index));
+            }
             break;
+        }
         case PickResult::Type::CameraSink:
-            on_camera_sink_selected(_level->camera_sink(pick.index));
+        {
+            if (level)
+            {
+                on_camera_sink_selected(level->camera_sink(pick.index));
+            }
             break;
+        }
         }
     }
 
@@ -1340,9 +1386,9 @@ namespace trview
 
     void Viewer::set_show_rooms(bool show)
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            _level->set_show_rooms(show);
+            level->set_show_rooms(show);
             _ui->set_toggle(Options::rooms, show);
         }
     }
@@ -1358,12 +1404,13 @@ namespace trview
 
     void Viewer::set_sector_highlight(const std::shared_ptr<ISector>& sector)
     {
-        if (!_level)
+        const auto level = _level.lock();
+        if (level)
         {
             return;
         }
 
-        const auto room_info = _level->room_info(_level->selected_room());
+        const auto room_info = level->room_info(level->selected_room());
         _sector_highlight->set_sector(sector,
             Matrix::CreateTranslation(room_info.x / trlevel::Scale_X, 0, room_info.z / trlevel::Scale_Z));
         _scene_changed = true;
@@ -1387,35 +1434,35 @@ namespace trview
 
     void Viewer::set_show_camera_sinks(bool show)
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            _level->set_show_camera_sinks(show);
+            level->set_show_camera_sinks(show);
             _ui->set_toggle(Options::camera_sinks, show);
         }
     }
 
     void Viewer::toggle_show_camera_sinks()
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            set_show_camera_sinks(!_level->show_camera_sinks());
+            set_show_camera_sinks(!level->show_camera_sinks());
         }
     }
 
     void Viewer::set_show_lighting(bool show)
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            _level->set_show_lighting(show);
+            level->set_show_lighting(show);
             _ui->set_toggle(Options::lighting, show);
         }
     }
 
     void Viewer::toggle_show_lighting()
     {
-        if (_level)
+        if (auto level = _level.lock())
         {
-            set_show_lighting(!_level->show_lighting());
+            set_show_lighting(!level->show_lighting());
         }
     }
 

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -646,7 +646,7 @@ namespace trview
             const auto filename = _level->filename();
             auto last_index = std::min(filename.find_last_of('\\'), filename.find_last_of('/'));
             auto name = last_index == filename.npos ? filename : filename.substr(std::min(last_index + 1, filename.size()));
-            _ui->set_level(name, _level->version());
+            _ui->set_level(name, _level);
             window().set_title("trview - " + name);
         }
         else if (open_mode == ILevel::OpenMode::Reload && old_level)

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -67,7 +67,7 @@ namespace trview
         virtual void render() override;
         virtual void render_ui() override;
         virtual void present(bool vsync) override;
-        virtual void open(ILevel* level, ILevel::OpenMode open_mode) override;
+        void open(const std::weak_ptr<ILevel>& level, ILevel::OpenMode open_mode) override;
         virtual void set_settings(const UserSettings& settings) override;
         virtual void select_item(const std::weak_ptr<IItem>& item) override;
         virtual void select_room(uint32_t room_number) override;
@@ -135,7 +135,7 @@ namespace trview
         const std::shared_ptr<graphics::IDevice> _device;
         const std::shared_ptr<IShortcuts>& _shortcuts;
         std::unique_ptr<graphics::IDeviceWindow> _main_window;
-        ILevel* _level{ nullptr };
+        std::weak_ptr<ILevel> _level;
         Timer _timer;
         OrbitCamera _camera;
         FreeCamera _free_camera;

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -179,6 +179,8 @@ namespace trview
         std::size_t _recent_orbit_index{ 0u };
 
         std::shared_ptr<IClipboard> _clipboard;
+
+        Point _previous_mouse_pos;
     };
 }
 

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -181,6 +181,7 @@ namespace trview
         std::shared_ptr<IClipboard> _clipboard;
 
         Point _previous_mouse_pos;
+        bool _camera_moved{ false };
     };
 }
 


### PR DESCRIPTION
Convert the "Go To" window to allow the user to search through the possible targets using either number or name. They can then arrow down to them or click on the result to select it.
`Viewer` and `ViewerUI` were changed to take `std::weak_ptr<ILevel>` instead of `ILevel` to be consistent with everything else.
Picking now only occurs when the mouse or camera moves and the tooltip is hidden when an entry is selected in a Go To window.
Closes #1187 