### PR TITLE
Save view options when changed

### DIFF
--- a/trview.app.tests/Settings/SettingsLoaderTests.cpp
+++ b/trview.app.tests/Settings/SettingsLoaderTests.cpp
@@ -693,3 +693,20 @@ TEST(SettingsLoader, PluginDirectoriesLoaded)
     ASSERT_EQ(settings.plugin_directories, expected);
 }
 
+TEST(SettingsLoader, TogglesSaved)
+{
+    std::string output;
+    auto loader = setup_save_setting(output);
+    UserSettings settings;
+    settings.toggles = { { "test1", false }, { "test2", true } };
+    loader->save_user_settings(settings);
+    EXPECT_THAT(output, HasSubstr("\"toggles\":{\"test1\":false,\"test2\":true}"));
+}
+
+TEST(SettingsLoader, TogglesLoaded)
+{
+    auto loader = setup_setting("{\"toggles\":{\"test1\":false,\"test2\":true}}");
+    auto settings = loader->load_user_settings();
+    const std::unordered_map<std::string, bool> expected{ { "test1", false }, { "test2", true } };
+    ASSERT_EQ(settings.toggles, expected);
+}

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -1064,3 +1064,20 @@ TEST(Viewer, SetRouteForwarded)
     auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
     viewer->set_route(mock_shared<MockRoute>());
 }
+
+TEST(Viewer, ToggleSaved)
+{
+    auto [ui_ptr, ui] = create_mock<MockViewerUI>();
+    auto viewer = register_test_module().with_ui(std::move(ui_ptr)).build();
+    viewer->set_settings({});
+
+    std::optional<UserSettings> raised;
+    auto token = viewer->on_settings += [&](const auto& new_settings) { raised = new_settings; };
+
+    ui.on_toggle_changed(IViewer::Options::water, true);
+
+    const std::unordered_map<std::string, bool> expected { { IViewer::Options::water, true } };
+
+    ASSERT_TRUE(raised);
+    ASSERT_EQ(raised.value().toggles, expected);
+}

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -89,6 +89,7 @@ namespace trview
             read_attribute(json, settings.camera_sink_startup, "camera_sink_startup");
             read_attribute(json, settings.window_placement, "window_placement");
             read_attribute(json, settings.plugin_directories, "plugin_directories");
+            read_attribute(json, settings.toggles, "toggles");
 
             settings.recent_files.resize(std::min<std::size_t>(settings.recent_files.size(), settings.max_recent_files));
         }
@@ -154,6 +155,7 @@ namespace trview
                 json["window_placement"] = settings.window_placement.value();
             }
             json["plugin_directories"] = settings.plugin_directories;
+            json["toggles"] = settings.toggles;
             _files->save_file(file_path, json.dump());
         }
         catch (...)

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -56,6 +56,7 @@ namespace trview
         std::unordered_map<std::string, RecentRoute> recent_routes;
         float fov{ 45 };
         std::vector<std::string> plugin_directories;
+        std::unordered_map<std::string, bool> toggles;
 
         bool operator==(const UserSettings& other) const;
     };

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -353,6 +353,10 @@ namespace trview
         _settings_window->set_plugin_directories(settings.plugin_directories);
         _camera_position->set_display_degrees(settings.camera_display_degrees);
         _map_renderer->set_colours(settings.map_colours);
+        for (const auto& toggle : settings.toggles)
+        {
+            set_toggle(toggle.first, toggle.second);
+        }
     }
 
     void ViewerUI::set_selected_item(uint32_t index)

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -69,6 +69,16 @@ namespace trview
         toggles[Options::camera_sinks] = [this](bool value) { set_show_camera_sinks(value); };
         toggles[Options::lighting] = [this](bool value) { set_show_lighting(value); };
 
+        const auto persist_toggle_value = [&](const std::string& name, bool value)
+        {
+            if (equals_any(name, Options::flip, Options::highlight, Options::depth_enabled))
+            {
+                return;
+            }
+            _settings.toggles[name] = value;
+            on_settings(_settings);
+        };
+
         std::unordered_map<std::string, std::function<void(int32_t)>> scalars;
         scalars[Options::depth] = [this](int32_t value) { if (_level) { _level->set_neighbour_depth(value); } };
 
@@ -83,7 +93,7 @@ namespace trview
             }
         };
         _token_store += _ui->on_select_room += [&](uint32_t room) { on_room_selected(room); };
-        _token_store += _ui->on_toggle_changed += [this, toggles](const std::string& name, bool value)
+        _token_store += _ui->on_toggle_changed += [this, toggles, persist_toggle_value](const std::string& name, bool value)
         {
             auto toggle = toggles.find(name);
             if (toggle == toggles.end())
@@ -91,6 +101,7 @@ namespace trview
                 return;
             }
             toggle->second(value);
+            persist_toggle_value(name, value);
         };
         _token_store += _ui->on_alternate_group += [&](uint32_t group, bool value) { set_alternate_group(group, value); };
         _token_store += _ui->on_scalar_changed += [this, scalars](const std::string& name, int32_t value)

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -68,6 +68,7 @@ namespace trview
         toggles[Options::rooms] = [this](bool value) { set_show_rooms(value); };
         toggles[Options::camera_sinks] = [this](bool value) { set_show_camera_sinks(value); };
         toggles[Options::lighting] = [this](bool value) { set_show_lighting(value); };
+        toggles[Options::notes] = [](bool) {};
 
         const auto persist_toggle_value = [&](const std::string& name, bool value)
         {


### PR DESCRIPTION
When the user toggles a view option save it to settings. Doesn't require a visit to the settings window for ease of use. 
Closes #1190