### PR TITLE
Fix issue with spaces in paths on open with

### DIFF
--- a/trview.app.tests/Settings/StartupOptionsTests.cpp
+++ b/trview.app.tests/Settings/StartupOptionsTests.cpp
@@ -18,7 +18,7 @@ TEST(StartupOptions, FlagsWithNoFile)
 
 TEST(StartupOptions, FlagsWithFile)
 {
-    StartupOptions startup_options{ L"trview.exe c:\\test.tr2 -ff1 -ff2" };
+    StartupOptions startup_options{ L"trview.exe -ff1 -ff2 c:\\test.tr2" };
     ASSERT_EQ(startup_options.filename(), "c:\\test.tr2");
     ASSERT_EQ(startup_options.feature("ff1"), true);
     ASSERT_EQ(startup_options.feature("ff2"), true);
@@ -28,4 +28,18 @@ TEST(StartupOptions, MissingFlagIsFalse)
 {
     StartupOptions startup_options{ L"trview.exe c:\\test.tr2 -ff2" };
     ASSERT_EQ(startup_options.feature("ff1"), false);
+}
+
+TEST(StartupOptions, FilenameWithSpaces)
+{
+    StartupOptions startup_options{ L"trview.exe C:\\Path with spaces\\test.tr2" };
+    ASSERT_EQ(startup_options.filename(), "C:\\Path with spaces\\test.tr2");
+}
+
+TEST(StartupOptions, FlagsWithFileAndSpaces)
+{
+    StartupOptions startup_options{ L"trview.exe -ff1 -ff2 c:\\test 2.tr2" };
+    ASSERT_EQ(startup_options.filename(), "c:\\test 2.tr2");
+    ASSERT_EQ(startup_options.feature("ff1"), true);
+    ASSERT_EQ(startup_options.feature("ff2"), true);
 }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -159,7 +159,7 @@ namespace trview
         _map_renderer = map_renderer_source(window.size());
         _token_store += _map_renderer->on_sector_hover += [this](const std::shared_ptr<ISector>& sector)
         {
-            if (ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
+            if (ImGui::GetCurrentContext() && ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
             {
                 _map_renderer->clear_hovered_sector();
                 return;


### PR DESCRIPTION
When trview is associated with level files and you open a level in explorer if the path has spaces in then the `CommandLineToArgvW` will split on spaces - we now stick them back together to form the original path.
This means flags have to come first but they aren't really used yet anyway.
Also fixes an issue in the map renderer where it would try to use imgui before it was ready in some situations. 
Closes #1192