### PR TITLE
Change picking to consider all room results first

### DIFF
--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -180,7 +180,7 @@ TEST(Level, OcbAdjustmentsPerformedWhenNeeded)
     auto room = mock_shared<MockRoom>();
     PickResult result{};
     result.hit = true;
-    EXPECT_CALL(*room, pick).WillRepeatedly(Return(result));
+    EXPECT_CALL(*room, pick).WillRepeatedly(Return(std::vector<PickResult> { result }));
     
     auto level = register_test_module().with_level(std::move(mock_level_ptr))
         .with_room_source(
@@ -215,7 +215,7 @@ TEST(Level, OcbAdjustmentsNotPerformedWhenNotNeeded)
                 auto room = mock_shared<MockRoom>();
                 PickResult result{};
                 result.hit = true;
-                EXPECT_CALL(*room, pick).WillRepeatedly(Return(result));
+                EXPECT_CALL(*room, pick).WillRepeatedly(Return(std::vector<PickResult> { result }));
                 return room;
             })
         .with_entity_source(

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -345,7 +345,9 @@ TEST(Room, PickTestsEntities)
     EXPECT_CALL(*entity, pick).Times(1).WillOnce(Return(PickResult{ true, 0, {}, {}, PickResult::Type::Entity, 10 }));
     room->add_entity(entity);
 
-    auto result = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), PickFilter::Entities);
+    auto results = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), PickFilter::Entities);
+    ASSERT_EQ(results.size(), 1);
+    auto result = results.front();
     ASSERT_EQ(result.hit, true);
     ASSERT_EQ(result.type, PickResult::Type::Entity);
     ASSERT_EQ(result.index, 10);
@@ -365,7 +367,9 @@ TEST(Room, PickTestsTriggers)
     EXPECT_CALL(*trigger, pick).Times(1).WillOnce(Return(PickResult{ true, 0, {}, {}, PickResult::Type::Trigger, 10 }));
     room->add_trigger(trigger);
 
-    auto result = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), PickFilter::Triggers);
+    auto results = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), PickFilter::Triggers);
+    ASSERT_EQ(results.size(), 1);
+    auto result = results.front();
     ASSERT_EQ(result.hit, true);
     ASSERT_EQ(result.type, PickResult::Type::Trigger);
     ASSERT_EQ(result.index, 10);
@@ -390,7 +394,9 @@ TEST(Room, PickChoosesClosest)
     EXPECT_CALL(*entity2, pick).Times(1).WillOnce(Return(PickResult{ true, 1.0f, {}, {}, PickResult::Type::Entity, 10 }));
     room->add_entity(entity2);
 
-    auto result = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), PickFilter::Entities | PickFilter::Triggers);
+    auto results = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), PickFilter::Entities | PickFilter::Triggers);
+    ASSERT_EQ(results.size(), 2);
+    auto result = results.front();
     ASSERT_EQ(result.hit, true);
     ASSERT_EQ(result.type, PickResult::Type::Entity);
     ASSERT_EQ(result.index, 5);
@@ -415,7 +421,9 @@ TEST(Room, PickChoosesEntityOverTrigger)
     EXPECT_CALL(*trigger, pick).Times(0);
     room->add_trigger(trigger);
 
-    auto result = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), PickFilter::Entities | PickFilter::Triggers);
+    auto results = room->pick(Vector3(0, 0, -2), Vector3(0, 0, 1), PickFilter::Entities | PickFilter::Triggers);
+    ASSERT_EQ(results.size(), 1);
+    auto result = results.front();
     ASSERT_EQ(result.hit, true);
     ASSERT_EQ(result.type, PickResult::Type::Entity);
     ASSERT_EQ(result.index, 5);

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -219,7 +219,7 @@ namespace trview
         /// <param name="direction">The direction of the ray.</param>
         /// <param name="filters">The types of objects to include the picking operation.</param>
         /// <returns>The <see cref="PickResult"/>.</returns>
-        virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, PickFilter filters = PickFilter::Default) const = 0;
+        virtual std::vector<PickResult> pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, PickFilter filters = PickFilter::Default) const = 0;
         /// <summary>
         /// Gets whether the room is a quicksand room based on the room flags. This can only be true if the game is TR3 or later.
         /// </summary>

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -94,7 +94,7 @@ namespace trview
         return _neighbours;
     }
 
-    PickResult Room::pick(const Vector3& position, const Vector3& direction, PickFilter filters) const
+    std::vector<PickResult> Room::pick(const Vector3& position, const Vector3& direction, PickFilter filters) const
     {
         using namespace DirectX::TriangleTests;
 
@@ -102,7 +102,7 @@ namespace trview
         float box_distance = 0;
         if (!_bounding_box.Intersects(position, direction, box_distance))
         {
-            return PickResult();
+            return {};
         }
 
         std::vector<PickResult> pick_results;
@@ -126,7 +126,7 @@ namespace trview
             }
         }
 
-        if (has_flag(filters, PickFilter::Lights) && pick_results.empty())
+        if (has_flag(filters, PickFilter::Lights))
         {
             for (const auto& light : _lights)
             {
@@ -144,7 +144,7 @@ namespace trview
             }
         }
 
-        if (has_flag(filters, PickFilter::CameraSinks) && pick_results.empty())
+        if (has_flag(filters, PickFilter::CameraSinks))
         {
             for (const auto& camera_sink : _camera_sinks)
             {
@@ -162,7 +162,7 @@ namespace trview
             }
         }
 
-        if (has_flag(filters, PickFilter::Triggers) && pick_results.empty())
+        if (has_flag(filters, PickFilter::Triggers))
         {
             for (const auto& trigger_pair : _triggers)
             {
@@ -219,15 +219,9 @@ namespace trview
             }
         }
 
-        if (pick_results.empty())
-        {
-            return PickResult();
-        }
-
-        // Choose the closest pick out of all results.
         std::sort(pick_results.begin(), pick_results.end(),
             [](const auto& l, const auto& r) { return l.distance < r.distance; });
-        return pick_results.front();
+        return pick_results;
     }
 
     void Room::render(const ICamera& camera, SelectionMode selected, RenderFilter render_filter, const std::unordered_set<uint32_t>& visible_rooms)

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -36,7 +36,7 @@ namespace trview
         Room& operator=(const Room&) = delete;
         virtual RoomInfo info() const override;
         virtual std::set<uint16_t> neighbours() const override;
-        virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, PickFilter filters = PickFilter::Default) const override;
+        virtual std::vector<PickResult> pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction, PickFilter filters = PickFilter::Default) const override;
         virtual void render(const ICamera& camera, SelectionMode selected, RenderFilter render_filter, const std::unordered_set<uint32_t>& visible_rooms) override;
         virtual void render_bounding_boxes(const ICamera& camera) override;
         virtual void render_lights(const ICamera& camera, const std::weak_ptr<ILight>& selected_light) override;

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -33,7 +33,7 @@ namespace trview
             MOCK_METHOD(uint16_t, num_z_sectors, (), (const, override));
             MOCK_METHOD(uint32_t, number, (), (const, override));
             MOCK_METHOD(bool, outside, (), (const, override));
-            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, PickFilter), (const, override));
+            MOCK_METHOD(std::vector<PickResult>, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&, PickFilter), (const, override));
             MOCK_METHOD(bool, quicksand, (), (const, override));
             MOCK_METHOD(void, render, (const ICamera&, SelectionMode, RenderFilter, const std::unordered_set<uint32_t>&), (override));
             MOCK_METHOD(void, render_bounding_boxes, (const ICamera&), (override));


### PR DESCRIPTION
Change picking to take results from all rooms and then proceed until it finds a wall, at which point it will give up.
Items will be the priority up until that point.
Closes #1197