### PR TITLE
Add Categories property to Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Clear Body | Whether to remove a dead body when a bodybag trigger is triggered
 Invisible | Whether this item is invisible
 Flags | Entity activation flags
 OCB | Used to change entity behaviour
+Categories | Categories to which the item is assigned
 
 ## Add To Route
 Clicking the `Add to Route` button will insert this item at the current position in the route.

--- a/doc/lua/item.md
+++ b/doc/lua/item.md
@@ -7,6 +7,7 @@ The Item library provides information about an item in a [level](level.md).
 | ---- | ---- | ---- | ---- |
 | activation_flags | number | R | Bit flags used in combination with trigger flags |
 | angle | number | R | Y rotation in range 0-65535 |
+| categories | string[] | RW | Categories that the item belongs to. Initially inherited by trview type list but can be overwrritten |
 | clear_body | boolean | R | Flag used together with Clear Bodies trigger action to remove the body of dead enemy from the level to conserve resources |
 | invisible | boolean | R | Flag that determines whether the item is invisible in-game or not |
 | number | number | R | Item number |

--- a/trview.app.tests/Elements/ItemTests.cpp
+++ b/trview.app.tests/Elements/ItemTests.cpp
@@ -135,9 +135,3 @@ TEST(Item, MutantEggContentsFlags)
     ASSERT_EQ(22, mutant_egg_contents(8));
     ASSERT_EQ(20, mutant_egg_contents(1851));
 }
-
-TEST(Item, PickupCategoryMarksPickup)
-{
-    auto item = register_test_module().with_type_info({ .categories = { "Pickup" } }).build();
-    ASSERT_TRUE(item->is_pickup());
-}

--- a/trview.app.tests/Elements/ItemTests.cpp
+++ b/trview.app.tests/Elements/ItemTests.cpp
@@ -22,7 +22,7 @@ namespace
             std::shared_ptr<IMeshStorage> mesh_storage = mock_shared<MockMeshStorage>();
             trlevel::tr2_entity entity{};
             uint32_t index{ 0u };
-            TypeInfo type{ .name = "Lara", .pickup = false };
+            TypeInfo type{ .name = "Lara" };
             std::vector<std::weak_ptr<ITrigger>> triggers;
             std::shared_ptr<ILevel> owning_level{ mock_shared<MockLevel>() };
             std::shared_ptr<IRoom> room { mock_shared<MockRoom>() };
@@ -40,7 +40,14 @@ namespace
 
             test_module& with_pickup(bool value)
             {
-                type.pickup = value;
+                if (value)
+                {
+                    type.categories.insert("Pickup");
+                }
+                else
+                {
+                    type.categories.erase("Pickup");
+                }
                 return *this;
             }
 
@@ -131,6 +138,6 @@ TEST(Item, MutantEggContentsFlags)
 
 TEST(Item, PickupCategoryMarksPickup)
 {
-    auto item = register_test_module().with_type_info({ .pickup = false, .categories = { "Pickup" } }).build();
+    auto item = register_test_module().with_type_info({ .categories = { "Pickup" } }).build();
     ASSERT_TRUE(item->is_pickup());
 }

--- a/trview.app.tests/Elements/ItemTests.cpp
+++ b/trview.app.tests/Elements/ItemTests.cpp
@@ -22,15 +22,14 @@ namespace
             std::shared_ptr<IMeshStorage> mesh_storage = mock_shared<MockMeshStorage>();
             trlevel::tr2_entity entity{};
             uint32_t index{ 0u };
-            bool is_pickup{ false };
-            std::string type{ "Lara" };
+            TypeInfo type{ .name = "Lara", .pickup = false };
             std::vector<std::weak_ptr<ITrigger>> triggers;
             std::shared_ptr<ILevel> owning_level{ mock_shared<MockLevel>() };
             std::shared_ptr<IRoom> room { mock_shared<MockRoom>() };
 
             std::unique_ptr<Item> build()
             {
-                return std::make_unique<Item>(mesh_source, *level, entity, *mesh_storage, owning_level, index, type, triggers, is_pickup, room);
+                return std::make_unique<Item>(mesh_source, *level, entity, *mesh_storage, owning_level, index, type, triggers, room);
             }
 
             test_module& with_level(const std::shared_ptr<trlevel::ILevel>& level)
@@ -41,7 +40,7 @@ namespace
 
             test_module& with_pickup(bool value)
             {
-                this->is_pickup = value;
+                type.pickup = value;
                 return *this;
             }
 

--- a/trview.app.tests/Elements/ItemTests.cpp
+++ b/trview.app.tests/Elements/ItemTests.cpp
@@ -49,6 +49,12 @@ namespace
                 this->entity = entity;
                 return *this;
             }
+
+            test_module& with_type_info(const TypeInfo& type_info)
+            {
+                this->type = type_info;
+                return *this;
+            }
         };
         return test_module{};
     }
@@ -121,4 +127,10 @@ TEST(Item, MutantEggContentsFlags)
     ASSERT_EQ(34, mutant_egg_contents(4));
     ASSERT_EQ(22, mutant_egg_contents(8));
     ASSERT_EQ(20, mutant_egg_contents(1851));
+}
+
+TEST(Item, PickupCategoryMarksPickup)
+{
+    auto item = register_test_module().with_type_info({ .pickup = false, .categories = { "Pickup" } }).build();
+    ASSERT_TRUE(item->is_pickup());
 }

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -6,7 +6,6 @@
 #include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
 #include <trview.app/Mocks/Graphics/ISelectionRenderer.h>
-#include <trview.app/Mocks/Elements/ITypeNameLookup.h>
 #include <trview.app/Mocks/Elements/IItem.h>
 #include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>

--- a/trview.app.tests/Elements/TypeInfoLookupTests.cpp
+++ b/trview.app.tests/Elements/TypeInfoLookupTests.cpp
@@ -10,7 +10,7 @@ TEST(TypeInfoLookup, LookupTR1)
 
     TypeInfoLookup lookup(json);
 
-    ASSERT_EQ("Test Name", lookup.lookup_type_name(LevelVersion::Tomb1, 123, 0));
+    ASSERT_EQ("Test Name", lookup.lookup(LevelVersion::Tomb1, 123, 0).name);
 }
 
 // Tests that if there are identical entries for different games, the correct result is returned.
@@ -20,8 +20,8 @@ TEST(TypeInfoLookup, LookupMultipleGames)
 
     TypeInfoLookup lookup(json);
 
-    ASSERT_EQ("Test Name TR1", lookup.lookup_type_name(LevelVersion::Tomb1, 123, 0));
-    ASSERT_EQ("Test Name TR2", lookup.lookup_type_name(LevelVersion::Tomb2, 123, 0));
+    ASSERT_EQ("Test Name TR1", lookup.lookup(LevelVersion::Tomb1, 123, 0).name);
+    ASSERT_EQ("Test Name TR2", lookup.lookup(LevelVersion::Tomb2, 123, 0).name);
 }
 
 // Tests that if the name is missing, it still returns the number.
@@ -31,7 +31,7 @@ TEST(TypeInfoLookup, LookupMissingItem)
 
     TypeInfoLookup lookup(json);
 
-    ASSERT_EQ("123", lookup.lookup_type_name(LevelVersion::Tomb3, 123, 0));
+    ASSERT_EQ("123", lookup.lookup(LevelVersion::Tomb3, 123, 0).name);
 }
 
 TEST(TypeInfoLookup, LookupNormalMutantEggs)
@@ -39,12 +39,12 @@ TEST(TypeInfoLookup, LookupNormalMutantEggs)
     std::string json = "{\"games\":{\"tr1\":[{\"id\":163,\"name\":\"Test Name 1\"}]}}";
     TypeInfoLookup lookup(json);
 
-    auto winged = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 0);
-    auto shooter = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 1 << 9);
-    auto centaur = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 2 << 9);
-    auto torso = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 4 << 9);
-    auto grounded = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 8 << 9);
-    auto def = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 3 << 9);
+    auto winged = lookup.lookup(trlevel::LevelVersion::Tomb1, 163, 0).name;
+    auto shooter = lookup.lookup(trlevel::LevelVersion::Tomb1, 163, 1 << 9).name;
+    auto centaur = lookup.lookup(trlevel::LevelVersion::Tomb1, 163, 2 << 9).name;
+    auto torso = lookup.lookup(trlevel::LevelVersion::Tomb1, 163, 4 << 9).name;
+    auto grounded = lookup.lookup(trlevel::LevelVersion::Tomb1, 163, 8 << 9).name;
+    auto def = lookup.lookup(trlevel::LevelVersion::Tomb1, 163, 3 << 9).name;
 
     ASSERT_EQ(winged, "Mutant Egg (Winged)");
     ASSERT_EQ(shooter, "Mutant Egg (Shooter)");
@@ -59,12 +59,12 @@ TEST(TypeInfoLookup, LookupBigMutantEggs)
     std::string json = "{\"games\":{\"tr1\":[{\"id\":181,\"name\":\"Test Name 2\"}]}}";
     TypeInfoLookup lookup(json);
 
-    auto winged = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 0);
-    auto shooter = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 1 << 9);
-    auto centaur = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 2 << 9);
-    auto torso = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 4 << 9);
-    auto grounded = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 8 << 9);
-    auto def = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 3 << 9);
+    auto winged = lookup.lookup(trlevel::LevelVersion::Tomb1, 181, 0).name;
+    auto shooter = lookup.lookup(trlevel::LevelVersion::Tomb1, 181, 1 << 9).name;
+    auto centaur = lookup.lookup(trlevel::LevelVersion::Tomb1, 181, 2 << 9).name;
+    auto torso = lookup.lookup(trlevel::LevelVersion::Tomb1, 181, 4 << 9).name;
+    auto grounded = lookup.lookup(trlevel::LevelVersion::Tomb1, 181, 8 << 9).name;
+    auto def = lookup.lookup(trlevel::LevelVersion::Tomb1, 181, 3 << 9).name;
 
     ASSERT_EQ(winged, "Mutant Egg (Winged)");
     ASSERT_EQ(shooter, "Mutant Egg (Shooter)");
@@ -79,7 +79,7 @@ TEST(TypeInfoLookup, LookupNormalMutantEggsTR2)
     std::string json = "{\"games\":{\"tr1\":[{\"id\":163,\"name\":\"Test Name 1\"}],\"tr2\":[{\"id\":163,\"name\":\"Test Name 2\"}]}}";
     TypeInfoLookup lookup(json);
 
-    auto winged = lookup.lookup_type_name(trlevel::LevelVersion::Tomb2, 163, 0);
+    auto winged = lookup.lookup(trlevel::LevelVersion::Tomb2, 163, 0).name;
 
     ASSERT_EQ(winged, "Test Name 2");
 }

--- a/trview.app.tests/Elements/TypeInfoLookupTests.cpp
+++ b/trview.app.tests/Elements/TypeInfoLookupTests.cpp
@@ -1,43 +1,43 @@
-#include <trview.app/Elements/TypeNameLookup.h>
+#include <trview.app/Elements/TypeInfoLookup.h>
 
 using namespace trview;
 using namespace trlevel;
 
 // Test that looking up an ID gives the correct result.
-TEST(TypeNameLookup, LookupTR1)
+TEST(TypeInfoLookup, LookupTR1)
 {
     std::string json = "{\"games\":{\"tr1\":[{\"id\":123,\"name\":\"Test Name\"}]}}";
 
-    TypeNameLookup lookup(json);
+    TypeInfoLookup lookup(json);
 
     ASSERT_EQ("Test Name", lookup.lookup_type_name(LevelVersion::Tomb1, 123, 0));
 }
 
 // Tests that if there are identical entries for different games, the correct result is returned.
-TEST(TypeNameLookup, LookupMultipleGames)
+TEST(TypeInfoLookup, LookupMultipleGames)
 {
     std::string json = "{\"games\":{\"tr1\":[{\"id\":123,\"name\":\"Test Name TR1\"}],\"tr2\":[{\"id\":123,\"name\":\"Test Name TR2\"}]}}";
 
-    TypeNameLookup lookup(json);
+    TypeInfoLookup lookup(json);
 
     ASSERT_EQ("Test Name TR1", lookup.lookup_type_name(LevelVersion::Tomb1, 123, 0));
     ASSERT_EQ("Test Name TR2", lookup.lookup_type_name(LevelVersion::Tomb2, 123, 0));
 }
 
 // Tests that if the name is missing, it still returns the number.
-TEST(TypeNameLookup, LookupMissingItem)
+TEST(TypeInfoLookup, LookupMissingItem)
 {
     std::string json = "{}";
 
-    TypeNameLookup lookup(json);
+    TypeInfoLookup lookup(json);
 
     ASSERT_EQ("123", lookup.lookup_type_name(LevelVersion::Tomb3, 123, 0));
 }
 
-TEST(TypeNameLookup, LookupNormalMutantEggs)
+TEST(TypeInfoLookup, LookupNormalMutantEggs)
 {
     std::string json = "{\"games\":{\"tr1\":[{\"id\":163,\"name\":\"Test Name 1\"}]}}";
-    TypeNameLookup lookup(json);
+    TypeInfoLookup lookup(json);
 
     auto winged = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 0);
     auto shooter = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 163, 1 << 9);
@@ -54,10 +54,10 @@ TEST(TypeNameLookup, LookupNormalMutantEggs)
     ASSERT_EQ(def, "Mutant Egg (Winged)");
 }
 
-TEST(TypeNameLookup, LookupBigMutantEggs)
+TEST(TypeInfoLookup, LookupBigMutantEggs)
 {
     std::string json = "{\"games\":{\"tr1\":[{\"id\":181,\"name\":\"Test Name 2\"}]}}";
-    TypeNameLookup lookup(json);
+    TypeInfoLookup lookup(json);
 
     auto winged = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 0);
     auto shooter = lookup.lookup_type_name(trlevel::LevelVersion::Tomb1, 181, 1 << 9);
@@ -74,10 +74,10 @@ TEST(TypeNameLookup, LookupBigMutantEggs)
     ASSERT_EQ(def, "Mutant Egg (Winged)");
 }
 
-TEST(TypeNameLookup, LookupNormalMutantEggsTR2)
+TEST(TypeInfoLookup, LookupNormalMutantEggsTR2)
 {
     std::string json = "{\"games\":{\"tr1\":[{\"id\":163,\"name\":\"Test Name 1\"}],\"tr2\":[{\"id\":163,\"name\":\"Test Name 2\"}]}}";
-    TypeNameLookup lookup(json);
+    TypeInfoLookup lookup(json);
 
     auto winged = lookup.lookup_type_name(trlevel::LevelVersion::Tomb2, 163, 0);
 

--- a/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
@@ -40,6 +40,25 @@ TEST(Lua_Item, Angle)
     ASSERT_EQ(123, lua_tointeger(L, -1));
 }
 
+TEST(Lua_Item, Categories)
+{
+    auto item = mock_shared<MockItem>();
+    EXPECT_CALL(*item, categories).WillOnce(Return<std::unordered_set<std::string>>({ "One", "Two" }));
+
+    LuaState L;
+    lua::create_item(L, item);
+    lua_setglobal(L, "i");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return i.categories"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "x = i.categories[1]"));
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    ASSERT_EQ("One", lua_tostring(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "x = i.categories[2]"));
+    ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
+    ASSERT_EQ("Two", lua_tostring(L, -1));
+}
+
 TEST(Lua_Item, ClearBody)
 {
     auto item = mock_shared<MockItem>();
@@ -201,6 +220,21 @@ TEST(Lua_Item, Visible)
     ASSERT_EQ(true, lua_toboolean(L, -1));
 }
 
+TEST(Lua_Item, SetCategories)
+{
+    std::unordered_set<std::string> categories;
+    auto item = mock_shared<MockItem>();
+    EXPECT_CALL(*item, set_categories).WillOnce(SaveArg<0>(&categories));
+
+    LuaState L;
+    lua::create_item(L, item);
+    lua_setglobal(L, "i");
+
+    ASSERT_EQ(0, luaL_dostring(L, "i.categories = { \"One\", \"Two\" }"));
+
+    const std::unordered_set<std::string> expected{ "One", "Two" };
+    ASSERT_EQ(categories, expected);
+}
 TEST(Lua_Item, SetVisible)
 {
     auto level = mock_shared<MockLevel>();

--- a/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_ItemTests.cpp
@@ -43,7 +43,7 @@ TEST(Lua_Item, Angle)
 TEST(Lua_Item, Categories)
 {
     auto item = mock_shared<MockItem>();
-    EXPECT_CALL(*item, categories).WillOnce(Return<std::unordered_set<std::string>>({ "One", "Two" }));
+    EXPECT_CALL(*item, categories).WillRepeatedly(Return<std::unordered_set<std::string>>({ "One", "Two" }));
 
     LuaState L;
     lua::create_item(L, item);
@@ -51,12 +51,12 @@ TEST(Lua_Item, Categories)
 
     ASSERT_EQ(0, luaL_dostring(L, "return i.categories"));
     ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
-    ASSERT_EQ(0, luaL_dostring(L, "x = i.categories[1]"));
+    ASSERT_EQ(0, luaL_dostring(L, "return i.categories[1]"));
     ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
-    ASSERT_EQ("One", lua_tostring(L, -1));
-    ASSERT_EQ(0, luaL_dostring(L, "x = i.categories[2]"));
+    ASSERT_STREQ("One", lua_tostring(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return i.categories[2]"));
     ASSERT_EQ(LUA_TSTRING, lua_type(L, -1));
-    ASSERT_EQ("Two", lua_tostring(L, -1));
+    ASSERT_STREQ("Two", lua_tostring(L, -1));
 }
 
 TEST(Lua_Item, ClearBody)

--- a/trview.app.tests/stdafx.h
+++ b/trview.app.tests/stdafx.h
@@ -52,7 +52,7 @@ namespace testing
 #include <trview.app/Mocks/Elements/ILevel.h>
 #include <trview.app/Mocks/Elements/IStaticMesh.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
-#include <trview.app/Mocks/Elements/ITypeNameLookup.h>
+#include <trview.app/Mocks/Elements/ITypeInfoLookup.h>
 #include <trview.app/Mocks/Menus/IUpdateChecker.h>
 #include <trview.app/Mocks/Routing/IRoute.h>
 #include <trview.app/Mocks/Routing/IWaypoint.h>

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -33,7 +33,7 @@
     <ClCompile Include="Elements\SectorTests.cpp" />
     <ClCompile Include="Elements\StaticMeshTests.cpp" />
     <ClCompile Include="Elements\TriggerTests.cpp" />
-    <ClCompile Include="Elements\TypeNameLookupTests.cpp" />
+    <ClCompile Include="Elements\TypeInfoLookupTests.cpp" />
     <ClCompile Include="Filters\FiltersTests.cpp" />
     <ClCompile Include="FreeCameraTests.cpp" />
     <ClCompile Include="Graphics\LevelTextureStorageTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -17,7 +17,7 @@
     <ClCompile Include="UI\CameraPositionTests.cpp">
       <Filter>UI</Filter>
     </ClCompile>
-    <ClCompile Include="Elements\TypeNameLookupTests.cpp">
+    <ClCompile Include="Elements\TypeInfoLookupTests.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
     <ClCompile Include="Elements\LevelTests.cpp">

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -5,7 +5,7 @@
 
 #include <trlevel/ILevel.h>
 
-#include <trview.app/Elements/ITypeNameLookup.h>
+#include "Elements/ITypeInfoLookup.h"
 #include <trview.app/Menus/IFileMenu.h>
 #include <trview.app/Menus/IUpdateChecker.h>
 #include <trview.app/Menus/ViewMenu.h>
@@ -149,7 +149,7 @@ namespace trview
         HINSTANCE _instance{ nullptr };
 
         // Level data components
-        std::unique_ptr<ITypeNameLookup> _type_name_lookup;
+        std::unique_ptr<ITypeInfoLookup> _type_info_lookup;
         std::shared_ptr<ILevel> _level;
         ILevel::Source _level_source;
 

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -210,15 +210,14 @@ namespace trview
         auto entity_source = [=](auto&& level, auto&& entity, auto&& index, auto&& triggers, auto&& mesh_storage, auto&& owning_level, auto&& room)
         {
             return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index,
-                type_info_lookup->lookup_type_name(level.get_version(), entity.TypeID, entity.Flags),
+                type_info_lookup->lookup(level.get_version(), entity.TypeID, entity.Flags),
                 triggers,
-                type_info_lookup->is_pickup(level.get_version(), entity.TypeID),
                 room);
         };
 
         auto ai_source = [=](auto&& level, auto&& entity, auto&& index, auto&& mesh_storage, auto&& owning_level, auto&& room)
         {
-            return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index, type_info_lookup->lookup_type_name(level.get_version(), entity.type_id, entity.flags), std::vector<std::weak_ptr<ITrigger>>{}, room);
+            return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index, type_info_lookup->lookup(level.get_version(), entity.type_id, entity.flags), std::vector<std::weak_ptr<ITrigger>>{}, room);
         };
 
         auto log = std::make_shared<Log>();

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -20,7 +20,7 @@
 #include "Resources/DefaultTextures.h"
 #include "Resources/DefaultFonts.h"
 
-#include "Elements/TypeNameLookup.h"
+#include "Elements/TypeInfoLookup.h"
 #include "Elements/CameraSink/CameraSink.h"
 #include "Elements/Item.h"
 #include "Elements/Light.h"
@@ -155,7 +155,7 @@ namespace trview
         auto font_factory = std::make_shared<graphics::FontFactory>();
 
         Resource type_list = get_resource_memory(IDR_TYPE_NAMES, L"TEXT");
-        auto type_name_lookup = std::make_shared<TypeNameLookup>(std::string(type_list.data, type_list.data + type_list.size));
+        auto type_info_lookup = std::make_shared<TypeInfoLookup>(std::string(type_list.data, type_list.data + type_list.size));
 
         load_default_shaders(device, shader_storage);
         load_default_fonts(device, font_factory);
@@ -210,15 +210,15 @@ namespace trview
         auto entity_source = [=](auto&& level, auto&& entity, auto&& index, auto&& triggers, auto&& mesh_storage, auto&& owning_level, auto&& room)
         {
             return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index,
-                type_name_lookup->lookup_type_name(level.get_version(), entity.TypeID, entity.Flags),
+                type_info_lookup->lookup_type_name(level.get_version(), entity.TypeID, entity.Flags),
                 triggers,
-                type_name_lookup->is_pickup(level.get_version(), entity.TypeID),
+                type_info_lookup->is_pickup(level.get_version(), entity.TypeID),
                 room);
         };
 
         auto ai_source = [=](auto&& level, auto&& entity, auto&& index, auto&& mesh_storage, auto&& owning_level, auto&& room)
         {
-            return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index, type_name_lookup->lookup_type_name(level.get_version(), entity.type_id, entity.flags), std::vector<std::weak_ptr<ITrigger>>{}, room);
+            return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index, type_info_lookup->lookup_type_name(level.get_version(), entity.type_id, entity.flags), std::vector<std::weak_ptr<ITrigger>>{}, room);
         };
 
         auto log = std::make_shared<Log>();

--- a/trview.app/Elements/IItem.h
+++ b/trview.app/Elements/IItem.h
@@ -49,6 +49,7 @@ namespace trview
         virtual int32_t angle() const = 0;
         virtual bool is_pickup() const = 0;
         virtual std::unordered_set<std::string> categories() const = 0;
+        virtual void set_categories(const std::unordered_set<std::string>& categories) = 0;
     };
 
     bool is_mutant_egg(const IItem& item);

--- a/trview.app/Elements/IItem.h
+++ b/trview.app/Elements/IItem.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_set>
 #include <external/DirectXTK/Inc/SimpleMath.h>
 #include <trlevel/ILevel.h>
 #include <trlevel/trtypes.h>
@@ -47,6 +48,7 @@ namespace trview
         virtual std::weak_ptr<ILevel> level() const = 0;
         virtual int32_t angle() const = 0;
         virtual bool is_pickup() const = 0;
+        virtual std::unordered_set<std::string> categories() const = 0;
     };
 
     bool is_mutant_egg(const IItem& item);

--- a/trview.app/Elements/IItem.h
+++ b/trview.app/Elements/IItem.h
@@ -47,7 +47,6 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
         virtual std::weak_ptr<ILevel> level() const = 0;
         virtual int32_t angle() const = 0;
-        virtual bool is_pickup() const = 0;
         virtual std::unordered_set<std::string> categories() const = 0;
         virtual void set_categories(const std::unordered_set<std::string>& categories) = 0;
     };

--- a/trview.app/Elements/IItem.h
+++ b/trview.app/Elements/IItem.h
@@ -46,6 +46,7 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
         virtual std::weak_ptr<ILevel> level() const = 0;
         virtual int32_t angle() const = 0;
+        virtual bool is_pickup() const = 0;
     };
 
     bool is_mutant_egg(const IItem& item);

--- a/trview.app/Elements/ITypeInfoLookup.h
+++ b/trview.app/Elements/ITypeInfoLookup.h
@@ -11,7 +11,6 @@ namespace trview
     {
     public:
         virtual ~ITypeInfoLookup() = 0;
-        virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const = 0;
         virtual TypeInfo lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const = 0;
     };
 }

--- a/trview.app/Elements/ITypeInfoLookup.h
+++ b/trview.app/Elements/ITypeInfoLookup.h
@@ -8,10 +8,10 @@
 
 namespace trview
 {
-    struct ITypeNameLookup
+    struct ITypeInfoLookup
     {
     public:
-        virtual ~ITypeNameLookup() = 0;
+        virtual ~ITypeInfoLookup() = 0;
         virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint16_t flags) const = 0;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const = 0;
         virtual std::optional<TypeInfo> lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const = 0;

--- a/trview.app/Elements/ITypeInfoLookup.h
+++ b/trview.app/Elements/ITypeInfoLookup.h
@@ -11,7 +11,6 @@ namespace trview
     {
     public:
         virtual ~ITypeInfoLookup() = 0;
-        virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint16_t flags) const = 0;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const = 0;
         virtual TypeInfo lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const = 0;
     };

--- a/trview.app/Elements/ITypeInfoLookup.h
+++ b/trview.app/Elements/ITypeInfoLookup.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <optional>
 #include <cstdint>
 #include <string>
 #include <trlevel/LevelVersion.h>
@@ -14,6 +13,6 @@ namespace trview
         virtual ~ITypeInfoLookup() = 0;
         virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint16_t flags) const = 0;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const = 0;
-        virtual std::optional<TypeInfo> lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const = 0;
+        virtual TypeInfo lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const = 0;
     };
 }

--- a/trview.app/Elements/ITypeNameLookup.h
+++ b/trview.app/Elements/ITypeNameLookup.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <optional>
 #include <cstdint>
 #include <string>
 #include <trlevel/LevelVersion.h>
+#include "TypeInfo.h"
 
 namespace trview
 {
@@ -12,5 +14,6 @@ namespace trview
         virtual ~ITypeNameLookup() = 0;
         virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint16_t flags) const = 0;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const = 0;
+        virtual std::optional<TypeInfo> lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const = 0;
     };
 }

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -77,7 +77,7 @@ namespace trview
 
     Item::Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id,
         const Vector3& position, int32_t angle, int32_t ocb, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags, bool is_pickup)
-        : _room(room), _number(number), _type(type), _triggers(triggers), _type_id(type_id), _ocb(ocb), _flags(flags), _level(owning_level), _angle(angle)
+        : _room(room), _number(number), _type(type), _triggers(triggers), _type_id(type_id), _ocb(ocb), _flags(flags), _level(owning_level), _angle(angle), _is_pickup(is_pickup)
     {
         // Extract the meshes required from the model.
         load_meshes(level, type_id, mesh_storage);
@@ -449,6 +449,11 @@ namespace trview
     int32_t Item::angle() const
     {
         return _angle;
+    }
+
+    bool Item::is_pickup() const
+    {
+        return _is_pickup;
     }
 
     bool is_mutant_egg(const IItem& item)

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -453,7 +453,7 @@ namespace trview
 
     bool Item::is_pickup() const
     {
-        return _type.pickup || _type.categories.find("Pickup") != _type.categories.end();
+        return _type.categories.find("Pickup") != _type.categories.end();
     }
 
     std::unordered_set<std::string> Item::categories() const

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -461,6 +461,11 @@ namespace trview
         return _type.categories;
     }
 
+    void Item::set_categories(const std::unordered_set<std::string>& categories)
+    {
+        _type.categories = categories;
+    }
+
     bool is_mutant_egg(const IItem& item)
     {
         return is_mutant_egg(item.type_id());

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -77,7 +77,7 @@ namespace trview
 
     Item::Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id,
         const Vector3& position, int32_t angle, int32_t ocb, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags)
-        : _room(room), _number(number), _type(type.name), _triggers(triggers), _type_id(type_id), _ocb(ocb), _flags(flags), _level(owning_level), _angle(angle), _is_pickup(type.pickup)
+        : _room(room), _number(number), _type(type), _triggers(triggers), _type_id(type_id), _ocb(ocb), _flags(flags), _level(owning_level), _angle(angle)
     {
         // Extract the meshes required from the model.
         load_meshes(level, type_id, mesh_storage);
@@ -403,7 +403,7 @@ namespace trview
 
     std::string Item::type() const
     {
-        return _type;
+        return _type.name;
     }
 
     std::vector<std::weak_ptr<ITrigger>> Item::triggers() const
@@ -453,7 +453,12 @@ namespace trview
 
     bool Item::is_pickup() const
     {
-        return _is_pickup;
+        return _type.pickup;
+    }
+
+    std::unordered_set<std::string> Item::categories() const
+    {
+        return _type.categories;
     }
 
     bool is_mutant_egg(const IItem& item)

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -453,7 +453,7 @@ namespace trview
 
     bool Item::is_pickup() const
     {
-        return _type.pickup;
+        return _type.pickup || _type.categories.find("Pickup") != _type.categories.end();
     }
 
     std::unordered_set<std::string> Item::categories() const

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -64,20 +64,20 @@ namespace trview
     {
     }
 
-    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, bool is_pickup, const std::weak_ptr<IRoom>& room)
-        : Item(mesh_source, mesh_storage, level, owning_level, room, number, entity.TypeID, entity.position(), entity.Angle, level.get_version() >= trlevel::LevelVersion::Tomb4 ? entity.Intensity2 : 0, type, triggers, entity.Flags, is_pickup)
+    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room)
+        : Item(mesh_source, mesh_storage, level, owning_level, room, number, entity.TypeID, entity.position(), entity.Angle, level.get_version() >= trlevel::LevelVersion::Tomb4 ? entity.Intensity2 : 0, type, triggers, entity.Flags)
     {
         
     }
 
-    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room)
-        : Item(mesh_source, mesh_storage, level, owning_level, room, number, entity.type_id, entity.position(), entity.angle, entity.ocb, type, triggers, entity.flags, false)
+    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room)
+        : Item(mesh_source, mesh_storage, level, owning_level, room, number, entity.type_id, entity.position(), entity.angle, entity.ocb, type, triggers, entity.flags)
     {
     }
 
     Item::Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id,
-        const Vector3& position, int32_t angle, int32_t ocb, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags, bool is_pickup)
-        : _room(room), _number(number), _type(type), _triggers(triggers), _type_id(type_id), _ocb(ocb), _flags(flags), _level(owning_level), _angle(angle), _is_pickup(is_pickup)
+        const Vector3& position, int32_t angle, int32_t ocb, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags)
+        : _room(room), _number(number), _type(type.name), _triggers(triggers), _type_id(type_id), _ocb(ocb), _flags(flags), _level(owning_level), _angle(angle), _is_pickup(type.pickup)
     {
         // Extract the meshes required from the model.
         load_meshes(level, type_id, mesh_storage);
@@ -101,7 +101,7 @@ namespace trview
         _position = position;
 
         generate_bounding_box();
-        apply_ocb_adjustment(level.get_version(), ocb, is_pickup);
+        apply_ocb_adjustment(level.get_version(), ocb, is_pickup());
     }
 
     void Item::load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage)

--- a/trview.app/Elements/Item.h
+++ b/trview.app/Elements/Item.h
@@ -57,6 +57,7 @@ namespace trview
         int32_t angle() const override;
         bool is_pickup() const override;
         std::unordered_set<std::string> categories() const override;
+        void set_categories(const std::unordered_set<std::string>& categories) override;
     private:
         Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags);
 

--- a/trview.app/Elements/Item.h
+++ b/trview.app/Elements/Item.h
@@ -54,6 +54,7 @@ namespace trview
         DirectX::SimpleMath::Vector3 position() const override;
         std::weak_ptr<ILevel> level() const override;
         int32_t angle() const override;
+        bool is_pickup() const override;
     private:
         Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags, bool is_pickup);
 
@@ -78,6 +79,7 @@ namespace trview
         std::vector<DirectX::BoundingOrientedBox> _oriented_boxes;
         bool                                      _visible{ true };
         bool _needs_ocb_adjustment{ false };
+        bool _is_pickup{ false };
 
         std::string _type;
         std::vector<std::weak_ptr<ITrigger>> _triggers;

--- a/trview.app/Elements/Item.h
+++ b/trview.app/Elements/Item.h
@@ -10,6 +10,7 @@
 #include <trview.app/Geometry/IRenderable.h>
 #include <trview.app/Geometry/IMesh.h>
 #include "IItem.h"
+#include "TypeInfo.h"
 
 namespace trlevel
 {
@@ -28,8 +29,8 @@ namespace trview
     class Item final : public IItem
     {
     public:
-        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, bool is_pickup, const std::weak_ptr<IRoom>& room);
-        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room);
+        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room);
+        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room);
         virtual ~Item() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         std::weak_ptr<IRoom> room() const override;
@@ -56,7 +57,7 @@ namespace trview
         int32_t angle() const override;
         bool is_pickup() const override;
     private:
-        Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, const std::string& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags, bool is_pickup);
+        Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags);
 
         void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);

--- a/trview.app/Elements/Item.h
+++ b/trview.app/Elements/Item.h
@@ -56,6 +56,7 @@ namespace trview
         std::weak_ptr<ILevel> level() const override;
         int32_t angle() const override;
         bool is_pickup() const override;
+        std::unordered_set<std::string> categories() const override;
     private:
         Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags);
 
@@ -80,9 +81,7 @@ namespace trview
         std::vector<DirectX::BoundingOrientedBox> _oriented_boxes;
         bool                                      _visible{ true };
         bool _needs_ocb_adjustment{ false };
-        bool _is_pickup{ false };
-
-        std::string _type;
+        TypeInfo _type;
         std::vector<std::weak_ptr<ITrigger>> _triggers;
         uint32_t _type_id{ 0u };
         int32_t _ocb{ 0u };

--- a/trview.app/Elements/Item.h
+++ b/trview.app/Elements/Item.h
@@ -55,7 +55,6 @@ namespace trview
         DirectX::SimpleMath::Vector3 position() const override;
         std::weak_ptr<ILevel> level() const override;
         int32_t angle() const override;
-        bool is_pickup() const override;
         std::unordered_set<std::string> categories() const override;
         void set_categories(const std::unordered_set<std::string>& categories) override;
     private:
@@ -65,6 +64,7 @@ namespace trview
         void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);
         void generate_bounding_box();
         void apply_ocb_adjustment(trlevel::LevelVersion version, uint32_t ocb, bool is_pickup);
+        bool is_pickup() const;
 
         DirectX::SimpleMath::Matrix               _world;
         std::vector<std::shared_ptr<IMesh>>       _meshes;

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -19,7 +19,6 @@ namespace trview
 {
     struct ILevelTextureStorage;
     struct ICamera;
-    struct ITypeNameLookup;
 
     namespace graphics
     {

--- a/trview.app/Elements/TypeInfo.h
+++ b/trview.app/Elements/TypeInfo.h
@@ -15,10 +15,6 @@ namespace trview
         /// </summary>
         std::string name;
         /// <summary>
-        /// Whether this is a pickup item - used for position adjustment.
-        /// </summary>
-        bool pickup{ false };
-        /// <summary>
         /// Any named categories that this item belongs to.
         /// </summary>
         std::unordered_set<std::string> categories;

--- a/trview.app/Elements/TypeInfo.h
+++ b/trview.app/Elements/TypeInfo.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <unordered_set>
+#include <string>
+
+namespace trview
+{
+    /// <summary>
+    /// Information about a game type.
+    /// </summary>
+    struct TypeInfo final
+    {
+        /// <summary>
+        /// Friendly name for the type.
+        /// </summary>
+        std::string name;
+        /// <summary>
+        /// Whether this is a pickup item - used for position adjustment.
+        /// </summary>
+        bool pickup{ false };
+        /// <summary>
+        /// Any named categories that this item belongs to.
+        /// </summary>
+        std::unordered_set<std::string> categories;
+    };
+}

--- a/trview.app/Elements/TypeInfoLookup.cpp
+++ b/trview.app/Elements/TypeInfoLookup.cpp
@@ -114,18 +114,18 @@ namespace trview
         return found_type->second.pickup;
     }
 
-    std::optional<TypeInfo> TypeInfoLookup::lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const
+    TypeInfo TypeInfoLookup::lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const
     {
         const auto& game_types = _type_names.find(level_version);
         if (game_types == _type_names.end())
         {
-            return std::nullopt;
+            return { .name = std::to_string(type_id) };
         }
 
         const auto found_type = game_types->second.find(type_id);
         if (found_type == game_types->second.end())
         {
-            return std::nullopt;
+            return { .name = std::to_string(type_id) };
         }
 
         TypeInfo result = found_type->second;

--- a/trview.app/Elements/TypeInfoLookup.cpp
+++ b/trview.app/Elements/TypeInfoLookup.cpp
@@ -62,7 +62,6 @@ namespace trview
                 type_names.insert({ element.at("id").get<uint32_t>(), 
                     {
                         name,
-                        read_attribute<bool>(element, "pickup"),
                         read_attribute<std::unordered_set<std::string>>(element, "categories")
                     } });
             }

--- a/trview.app/Elements/TypeInfoLookup.cpp
+++ b/trview.app/Elements/TypeInfoLookup.cpp
@@ -1,4 +1,4 @@
-#include "TypeNameLookup.h"
+#include "TypeInfoLookup.h"
 #include <trview.common/Json.h>
 #include "IItem.h"
 
@@ -24,11 +24,11 @@ namespace trview
         }
     }
 
-    ITypeNameLookup::~ITypeNameLookup()
+    ITypeInfoLookup::~ITypeInfoLookup()
     {
     }
 
-    TypeNameLookup::TypeNameLookup(const std::string& type_name_json)
+    TypeInfoLookup::TypeInfoLookup(const std::string& type_name_json)
     {
         auto json = nlohmann::json::parse(type_name_json.begin(), type_name_json.end());
         auto load_game_types = [&](LevelVersion version)
@@ -76,7 +76,7 @@ namespace trview
         load_game_types(LevelVersion::Tomb5);
     }
 
-    std::string TypeNameLookup::lookup_type_name(LevelVersion level_version, uint32_t type_id, uint16_t flags) const
+    std::string TypeInfoLookup::lookup_type_name(LevelVersion level_version, uint32_t type_id, uint16_t flags) const
     {
         const auto& game_types = _type_names.find(level_version);
         if (game_types == _type_names.end())
@@ -98,7 +98,7 @@ namespace trview
         return found_type->second.name;
     }
 
-    bool TypeNameLookup::is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const
+    bool TypeInfoLookup::is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const
     {
         const auto& game_types = _type_names.find(level_version);
         if (game_types == _type_names.end())
@@ -114,7 +114,7 @@ namespace trview
         return found_type->second.pickup;
     }
 
-    std::optional<TypeInfo> TypeNameLookup::lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const
+    std::optional<TypeInfo> TypeInfoLookup::lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const
     {
         const auto& game_types = _type_names.find(level_version);
         if (game_types == _type_names.end())

--- a/trview.app/Elements/TypeInfoLookup.cpp
+++ b/trview.app/Elements/TypeInfoLookup.cpp
@@ -76,22 +76,6 @@ namespace trview
         load_game_types(LevelVersion::Tomb5);
     }
 
-    bool TypeInfoLookup::is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const
-    {
-        const auto& game_types = _type_names.find(level_version);
-        if (game_types == _type_names.end())
-        {
-            return false;
-        }
-
-        const auto found_type = game_types->second.find(type_id);
-        if (found_type == game_types->second.end())
-        {
-            return false;
-        }
-        return found_type->second.pickup;
-    }
-
     TypeInfo TypeInfoLookup::lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const
     {
         const auto& game_types = _type_names.find(level_version);

--- a/trview.app/Elements/TypeInfoLookup.cpp
+++ b/trview.app/Elements/TypeInfoLookup.cpp
@@ -76,28 +76,6 @@ namespace trview
         load_game_types(LevelVersion::Tomb5);
     }
 
-    std::string TypeInfoLookup::lookup_type_name(LevelVersion level_version, uint32_t type_id, uint16_t flags) const
-    {
-        const auto& game_types = _type_names.find(level_version);
-        if (game_types == _type_names.end())
-        {
-            return std::to_string(type_id);
-        }
-
-        const auto found_type = game_types->second.find(type_id);
-        if (found_type == game_types->second.end())
-        {
-            return std::to_string(type_id);
-        }
-
-        if (level_version == LevelVersion::Tomb1 && is_mutant_egg(type_id))
-        {
-            return mutant_name(flags);
-        }
-
-        return found_type->second.name;
-    }
-
     bool TypeInfoLookup::is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const
     {
         const auto& game_types = _type_names.find(level_version);

--- a/trview.app/Elements/TypeInfoLookup.h
+++ b/trview.app/Elements/TypeInfoLookup.h
@@ -11,7 +11,6 @@ namespace trview
     public:
         explicit TypeInfoLookup(const std::string& type_name_json);
         virtual ~TypeInfoLookup() = default;
-        virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const override;
         TypeInfo lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const override;
     private:
         std::unordered_map<trlevel::LevelVersion, std::unordered_map<uint32_t, TypeInfo>> _type_names;

--- a/trview.app/Elements/TypeInfoLookup.h
+++ b/trview.app/Elements/TypeInfoLookup.h
@@ -1,16 +1,16 @@
 #pragma once
 
-#include "ITypeNameLookup.h"
+#include "ITypeInfoLookup.h"
 #include <unordered_map>
 #include <unordered_set>
 
 namespace trview
 {
-    class TypeNameLookup : public ITypeNameLookup
+    class TypeInfoLookup : public ITypeInfoLookup
     {
     public:
-        explicit TypeNameLookup(const std::string& type_name_json);
-        virtual ~TypeNameLookup() = default;
+        explicit TypeInfoLookup(const std::string& type_name_json);
+        virtual ~TypeInfoLookup() = default;
         virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint16_t flags) const override;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const override;
         std::optional<TypeInfo> lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const override;

--- a/trview.app/Elements/TypeInfoLookup.h
+++ b/trview.app/Elements/TypeInfoLookup.h
@@ -13,7 +13,7 @@ namespace trview
         virtual ~TypeInfoLookup() = default;
         virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint16_t flags) const override;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const override;
-        std::optional<TypeInfo> lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const override;
+        TypeInfo lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const override;
     private:
         std::unordered_map<trlevel::LevelVersion, std::unordered_map<uint32_t, TypeInfo>> _type_names;
     };

--- a/trview.app/Elements/TypeInfoLookup.h
+++ b/trview.app/Elements/TypeInfoLookup.h
@@ -11,7 +11,6 @@ namespace trview
     public:
         explicit TypeInfoLookup(const std::string& type_name_json);
         virtual ~TypeInfoLookup() = default;
-        virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint16_t flags) const override;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const override;
         TypeInfo lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const override;
     private:

--- a/trview.app/Elements/TypeNameLookup.cpp
+++ b/trview.app/Elements/TypeNameLookup.cpp
@@ -55,7 +55,7 @@ namespace trview
                 return;
             }
 
-            std::unordered_map<uint32_t, Type> type_names;
+            std::unordered_map<uint32_t, TypeInfo> type_names;
             for (const auto& element : json["games"][game_name])
             {
                 auto name = element.at("name").get<std::string>();
@@ -112,5 +112,27 @@ namespace trview
             return false;
         }
         return found_type->second.pickup;
+    }
+
+    std::optional<TypeInfo> TypeNameLookup::lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const
+    {
+        const auto& game_types = _type_names.find(level_version);
+        if (game_types == _type_names.end())
+        {
+            return std::nullopt;
+        }
+
+        const auto found_type = game_types->second.find(type_id);
+        if (found_type == game_types->second.end())
+        {
+            return std::nullopt;
+        }
+
+        TypeInfo result = found_type->second;
+        if (level_version == LevelVersion::Tomb1 && is_mutant_egg(type_id))
+        {
+            result.name = mutant_name(flags);
+        }
+        return result;
     }
 }

--- a/trview.app/Elements/TypeNameLookup.cpp
+++ b/trview.app/Elements/TypeNameLookup.cpp
@@ -62,7 +62,8 @@ namespace trview
                 type_names.insert({ element.at("id").get<uint32_t>(), 
                     {
                         name,
-                        read_attribute<bool>(element, "pickup")
+                        read_attribute<bool>(element, "pickup"),
+                        read_attribute<std::unordered_set<std::string>>(element, "categories")
                     } });
             }
             _type_names.insert({ version, type_names });

--- a/trview.app/Elements/TypeNameLookup.h
+++ b/trview.app/Elements/TypeNameLookup.h
@@ -13,14 +13,8 @@ namespace trview
         virtual ~TypeNameLookup() = default;
         virtual std::string lookup_type_name(trlevel::LevelVersion level_version, uint32_t type_id, uint16_t flags) const override;
         virtual bool is_pickup(trlevel::LevelVersion level_version, uint32_t type_id) const override;
+        std::optional<TypeInfo> lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const override;
     private:
-        struct Type
-        {
-            std::string name;
-            bool pickup{ false };
-            std::unordered_set<std::string> categories;
-        };
-
-        std::unordered_map<trlevel::LevelVersion, std::unordered_map<uint32_t, Type>> _type_names;
+        std::unordered_map<trlevel::LevelVersion, std::unordered_map<uint32_t, TypeInfo>> _type_names;
     };
 }

--- a/trview.app/Elements/TypeNameLookup.h
+++ b/trview.app/Elements/TypeNameLookup.h
@@ -2,6 +2,7 @@
 
 #include "ITypeNameLookup.h"
 #include <unordered_map>
+#include <unordered_set>
 
 namespace trview
 {
@@ -17,6 +18,7 @@ namespace trview
         {
             std::string name;
             bool pickup{ false };
+            std::unordered_set<std::string> categories;
         };
 
         std::unordered_map<trlevel::LevelVersion, std::unordered_map<uint32_t, Type>> _type_names;

--- a/trview.app/Lua/Elements/Item/Lua_Item.cpp
+++ b/trview.app/Lua/Elements/Item/Lua_Item.cpp
@@ -42,11 +42,6 @@ namespace trview
                     lua_pushboolean(L, item->invisible_flag());
                     return 1;
                 }
-                else if (key == "is_pickup")
-                {
-                    lua_pushboolean(L, item->is_pickup());
-                    return 1;
-                }
                 else if (key == "number")
                 {
                     lua_pushinteger(L, item->number());

--- a/trview.app/Lua/Elements/Item/Lua_Item.cpp
+++ b/trview.app/Lua/Elements/Item/Lua_Item.cpp
@@ -37,6 +37,11 @@ namespace trview
                     lua_pushboolean(L, item->invisible_flag());
                     return 1;
                 }
+                else if (key == "is_pickup")
+                {
+                    lua_pushboolean(L, item->is_pickup());
+                    return 1;
+                }
                 else if (key == "number")
                 {
                     lua_pushinteger(L, item->number());

--- a/trview.app/Lua/Elements/Item/Lua_Item.cpp
+++ b/trview.app/Lua/Elements/Item/Lua_Item.cpp
@@ -27,6 +27,11 @@ namespace trview
                     lua_pushinteger(L, item->angle());
                     return 1;
                 }
+                else if (key == "categories")
+                {
+                    lua::push_list(L, item->categories(), [](auto&& L, auto&& s) { lua_pushstring(L, s.c_str()); });
+                    return 1;
+                }
                 else if (key == "clear_body")
                 {
                     lua_pushboolean(L, item->clear_body_flag());
@@ -88,7 +93,20 @@ namespace trview
                 auto item = lua::get_self<IItem>(L);
 
                 const std::string key = lua_tostring(L, 2);
-                if (key == "visible")
+                if (key == "categories")
+                {
+                    luaL_checktype(L, 3, LUA_TTABLE);
+
+                    std::unordered_set<std::string> categories;
+                    lua_pushnil(L);
+                    while (lua_next(L, 3) != 0)
+                    {
+                        categories.insert(lua_tostring(L, -1));
+                        lua_pop(L, 1);
+                    }
+                    item->set_categories(categories);
+                }
+                else if (key == "visible")
                 {
                     if (auto level = item->level().lock())
                     {

--- a/trview.app/Mocks/Elements/IItem.h
+++ b/trview.app/Mocks/Elements/IItem.h
@@ -33,6 +33,7 @@ namespace trview
             MOCK_METHOD(int32_t, angle, (), (const, override));
             MOCK_METHOD(bool, is_pickup, (), (const, override));
             MOCK_METHOD(std::unordered_set<std::string>, categories, (), (const, override));
+            MOCK_METHOD(void, set_categories, (const std::unordered_set<std::string>&), (override));
 
             std::shared_ptr<MockItem> with_number(uint32_t number)
             {

--- a/trview.app/Mocks/Elements/IItem.h
+++ b/trview.app/Mocks/Elements/IItem.h
@@ -31,6 +31,7 @@ namespace trview
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
             MOCK_METHOD(int32_t, angle, (), (const, override));
+            MOCK_METHOD(bool, is_pickup, (), (const, override));
 
             std::shared_ptr<MockItem> with_number(uint32_t number)
             {

--- a/trview.app/Mocks/Elements/IItem.h
+++ b/trview.app/Mocks/Elements/IItem.h
@@ -31,7 +31,6 @@ namespace trview
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
             MOCK_METHOD(int32_t, angle, (), (const, override));
-            MOCK_METHOD(bool, is_pickup, (), (const, override));
             MOCK_METHOD(std::unordered_set<std::string>, categories, (), (const, override));
             MOCK_METHOD(void, set_categories, (const std::unordered_set<std::string>&), (override));
 

--- a/trview.app/Mocks/Elements/IItem.h
+++ b/trview.app/Mocks/Elements/IItem.h
@@ -32,6 +32,7 @@ namespace trview
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
             MOCK_METHOD(int32_t, angle, (), (const, override));
             MOCK_METHOD(bool, is_pickup, (), (const, override));
+            MOCK_METHOD(std::unordered_set<std::string>, categories, (), (const, override));
 
             std::shared_ptr<MockItem> with_number(uint32_t number)
             {

--- a/trview.app/Mocks/Elements/ITypeInfoLookup.h
+++ b/trview.app/Mocks/Elements/ITypeInfoLookup.h
@@ -1,15 +1,15 @@
 #pragma once
 
-#include "../../Elements/ITypeNameLookup.h"
+#include "../../Elements/ITypeInfoLookup.h"
 
 namespace trview
 {
     namespace mocks
     {
-        struct MockTypeNameLookup : public ITypeNameLookup
+        struct MockTypeInfoLookup : public ITypeInfoLookup
         {
-            MockTypeNameLookup();
-            virtual ~MockTypeNameLookup();
+            MockTypeInfoLookup();
+            virtual ~MockTypeInfoLookup();
             MOCK_METHOD(std::string, lookup_type_name, (trlevel::LevelVersion, uint32_t, uint16_t), (const, override));
             MOCK_METHOD(bool, is_pickup, (trlevel::LevelVersion, uint32_t), (const, override));
             MOCK_METHOD(std::optional<TypeInfo>, lookup, (trlevel::LevelVersion, uint32_t, int16_t), (const, override));

--- a/trview.app/Mocks/Elements/ITypeInfoLookup.h
+++ b/trview.app/Mocks/Elements/ITypeInfoLookup.h
@@ -10,7 +10,6 @@ namespace trview
         {
             MockTypeInfoLookup();
             virtual ~MockTypeInfoLookup();
-            MOCK_METHOD(bool, is_pickup, (trlevel::LevelVersion, uint32_t), (const, override));
             MOCK_METHOD(TypeInfo, lookup, (trlevel::LevelVersion, uint32_t, int16_t), (const, override));
         };
     }

--- a/trview.app/Mocks/Elements/ITypeInfoLookup.h
+++ b/trview.app/Mocks/Elements/ITypeInfoLookup.h
@@ -12,7 +12,7 @@ namespace trview
             virtual ~MockTypeInfoLookup();
             MOCK_METHOD(std::string, lookup_type_name, (trlevel::LevelVersion, uint32_t, uint16_t), (const, override));
             MOCK_METHOD(bool, is_pickup, (trlevel::LevelVersion, uint32_t), (const, override));
-            MOCK_METHOD(std::optional<TypeInfo>, lookup, (trlevel::LevelVersion, uint32_t, int16_t), (const, override));
+            MOCK_METHOD(TypeInfo, lookup, (trlevel::LevelVersion, uint32_t, int16_t), (const, override));
         };
     }
 }

--- a/trview.app/Mocks/Elements/ITypeInfoLookup.h
+++ b/trview.app/Mocks/Elements/ITypeInfoLookup.h
@@ -10,7 +10,6 @@ namespace trview
         {
             MockTypeInfoLookup();
             virtual ~MockTypeInfoLookup();
-            MOCK_METHOD(std::string, lookup_type_name, (trlevel::LevelVersion, uint32_t, uint16_t), (const, override));
             MOCK_METHOD(bool, is_pickup, (trlevel::LevelVersion, uint32_t), (const, override));
             MOCK_METHOD(TypeInfo, lookup, (trlevel::LevelVersion, uint32_t, int16_t), (const, override));
         };

--- a/trview.app/Mocks/Elements/ITypeNameLookup.h
+++ b/trview.app/Mocks/Elements/ITypeNameLookup.h
@@ -12,6 +12,7 @@ namespace trview
             virtual ~MockTypeNameLookup();
             MOCK_METHOD(std::string, lookup_type_name, (trlevel::LevelVersion, uint32_t, uint16_t), (const, override));
             MOCK_METHOD(bool, is_pickup, (trlevel::LevelVersion, uint32_t), (const, override));
+            MOCK_METHOD(std::optional<TypeInfo>, lookup, (trlevel::LevelVersion, uint32_t, int16_t), (const, override));
         };
     }
 }

--- a/trview.app/Mocks/Mocks.cpp
+++ b/trview.app/Mocks/Mocks.cpp
@@ -9,7 +9,7 @@
 #include "Elements/ISector.h"
 #include "Elements/IStaticMesh.h"
 #include "Elements/ITrigger.h"
-#include "Elements/ITypeNameLookup.h"
+#include "Elements/ITypeInfoLookup.h"
 #include "Geometry/IMesh.h"
 #include "Geometry/IPicking.h"
 #include "Geometry/ITransparencyBuffer.h"
@@ -89,8 +89,8 @@ namespace trview
         MockTrigger::MockTrigger() {}
         MockTrigger::~MockTrigger() {}
 
-        MockTypeNameLookup::MockTypeNameLookup() {}
-        MockTypeNameLookup::~MockTypeNameLookup() {}
+        MockTypeInfoLookup::MockTypeInfoLookup() {}
+        MockTypeInfoLookup::~MockTypeInfoLookup() {}
 
         MockMesh::MockMesh() {}
         MockMesh::~MockMesh() {}

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -3053,193 +3053,155 @@
             }, {
                 "id": 175,
                 "name": "Puzzle 1",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 176,
                 "name": "Puzzle 2",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 177,
                 "name": "Puzzle 3",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 178,
                 "name": "Puzzle 4",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 179,
                 "name": "Puzzle 5",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 180,
                 "name": "Puzzle 6",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 181,
                 "name": "Puzzle 7",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 182,
                 "name": "Puzzle 8",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 183,
                 "name": "Puzzle 9",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 184,
                 "name": "Puzzle 10",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 185,
                 "name": "Puzzle 11",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 186,
                 "name": "Puzzle 12",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 187,
                 "name": "Puzzle 1 Combo 1",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 188,
                 "name": "Puzzle 1 Combo 2",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 189,
                 "name": "Puzzle 2 Combo 1",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 190,
                 "name": "Puzzle 2 Combo 2",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 193,
                 "name": "Puzzle 4 Combo 1",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 194,
                 "name": "Puzzle 4 Combo 2",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 195,
                 "name": "Puzzle 5 Combo 1",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 196,
                 "name": "Puzzle 5 Combo 2",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 197,
                 "name": "Puzzle 6 Combo 1",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 198,
                 "name": "Puzzle 6 Combo 2",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 199,
                 "name": "Puzzle 7 Combo 1",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 200,
                 "name": "Puzzle 7 Combo 2",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 201,
                 "name": "Puzzle 8 Combo 1",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 202,
                 "name": "Puzzle 8 Combo 2",
-                "categories": [ "Pickup", "Puzzle" ],
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 203,
                 "name": "Key 1",
-                "categories": [ "Pickup", "Key" ],
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 204,
                 "name": "Key 2",
-                "categories": [ "Pickup", "Key" ],
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 205,
                 "name": "Key 3",
-                "categories": [ "Pickup", "Key" ],
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 206,
                 "name": "Key 4",
-                "categories": [ "Pickup", "Key" ],
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 207,
                 "name": "Key 5",
-                "categories": [ "Pickup", "Key" ],
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 208,
                 "name": "Key 6",
-                "categories": [ "Pickup", "Key" ],
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 209,
                 "name": "Key 7",
-                "categories": [ "Pickup", "Key" ],
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 210,
                 "name": "Key 8",
-                "categories": [ "Pickup", "Key" ],
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 211,
                 "name": "Key 9",
-                "categories": [ "Pickup", "Key" ],
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 212,
                 "name": "Key 10",
-                "categories": [ "Pickup", "Key" ],
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 213,
                 "name": "Key 11",
-                "categories": [ "Pickup", "Key" ],
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 214,
                 "name": "Key 12",
-                "categories": [ "Pickup", "Key" ],
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 231,
                 "name": "Item 1"
@@ -3258,13 +3220,11 @@
             }, {
                 "id": 246,
                 "name": "Crowbar",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 247,
                 "name": "Torch",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 249,
                 "name": "Winding Key",
@@ -3396,13 +3356,11 @@
             }, {
                 "id": 296,
                 "name": "Waterskin 1",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 300,
                 "name": "Waterskin 2",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 306,
                 "name": "Switch 1",
@@ -3552,108 +3510,87 @@
             }, {
                 "id": 349,
                 "name": "Pistols",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 350,
                 "name": "Pistol Ammo",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 351,
                 "name": "Uzis",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 352,
                 "name": "Uzi Ammo",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 353,
                 "name": "Shotgun",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 354,
                 "name": "Shotgun ammo (red)",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 355,
                 "name": "Shotgun ammo (blue)",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 356,
                 "name": "Crossbow",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 357,
                 "name": "Bolts",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 358,
                 "name": "Bolts (poison)",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 359,
                 "name": "Bolts (explosive)",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 361,
                 "name": "Grenade Launcher",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 362,
                 "name": "Grenades",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 363,
                 "name": "Grenades (super)",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 364,
                 "name": "Grenades (flash)",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 368,
                 "name": "Large medipack",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 366,
                 "name": "Revolver",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 367,
                 "name": "Revolver ammo",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 369,
                 "name": "Small medipack",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 370,
                 "name": "Lasersight",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 373,
                 "name": "Flares",
-                "categories": [ "Pickup" ],
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 375,
                 "name": "Compass"
@@ -3763,7 +3700,8 @@
         ],
         "tr5": [{
                 "id": 0,
-                "name": "Lara"
+                "name": "Lara",
+                "categories": [ "Entity" ]
             }, {
                 "id": 1,
                 "name": "LaraPistolsAnim"
@@ -3778,184 +3716,243 @@
                 "name": "LaraFlareAnim"
             }, {
                 "id": 33,
-                "name": "SWAT"
+                "name": "SWAT",
+                "categories": [ "Entity" ]
             }, {
                 "id": 35,
-                "name": "Advanced SWAT"
+                "name": "Advanced SWAT",
+                "categories": [ "Entity" ]
             }, {
                 "id": 36,
-                "name": "Advanced SWAT mip"
+                "name": "Advanced SWAT mip",
+                "categories": [ "Entity" ]
             }, {
                 "id": 37,
-                "name": "Guard"
+                "name": "Guard",
+                "categories": [ "Entity" ]
             }, {
                 "id": 38,
-                "name": "Blue Guard"
+                "name": "Blue Guard",
+                "categories": [ "Entity" ]
             }, {
                 "id": 39,
-                "name": "Two Gun"
+                "name": "Two Gun",
+                "categories": [ "Entity" ]
             }, {
                 "id": 40,
-                "name": "Two gun mip"
+                "name": "Two gun mip",
+                "categories": [ "Entity" ]
             }, {
                 "id": 41,
-                "name": "Dog"
+                "name": "Dog",
+                "categories": [ "Entity" ]
             }, {
                 "id": 42,
-                "name": "Dog mip"
+                "name": "Dog mip",
+                "categories": [ "Entity" ]
             }, {
                 "id": 43,
-                "name": "Crow"
+                "name": "Crow",
+                "categories": [ "Entity" ]
             }, {
                 "id": 44,
-                "name": "Crow mip"
+                "name": "Crow mip",
+                "categories": [ "Entity" ]
             }, {
                 "id": 45,
-                "name": "Larson"
+                "name": "Larson",
+                "categories": [ "Entity" ]
             }, {
                 "id": 46,
-                "name": "Larson mip"
+                "name": "Larson mip",
+                "categories": [ "Entity" ]
             }, {
                 "id": 48,
-                "name": "Pierre mip"
+                "name": "Pierre mip",
+                "categories": [ "Entity" ]
             }, {
                 "id": 49,
-                "name": "Soldier (MG)"
+                "name": "Soldier (MG)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 50,
-                "name": "Soldier (MG) mip"
+                "name": "Soldier (MG) mip",
+                "categories": [ "Entity" ]
             }, {
                 "id": 51,
-                "name": "Soldier (Pistols)"
+                "name": "Soldier (Pistols)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 54,
-                "name": "Sailor mip"
+                "name": "Sailor mip",
+                "categories": [ "Entity" ]
             }, {
                 "id": 56,
-                "name": "Sub Captain"
+                "name": "Sub Captain",
+                "categories": [ "Entity" ]
             }, {
                 "id": 57,
-                "name": "Lion"
+                "name": "Lion",
+                "categories": [ "Entity" ]
             }, {
                 "id": 59,
-                "name": "Gladiator"
+                "name": "Gladiator",
+                "categories": [ "Entity" ]
             }, {
                 "id": 61,
-                "name": "Soldier Statue"
+                "name": "Soldier Statue",
+                "categories": [ "Entity" ]
             }, {
                 "id": 63,
-                "name": "Hydra"
+                "name": "Hydra",
+                "categories": [ "Entity" ]
             }, {
                 "id": 64,
-                "name": "Hydra mip"
+                "name": "Hydra mip",
+                "categories": [ "Entity" ]
             }, {
                 "id": 65,
-                "name": "Guardian"
+                "name": "Guardian",
+                "categories": [ "Entity" ]
             }, {
                 "id": 67,
-                "name": "Cyborg"
+                "name": "Cyborg",
+                "categories": [ "Entity" ]
             }, {
                 "id": 69,
-                "name": "Scientist"
+                "name": "Scientist",
+                "categories": [ "Entity" ]
             }, {
                 "id": 71,
-                "name": "Will-o'-the-wisp"
+                "name": "Will-o'-the-wisp",
+                "categories": [ "Entity" ]
             }, {
                 "id": 73,
-                "name": "Skeleton"
+                "name": "Skeleton",
+                "categories": [ "Entity" ]
             }, {
                 "id": 77,
-                "name": "Maze Monster"
+                "name": "Maze Monster",
+                "categories": [ "Entity" ]
             }, {
                 "id": 79,
-                "name": "Water Monster"
+                "name": "Water Monster",
+                "categories": [ "Entity" ]
             }, {
                 "id": 81,
-                "name": "Attack Sub"
+                "name": "Attack Sub",
+                "categories": [ "Entity" ]
             }, {
                 "id": 83,
-                "name": "Sniper"
+                "name": "Sniper",
+                "categories": [ "Entity" ]
             }, {
                 "id": 85,
-                "name": "Dog"
+                "name": "Dog",
+                "categories": [ "Entity" ]
             }, {
                 "id": 86,
                 "name": "Ventilator"
             }, {
                 "id": 87,
-                "name": "Chef"
+                "name": "Chef",
+                "categories": [ "Entity" ]
             }, {
                 "id": 89,
-                "name": "Imp"
+                "name": "Imp",
+                "categories": [ "Entity" ]
             }, {
                 "id": 91,
-                "name": "Gunship"
+                "name": "Gunship",
+                "categories": [ "Entity" ]
             }, {
                 "id": 93,
-                "name": "Bats"
+                "name": "Bats",
+                "categories": [ "Entity" ]
             }, {
                 "id": 94,
-                "name": "Rats"
+                "name": "Rats",
+                "categories": [ "Entity" ]
             }, {
                 "id": 95,
-                "name": "Spiders"
+                "name": "Spiders",
+                "categories": [ "Entity" ]
             }, {
                 "id": 97,
-                "name": "Autogun"
+                "name": "Autogun",
+                "categories": [ "Entity" ]
             }, {
                 "id": 98,
-                "name": "Cables"
+                "name": "Cables",
+                "categories": [ "Entity" ]
             }, {
                 "id": 99,
-                "name": "Dart"
+                "name": "Dart",
+                "categories": [ "Trap" ]
             }, {
                 "id": 100,
-                "name": "Dart Emitter"
+                "name": "Dart Emitter",
+                "categories": [ "Trap" ]
             }, {
                 "id": 102,
-                "name": "Falling Ceiling"
+                "name": "Falling Ceiling",
+                "categories": [ "Trap" ]
             }, {
                 "id": 105,
-                "name": "Crumbling Floor"
+                "name": "Crumbling Floor",
+                "categories": [ "Trap" ]
             }, {
                 "id": 106,
-                "name": "Trapdoor 1"
+                "name": "Trapdoor 1",
+                "categories": [ "Trap" ]
             }, {
                 "id": 107,
-                "name": "Trapdoor 2"
+                "name": "Trapdoor 2",
+                "categories": [ "Trap" ]
             }, {
                 "id": 108,
-                "name": "Trapdoor 3"
+                "name": "Trapdoor 3",
+                "categories": [ "Trap" ]
             }, {
                 "id": 109,
-                "name": "Floor trapdoor 1"
+                "name": "Floor trapdoor 1",
+                "categories": [ "Trap" ]
             }, {
                 "id": 110,
-                "name": "Floor trapdoor 2"
+                "name": "Floor trapdoor 2",
+                "categories": [ "Trap" ]
             }, {
                 "id": 111,
-                "name": "Ceiling trapdoor"
+                "name": "Ceiling trapdoor",
+                "categories": [ "Trap" ]
             }, {
                 "id": 114,
-                "name": "Boulder"
+                "name": "Boulder",
+                "categories": [ "Trap" ]
             }, {
                 "id": 117,
-                "name": "Spikes"
+                "name": "Spikes",
+                "categories": [ "Trap" ]
             }, {
                 "id": 118,
-                "name": "Ram"
+                "name": "Ram",
+                "categories": [ "Trap" ]
             }, {
                 "id": 121,
-                "name": "Flame"
+                "name": "Flame",
+                "categories": [ "Trap" ]
             }, {
                 "id": 122,
-                "name": "Flame"
+                "name": "Flame",
+                "categories": [ "Trap" ]
             }, {
                 "id": 123,
-                "name": "Flame"
+                "name": "Flame",
+                "categories": [ "Trap" ]
             }, {
                 "id": 124,
-                "name": "Cooker Flame"
+                "name": "Cooker Flame",
+                "categories": [ "Trap" ]
             }, {
                 "id": 125,
                 "name": "Roots"
@@ -3985,19 +3982,24 @@
                 "name": "Expanding Platform"
             }, {
                 "id": 137,
-                "name": "Pushable 1"
+                "name": "Pushable 1",
+                "categories": [ "Movable" ]
             }, {
                 "id": 138,
-                "name": "Pushable 2"
+                "name": "Pushable 2",
+                "categories": [ "Movable" ]
             }, {
                 "id": 139,
-                "name": "Pushable 3"
+                "name": "Pushable 3",
+                "categories": [ "Movable" ]
             }, {
                 "id": 140,
-                "name": "Pushable 4"
+                "name": "Pushable 4",
+                "categories": [ "Movable" ]
             }, {
                 "id": 141,
-                "name": "Pushable 5"
+                "name": "Pushable 5",
+                "categories": [ "Movable" ]
             }, {
                 "id": 142,
                 "name": "The Claw"
@@ -4058,371 +4060,430 @@
             }, {
                 "id": 172,
                 "name": "Puzzle 1",
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 173,
                 "name": "Puzzle 2",
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 174,
                 "name": "Puzzle 3",
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 175,
                 "name": "Puzzle 4",
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 176,
                 "name": "Puzzle 5",
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 180,
                 "name": "Puzzle 1 Combo 1",
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 181,
                 "name": "Puzzle 1 Combo 2",
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 182,
                 "name": "Puzzle 2 Combo 1",
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 183,
                 "name": "Puzzle 2 Combo 2",
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 184,
                 "name": "Puzzle 3 Combo 1",
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 185,
                 "name": "Puzzle 3 Combo 2",
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 186,
                 "name": "Puzzle 4 Combo 1",
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 187,
                 "name": "Puzzle 4 Combo 2",
-                "pickup": true
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 196,
                 "name": "Key 1",
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 197,
                 "name": "Key 2",
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 198,
                 "name": "Key 3",
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 199,
                 "name": "Key 4",
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 200,
                 "name": "Key 5",
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 201,
                 "name": "Key 6",
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 202,
                 "name": "Key 7",
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 203,
                 "name": "Key 8",
-                "pickup": true
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 220,
                 "name": "Pickup 1",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 221,
                 "name": "Pickup 2",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 222,
                 "name": "Pickup 3",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 223,
                 "name": "Secret",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 235,
                 "name": "Bottle",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 236,
                 "name": "Cloth",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 240,
                 "name": "Crowbar",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 241,
                 "name": "Torch",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 242,
-                "name": "Slot 1"
+                "name": "Slot 1",
+                "categories": [ "Slot" ]
             }, {
                 "id": 243,
-                "name": "Slot 2"
+                "name": "Slot 2",
+                "categories": [ "Slot" ]
             }, {
                 "id": 244,
-                "name": "Slot 3"
+                "name": "Slot 3",
+                "categories": [ "Slot" ]
             }, {
                 "id": 245,
-                "name": "Slot 4"
+                "name": "Slot 4",
+                "categories": [ "Slot" ]
             }, {
                 "id": 246,
-                "name": "Slot 5"
+                "name": "Slot 5",
+                "categories": [ "Slot" ]
             }, {
                 "id": 247,
-                "name": "Slot 6"
+                "name": "Slot 6",
+                "categories": [ "Slot" ]
             }, {
                 "id": 248,
-                "name": "Slot 7"
+                "name": "Slot 7",
+                "categories": [ "Slot" ]
             }, {
                 "id": 249,
-                "name": "Slot 8"
+                "name": "Slot 8",
+                "categories": [ "Slot" ]
             }, {
                 "id": 250,
-                "name": "Slot 1 Done"
+                "name": "Slot 1 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 251,
-                "name": "Slot 2 Done"
+                "name": "Slot 2 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 252,
-                "name": "Slot 3 Done"
+                "name": "Slot 3 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 253,
-                "name": "Slot 4 Done"
+                "name": "Slot 4 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 254,
-                "name": "Slot 5 Done"
+                "name": "Slot 5 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 255,
-                "name": "Slot 6 Done"
+                "name": "Slot 6 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 256,
-                "name": "Slot 7 Done"
+                "name": "Slot 7 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 257,
-                "name": "Slot 8 Done"
+                "name": "Slot 8 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 258,
-                "name": "Keyhole 1"
+                "name": "Keyhole 1",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 259,
-                "name": "Keyhole 2"
+                "name": "Keyhole 2",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 260,
-                "name": "Keyhole 3"
+                "name": "Keyhole 3",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 261,
-                "name": "Keyhole 4"
+                "name": "Keyhole 4",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 262,
-                "name": "Keyhole 5"
+                "name": "Keyhole 5",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 263,
-                "name": "Keyhole 6"
+                "name": "Keyhole 6",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 264,
-                "name": "Keyhole 7"
+                "name": "Keyhole 7",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 265,
-                "name": "Keyhole 8"
+                "name": "Keyhole 8",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 266,
-                "name": "Switch 1"
+                "name": "Switch 1",
+                "categories": [ "Switch" ]
             }, {
                 "id": 267,
-                "name": "Switch 2"
+                "name": "Switch 2",
+                "categories": [ "Switch" ]
             }, {
                 "id": 268,
-                "name": "Switch 3"
+                "name": "Switch 3",
+                "categories": [ "Switch" ]
             }, {
                 "id": 269,
-                "name": "Switch 4"
+                "name": "Switch 4",
+                "categories": [ "Switch" ]
             }, {
                 "id": 270,
-                "name": "Switch 5"
+                "name": "Switch 5",
+                "categories": [ "Switch" ]
             }, {
                 "id": 271,
-                "name": "Switch 6"
+                "name": "Switch 6",
+                "categories": [ "Switch" ]
             }, {
                 "id": 272,
-                "name": "Shoot switch 1"
+                "name": "Shoot switch 1",
+                "categories": [ "Switch" ]
             }, {
                 "id": 273,
-                "name": "Shoot switch 2"
+                "name": "Shoot switch 2",
+                "categories": [ "Switch" ]
             }, {
                 "id": 274,
-                "name": "Switch 7"
+                "name": "Switch 7",
+                "categories": [ "Switch" ]
             }, {
                 "id": 278,
-                "name": "Cog Switch"
+                "name": "Cog Switch",
+                "categories": [ "Switch" ]
             }, {
                 "id": 280,
-                "name": "Jump Switch"
+                "name": "Jump Switch",
+                "categories": [ "Switch" ]
             }, {
                 "id": 282,
                 "name": "Pole"
             }, {
                 "id": 283,
-                "name": "Crow/Dove Switch"
+                "name": "Crow/Dove Switch",
+                "categories": [ "Switch" ]
             }, {
                 "id": 284,
-                "name": "Door 1"
+                "name": "Door 1",
+                "categories": [ "Door" ]
             }, {
                 "id": 286,
-                "name": "Door 2"
+                "name": "Door 2",
+                "categories": [ "Door" ]
             }, {
                 "id": 288,
-                "name": "Door 3"
+                "name": "Door 3",
+                "categories": [ "Door" ]
             }, {
                 "id": 290,
-                "name": "Door 4"
+                "name": "Door 4",
+                "categories": [ "Door" ]
             }, {
                 "id": 292,
-                "name": "Door 5"
+                "name": "Door 5",
+                "categories": [ "Door" ]
             }, {
                 "id": 294,
-                "name": "Door 6"
+                "name": "Door 6",
+                "categories": [ "Door" ]
             }, {
                 "id": 296,
-                "name": "Door 7"
+                "name": "Door 7",
+                "categories": [ "Door" ]
             }, {
                 "id": 298,
-                "name": "Door 8"
+                "name": "Door 8",
+                "categories": [ "Door" ]
             }, {
                 "id": 300,
-                "name": "Closed Door 1"
+                "name": "Closed Door 1",
+                "categories": [ "Door" ]
             }, {
                 "id": 302,
-                "name": "Closed Door 2"
+                "name": "Closed Door 2",
+                "categories": [ "Door" ]
             }, {
                 "id": 304,
-                "name": "Closed Door 3"
+                "name": "Closed Door 3",
+                "categories": [ "Door" ]
             }, {
                 "id": 306,
-                "name": "Closed Door 4"
+                "name": "Closed Door 4",
+                "categories": [ "Door" ]
             }, {
                 "id": 308,
-                "name": "Closed Door 5"
+                "name": "Closed Door 5",
+                "categories": [ "Door" ]
             }, {
                 "id": 310,
-                "name": "Closed Door 6"
+                "name": "Closed Door 6",
+                "categories": [ "Door" ]
             }, {
                 "id": 312,
-                "name": "Lift Doors 1"
+                "name": "Lift Doors 1",
+                "categories": [ "Door" ]
             }, {
                 "id": 314,
-                "name": "Lift Doors 2"
+                "name": "Lift Doors 2",
+                "categories": [ "Door" ]
             }, {
                 "id": 320,
-                "name": "Kick Door 1"
+                "name": "Kick Door 1",
+                "categories": [ "Door" ]
             }, {
                 "id": 326,
-                "name": "Double doors"
+                "name": "Double doors",
+                "categories": [ "Door" ]
             }, {
                 "id": 328,
-                "name": "Sequence Door 1"
+                "name": "Sequence Door 1",
+                "categories": [ "Door" ]
             }, {
                 "id": 329,
-                "name": "Sequence Switch 1"
+                "name": "Sequence Switch 1",
+                "categories": [ "Switch" ]
             }, {
                 "id": 330,
-                "name": "Sequence Switch 2"
+                "name": "Sequence Switch 2",
+                "categories": [ "Switch" ]
             }, {
                 "id": 331,
-                "name": "Sequence Switch 3"
+                "name": "Sequence Switch 3",
+                "categories": [ "Switch" ]
             }, {
                 "id": 332,
-                "name": "Steel Door"
+                "name": "Steel Door",
+                "categories": [ "Door" ]
             }, {
                 "id": 334,
                 "name": "Pistols",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 335,
                 "name": "Pistol  Ammo",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 336,
                 "name": "Uzis",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 337,
                 "name": "Uzi Ammo",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 338,
                 "name": "Shotgun",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 339,
                 "name": "Shotgun ammo (red)",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 340,
                 "name": "Shotgun ammo (blue)",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 341,
                 "name": "Grappling Gun",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 342,
                 "name": "Grappling Ammo",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 345,
                 "name": "HK",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 346,
                 "name": "HK Ammo",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 347,
                 "name": "Revolver",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 348,
                 "name": "Revolver ammo",
-                "pickup": true
+                "categories": [ "Pickup" ]
             },  {
                 "id": 349,
                 "name": "Large medipack",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 350,
                 "name": "Small medipack",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 351,
                 "name": "Lasersight",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 354,
                 "name": "Flare",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 355,
                 "name": "Flares",
-                "pickup": true
+                "categories": [ "Pickup" ]
             }, {
                 "id": 356,
                 "name": "Compass"
@@ -4494,13 +4555,16 @@
                 "name": "Raising Cog"
             }, {
                 "id": 390,
-                "name": "Lasers"
+                "name": "Lasers",
+                "categories": [ "Trap" ]
             }, {
                 "id": 391,
-                "name": "Steam lasers"
+                "name": "Steam lasers",
+                "categories": [ "Trap" ]
             }, {
                 "id": 392,
-                "name": "Floor Lasers"
+                "name": "Floor Lasers",
+                "categories": [ "Trap" ]
             }, {
                 "id": 394,
                 "name": "Trigger triggerer"
@@ -4635,13 +4699,16 @@
                 "name": "Animating 16 mip"
             }, {
                 "id": 448,
-                "name": "Bridge (Flat)"
+                "name": "Bridge (Flat)",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 450,
-                "name": "Bridge (Tilt 1)"
+                "name": "Bridge (Tilt 1)",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 452,
-                "name": "Bridge (Tilt 2)"
+                "name": "Bridge (Tilt 2)",
+                "categories": [ "Scenery" ]
             }
         ]
     }

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -189,7 +189,8 @@
                 "categories": [ "Trap" ]
             }, {
                 "id": 47,
-                "name": "Barricade"
+                "name": "Barricade",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 48,
                 "name": "Pushable Block 1",
@@ -289,13 +290,16 @@
                 "name": "LarasHomePolaroid"
             }, {
                 "id": 74,
-                "name": "Animating 1"
+                "name": "Animating 1",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 75,
-                "name": "Animating 2"
+                "name": "Animating 2",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 76,
-                "name": "Animating 3"
+                "name": "Animating 3",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 77,
                 "name": "CutsceneActor1"
@@ -531,7 +535,8 @@
                 "name": "Scion Piece"
             }, {
                 "id": 145,
-                "name": "Scion"
+                "name": "Scion",
+                "categories": [ "Entity" ]
             }, {
                 "id": 146,
                 "name": "Scion",
@@ -950,7 +955,8 @@
                 "categories": [ "Trap" ]
             }, {
                 "id": 65,
-                "name": "Elevator"
+                "name": "Elevator",
+                "categories": [ "Movable" ]
             }, {
                 "id": 66,
                 "name": "Minisub",
@@ -1085,7 +1091,8 @@
                 "categories": [ "Trap" ]
             }, {
                 "id": 102,
-                "name": "Zipline"
+                "name": "Zipline",
+                "categories": [ "Vehicle" ]
             }, {
                 "id": 103,
                 "name": "Button",
@@ -1494,7 +1501,8 @@
                 "categories": [ "Effect" ]
             }, {
                 "id": 216,
-                "name": "BartoliHideoutClock"
+                "name": "BartoliHideoutClock",
+                "categories": [ "Effect" ]
             }, {
                 "id": 217,
                 "name": "Placeholder"
@@ -1532,7 +1540,8 @@
                 "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 228,
-                "name": "Helicopter"
+                "name": "Helicopter",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 229,
                 "name": "Explosion"
@@ -1585,13 +1594,15 @@
                 "name": "LavaParticles"
             }, {
                 "id": 251,
-                "name": "Lava Emitter"
+                "name": "Lava Emitter",
+                "categories": [ "Trap" ]
             }, {
                 "id": 252,
                 "name": "Flame"
             }, {
                 "id": 253,
-                "name": "Flame Emitter"
+                "name": "Flame Emitter",
+                "categories": [ "Fire" ]
             }, {
                 "id": 254,
                 "name": "Skybox"
@@ -1600,29 +1611,36 @@
                 "name": "FontGraphics"
             }, {
                 "id": 256,
-                "name": "Monk"
+                "name": "Monk",
+                "categories": [ "Entity" ]
             }, {
                 "id": 257,
-                "name": "Doorbell"
+                "name": "Doorbell",
+                "categories": [ "Effect" ]
             }, {
                 "id": 258,
-                "name": "AlarmBell"
+                "name": "AlarmBell",
+                "categories": [ "Effect" ]
             }, {
                 "id": 259,
-                "name": "Helicopter"
+                "name": "Helicopter",
+                "categories": [ "Entity" ]
             }, {
                 "id": 260,
                 "name": "Winston",
                 "categories": [ "Entity" ]
             }, {
                 "id": 262,
-                "name": "LaraCutscenePlacement"
+                "name": "LaraCutscenePlacement",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 263,
-                "name": "ShotgunAnimation"
+                "name": "ShotgunAnimation",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 264,
-                "name": "Dragon (Emitter)"
+                "name": "Dragon (Emitter)",
+                "categories": [ "Entity" ]
             }
         ],
         "tr3": [{
@@ -1791,10 +1809,12 @@
                 "categories": [ "Entity" ]
             }, {
                 "id": 47,
-                "name": "Wasp Spawn"
+                "name": "Wasp Spawn",
+                "categories": [ "Entity" ]
             }, {
                 "id": 48,
-                "name": "Raptor Spawn"
+                "name": "Raptor Spawn",
+                "categories": [ "Entity" ]
             }, {
                 "id": 49,
                 "name": "Willard",
@@ -1855,7 +1875,8 @@
                 "name": "Electrified Wire"
             }, {
                 "id": 68,
-                "name": "Killer Tripwire"
+                "name": "Killer Tripwire",
+                "categories": [ "Trap" ]
             }, {
                 "id": 69,
                 "name": "Cobra",
@@ -1874,28 +1895,36 @@
                 "categories": [ "Entity" ]
             }, {
                 "id": 74,
-                "name": "AI Guard"
+                "name": "AI Guard",
+                "categories": [ "AI" ]
             }, {
                 "id": 75,
-                "name": "AI Ambush"
+                "name": "AI Ambush",
+                "categories": [ "AI" ]
             }, {
                 "id": 76,
-                "name": "AI Patrol 1"
+                "name": "AI Patrol 1",
+                "categories": [ "AI" ]
             }, {
                 "id": 77,
-                "name": "AI Modify"
+                "name": "AI Modify",
+                "categories": [ "AI" ]
             }, {
                 "id": 78,
-                "name": "AI Follow"
+                "name": "AI Follow",
+                "categories": [ "AI" ]
             }, {
                 "id": 79,
-                "name": "AI Patrol 2"
+                "name": "AI Patrol 2",
+                "categories": [ "AI" ]
             }, {
                 "id": 80,
-                "name": "AI Path"
+                "name": "AI Path",
+                "categories": [ "AI" ]
             }, {
                 "id": 81,
-                "name": "AI Check"
+                "name": "AI Check",
+                "categories": [ "AI" ]
             }, {
                 "id": 82,
                 "name": "Unknown"
@@ -1941,10 +1970,12 @@
                 "categories": [ "Movable" ]
             }, {
                 "id": 101,
-                "name": "Breakable Window"
+                "name": "Breakable Window",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 102,
-                "name": "Breakable Window"
+                "name": "Breakable Window",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 106,
                 "name": "Hook",
@@ -2507,10 +2538,12 @@
                 "name": "GrenadeSingle"
             }, {
                 "id": 312,
-                "name": "Missile"
+                "name": "Missile",
+                "categories": [ "Effect", "Scenery" ]
             }, {
                 "id": 313,
-                "name": "Smoke"
+                "name": "Smoke",
+                "categories": [ "Effect" ]
             }, {
                 "id": 314,
                 "name": "Movable Boom",
@@ -2566,25 +2599,32 @@
                 "categories": [ "Trap" ]
             }, {
                 "id": 331,
-                "name": "Alternate Fire"
+                "name": "Alternate Fire",
+                "categories": [ "Scenery", "Trap" ]
             }, {
                 "id": 332,
-                "name": "Alternate Fire 2"
+                "name": "Alternate Fire 2",
+                "categories": [ "Scenery", "Trap" ]
             }, {
                 "id": 333,
-                "name": "Fire 2"
+                "name": "Fire 2",
+                "categories": [ "Trap" ]
             }, {
                 "id": 334,
-                "name": "Smoke 2"
+                "name": "Smoke 2",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 335,
-                "name": "Smoke 3"
+                "name": "Smoke 3",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 336,
-                "name": "Smoke 4"
+                "name": "Smoke 4",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 337,
-                "name": "Greenish Smoke"
+                "name": "Greenish Smoke",
+                "categories": [ "Effect" ]
             }, {
                 "id": 338,
                 "name": "Piranhas",
@@ -2599,22 +2639,28 @@
                 "categories": [ "Scenery" ]
             }, {
                 "id": 349,
-                "name": "Animating 1"
+                "name": "Animating 1",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 350,
-                "name": "Animating 2"
+                "name": "Animating 2",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 351,
-                "name": "Animating 3"
+                "name": "Animating 3",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 352,
-                "name": "Animating 4"
+                "name": "Animating 4",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 353,
-                "name": "Animating 5"
+                "name": "Animating 5",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 354,
-                "name": "Animating 6"
+                "name": "Animating 6",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 355,
                 "name": "Skybox"
@@ -2623,7 +2669,8 @@
                 "name": "FontGraphics"
             }, {
                 "id": 357,
-                "name": "Doorbell"
+                "name": "Doorbell",
+                "categories": [ "Effect" ]
             }, {
                 "id": 358,
                 "name": "UnknownID358"
@@ -2650,7 +2697,8 @@
                 "name": "RedShellCasing"
             }, {
                 "id": 370,
-                "name": "Light Shaft"
+                "name": "Light Shaft",
+                "categories": [ "Effect" ]
             }, {
                 "id": 373,
                 "name": "Electrical Switch Box",

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -1,3979 +1,4088 @@
 {
-	"games": {
-		"tr1": [{
-				"id": 0,
-				"name": "Lara",
-				"categories": [ "entity" ]
-			}, {
-				"id": 1,
-				"name": "LaraPistolsAnim"
-			}, {
-				"id": 2,
-				"name": "LaraShotgunAnim"
-			}, {
-				"id": 3,
-				"name": "LaraMagnumsAnim"
-			}, {
-				"id": 4,
-				"name": "LaraUzisAnim"
-			}, {
-				"id": 5,
-				"name": "AlternativeLara"
-			}, {
-				"id": 6,
-				"name": "Doppelganger"
-			}, {
-				"id": 7,
-				"name": "Wolf"
-			}, {
-				"id": 8,
-				"name": "Bear"
-			}, {
-				"id": 9,
-				"name": "Bat"
-			}, {
-				"id": 10,
-				"name": "Crocodile"
-			}, {
-				"id": 11,
-				"name": "Crocodile"
-			}, {
-				"id": 12,
-				"name": "Lion (Male)"
-			}, {
-				"id": 13,
-				"name": "Lion (Female)"
-			}, {
-				"id": 14,
-				"name": "Panther"
-			}, {
-				"id": 15,
-				"name": "Gorilla"
-			}, {
-				"id": 16,
-				"name": "Rat"
-			}, {
-				"id": 17,
-				"name": "Rat"
-			}, {
-				"id": 18,
-				"name": "T-Rex"
-			}, {
-				"id": 19,
-				"name": "Raptor"
-			}, {
-				"id": 20,
-				"name": "Mutant (Winged)"
-			}, {
-				"id": 21,
-				"name": "Mutant (Shooter)"
-			}, {
-				"id": 22,
-				"name": "Mutant"
-			}, {
-				"id": 23,
-				"name": "Centaur"
-			}, {
-				"id": 24,
-				"name": "Mummy"
-			}, {
-				"id": 25,
-				"name": "DinoWarrior"
-			}, {
-				"id": 26,
-				"name": "Fish"
-			}, {
-				"id": 27,
-				"name": "Larson"
-			}, {
-				"id": 28,
-				"name": "Pierre"
-			}, {
-				"id": 29,
-				"name": "Skateboard"
-			}, {
-				"id": 30,
-				"name": "Skater Boy"
-			}, {
-				"id": 31,
-				"name": "Cowboy"
-			}, {
-				"id": 32,
-				"name": "Kold"
-			}, {
-				"id": 33,
-				"name": "WingedNatla"
-			}, {
-				"id": 34,
-				"name": "TorsoBoss"
-			}, {
-				"id": 35,
-				"name": "Breakable Tile"
-			}, {
-				"id": 36,
-				"name": "Swinging Blade"
-			}, {
-				"id": 37,
-				"name": "Spikes"
-			}, {
-				"id": 38,
-				"name": "Boulder"
-			}, {
-				"id": 39,
-				"name": "Dart"
-			}, {
-				"id": 40,
-				"name": "Dart Emitter"
-			}, {
-				"id": 41,
-				"name": "LiftingDoor"
-			}, {
-				"id": 42,
-				"name": "Slamming Doors"
-			}, {
-				"id": 43,
-				"name": "Sword"
-			}, {
-				"id": 44,
-				"name": "Hammer Handle"
-			}, {
-				"id": 45,
-				"name": "Hammer Block"
-			}, {
-				"id": 46,
-				"name": "Lightning Ball"
-			}, {
-				"id": 47,
-				"name": "Barricade"
-			}, {
-				"id": 48,
-				"name": "Pushable Block 1"
-			}, {
-				"id": 49,
-				"name": "Pushable Block 2"
-			}, {
-				"id": 50,
-				"name": "Pushable Block 3"
-			}, {
-				"id": 51,
-				"name": "Pushable Block 4"
-			}, {
-				"id": 52,
-				"name": "Moving Block"
-			}, {
-				"id": 53,
-				"name": "Falling Ceiling"
-			}, {
-				"id": 54,
-				"name": "Sword 2"
-			}, {
-				"id": 55,
-				"name": "Wall Switch"
-			}, {
-				"id": 56,
-				"name": "Underwater Lever"
-			}, {
-				"id": 57,
-				"name": "Door 1"
-			}, {
-				"id": 58,
-				"name": "Door 2"
-			}, {
-				"id": 59,
-				"name": "Door 3"
-			}, {
-				"id": 60,
-				"name": "Door 4"
-			}, {
-				"id": 61,
-				"name": "Door 5"
-			}, {
-				"id": 62,
-				"name": "Door 6"
-			}, {
-				"id": 63,
-				"name": "Door 7"
-			}, {
-				"id": 64,
-				"name": "Door 8"
-			}, {
-				"id": 65,
-				"name": "Trapdoor 1"
-			}, {
-				"id": 66,
-				"name": "Trapdoor 2"
-			}, {
-				"id": 68,
-				"name": "Bridge (Flat)"
-			}, {
-				"id": 69,
-				"name": "Bridge (Tilt 1)"
-			}, {
-				"id": 70,
-				"name": "Bridge (Tilt 2)"
-			}, {
-				"id": 71,
-				"name": "PassportOpening"
-			}, {
-				"id": 72,
-				"name": "Compass"
-			}, {
-				"id": 73,
-				"name": "LarasHomePolaroid"
-			}, {
-				"id": 74,
-				"name": "Animating 1"
-			}, {
-				"id": 75,
-				"name": "Animating 2"
-			}, {
-				"id": 76,
-				"name": "Animating 3"
-			}, {
-				"id": 77,
-				"name": "CutsceneActor1"
-			}, {
-				"id": 78,
-				"name": "CutsceneActor2"
-			}, {
-				"id": 79,
-				"name": "CutsceneActor3"
-			}, {
-				"id": 80,
-				"name": "CutsceneActor4"
-			}, {
-				"id": 81,
-				"name": "PassportClosed"
-			}, {
-				"id": 82,
-				"name": "Map"
-			}, {
-				"id": 83,
-				"name": "Savegame Crystal"
-			}, {
-				"id": 84,
-				"name": "Pistols"
-			}, {
-				"id": 85,
-				"name": "Shotgun"
-			}, {
-				"id": 86,
-				"name": "Magnums"
-			}, {
-				"id": 87,
-				"name": "Uzis"
-			}, {
-				"id": 88,
-				"name": "Pistol ammo"
-			}, {
-				"id": 89,
-				"name": "Shotgun ammo"
-			}, {
-				"id": 90,
-				"name": "Magnum ammo"
-			}, {
-				"id": 91,
-				"name": "Uzi ammo"
-			}, {
-				"id": 92,
-				"name": "ExplosiveSprite"
-			}, {
-				"id": 93,
-				"name": "Small medipack"
-			}, {
-				"id": 94,
-				"name": "Large medipack"
-			}, {
-				"id": 95,
-				"name": "Sunglasses"
-			}, {
-				"id": 96,
-				"name": "CassettePlayer"
-			}, {
-				"id": 97,
-				"name": "DirectionKeys"
-			}, {
-				"id": 98,
-				"name": "Flashlight"
-			}, {
-				"id": 99,
-				"name": "Pistols"
-			}, {
-				"id": 100,
-				"name": "Shotgun"
-			}, {
-				"id": 101,
-				"name": "Magnums"
-			}, {
-				"id": 102,
-				"name": "Uzis"
-			}, {
-				"id": 103,
-				"name": "PistolAmmo"
-			}, {
-				"id": 104,
-				"name": "ShotgunAmmo"
-			}, {
-				"id": 105,
-				"name": "MagnumAmmo"
-			}, {
-				"id": 106,
-				"name": "UziAmmo"
-			}, {
-				"id": 107,
-				"name": "Explosive"
-			}, {
-				"id": 108,
-				"name": "Small medipack"
-			}, {
-				"id": 109,
-				"name": "Large medipack"
-			}, {
-				"id": 110,
-				"name": "Puzzle 1"
-			}, {
-				"id": 111,
-				"name": "Puzzle 2"
-			}, {
-				"id": 112,
-				"name": "Puzzle 3"
-			}, {
-				"id": 113,
-				"name": "Puzzle 4"
-			}, {
-				"id": 114,
-				"name": "Puzzle 1"
-			}, {
-				"id": 115,
-				"name": "Puzzle 2"
-			}, {
-				"id": 116,
-				"name": "Puzzle 3"
-			}, {
-				"id": 117,
-				"name": "Puzzle 4"
-			}, {
-				"id": 118,
-				"name": "Slot 1"
-			}, {
-				"id": 119,
-				"name": "Slot 2"
-			}, {
-				"id": 120,
-				"name": "Slot 3"
-			}, {
-				"id": 121,
-				"name": "Slot 4"
-			}, {
-				"id": 122,
-				"name": "Slot 1 Done"
-			}, {
-				"id": 123,
-				"name": "Slot 2 Done"
-			}, {
-				"id": 124,
-				"name": "Slot 3 Done"
-			}, {
-				"id": 125,
-				"name": "Slot 4 Done"
-			}, {
-				"id": 126,
-				"name": "Lead Bar"
-			}, {
-				"id": 127,
-				"name": "Lead Bar"
-			}, {
-				"id": 128,
-				"name": "Midas Hand"
-			}, {
-				"id": 129,
-				"name": "Key 1",
-				"categories": [ "pickup", "key" ]
-			}, {
-				"id": 130,
-				"name": "Key 2"
-			}, {
-				"id": 131,
-				"name": "Key 3"
-			}, {
-				"id": 132,
-				"name": "Key 4"
-			}, {
-				"id": 133,
-				"name": "Key 1"
-			}, {
-				"id": 134,
-				"name": "Key 2"
-			}, {
-				"id": 135,
-				"name": "Key 3"
-			}, {
-				"id": 136,
-				"name": "Key 4"
-			}, {
-				"id": 137,
-				"name": "Keyhole 1"
-			}, {
-				"id": 138,
-				"name": "Keyhole 2"
-			}, {
-				"id": 139,
-				"name": "Keyhole 3"
-			}, {
-				"id": 140,
-				"name": "Keyhole 4"
-			}, {
-				"id": 143,
-				"name": "Scion Piece"
-			}, {
-				"id": 144,
-				"name": "Scion Piece"
-			}, {
-				"id": 145,
-				"name": "Scion"
-			}, {
-				"id": 146,
-				"name": "Scion"
-			}, {
-				"id": 147,
-				"name": "Scion Holder"
-			}, {
-				"id": 150,
-				"name": "ScionPiece2"
-			}, {
-				"id": 151,
-				"name": "Explosion"
-			}, {
-				"id": 153,
-				"name": "Splash"
-			}, {
-				"id": 155,
-				"name": "Bubbles"
-			}, {
-				"id": 158,
-				"name": "Blood"
-			}, {
-				"id": 160,
-				"name": "Smoke"
-			}, {
-				"id": 161,
-				"name": "Centaur"
-			}, {
-				"id": 162,
-				"name": "Suspended Shack"
-			}, {
-				"id": 163,
-				"name": "Mutant Egg (Big)"
-			}, {
-				"id": 164,
-				"name": "Ricochet"
-			}, {
-				"id": 165,
-				"name": "Sparkles"
-			}, {
-				"id": 166,
-				"name": "Gunflare"
-			}, {
-				"id": 169,
-				"name": "Camera Target"
-			}, {
-				"id": 170,
-				"name": "Waterfall Mist"
-			}, {
-				"id": 172,
-				"name": "MutantBullet"
-			}, {
-				"id": 173,
-				"name": "MutantGrenade"
-			}, {
-				"id": 176,
-				"name": "LavaParticles"
-			}, {
-				"id": 177,
-				"name": "Lava Emitter"
-			}, {
-				"id": 178,
-				"name": "Flame"
-			}, {
-				"id": 179,
-				"name": "Flame Emitter"
-			}, {
-				"id": 180,
-				"name": "Lava Flow"
-			}, {
-				"id": 181,
-				"name": "MutantEggBig"
-			}, {
-				"id": 182,
-				"name": "Motorboat"
-			}, {
-				"id": 183,
-				"name": "Earthquake"
-			}, {
-				"id": 189,
-				"name": "LaraPonytail"
-			}, {
-				"id": 190,
-				"name": "FontGraphics"
-			}, {
-				"id": 191,
-				"name": "Plant1"
-			}, {
-				"id": 192,
-				"name": "Plant2"
-			}, {
-				"id": 193,
-				"name": "Plant3"
-			}, {
-				"id": 194,
-				"name": "Plant4"
-			}, {
-				"id": 195,
-				"name": "Plant5"
-			}, {
-				"id": 200,
-				"name": "Bag1"
-			}, {
-				"id": 204,
-				"name": "Bag2"
-			}, {
-				"id": 212,
-				"name": "Rock1"
-			}, {
-				"id": 213,
-				"name": "Rock2"
-			}, {
-				"id": 214,
-				"name": "Rock3"
-			}, {
-				"id": 215,
-				"name": "Bag3"
-			}, {
-				"id": 216,
-				"name": "Pottery1"
-			}, {
-				"id": 217,
-				"name": "Pottery2"
-			}, {
-				"id": 231,
-				"name": "PaintedPot"
-			}, {
-				"id": 233,
-				"name": "IncaMummy"
-			}, {
-				"id": 236,
-				"name": "Pottery3"
-			}, {
-				"id": 237,
-				"name": "Pottery4"
-			}, {
-				"id": 238,
-				"name": "Pottery5"
-			}, {
-				"id": 239,
-				"name": "Pottery6"
-			}
-		],
-		"tr2": [{
-				"id": 0,
-				"name": "Lara"
-			}, {
-				"id": 1,
-				"name": "LaraPistolsAnim"
-			}, {
-				"id": 2,
-				"name": "LaraPonytail"
-			}, {
-				"id": 3,
-				"name": "LaraShotgunAnim"
-			}, {
-				"id": 4,
-				"name": "LaraAutopistolsAnim"
-			}, {
-				"id": 5,
-				"name": "LaraUzisAnim"
-			}, {
-				"id": 6,
-				"name": "LaraM16Anim"
-			}, {
-				"id": 7,
-				"name": "LaraGrenadeLauncherAnim"
-			}, {
-				"id": 8,
-				"name": "LaraHarpoonGunAnim"
-			}, {
-				"id": 9,
-				"name": "LaraFlareAnim"
-			}, {
-				"id": 10,
-				"name": "LaraSnowmobileAnim"
-			}, {
-				"id": 11,
-				"name": "LaraBoatAnim"
-			}, {
-				"id": 12,
-				"name": "AlternativeLara"
-			}, {
-				"id": 13,
-				"name": "Skidoo"
-			}, {
-				"id": 14,
-				"name": "Boat"
-			}, {
-				"id": 15,
-				"name": "Dog"
-			}, {
-				"id": 16,
-				"name": "Masked Goon 1"
-			}, {
-				"id": 17,
-				"name": "Masked Goon 2"
-			}, {
-				"id": 18,
-				"name": "Masked Goon 3"
-			}, {
-				"id": 19,
-				"name": "Knife thrower"
-			}, {
-				"id": 20,
-				"name": "Shotgun Goon"
-			}, {
-				"id": 21,
-				"name": "Rat"
-			}, {
-				"id": 22,
-				"name": "DragonFront"
-			}, {
-				"id": 23,
-				"name": "DragonBack"
-			}, {
-				"id": 24,
-				"name": "Gondola"
-			}, {
-				"id": 25,
-				"name": "Shark"
-			}, {
-				"id": 26,
-				"name": "Yellow Eel"
-			}, {
-				"id": 27,
-				"name": "Black Eel"
-			}, {
-				"id": 28,
-				"name": "Barracuda"
-			}, {
-				"id": 29,
-				"name": "Scuba Diver"
-			}, {
-				"id": 30,
-				"name": "Shotgun Goon"
-			}, {
-				"id": 31,
-				"name": "Rifle Goon"
-			}, {
-				"id": 32,
-				"name": "Stick Goon 1"
-			}, {
-				"id": 33,
-				"name": "Stick Goon 2"
-			}, {
-				"id": 34,
-				"name": "Flamethrower"
-			}, {
-				"id": 36,
-				"name": "Spider"
-			}, {
-				"id": 37,
-				"name": "Giant Spider"
-			}, {
-				"id": 38,
-				"name": "Crow"
-			}, {
-				"id": 39,
-				"name": "Tiger/Leopard"
-			}, {
-				"id": 40,
-				"name": "Bartoli"
-			}, {
-				"id": 41,
-				"name": "Guard (Spear)"
-			}, {
-				"id": 42,
-				"name": "XianGuardSpearStatue"
-			}, {
-				"id": 43,
-				"name": "Guard (Sword)"
-			}, {
-				"id": 44,
-				"name": "XianGuardSwordStatue"
-			}, {
-				"id": 45,
-				"name": "Yeti"
-			}, {
-				"id": 46,
-				"name": "Guardian"
-			}, {
-				"id": 47,
-				"name": "Eagle"
-			}, {
-				"id": 48,
-				"name": "Mercenary 1"
-			}, {
-				"id": 49,
-				"name": "Mercenary 2"
-			}, {
-				"id": 50,
-				"name": "Mercenary 3"
-			}, {
-				"id": 51,
-				"name": "Black Skidoo"
-			}, {
-				"id": 52,
-				"name": "Skidoo Driver"
-			}, {
-				"id": 53,
-				"name": "Monk 1"
-			}, {
-				"id": 54,
-				"name": "Monk 2"
-			}, {
-				"id": 55,
-				"name": "Breakable Tile"
-			}, {
-				"id": 57,
-				"name": "Loose Boards"
-			}, {
-				"id": 58,
-				"name": "Swinging Sandbag"
-			}, {
-				"id": 59,
-				"name": "Spikes"
-			}, {
-				"id": 60,
-				"name": "Boulder"
-			}, {
-				"id": 61,
-				"name": "Dart"
-			}, {
-				"id": 62,
-				"name": "Dart Emitter"
-			}, {
-				"id": 63,
-				"name": "Drawbridge"
-			}, {
-				"id": 64,
-				"name": "Slamming Doors"
-			}, {
-				"id": 65,
-				"name": "Elevator"
-			}, {
-				"id": 66,
-				"name": "Minisub"
-			}, {
-				"id": 67,
-				"name": "Pushable Block 1"
-			}, {
-				"id": 68,
-				"name": "Pushable Block 2"
-			}, {
-				"id": 69,
-				"name": "Pushable Block 3"
-			}, {
-				"id": 70,
-				"name": "Pushable Block 4"
-			}, {
-				"id": 71,
-				"name": "Lava bowl"
-			}, {
-				"id": 72,
-				"name": "Breakable Window"
-			}, {
-				"id": 73,
-				"name": "Breakable Window"
-			}, {
-				"id": 76,
-				"name": "Propeller"
-			}, {
-				"id": 77,
-				"name": "PowerSaw"
-			}, {
-				"id": 78,
-				"name": "Hook"
-			}, {
-				"id": 79,
-				"name": "Falling Ceiling"
-			}, {
-				"id": 80,
-				"name": "Rolling Spindle"
-			}, {
-				"id": 81,
-				"name": "Wall Blade"
-			}, {
-				"id": 82,
-				"name": "Statue Blade"
-			}, {
-				"id": 83,
-				"name": "Boulders"
-			}, {
-				"id": 84,
-				"name": "Icicles"
-			}, {
-				"id": 85,
-				"name": "Spike Wall"
-			}, {
-				"id": 86,
-				"name": "Springboard"
-			}, {
-				"id": 87,
-				"name": "Spike Ceiling"
-			}, {
-				"id": 88,
-				"name": "Bell"
-			}, {
-				"id": 89,
-				"name": "BoatWake"
-			}, {
-				"id": 90,
-				"name": "SnowmobileWake"
-			}, {
-				"id": 91,
-				"name": "SnowmobileBelt"
-			}, {
-				"id": 92,
-				"name": "Wheel Door"
-			}, {
-				"id": 93,
-				"name": "Small Switch"
-			}, {
-				"id": 94,
-				"name": "Underwater Fan"
-			}, {
-				"id": 95,
-				"name": "Fan"
-			}, {
-				"id": 96,
-				"name": "Swinging Box"
-			}, {
-				"id": 97,
-				"name": "CutsceneActor1"
-			}, {
-				"id": 98,
-				"name": "CutsceneActor2"
-			}, {
-				"id": 99,
-				"name": "CutsceneActor3"
-			}, {
-				"id": 100,
-				"name": "UIFrame"
-			}, {
-				"id": 101,
-				"name": "Rolling Barrels"
-			}, {
-				"id": 102,
-				"name": "Zipline"
-			}, {
-				"id": 103,
-				"name": "Button"
-			}, {
-				"id": 104,
-				"name": "Wall Switch"
-			}, {
-				"id": 105,
-				"name": "Underwater Lever"
-			}, {
-				"id": 106,
-				"name": "Door 1"
-			}, {
-				"id": 107,
-				"name": "Door 2"
-			}, {
-				"id": 108,
-				"name": "Door 3"
-			}, {
-				"id": 109,
-				"name": "Door 4"
-			}, {
-				"id": 110,
-				"name": "Door 5"
-			}, {
-				"id": 111,
-				"name": "Door 6"
-			}, {
-				"id": 112,
-				"name": "Door 7"
-			}, {
-				"id": 113,
-				"name": "Door 8"
-			}, {
-				"id": 114,
-				"name": "Trapdoor 1"
-			}, {
-				"id": 115,
-				"name": "Trapdoor 2"
-			}, {
-				"id": 116,
-				"name": "Trapdoor 3"
-			}, {
-				"id": 117,
-				"name": "Bridge (Flat)"
-			}, {
-				"id": 118,
-				"name": "Bridge (Tilt 1)"
-			}, {
-				"id": 119,
-				"name": "Bridge (Tilt 2)"
-			}, {
-				"id": 120,
-				"name": "PassportOpening"
-			}, {
-				"id": 121,
-				"name": "Compass"
-			}, {
-				"id": 122,
-				"name": "LarasHomePolaroid"
-			}, {
-				"id": 123,
-				"name": "CutsceneActor4"
-			}, {
-				"id": 124,
-				"name": "CutsceneActor5"
-			}, {
-				"id": 125,
-				"name": "CutsceneActor6"
-			}, {
-				"id": 126,
-				"name": "CutsceneActor7"
-			}, {
-				"id": 127,
-				"name": "CutsceneActor8"
-			}, {
-				"id": 128,
-				"name": "CutsceneActor9"
-			}, {
-				"id": 129,
-				"name": "CutsceneActor10"
-			}, {
-				"id": 130,
-				"name": "CutsceneActor11"
-			}, {
-				"id": 133,
-				"name": "PassportClosed"
-			}, {
-				"id": 134,
-				"name": "Map"
-			}, {
-				"id": 135,
-				"name": "Pistols"
-			}, {
-				"id": 136,
-				"name": "Shotgun"
-			}, {
-				"id": 137,
-				"name": "Auto pistols"
-			}, {
-				"id": 138,
-				"name": "Uzis"
-			}, {
-				"id": 139,
-				"name": "Harpoon Gun"
-			}, {
-				"id": 140,
-				"name": "M16"
-			}, {
-				"id": 141,
-				"name": "Grenade launcher"
-			}, {
-				"id": 142,
-				"name": "PistolAmmoSprite"
-			}, {
-				"id": 143,
-				"name": "Shotgun shells"
-			}, {
-				"id": 144,
-				"name": "Auto pistol ammo"
-			}, {
-				"id": 145,
-				"name": "Uzi ammo"
-			}, {
-				"id": 146,
-				"name": "Harpoons"
-			}, {
-				"id": 147,
-				"name": "M16 ammo"
-			}, {
-				"id": 148,
-				"name": "Grenades"
-			}, {
-				"id": 149,
-				"name": "Small medipack"
-			}, {
-				"id": 150,
-				"name": "Large medipack"
-			}, {
-				"id": 151,
-				"name": "Flares"
-			}, {
-				"id": 152,
-				"name": "Flare"
-			}, {
-				"id": 153,
-				"name": "Sunglasses"
-			}, {
-				"id": 154,
-				"name": "CassettePlayer"
-			}, {
-				"id": 155,
-				"name": "DirectionKeys"
-			}, {
-				"id": 157,
-				"name": "Pistols"
-			}, {
-				"id": 158,
-				"name": "Shotgun"
-			}, {
-				"id": 159,
-				"name": "Autopistols"
-			}, {
-				"id": 160,
-				"name": "Uzis"
-			}, {
-				"id": 161,
-				"name": "HarpoonGun"
-			}, {
-				"id": 162,
-				"name": "M16"
-			}, {
-				"id": 163,
-				"name": "GrenadeLauncher"
-			}, {
-				"id": 164,
-				"name": "PistolAmmo"
-			}, {
-				"id": 165,
-				"name": "ShotgunAmmo"
-			}, {
-				"id": 166,
-				"name": "AutopistolAmmo"
-			}, {
-				"id": 167,
-				"name": "UziAmmo"
-			}, {
-				"id": 168,
-				"name": "HarpoonGunAmmo"
-			}, {
-				"id": 169,
-				"name": "M16Ammo"
-			}, {
-				"id": 170,
-				"name": "GrenadeLauncherAmmo"
-			}, {
-				"id": 171,
-				"name": "SmallMedipack"
-			}, {
-				"id": 172,
-				"name": "LargeMedipack"
-			}, {
-				"id": 173,
-				"name": "Flares"
-			}, {
-				"id": 174,
-				"name": "Puzzle 1"
-			}, {
-				"id": 175,
-				"name": "Puzzle 2"
-			}, {
-				"id": 176,
-				"name": "Puzzle 3"
-			}, {
-				"id": 177,
-				"name": "Puzzle 4"
-			}, {
-				"id": 178,
-				"name": "Puzzle 1"
-			}, {
-				"id": 179,
-				"name": "Puzzle 2"
-			}, {
-				"id": 180,
-				"name": "Puzzle 3"
-			}, {
-				"id": 181,
-				"name": "Puzzle 4"
-			}, {
-				"id": 182,
-				"name": "Slot 1"
-			}, {
-				"id": 183,
-				"name": "Slot 2"
-			}, {
-				"id": 184,
-				"name": "Slot 3"
-			}, {
-				"id": 185,
-				"name": "Slot 4"
-			}, {
-				"id": 186,
-				"name": "Slot 1 Done"
-			}, {
-				"id": 187,
-				"name": "Slot 2 Done"
-			}, {
-				"id": 188,
-				"name": "Slot 3 Done"
-			}, {
-				"id": 189,
-				"name": "Slot 4 Done"
-			}, {
-				"id": 190,
-				"name": "Secret (Gold)"
-			}, {
-				"id": 191,
-				"name": "Secret (Jade)"
-			}, {
-				"id": 192,
-				"name": "Secret (Stone)"
-			}, {
-				"id": 193,
-				"name": "Key 1"
-			}, {
-				"id": 194,
-				"name": "Key 2"
-			}, {
-				"id": 195,
-				"name": "Key 3"
-			}, {
-				"id": 196,
-				"name": "Key 4"
-			}, {
-				"id": 197,
-				"name": "Key 1"
-			}, {
-				"id": 198,
-				"name": "Key 2"
-			}, {
-				"id": 199,
-				"name": "Key 3"
-			}, {
-				"id": 200,
-				"name": "Key 4"
-			}, {
-				"id": 201,
-				"name": "Keyhole 1"
-			}, {
-				"id": 202,
-				"name": "Keyhole 2"
-			}, {
-				"id": 203,
-				"name": "Keyhole 3"
-			}, {
-				"id": 204,
-				"name": "Keyhole 4"
-			}, {
-				"id": 205,
-				"name": "Quest Item 1"
-			}, {
-				"id": 206,
-				"name": "The Talion"
-			}, {
-				"id": 207,
-				"name": "QuestItem1"
-			}, {
-				"id": 208,
-				"name": "QuestItem2"
-			}, {
-				"id": 209,
-				"name": "DragonExplosionEffect"
-			}, {
-				"id": 210,
-				"name": "DragonExplosionEffect2"
-			}, {
-				"id": 211,
-				"name": "DragonExplosionEffect3"
-			}, {
-				"id": 212,
-				"name": "Alarm"
-			}, {
-				"id": 213,
-				"name": "Dripping Water"
-			}, {
-				"id": 214,
-				"name": "T-Rex"
-			}, {
-				"id": 215,
-				"name": "Singing Birds"
-			}, {
-				"id": 216,
-				"name": "BartoliHideoutClock"
-			}, {
-				"id": 217,
-				"name": "Placeholder"
-			}, {
-				"id": 218,
-				"name": "DragonBonesFront"
-			}, {
-				"id": 219,
-				"name": "DragonBonesBack"
-			}, {
-				"id": 220,
-				"name": "ExtraFire"
-			}, {
-				"id": 222,
-				"name": "Mine"
-			}, {
-				"id": 223,
-				"name": "MenuBackground"
-			}, {
-				"id": 224,
-				"name": "GrayDisk"
-			}, {
-				"id": 225,
-				"name": "GongStick"
-			}, {
-				"id": 226,
-				"name": "Gong"
-			}, {
-				"id": 227,
-				"name": "Detonator"
-			}, {
-				"id": 228,
-				"name": "Helicopter"
-			}, {
-				"id": 229,
-				"name": "Explosion"
-			}, {
-				"id": 230,
-				"name": "Splash"
-			}, {
-				"id": 231,
-				"name": "Bubbles"
-			}, {
-				"id": 233,
-				"name": "Blood"
-			}, {
-				"id": 235,
-				"name": "FlareSparkles"
-			}, {
-				"id": 236,
-				"name": "Glow"
-			}, {
-				"id": 238,
-				"name": "Ricochet"
-			}, {
-				"id": 240,
-				"name": "Gunflare"
-			}, {
-				"id": 241,
-				"name": "M16Gunflare"
-			}, {
-				"id": 243,
-				"name": "Camera Target"
-			}, {
-				"id": 244,
-				"name": "Waterfall Mist"
-			}, {
-				"id": 245,
-				"name": "Harpoon"
-			}, {
-				"id": 247,
-				"name": "Placeholder"
-			}, {
-				"id": 248,
-				"name": "GrenadeSingle"
-			}, {
-				"id": 249,
-				"name": "HarpoonFlying"
-			}, {
-				"id": 250,
-				"name": "LavaParticles"
-			}, {
-				"id": 251,
-				"name": "Lava Emitter"
-			}, {
-				"id": 252,
-				"name": "Flame"
-			}, {
-				"id": 253,
-				"name": "Flame Emitter"
-			}, {
-				"id": 254,
-				"name": "Skybox"
-			}, {
-				"id": 255,
-				"name": "FontGraphics"
-			}, {
-				"id": 256,
-				"name": "Monk"
-			}, {
-				"id": 257,
-				"name": "Doorbell"
-			}, {
-				"id": 258,
-				"name": "AlarmBell"
-			}, {
-				"id": 259,
-				"name": "Helicopter"
-			}, {
-				"id": 260,
-				"name": "Winston"
-			}, {
-				"id": 262,
-				"name": "LaraCutscenePlacement"
-			}, {
-				"id": 263,
-				"name": "ShotgunAnimation"
-			}, {
-				"id": 264,
-				"name": "Dragon (Emitter)"
-			}
-		],
-		"tr3": [{
-				"id": 0,
-				"name": "Lara"
-			}, {
-				"id": 1,
-				"name": "LaraPistolsAnim"
-			}, {
-				"id": 2,
-				"name": "LaraPonytail"
-			}, {
-				"id": 3,
-				"name": "LaraShotgunAnim"
-			}, {
-				"id": 4,
-				"name": "LaraDesertEagleAnim"
-			}, {
-				"id": 5,
-				"name": "LaraUzisAnim"
-			}, {
-				"id": 6,
-				"name": "LaraMP5Anim"
-			}, {
-				"id": 7,
-				"name": "LaraRocketLauncherAnim"
-			}, {
-				"id": 8,
-				"name": "LaraGrenadeLauncherAnim"
-			}, {
-				"id": 9,
-				"name": "LaraHarpoonGunAnim"
-			}, {
-				"id": 10,
-				"name": "LaraFlareAnim"
-			}, {
-				"id": 11,
-				"name": "LaraUPVAnim"
-			}, {
-				"id": 12,
-				"name": "UPV"
-			}, {
-				"id": 14,
-				"name": "Kayak"
-			}, {
-				"id": 15,
-				"name": "Inflatable Boat"
-			}, {
-				"id": 16,
-				"name": "Quadbike"
-			}, {
-				"id": 17,
-				"name": "Minecart"
-			}, {
-				"id": 18,
-				"name": "Turret"
-			}, {
-				"id": 19,
-				"name": "UPV"
-			}, {
-				"id": 20,
-				"name": "Tribesman (Axe)"
-			}, {
-				"id": 21,
-				"name": "Tribesman (Dart)"
-			}, {
-				"id": 22,
-				"name": "Dog"
-			}, {
-				"id": 23,
-				"name": "Rat"
-			}, {
-				"id": 24,
-				"name": "Kill All Triggers"
-			}, {
-				"id": 25,
-				"name": "Killer Whale"
-			}, {
-				"id": 26,
-				"name": "Scuba Diver"
-			}, {
-				"id": 27,
-				"name": "Crow"
-			}, {
-				"id": 28,
-				"name": "Tiger"
-			}, {
-				"id": 29,
-				"name": "Vulture"
-			}, {
-				"id": 30,
-				"name": "Target"
-			}, {
-				"id": 31,
-				"name": "Crawler Mutant"
-			}, {
-				"id": 32,
-				"name": "Crocodile"
-			}, {
-				"id": 34,
-				"name": "Compsognathus"
-			}, {
-				"id": 35,
-				"name": "Lizard"
-			}, {
-				"id": 36,
-				"name": "Puna"
-			}, {
-				"id": 37,
-				"name": "Mercenary"
-			}, {
-				"id": 38,
-				"name": "Hanging Raptor"
-			}, {
-				"id": 39,
-				"name": "RX-Tech Guy (Red)"
-			}, {
-				"id": 40,
-				"name": "RX-Tech Guy (White)"
-			}, {
-				"id": 41,
-				"name": "Dog"
-			}, {
-				"id": 42,
-				"name": "Crawler Mutant"
-			}, {
-				"id": 44,
-				"name": "Wasp"
-			}, {
-				"id": 45,
-				"name": "Monster"
-			}, {
-				"id": 46,
-				"name": "Monster (Claw)"
-			}, {
-				"id": 47,
-				"name": "Wasp Spawn"
-			}, {
-				"id": 48,
-				"name": "Raptor Spawn"
-			}, {
-				"id": 49,
-				"name": "Willard"
-			}, {
-				"id": 50,
-				"name": "Flamethrower Guy"
-			}, {
-				"id": 51,
-				"name": "Guard (MP5)"
-			}, {
-				"id": 53,
-				"name": "Punk"
-			}, {
-				"id": 56,
-				"name": "Guard (Handgun)"
-			}, {
-				"id": 57,
-				"name": "Sophia Leigh"
-			}, {
-				"id": 58,
-				"name": "Cleaner Robot"
-			}, {
-				"id": 60,
-				"name": "MP (Baton)"
-			}, {
-				"id": 61,
-				"name": "MP (Handgun)"
-			}, {
-				"id": 62,
-				"name": "Prisoner"
-			}, {
-				"id": 63,
-				"name": "MP (MP5)"
-			}, {
-				"id": 64,
-				"name": "Gun Turret"
-			}, {
-				"id": 65,
-				"name": "Dam Guard"
-			}, {
-				"id": 66,
-				"name": "Tripwire"
-			}, {
-				"id": 67,
-				"name": "Electrified Wire"
-			}, {
-				"id": 68,
-				"name": "Killer Tripwire"
-			}, {
-				"id": 69,
-				"name": "Cobra"
-			}, {
-				"id": 70,
-				"name": "Shiva"
-			}, {
-				"id": 71,
-				"name": "Monkey"
-			}, {
-				"id": 73,
-				"name": "Tony"
-			}, {
-				"id": 74,
-				"name": "AI Guard"
-			}, {
-				"id": 75,
-				"name": "AI Ambush"
-			}, {
-				"id": 76,
-				"name": "AI Patrol 1"
-			}, {
-				"id": 77,
-				"name": "AI Modify"
-			}, {
-				"id": 78,
-				"name": "AI Follow"
-			}, {
-				"id": 79,
-				"name": "AI Patrol 2"
-			}, {
-				"id": 80,
-				"name": "AI Path"
-			}, {
-				"id": 81,
-				"name": "AI Check"
-			}, {
-				"id": 82,
-				"name": "Unknown"
-			}, {
-				"id": 83,
-				"name": "Breakable tile"
-			}, {
-				"id": 86,
-				"name": "Swinging Thing"
-			}, {
-				"id": 87,
-				"name": "Spikes"
-			}, {
-				"id": 88,
-				"name": "Boulder"
-			}, {
-				"id": 89,
-				"name": "Giant Boulder"
-			}, {
-				"id": 90,
-				"name": "Dart"
-			}, {
-				"id": 91,
-				"name": "Dart Emitter"
-			}, {
-				"id": 94,
-				"name": "Skeleton Trap"
-			}, {
-				"id": 97,
-				"name": "Pushable Block 1"
-			}, {
-				"id": 98,
-				"name": "Pushable Block 2"
-			}, {
-				"id": 101,
-				"name": "Breakable Window"
-			}, {
-				"id": 102,
-				"name": "Breakable Window"
-			}, {
-				"id": 106,
-				"name": "Hook"
-			}, {
-				"id": 107,
-				"name": "Falling Ceiling"
-			}, {
-				"id": 108,
-				"name": "Rolling Spindle"
-			}, {
-				"id": 110,
-				"name": "Train"
-			}, {
-				"id": 111,
-				"name": "Wall Blade"
-			}, {
-				"id": 113,
-				"name": "Icicles"
-			}, {
-				"id": 114,
-				"name": "Spike Wall"
-			}, {
-				"id": 116,
-				"name": "Spike Wall (Vertical)"
-			}, {
-				"id": 117,
-				"name": "Wheel Door"
-			}, {
-				"id": 118,
-				"name": "Small Switch"
-			}, {
-				"id": 119,
-				"name": "Propeller/Diver/Meteor"
-			}, {
-				"id": 120,
-				"name": "Fan"
-			}, {
-				"id": 121,
-				"name": "Stamper/Drum/Blades"
-			}, {
-				"id": 122,
-				"name": "Shiva"
-			}, {
-				"id": 123,
-				"name": "MonkeyMedipackMeshswap"
-			}, {
-				"id": 124,
-				"name": "MonkeyKeyMeshswap"
-			}, {
-				"id": 125,
-				"name": "UIFrame"
-			}, {
-				"id": 127,
-				"name": "Zipline"
-			}, {
-				"id": 128,
-				"name": "Button"
-			}, {
-				"id": 129,
-				"name": "Wall Switch"
-			}, {
-				"id": 130,
-				"name": "Underwater Lever"
-			}, {
-				"id": 131,
-				"name": "Door 1"
-			}, {
-				"id": 132,
-				"name": "Door 2"
-			}, {
-				"id": 133,
-				"name": "Door 3"
-			}, {
-				"id": 134,
-				"name": "Door 4"
-			}, {
-				"id": 135,
-				"name": "Door 5"
-			}, {
-				"id": 136,
-				"name": "Door 6"
-			}, {
-				"id": 137,
-				"name": "Door 7"
-			}, {
-				"id": 138,
-				"name": "Door 8"
-			}, {
-				"id": 139,
-				"name": "Trapdoor 1"
-			}, {
-				"id": 140,
-				"name": "Trapdoor 2"
-			}, {
-				"id": 141,
-				"name": "Trapdoor 3"
-			}, {
-				"id": 142,
-				"name": "Bridge (Flat)"
-			}, {
-				"id": 143,
-				"name": "Bridge (Tilt 1)"
-			}, {
-				"id": 144,
-				"name": "Bridge (Tilt 2)"
-			}, {
-				"id": 145,
-				"name": "PassportOpening"
-			}, {
-				"id": 146,
-				"name": "Compass"
-			}, {
-				"id": 147,
-				"name": "LarasHomePolaroid"
-			}, {
-				"id": 148,
-				"name": "CutsceneActor1"
-			}, {
-				"id": 149,
-				"name": "CutsceneActor2"
-			}, {
-				"id": 150,
-				"name": "CutsceneActor3"
-			}, {
-				"id": 151,
-				"name": "CutsceneActor4"
-			}, {
-				"id": 152,
-				"name": "CutsceneActor5"
-			}, {
-				"id": 153,
-				"name": "CutsceneActor6"
-			}, {
-				"id": 154,
-				"name": "CutsceneActor7"
-			}, {
-				"id": 155,
-				"name": "CutsceneActor8"
-			}, {
-				"id": 156,
-				"name": "CutsceneActor9"
-			}, {
-				"id": 158,
-				"name": "PassportClosed"
-			}, {
-				"id": 159,
-				"name": "Map"
-			}, {
-				"id": 160,
-				"name": "Pistols"
-			}, {
-				"id": 161,
-				"name": "Shotgun"
-			}, {
-				"id": 162,
-				"name": "Desert Eagle"
-			}, {
-				"id": 163,
-				"name": "Uzis"
-			}, {
-				"id": 164,
-				"name": "Harpoon Gun"
-			}, {
-				"id": 165,
-				"name": "MP5"
-			}, {
-				"id": 166,
-				"name": "Rocket Launcher"
-			}, {
-				"id": 167,
-				"name": "Grenade Launcher"
-			}, {
-				"id": 168,
-				"name": "PistolAmmoOnGround"
-			}, {
-				"id": 169,
-				"name": "Shotgun shells"
-			}, {
-				"id": 170,
-				"name": "Desert Eagle ammo"
-			}, {
-				"id": 171,
-				"name": "Uzi ammo"
-			}, {
-				"id": 172,
-				"name": "Harpoons"
-			}, {
-				"id": 173,
-				"name": "MP5 ammo"
-			}, {
-				"id": 174,
-				"name": "Rocket"
-			}, {
-				"id": 175,
-				"name": "Grenades"
-			}, {
-				"id": 176,
-				"name": "Small Medipack"
-			}, {
-				"id": 177,
-				"name": "Large Medipack"
-			}, {
-				"id": 178,
-				"name": "Flares"
-			}, {
-				"id": 179,
-				"name": "Flare"
-			}, {
-				"id": 180,
-				"name": "Savegame Crystal"
-			}, {
-				"id": 181,
-				"name": "Sunglasses"
-			}, {
-				"id": 182,
-				"name": "CassettePlayer"
-			}, {
-				"id": 183,
-				"name": "DirectionKeys"
-			}, {
-				"id": 184,
-				"name": "Globe"
-			}, {
-				"id": 185,
-				"name": "Pistols"
-			}, {
-				"id": 186,
-				"name": "Shotgun"
-			}, {
-				"id": 187,
-				"name": "Desert Eagle"
-			}, {
-				"id": 188,
-				"name": "Uzis"
-			}, {
-				"id": 189,
-				"name": "Harpoon Gun"
-			}, {
-				"id": 190,
-				"name": "MP5"
-			}, {
-				"id": 191,
-				"name": "Rocket Launcher"
-			}, {
-				"id": 192,
-				"name": "Grenade Launcher"
-			}, {
-				"id": 193,
-				"name": "PistolAmmo"
-			}, {
-				"id": 194,
-				"name": "ShotgunAmmo"
-			}, {
-				"id": 195,
-				"name": "DesertEagleAmmo"
-			}, {
-				"id": 196,
-				"name": "UziAmmo"
-			}, {
-				"id": 197,
-				"name": "HarpoonGunAmmo"
-			}, {
-				"id": 198,
-				"name": "MP5Ammo"
-			}, {
-				"id": 199,
-				"name": "RocketLauncherAmmo"
-			}, {
-				"id": 200,
-				"name": "GrenadeLauncherAmmo"
-			}, {
-				"id": 201,
-				"name": "SmallMedipack"
-			}, {
-				"id": 202,
-				"name": "LargeMedipack"
-			}, {
-				"id": 203,
-				"name": "Flares"
-			}, {
-				"id": 204,
-				"name": "SavegameCrystalInventory"
-			}, {
-				"id": 205,
-				"name": "Puzzle 1"
-			}, {
-				"id": 206,
-				"name": "Puzzle 2"
-			}, {
-				"id": 207,
-				"name": "Puzzle 3"
-			}, {
-				"id": 208,
-				"name": "Puzzle 4"
-			}, {
-				"id": 209,
-				"name": "Puzzle 1"
-			}, {
-				"id": 210,
-				"name": "Puzzle 2"
-			}, {
-				"id": 211,
-				"name": "Puzzle 3"
-			}, {
-				"id": 212,
-				"name": "Puzzle 4"
-			}, {
-				"id": 213,
-				"name": "Slot 1"
-			}, {
-				"id": 214,
-				"name": "Slot 2"
-			}, {
-				"id": 215,
-				"name": "Slot 3"
-			}, {
-				"id": 216,
-				"name": "Slot 4"
-			}, {
-				"id": 217,
-				"name": "Slot 1 Done"
-			}, {
-				"id": 218,
-				"name": "Slot 2 Done"
-			}, {
-				"id": 219,
-				"name": "Slot 3 Done"
-			}, {
-				"id": 220,
-				"name": "Slot 4 Done"
-			}, {
-				"id": 224,
-				"name": "Key 1"
-			}, {
-				"id": 225,
-				"name": "Key 2"
-			}, {
-				"id": 226,
-				"name": "Key 3"
-			}, {
-				"id": 227,
-				"name": "Key 4"
-			}, {
-				"id": 228,
-				"name": "Key 1"
-			}, {
-				"id": 229,
-				"name": "Key 2"
-			}, {
-				"id": 230,
-				"name": "Key 3"
-			}, {
-				"id": 231,
-				"name": "Key 4"
-			}, {
-				"id": 232,
-				"name": "Keyhole 1"
-			}, {
-				"id": 233,
-				"name": "Keyhole 2"
-			}, {
-				"id": 234,
-				"name": "Keyhole 3"
-			}, {
-				"id": 235,
-				"name": "Keyhole 4"
-			}, {
-				"id": 236,
-				"name": "Quest Item 1"
-			}, {
-				"id": 237,
-				"name": "Quest Item 2"
-			}, {
-				"id": 238,
-				"name": "QuestItem1"
-			}, {
-				"id": 239,
-				"name": "QuestItem2"
-			}, {
-				"id": 240,
-				"name": "Infada Stone"
-			}, {
-				"id": 241,
-				"name": "Element 115"
-			}, {
-				"id": 242,
-				"name": "Eye Of Isis"
-			}, {
-				"id": 243,
-				"name": "Ora Dagger"
-			}, {
-				"id": 244,
-				"name": "InfadaStone"
-			}, {
-				"id": 245,
-				"name": "Element115"
-			}, {
-				"id": 246,
-				"name": "EyeOfIsis"
-			}, {
-				"id": 247,
-				"name": "OraDagger"
-			}, {
-				"id": 272,
-				"name": "KeysSprite1"
-			}, {
-				"id": 273,
-				"name": "KeysSprite2"
-			}, {
-				"id": 276,
-				"name": "Infada Stone"
-			}, {
-				"id": 277,
-				"name": "Element 115"
-			}, {
-				"id": 278,
-				"name": "Eye Of Isis"
-			}, {
-				"id": 279,
-				"name": "Ora Dagger"
-			}, {
-				"id": 282,
-				"name": "FireBreathingDragonStatue"
-			}, {
-				"id": 285,
-				"name": "UnknownVisible285"
-			}, {
-				"id": 287,
-				"name": "T-Rex"
-			}, {
-				"id": 288,
-				"name": "Raptor"
-			}, {
-				"id": 291,
-				"name": "Moving Lasers"
-			}, {
-				"id": 292,
-				"name": "Electrified Field"
-			}, {
-				"id": 294,
-				"name": "Shadow Sprite"
-			}, {
-				"id": 295,
-				"name": "Detonator"
-			}, {
-				"id": 296,
-				"name": "Misc Sprites"
-			}, {
-				"id": 297,
-				"name": "Bubble"
-			}, {
-				"id": 299,
-				"name": "Glow"
-			}, {
-				"id": 300,
-				"name": "Gunflare"
-			}, {
-				"id": 301,
-				"name": "MP5Gunflare"
-			}, {
-				"id": 304,
-				"name": "Camera Target"
-			}, {
-				"id": 305,
-				"name": "Waterfall Mist"
-			}, {
-				"id": 306,
-				"name": "HarpoonFlying2"
-			}, {
-				"id": 309,
-				"name": "RocketSingle"
-			}, {
-				"id": 310,
-				"name": "HarpoonFlying"
-			}, {
-				"id": 311,
-				"name": "GrenadeSingle"
-			}, {
-				"id": 312,
-				"name": "Missile"
-			}, {
-				"id": 313,
-				"name": "Smoke"
-			}, {
-				"id": 314,
-				"name": "Movable Boom"
-			}, {
-				"id": 315,
-				"name": "LaraSkin"
-			}, {
-				"id": 316,
-				"name": "Glow 2"
-			}, {
-				"id": 317,
-				"name": "UnknownVisible317"
-			}, {
-				"id": 318,
-				"name": "Alarm Light"
-			}, {
-				"id": 319,
-				"name": "Light"
-			}, {
-				"id": 321,
-				"name": "Light 2"
-			}, {
-				"id": 322,
-				"name": "Pulsating Light"
-			}, {
-				"id": 324,
-				"name": "Red Light"
-			}, {
-				"id": 325,
-				"name": "Green Light"
-			}, {
-				"id": 326,
-				"name": "Blue Light"
-			}, {
-				"id": 327,
-				"name": "Light 3"
-			}, {
-				"id": 328,
-				"name": "Light 4"
-			}, {
-				"id": 330,
-				"name": "Fire"
-			}, {
-				"id": 331,
-				"name": "Alternate Fire"
-			}, {
-				"id": 332,
-				"name": "Alternate Fire 2"
-			}, {
-				"id": 333,
-				"name": "Fire 2"
-			}, {
-				"id": 334,
-				"name": "Smoke 2"
-			}, {
-				"id": 335,
-				"name": "Smoke 3"
-			}, {
-				"id": 336,
-				"name": "Smoke 4"
-			}, {
-				"id": 337,
-				"name": "Greenish Smoke"
-			}, {
-				"id": 338,
-				"name": "Piranhas"
-			}, {
-				"id": 339,
-				"name": "Fish"
-			}, {
-				"id": 347,
-				"name": "Bat Swarm"
-			}, {
-				"id": 349,
-				"name": "Animating 1"
-			}, {
-				"id": 350,
-				"name": "Animating 2"
-			}, {
-				"id": 351,
-				"name": "Animating 3"
-			}, {
-				"id": 352,
-				"name": "Animating 4"
-			}, {
-				"id": 353,
-				"name": "Animating 5"
-			}, {
-				"id": 354,
-				"name": "Animating 6"
-			}, {
-				"id": 355,
-				"name": "Skybox"
-			}, {
-				"id": 356,
-				"name": "FontGraphics"
-			}, {
-				"id": 357,
-				"name": "Doorbell"
-			}, {
-				"id": 358,
-				"name": "UnknownID358"
-			}, {
-				"id": 360,
-				"name": "Winston"
-			}, {
-				"id": 361,
-				"name": "Winston (Camo)"
-			}, {
-				"id": 362,
-				"name": "TimerFontGraphics"
-			}, {
-				"id": 365,
-				"name": "Earthquake"
-			}, {
-				"id": 366,
-				"name": "YellowShellCasing"
-			}, {
-				"id": 367,
-				"name": "RedShellCasing"
-			}, {
-				"id": 370,
-				"name": "Light Shaft"
-			}, {
-				"id": 373,
-				"name": "Electrical Switch Box"
-			}
-		],
-		"tr4": [{
-				"id": 0,
-				"name": "Lara"
-			}, {
-				"id": 1,
-				"name": "LaraPistolsAnim"
-			}, {
-				"id": 2,
-				"name": "LaraUzisAnim"
-			}, {
-				"id": 3,
-				"name": "LaraShotgunAnim"
-			}, {
-				"id": 31,
-				"name": "Motorbike"
-			}, {
-				"id": 32,
-				"name": "Jeep"
-			}, {
-				"id": 34,
-				"name": "Enemy jeep"
-			}, {
-				"id": 35,
-				"name": "Skeleton"
-			}, {
-				"id": 37,
-				"name": "Guide"
-			}, {
-				"id": 39,
-				"name": "Von Croy"
-			}, {
-				"id": 41,
-				"name": "Enemy 1"
-			}, {
-				"id": 43,
-				"name": "Enemy 2"
-			}, {
-				"id": 45,
-				"name": "Horus"
-			}, {
-				"id": 47,
-				"name": "Mummy"
-			}, {
-				"id": 49,
-				"name": "Guardian"
-			}, {
-				"id": 51,
-				"name": "Crocodile"
-			}, {
-				"id": 53,
-				"name": "Horseman"
-			}, {
-				"id": 55,
-				"name": "Giant Scorpion"
-			}, {
-				"id": 57,
-				"name": "Jean Yves"
-			}, {
-				"id": 59,
-				"name": "Soldier"
-			}, {
-				"id": 61,
-				"name": "Knight Templar"
-			}, {
-				"id": 63,
-				"name": "Dragon"
-			}, {
-				"id": 65,
-				"name": "Horse"
-			}, {
-				"id": 67,
-				"name": "Monkey"
-			}, {
-				"id": 69,
-				"name": "Monkey (invisible)"
-			}, {
-				"id": 71,
-				"name": "Monkey (black)"
-			}, {
-				"id": 73,
-				"name": "Boar"
-			}, {
-				"id": 75,
-				"name": "Harpy"
-			}, {
-				"id": 77,
-				"name": "Demigod 1"
-			}, {
-				"id": 79,
-				"name": "Demigod 2"
-			}, {
-				"id": 81,
-				"name": "Demigod 3"
-			}, {
-				"id": 83,
-				"name": "Scarab"
-			}, {
-				"id": 84,
-				"name": "Giant Beetle"
-			}, {
-				"id": 86,
-				"name": "Wraith 1"
-			}, {
-				"id": 87,
-				"name": "Wraith 2"
-			}, {
-				"id": 88,
-				"name": "Wraith 3"
-			}, {
-				"id": 90,
-				"name": "Bat"
-			}, {
-				"id": 91,
-				"name": "Dog"
-			}, {
-				"id": 93,
-				"name": "Hammerhead"
-			}, {
-				"id": 95,
-				"name": "Soldier"
-			}, {
-				"id": 101,
-				"name": "Dead soldier"
-			}, {
-				"id": 102,
-				"name": "Ammit"
-			}, {
-				"id": 104,
-				"name": "Lara double"
-			}, {
-				"id": 106,
-				"name": "Scorpion"
-			}, {
-				"id": 107,
-				"name": "Fish"
-			}, {
-				"id": 108,
-				"name": "Senet (red)"
-			}, {
-				"id": 109,
-				"name": "Senet (green)"
-			}, {
-				"id": 110,
-				"name": "Senet (blue)"
-			}, {
-				"id": 111,
-				"name": "Senet (enemy)"
-			}, {
-				"id": 112,
-				"name": "Tile spinner"
-			}, {
-				"id": 113,
-				"name": "Scales"
-			}, {
-				"id": 114,
-				"name": "Dart"
-			}, {
-				"id": 115,
-				"name": "Dart Emitter"
-			}, {
-				"id": 117,
-				"name": "Falling Ceiling"
-			}, {
-				"id": 118,
-				"name": "Breakable Tile"
-			}, {
-				"id": 120,
-				"name": "Breakable wall"
-			}, {
-				"id": 121,
-				"name": "Breakable floor"
-			}, {
-				"id": 122,
-				"name": "Trapdoor 1"
-			}, {
-				"id": 123,
-				"name": "Trapdoor 2"
-			}, {
-				"id": 124,
-				"name": "Trapdoor 3"
-			}, {
-				"id": 125,
-				"name": "Floor Trapdoor 1"
-			}, {
-				"id": 126,
-				"name": "Floor Trapdoor 2"
-			}, {
-				"id": 127,
-				"name": "Ceiling trapdoor"
-			}, {
-				"id": 130,
-				"name": "Boulder"
-			}, {
-				"id": 132,
-				"name": "Spikes"
-			}, {
-				"id": 133,
-				"name": "Drill blades"
-			}, {
-				"id": 134,
-				"name": "Rolling Spikes"
-			}, {
-				"id": 135,
-				"name": "Flame emitter"
-			}, {
-				"id": 136,
-				"name": "Rotating blade"
-			}, {
-				"id": 137,
-				"name": "Blade ring"
-			}, {
-				"id": 138,
-				"name": "Hammer"
-			}, {
-				"id": 139,
-				"name": "Burning floor"
-			}, {
-				"id": 140,
-				"name": "Cog"
-			}, {
-				"id": 141,
-				"name": "Spike ball"
-			}, {
-				"id": 143,
-				"name": "Flame emitter"
-			}, {
-				"id": 144,
-				"name": "Flame emitter"
-			}, {
-				"id": 145,
-				"name": "Flame emitter"
-			}, {
-				"id": 146,
-				"name": "Rope"
-			}, {
-				"id": 147,
-				"name": "Fire rope"
-			}, {
-				"id": 148,
-				"name": "Pole"
-			}, {
-				"id": 150,
-				"name": "Platform"
-			}, {
-				"id": 151,
-				"name": "Raising block"
-			}, {
-				"id": 152,
-				"name": "Raising block"
-			}, {
-				"id": 153,
-				"name": "Expanding platform"
-			}, {
-				"id": 154,
-				"name": "Sliding block"
-			}, {
-				"id": 155,
-				"name": "Falling block"
-			}, {
-				"id": 156,
-				"name": "Pushable 1"
-			}, {
-				"id": 157,
-				"name": "Pushable 2"
-			}, {
-				"id": 158,
-				"name": "Pushable 3"
-			}, {
-				"id": 159,
-				"name": "Pushable 4"
-			}, {
-				"id": 160,
-				"name": "Pushable 5"
-			}, {
-				"id": 162,
-				"name": "Sentry Gun"
-			}, {
-				"id": 163,
-				"name": "Helicopter"
-			}, {
-				"id": 164,
-				"name": "Mapper"
-			}, {
-				"id": 165,
-				"name": "Obelisk"
-			}, {
-				"id": 166,
-				"name": "Blade trap"
-			}, {
-				"id": 168,
-				"name": "Bird blade"
-			}, {
-				"id": 169,
-				"name": "Blade trap"
-			}, {
-				"id": 170,
-				"name": "Wall blade"
-			}, {
-				"id": 171,
-				"name": "Pedestal blades"
-			}, {
-				"id": 172,
-				"name": "Blade"
-			}, {
-				"id": 173,
-				"name": "Lightning conductor"
-			}, {
-				"id": 174,
-				"name": "Element Puzzle"
-			}, {
-				"id": 175,
-				"name": "Puzzle 1",
-				"pickup": true
-			}, {
-				"id": 176,
-				"name": "Puzzle 2",
-				"pickup": true
-			}, {
-				"id": 177,
-				"name": "Puzzle 3",
-				"pickup": true
-			}, {
-				"id": 178,
-				"name": "Puzzle 4",
-				"pickup": true
-			}, {
-				"id": 179,
-				"name": "Puzzle 5",
-				"pickup": true
-			}, {
-				"id": 180,
-				"name": "Puzzle 6",
-				"pickup": true
-			}, {
-				"id": 181,
-				"name": "Puzzle 7",
-				"pickup": true
-			}, {
-				"id": 182,
-				"name": "Puzzle 8",
-				"pickup": true
-			}, {
-				"id": 183,
-				"name": "Puzzle 9",
-				"pickup": true
-			}, {
-				"id": 184,
-				"name": "Puzzle 10",
-				"pickup": true
-			}, {
-				"id": 185,
-				"name": "Puzzle 11",
-				"pickup": true
-			}, {
-				"id": 186,
-				"name": "Puzzle 12",
-				"pickup": true
-			}, {
-				"id": 187,
-				"name": "Puzzle 1 Combo 1",
-				"pickup": true
-			}, {
-				"id": 188,
-				"name": "Puzzle 1 Combo 2",
-				"pickup": true
-			}, {
-				"id": 189,
-				"name": "Puzzle 2 Combo 1",
-				"pickup": true
-			}, {
-				"id": 190,
-				"name": "Puzzle 2 Combo 2",
-				"pickup": true
-			}, {
-				"id": 193,
-				"name": "Puzzle 4 Combo 1",
-				"pickup": true
-			}, {
-				"id": 194,
-				"name": "Puzzle 4 Combo 2",
-				"pickup": true
-			}, {
-				"id": 195,
-				"name": "Puzzle 5 Combo 1",
-				"pickup": true
-			}, {
-				"id": 196,
-				"name": "Puzzle 5 Combo 2",
-				"pickup": true
-			}, {
-				"id": 197,
-				"name": "Puzzle 6 Combo 1",
-				"pickup": true
-			}, {
-				"id": 198,
-				"name": "Puzzle 6 Combo 2",
-				"pickup": true
-			}, {
-				"id": 199,
-				"name": "Puzzle 7 Combo 1",
-				"pickup": true
-			}, {
-				"id": 200,
-				"name": "Puzzle 7 Combo 2",
-				"pickup": true
-			}, {
-				"id": 201,
-				"name": "Puzzle 8 Combo 1",
-				"pickup": true
-			}, {
-				"id": 202,
-				"name": "Puzzle 8 Combo 2",
-				"pickup": true
-			}, {
-				"id": 203,
-				"name": "Key 1",
-				"pickup": true
-			}, {
-				"id": 204,
-				"name": "Key 2",
-				"pickup": true
-			}, {
-				"id": 205,
-				"name": "Key 3",
-				"pickup": true
-			}, {
-				"id": 206,
-				"name": "Key 4",
-				"pickup": true
-			}, {
-				"id": 207,
-				"name": "Key 5",
-				"pickup": true
-			}, {
-				"id": 208,
-				"name": "Key 6",
-				"pickup": true
-			}, {
-				"id": 209,
-				"name": "Key 7",
-				"pickup": true
-			}, {
-				"id": 210,
-				"name": "Key 8",
-				"pickup": true
-			}, {
-				"id": 211,
-				"name": "Key 9",
-				"pickup": true
-			}, {
-				"id": 212,
-				"name": "Key 10",
-				"pickup": true
-			}, {
-				"id": 213,
-				"name": "Key 11",
-				"pickup": true
-			}, {
-				"id": 214,
-				"name": "Key 12",
-				"pickup": true
-			}, {
-				"id": 231,
-				"name": "Item 1"
-			}, {
-				"id": 232,
-				"name": "Item 2"
-			}, {
-				"id": 243,
-				"name": "Examine 1"
-			}, {
-				"id": 244,
-				"name": "Examine 2"
-			}, {
-				"id": 245,
-				"name": "Examine 3"
-			}, {
-				"id": 246,
-				"name": "Crowbar",
-				"pickup": true
-			}, {
-				"id": 247,
-				"name": "Torch",
-				"pickup": true
-			}, {
-				"id": 249,
-				"name": "Winding Key"
-			}, {
-				"id": 250,
-				"name": "Mechanical Scarab"
-			}, {
-				"id": 252,
-				"name": "Quest Item 1"
-			}, {
-				"id": 253,
-				"name": "Quest Item 2"
-			}, {
-				"id": 254,
-				"name": "Quest Item 3"
-			}, {
-				"id": 255,
-				"name": "Quest Item 4"
-			}, {
-				"id": 256,
-				"name": "Quest Item 5"
-			}, {
-				"id": 257,
-				"name": "Quest Item 6"
-			}, {
-				"id": 260,
-				"name": "Slot 1"
-			}, {
-				"id": 261,
-				"name": "Slot 2"
-			}, {
-				"id": 262,
-				"name": "Slot 3"
-			}, {
-				"id": 263,
-				"name": "Slot 4"
-			}, {
-				"id": 264,
-				"name": "Slot 5"
-			}, {
-				"id": 265,
-				"name": "Slot 6"
-			}, {
-				"id": 266,
-				"name": "Slot 7"
-			}, {
-				"id": 267,
-				"name": "Slot 8"
-			}, {
-				"id": 268,
-				"name": "Slot 9"
-			}, {
-				"id": 269,
-				"name": "Slot 10"
-			}, {
-				"id": 270,
-				"name": "Slot 11"
-			}, {
-				"id": 271,
-				"name": "Slot 12"
-			}, {
-				"id": 284,
-				"name": "Lock 1"
-			}, {
-				"id": 285,
-				"name": "Lock 2"
-			}, {
-				"id": 286,
-				"name": "Lock 3"
-			}, {
-				"id": 287,
-				"name": "Lock 4"
-			}, {
-				"id": 288,
-				"name": "Lock 5"
-			}, {
-				"id": 289,
-				"name": "Lock 6"
-			}, {
-				"id": 290,
-				"name": "Lock 7"
-			}, {
-				"id": 291,
-				"name": "Lock 8"
-			}, {
-				"id": 292,
-				"name": "Lock 9"
-			}, {
-				"id": 293,
-				"name": "Lock 10"
-			}, {
-				"id": 294,
-				"name": "Lock 11"
-			}, {
-				"id": 295,
-				"name": "Lock 12"
-			}, {
-				"id": 296,
-				"name": "Waterskin 1",
-				"pickup": true
-			}, {
-				"id": 300,
-				"name": "Waterskin 2",
-				"pickup": true
-			}, {
-				"id": 306,
-				"name": "Switch 1"
-			}, {
-				"id": 307,
-				"name": "Switch 2"
-			}, {
-				"id": 308,
-				"name": "Switch 3"
-			}, {
-				"id": 309,
-				"name": "Switch 4"
-			}, {
-				"id": 310,
-				"name": "Switch 5"
-			}, {
-				"id": 311,
-				"name": "Switch 6"
-			}, {
-				"id": 312,
-				"name": "Switch 7"
-			}, {
-				"id": 313,
-				"name": "Switch 8"
-			}, {
-				"id": 315,
-				"name": "Lever (underwater)"
-			}, {
-				"id": 316,
-				"name": "Turn lever"
-			}, {
-				"id": 317,
-				"name": "Wheel lever"
-			}, {
-				"id": 318,
-				"name": "Lever"
-			}, {
-				"id": 319,
-				"name": "Jump lever"
-			}, {
-				"id": 320,
-				"name": "Crowbar lever"
-			}, {
-				"id": 321,
-				"name": "Pulley"
-			}, {
-				"id": 322,
-				"name": "Door 1"
-			}, {
-				"id": 323,
-				"name": "Door 2"
-			}, {
-				"id": 324,
-				"name": "Door 3"
-			}, {
-				"id": 325,
-				"name": "Door 4"
-			}, {
-				"id": 326,
-				"name": "Door 5"
-			}, {
-				"id": 327,
-				"name": "Door 6"
-			}, {
-				"id": 328,
-				"name": "Door 7"
-			}, {
-				"id": 329,
-				"name": "Door 8"
-			}, {
-				"id": 330,
-				"name": "Push/pull door 1"
-			}, {
-				"id": 332,
-				"name": "Kick door 1"
-			}, {
-				"id": 334,
-				"name": "Underwater door"
-			}, {
-				"id": 335,
-				"name": "Double doors"
-			}, {
-				"id": 336,
-				"name": "Bridge (flat)"
-			}, {
-				"id": 337,
-				"name": "Bridge (tilt)"
-			}, {
-				"id": 339,
-				"name": "Sarcophagus"
-			}, {
-				"id": 340,
-				"name": "Sequence Door 1"
-			}, {
-				"id": 341,
-				"name": "Sequence Button 3"
-			}, {
-				"id": 342,
-				"name": "Sequence Button 1"
-			}, {
-				"id": 343,
-				"name": "Sequence Button 2"
-			}, {
-				"id": 344,
-				"name": "Cutscene"
-			}, {
-				"id": 345,
-				"name": "Horus Statue"
-			}, {
-				"id": 346,
-				"name": "Face"
-			}, {
-				"id": 348,
-				"name": "Plinth"
-			}, {
-				"id": 349,
-				"name": "Pistols",
-				"pickup": true
-			}, {
-				"id": 350,
-				"name": "Pistol Ammo",
-				"pickup": true
-			}, {
-				"id": 351,
-				"name": "Uzis",
-				"pickup": true
-			}, {
-				"id": 352,
-				"name": "Uzi Ammo",
-				"pickup": true
-			}, {
-				"id": 353,
-				"name": "Shotgun",
-				"pickup": true
-			}, {
-				"id": 354,
-				"name": "Shotgun ammo (red)",
-				"pickup": true
-			}, {
-				"id": 355,
-				"name": "Shotgun ammo (blue)",
-				"pickup": true
-			}, {
-				"id": 356,
-				"name": "Crossbow",
-				"pickup": true
-			}, {
-				"id": 357,
-				"name": "Bolts",
-				"pickup": true
-			}, {
-				"id": 358,
-				"name": "Bolts (poison)",
-				"pickup": true
-			}, {
-				"id": 359,
-				"name": "Bolts (explosive)",
-				"pickup": true
-			}, {
-				"id": 361,
-				"name": "Grenade Launcher",
-				"pickup": true
-			}, {
-				"id": 362,
-				"name": "Grenades",
-				"pickup": true
-			}, {
-				"id": 363,
-				"name": "Grenades (super)",
-				"pickup": true
-			}, {
-				"id": 364,
-				"name": "Grenades (flash)",
-				"pickup": true
-			}, {
-				"id": 368,
-				"name": "Large medipack",
-				"pickup": true
-			}, {
-				"id": 366,
-				"name": "Revolver",
-				"pickup": true
-			}, {
-				"id": 367,
-				"name": "Revolver ammo",
-				"pickup": true
-			}, {
-				"id": 369,
-				"name": "Small medipack",
-				"pickup": true
-			}, {
-				"id": 370,
-				"name": "Lasersight",
-				"pickup": true
-			}, {
-				"id": 373,
-				"name": "Flares",
-				"pickup": true
-			}, {
-				"id": 375,
-				"name": "Compass"
-			}, {
-				"id": 380,
-				"name": "White smoke emitter"
-			}, {
-				"id": 381,
-				"name": "Black smoke emitter"
-			}, {
-				"id": 382,
-				"name": "Steam emitter"
-			}, {
-				"id": 383,
-				"name": "Earthquake"
-			}, {
-				"id": 385,
-				"name": "Waterfall Mist"
-			}, {
-				"id": 390,
-				"name": "Sprinkler"
-			}, {
-				"id": 394,
-				"name": "Amber light"
-			}, {
-				"id": 397,
-				"name": "Lens flare"
-			}, {
-				"id": 402,
-				"name": "AI Follow"
-			}, {
-				"id": 404,
-				"name": "AI X1"
-			}, {
-				"id": 405,
-				"name": "AI X2"
-			}, {
-				"id": 406,
-				"name": "Lara Start Pos"
-			}, {
-				"id": 408,
-				"name": "Trigger triggerer"
-			}, {
-				"id": 422,
-				"name": "Camera Target"
-			}, {
-				"id": 423,
-				"name": "Waterfall"
-			}, {
-				"id": 424,
-				"name": "Waterfall"
-			}, {
-				"id": 425,
-				"name": "Waterfall"
-			}, {
-				"id": 426,
-				"name": "Planet effect"
-			}, {
-				"id": 427,
-				"name": "Animating 1"
-			}, {
-				"id": 429,
-				"name": "Animating 2"
-			}, {
-				"id": 431,
-				"name": "Animating 3"
-			}, {
-				"id": 433,
-				"name": "Animating 4"
-			}, {
-				"id": 435,
-				"name": "Animating 5"
-			}, {
-				"id": 437,
-				"name": "Animating 6"
-			}, {
-				"id": 439,
-				"name": "Animating 7"
-			}, {
-				"id": 441,
-				"name": "Animating 8"
-			}, {
-				"id": 443,
-				"name": "Animating 9"
-			}, {
-				"id": 445,
-				"name": "Animating 10"
-			}, {
-				"id": 447,
-				"name": "Animating 11"
-			}, {
-				"id": 449,
-				"name": "Animating 12"
-			}, {
-				"id": 451,
-				"name": "Animating 13"
-			}, {
-				"id": 453,
-				"name": "Animating 14"
-			}, {
-				"id": 455,
-				"name": "Animating 15"
-			}, {
+    "games": {
+        "tr1": [{
+                "id": 0,
+                "name": "Lara",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 1,
+                "name": "LaraPistolsAnim",
+                "categories": [ "Animation" ]
+            }, {
+                "id": 2,
+                "name": "LaraShotgunAnim",
+                "categories": [ "Animation" ]
+            }, {
+                "id": 3,
+                "name": "LaraMagnumsAnim",
+                "categories": [ "Animation" ]
+            }, {
+                "id": 4,
+                "name": "LaraUzisAnim",
+                "categories": [ "Animation" ]
+            }, {
+                "id": 5,
+                "name": "AlternativeLara"
+            }, {
+                "id": 6,
+                "name": "Doppelganger",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 7,
+                "name": "Wolf",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 8,
+                "name": "Bear",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 9,
+                "name": "Bat",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 10,
+                "name": "Crocodile",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 11,
+                "name": "Crocodile",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 12,
+                "name": "Lion (Male)",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 13,
+                "name": "Lion (Female)",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 14,
+                "name": "Panther",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 15,
+                "name": "Gorilla",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 16,
+                "name": "Rat",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 17,
+                "name": "Rat",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 18,
+                "name": "T-Rex",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 19,
+                "name": "Raptor",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 20,
+                "name": "Mutant (Winged)",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 21,
+                "name": "Mutant (Shooter)",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 22,
+                "name": "Mutant",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 23,
+                "name": "Centaur",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 24,
+                "name": "Mummy",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 25,
+                "name": "DinoWarrior",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 26,
+                "name": "Fish",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 27,
+                "name": "Larson",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 28,
+                "name": "Pierre",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 29,
+                "name": "Skateboard",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 30,
+                "name": "Skater Boy",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 31,
+                "name": "Cowboy",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 32,
+                "name": "Kold",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 33,
+                "name": "WingedNatla",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 34,
+                "name": "TorsoBoss",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 35,
+                "name": "Breakable Tile",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 36,
+                "name": "Swinging Blade",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 37,
+                "name": "Spikes",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 38,
+                "name": "Boulder",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 39,
+                "name": "Dart",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 40,
+                "name": "Dart Emitter",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 41,
+                "name": "LiftingDoor"
+            }, {
+                "id": 42,
+                "name": "Slamming Doors",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 43,
+                "name": "Sword",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 44,
+                "name": "Hammer Handle",
+                "categories": [ "Puzzle" ]
+            }, {
+                "id": 45,
+                "name": "Hammer Block",
+                "categories": [ "Puzzle" ]
+            }, {
+                "id": 46,
+                "name": "Lightning Ball",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 47,
+                "name": "Barricade"
+            }, {
+                "id": 48,
+                "name": "Pushable Block 1",
+                "categories": [ "Puzzle", "Movable" ]
+            }, {
+                "id": 49,
+                "name": "Pushable Block 2",
+                "categories": [ "Puzzle", "Movable" ]
+            }, {
+                "id": 50,
+                "name": "Pushable Block 3",
+                "categories": [ "Puzzle", "Movable" ]
+            }, {
+                "id": 51,
+                "name": "Pushable Block 4",
+                "categories": [ "Puzzle", "Movable" ]
+            }, {
+                "id": 52,
+                "name": "Moving Block"
+            }, {
+                "id": 53,
+                "name": "Falling Ceiling",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 54,
+                "name": "Sword 2",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 55,
+                "name": "Wall Switch",
+                "categories": [ "Switch" ]
+            }, {
+                "id": 56,
+                "name": "Underwater Lever",
+                "categories": [ "Switch" ]
+            }, {
+                "id": 57,
+                "name": "Door 1",
+                "categories": [ "Door" ]
+            }, {
+                "id": 58,
+                "name": "Door 2",
+                "categories": [ "Door" ]
+            }, {
+                "id": 59,
+                "name": "Door 3",
+                "categories": [ "Door" ]
+            }, {
+                "id": 60,
+                "name": "Door 4",
+                "categories": [ "Door" ]
+            }, {
+                "id": 61,
+                "name": "Door 5",
+                "categories": [ "Door" ]
+            }, {
+                "id": 62,
+                "name": "Door 6",
+                "categories": [ "Door" ]
+            }, {
+                "id": 63,
+                "name": "Door 7",
+                "categories": [ "Door" ]
+            }, {
+                "id": 64,
+                "name": "Door 8",
+                "categories": [ "Door" ]
+            }, {
+                "id": 65,
+                "name": "Trapdoor 1",
+                "categories": [ "Door", "Trapdoor" ]
+            }, {
+                "id": 66,
+                "name": "Trapdoor 2",
+                "categories": [ "Door", "Trapdoor" ]
+            }, {
+                "id": 68,
+                "name": "Bridge (Flat)",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 69,
+                "name": "Bridge (Tilt 1)",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 70,
+                "name": "Bridge (Tilt 2)",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 71,
+                "name": "PassportOpening"
+            }, {
+                "id": 72,
+                "name": "Compass"
+            }, {
+                "id": 73,
+                "name": "LarasHomePolaroid"
+            }, {
+                "id": 74,
+                "name": "Animating 1"
+            }, {
+                "id": 75,
+                "name": "Animating 2"
+            }, {
+                "id": 76,
+                "name": "Animating 3"
+            }, {
+                "id": 77,
+                "name": "CutsceneActor1"
+            }, {
+                "id": 78,
+                "name": "CutsceneActor2"
+            }, {
+                "id": 79,
+                "name": "CutsceneActor3"
+            }, {
+                "id": 80,
+                "name": "CutsceneActor4"
+            }, {
+                "id": 81,
+                "name": "PassportClosed"
+            }, {
+                "id": 82,
+                "name": "Map"
+            }, {
+                "id": 83,
+                "name": "Savegame Crystal",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 84,
+                "name": "Pistols",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 85,
+                "name": "Shotgun",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 86,
+                "name": "Magnums",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 87,
+                "name": "Uzis",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 88,
+                "name": "Pistol ammo",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 89,
+                "name": "Shotgun ammo",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 90,
+                "name": "Magnum ammo",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 91,
+                "name": "Uzi ammo",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 92,
+                "name": "ExplosiveSprite"
+            }, {
+                "id": 93,
+                "name": "Small medipack",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 94,
+                "name": "Large medipack",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 95,
+                "name": "Sunglasses"
+            }, {
+                "id": 96,
+                "name": "CassettePlayer"
+            }, {
+                "id": 97,
+                "name": "DirectionKeys"
+            }, {
+                "id": 98,
+                "name": "Flashlight"
+            }, {
+                "id": 99,
+                "name": "Pistols"
+            }, {
+                "id": 100,
+                "name": "Shotgun"
+            }, {
+                "id": 101,
+                "name": "Magnums"
+            }, {
+                "id": 102,
+                "name": "Uzis"
+            }, {
+                "id": 103,
+                "name": "PistolAmmo"
+            }, {
+                "id": 104,
+                "name": "ShotgunAmmo"
+            }, {
+                "id": 105,
+                "name": "MagnumAmmo"
+            }, {
+                "id": 106,
+                "name": "UziAmmo"
+            }, {
+                "id": 107,
+                "name": "Explosive"
+            }, {
+                "id": 108,
+                "name": "Small medipack"
+            }, {
+                "id": 109,
+                "name": "Large medipack"
+            }, {
+                "id": 110,
+                "name": "Puzzle 1"
+            }, {
+                "id": 111,
+                "name": "Puzzle 2"
+            }, {
+                "id": 112,
+                "name": "Puzzle 3"
+            }, {
+                "id": 113,
+                "name": "Puzzle 4"
+            }, {
+                "id": 114,
+                "name": "Puzzle 1"
+            }, {
+                "id": 115,
+                "name": "Puzzle 2"
+            }, {
+                "id": 116,
+                "name": "Puzzle 3"
+            }, {
+                "id": 117,
+                "name": "Puzzle 4"
+            }, {
+                "id": 118,
+                "name": "Slot 1"
+            }, {
+                "id": 119,
+                "name": "Slot 2"
+            }, {
+                "id": 120,
+                "name": "Slot 3"
+            }, {
+                "id": 121,
+                "name": "Slot 4"
+            }, {
+                "id": 122,
+                "name": "Slot 1 Done"
+            }, {
+                "id": 123,
+                "name": "Slot 2 Done"
+            }, {
+                "id": 124,
+                "name": "Slot 3 Done"
+            }, {
+                "id": 125,
+                "name": "Slot 4 Done"
+            }, {
+                "id": 126,
+                "name": "Lead Bar"
+            }, {
+                "id": 127,
+                "name": "Lead Bar"
+            }, {
+                "id": 128,
+                "name": "Midas Hand"
+            }, {
+                "id": 129,
+                "name": "Key 1",
+                "categories": [ "Pickup", "Key" ]
+            }, {
+                "id": 130,
+                "name": "Key 2",
+                "categories": [ "Pickup", "Key" ]
+            }, {
+                "id": 131,
+                "name": "Key 3",
+                "categories": [ "Pickup", "Key" ]
+            }, {
+                "id": 132,
+                "name": "Key 4",
+                "categories": [ "Pickup", "Key" ]
+            }, {
+                "id": 133,
+                "name": "Key 1"
+            }, {
+                "id": 134,
+                "name": "Key 2"
+            }, {
+                "id": 135,
+                "name": "Key 3"
+            }, {
+                "id": 136,
+                "name": "Key 4"
+            }, {
+                "id": 137,
+                "name": "Keyhole 1",
+                "categories": [ "Keyhole" ]
+            }, {
+                "id": 138,
+                "name": "Keyhole 2",
+                "categories": [ "Keyhole" ]
+            }, {
+                "id": 139,
+                "name": "Keyhole 3",
+                "categories": [ "Keyhole" ]
+            }, {
+                "id": 140,
+                "name": "Keyhole 4",
+                "categories": [ "Keyhole" ]
+            }, {
+                "id": 143,
+                "name": "Scion Piece"
+            }, {
+                "id": 144,
+                "name": "Scion Piece"
+            }, {
+                "id": 145,
+                "name": "Scion"
+            }, {
+                "id": 146,
+                "name": "Scion"
+            }, {
+                "id": 147,
+                "name": "Scion Holder"
+            }, {
+                "id": 150,
+                "name": "ScionPiece2"
+            }, {
+                "id": 151,
+                "name": "Explosion"
+            }, {
+                "id": 153,
+                "name": "Splash"
+            }, {
+                "id": 155,
+                "name": "Bubbles"
+            }, {
+                "id": 158,
+                "name": "Blood"
+            }, {
+                "id": 160,
+                "name": "Smoke"
+            }, {
+                "id": 161,
+                "name": "Centaur",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 162,
+                "name": "Suspended Shack"
+            }, {
+                "id": 163,
+                "name": "Mutant Egg (Big)",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 164,
+                "name": "Ricochet"
+            }, {
+                "id": 165,
+                "name": "Sparkles"
+            }, {
+                "id": 166,
+                "name": "Gunflare"
+            }, {
+                "id": 169,
+                "name": "Camera Target"
+            }, {
+                "id": 170,
+                "name": "Waterfall Mist"
+            }, {
+                "id": 172,
+                "name": "MutantBullet"
+            }, {
+                "id": 173,
+                "name": "MutantGrenade"
+            }, {
+                "id": 176,
+                "name": "LavaParticles",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 177,
+                "name": "Lava Emitter",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 178,
+                "name": "Flame",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 179,
+                "name": "Flame Emitter",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 180,
+                "name": "Lava Flow",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 181,
+                "name": "MutantEggBig"
+            }, {
+                "id": 182,
+                "name": "Motorboat"
+            }, {
+                "id": 183,
+                "name": "Earthquake"
+            }, {
+                "id": 189,
+                "name": "LaraPonytail"
+            }, {
+                "id": 190,
+                "name": "FontGraphics"
+            }, {
+                "id": 191,
+                "name": "Plant1",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 192,
+                "name": "Plant2",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 193,
+                "name": "Plant3",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 194,
+                "name": "Plant4",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 195,
+                "name": "Plant5",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 200,
+                "name": "Bag1",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 204,
+                "name": "Bag2",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 212,
+                "name": "Rock1",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 213,
+                "name": "Rock2",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 214,
+                "name": "Rock3",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 215,
+                "name": "Bag3",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 216,
+                "name": "Pottery1",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 217,
+                "name": "Pottery2",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 231,
+                "name": "PaintedPot",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 233,
+                "name": "IncaMummy",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 236,
+                "name": "Pottery3",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 237,
+                "name": "Pottery4",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 238,
+                "name": "Pottery5",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 239,
+                "name": "Pottery6",
+                "categories": [ "Scenery" ]
+            }
+        ],
+        "tr2": [{
+                "id": 0,
+                "name": "Lara"
+            }, {
+                "id": 1,
+                "name": "LaraPistolsAnim"
+            }, {
+                "id": 2,
+                "name": "LaraPonytail"
+            }, {
+                "id": 3,
+                "name": "LaraShotgunAnim"
+            }, {
+                "id": 4,
+                "name": "LaraAutopistolsAnim"
+            }, {
+                "id": 5,
+                "name": "LaraUzisAnim"
+            }, {
+                "id": 6,
+                "name": "LaraM16Anim"
+            }, {
+                "id": 7,
+                "name": "LaraGrenadeLauncherAnim"
+            }, {
+                "id": 8,
+                "name": "LaraHarpoonGunAnim"
+            }, {
+                "id": 9,
+                "name": "LaraFlareAnim"
+            }, {
+                "id": 10,
+                "name": "LaraSnowmobileAnim"
+            }, {
+                "id": 11,
+                "name": "LaraBoatAnim"
+            }, {
+                "id": 12,
+                "name": "AlternativeLara"
+            }, {
+                "id": 13,
+                "name": "Skidoo"
+            }, {
+                "id": 14,
+                "name": "Boat"
+            }, {
+                "id": 15,
+                "name": "Dog"
+            }, {
+                "id": 16,
+                "name": "Masked Goon 1"
+            }, {
+                "id": 17,
+                "name": "Masked Goon 2"
+            }, {
+                "id": 18,
+                "name": "Masked Goon 3"
+            }, {
+                "id": 19,
+                "name": "Knife thrower"
+            }, {
+                "id": 20,
+                "name": "Shotgun Goon"
+            }, {
+                "id": 21,
+                "name": "Rat"
+            }, {
+                "id": 22,
+                "name": "DragonFront"
+            }, {
+                "id": 23,
+                "name": "DragonBack"
+            }, {
+                "id": 24,
+                "name": "Gondola"
+            }, {
+                "id": 25,
+                "name": "Shark"
+            }, {
+                "id": 26,
+                "name": "Yellow Eel"
+            }, {
+                "id": 27,
+                "name": "Black Eel"
+            }, {
+                "id": 28,
+                "name": "Barracuda"
+            }, {
+                "id": 29,
+                "name": "Scuba Diver"
+            }, {
+                "id": 30,
+                "name": "Shotgun Goon"
+            }, {
+                "id": 31,
+                "name": "Rifle Goon"
+            }, {
+                "id": 32,
+                "name": "Stick Goon 1"
+            }, {
+                "id": 33,
+                "name": "Stick Goon 2"
+            }, {
+                "id": 34,
+                "name": "Flamethrower"
+            }, {
+                "id": 36,
+                "name": "Spider"
+            }, {
+                "id": 37,
+                "name": "Giant Spider"
+            }, {
+                "id": 38,
+                "name": "Crow"
+            }, {
+                "id": 39,
+                "name": "Tiger/Leopard"
+            }, {
+                "id": 40,
+                "name": "Bartoli"
+            }, {
+                "id": 41,
+                "name": "Guard (Spear)"
+            }, {
+                "id": 42,
+                "name": "XianGuardSpearStatue"
+            }, {
+                "id": 43,
+                "name": "Guard (Sword)"
+            }, {
+                "id": 44,
+                "name": "XianGuardSwordStatue"
+            }, {
+                "id": 45,
+                "name": "Yeti"
+            }, {
+                "id": 46,
+                "name": "Guardian"
+            }, {
+                "id": 47,
+                "name": "Eagle"
+            }, {
+                "id": 48,
+                "name": "Mercenary 1"
+            }, {
+                "id": 49,
+                "name": "Mercenary 2"
+            }, {
+                "id": 50,
+                "name": "Mercenary 3"
+            }, {
+                "id": 51,
+                "name": "Black Skidoo"
+            }, {
+                "id": 52,
+                "name": "Skidoo Driver"
+            }, {
+                "id": 53,
+                "name": "Monk 1"
+            }, {
+                "id": 54,
+                "name": "Monk 2"
+            }, {
+                "id": 55,
+                "name": "Breakable Tile"
+            }, {
+                "id": 57,
+                "name": "Loose Boards"
+            }, {
+                "id": 58,
+                "name": "Swinging Sandbag"
+            }, {
+                "id": 59,
+                "name": "Spikes"
+            }, {
+                "id": 60,
+                "name": "Boulder"
+            }, {
+                "id": 61,
+                "name": "Dart"
+            }, {
+                "id": 62,
+                "name": "Dart Emitter"
+            }, {
+                "id": 63,
+                "name": "Drawbridge"
+            }, {
+                "id": 64,
+                "name": "Slamming Doors"
+            }, {
+                "id": 65,
+                "name": "Elevator"
+            }, {
+                "id": 66,
+                "name": "Minisub"
+            }, {
+                "id": 67,
+                "name": "Pushable Block 1"
+            }, {
+                "id": 68,
+                "name": "Pushable Block 2"
+            }, {
+                "id": 69,
+                "name": "Pushable Block 3"
+            }, {
+                "id": 70,
+                "name": "Pushable Block 4"
+            }, {
+                "id": 71,
+                "name": "Lava bowl"
+            }, {
+                "id": 72,
+                "name": "Breakable Window"
+            }, {
+                "id": 73,
+                "name": "Breakable Window"
+            }, {
+                "id": 76,
+                "name": "Propeller"
+            }, {
+                "id": 77,
+                "name": "PowerSaw"
+            }, {
+                "id": 78,
+                "name": "Hook"
+            }, {
+                "id": 79,
+                "name": "Falling Ceiling"
+            }, {
+                "id": 80,
+                "name": "Rolling Spindle"
+            }, {
+                "id": 81,
+                "name": "Wall Blade"
+            }, {
+                "id": 82,
+                "name": "Statue Blade"
+            }, {
+                "id": 83,
+                "name": "Boulders"
+            }, {
+                "id": 84,
+                "name": "Icicles"
+            }, {
+                "id": 85,
+                "name": "Spike Wall"
+            }, {
+                "id": 86,
+                "name": "Springboard"
+            }, {
+                "id": 87,
+                "name": "Spike Ceiling"
+            }, {
+                "id": 88,
+                "name": "Bell"
+            }, {
+                "id": 89,
+                "name": "BoatWake"
+            }, {
+                "id": 90,
+                "name": "SnowmobileWake"
+            }, {
+                "id": 91,
+                "name": "SnowmobileBelt"
+            }, {
+                "id": 92,
+                "name": "Wheel Door"
+            }, {
+                "id": 93,
+                "name": "Small Switch"
+            }, {
+                "id": 94,
+                "name": "Underwater Fan"
+            }, {
+                "id": 95,
+                "name": "Fan"
+            }, {
+                "id": 96,
+                "name": "Swinging Box"
+            }, {
+                "id": 97,
+                "name": "CutsceneActor1"
+            }, {
+                "id": 98,
+                "name": "CutsceneActor2"
+            }, {
+                "id": 99,
+                "name": "CutsceneActor3"
+            }, {
+                "id": 100,
+                "name": "UIFrame"
+            }, {
+                "id": 101,
+                "name": "Rolling Barrels"
+            }, {
+                "id": 102,
+                "name": "Zipline"
+            }, {
+                "id": 103,
+                "name": "Button"
+            }, {
+                "id": 104,
+                "name": "Wall Switch"
+            }, {
+                "id": 105,
+                "name": "Underwater Lever"
+            }, {
+                "id": 106,
+                "name": "Door 1"
+            }, {
+                "id": 107,
+                "name": "Door 2"
+            }, {
+                "id": 108,
+                "name": "Door 3"
+            }, {
+                "id": 109,
+                "name": "Door 4"
+            }, {
+                "id": 110,
+                "name": "Door 5"
+            }, {
+                "id": 111,
+                "name": "Door 6"
+            }, {
+                "id": 112,
+                "name": "Door 7"
+            }, {
+                "id": 113,
+                "name": "Door 8"
+            }, {
+                "id": 114,
+                "name": "Trapdoor 1"
+            }, {
+                "id": 115,
+                "name": "Trapdoor 2"
+            }, {
+                "id": 116,
+                "name": "Trapdoor 3"
+            }, {
+                "id": 117,
+                "name": "Bridge (Flat)"
+            }, {
+                "id": 118,
+                "name": "Bridge (Tilt 1)"
+            }, {
+                "id": 119,
+                "name": "Bridge (Tilt 2)"
+            }, {
+                "id": 120,
+                "name": "PassportOpening"
+            }, {
+                "id": 121,
+                "name": "Compass"
+            }, {
+                "id": 122,
+                "name": "LarasHomePolaroid"
+            }, {
+                "id": 123,
+                "name": "CutsceneActor4"
+            }, {
+                "id": 124,
+                "name": "CutsceneActor5"
+            }, {
+                "id": 125,
+                "name": "CutsceneActor6"
+            }, {
+                "id": 126,
+                "name": "CutsceneActor7"
+            }, {
+                "id": 127,
+                "name": "CutsceneActor8"
+            }, {
+                "id": 128,
+                "name": "CutsceneActor9"
+            }, {
+                "id": 129,
+                "name": "CutsceneActor10"
+            }, {
+                "id": 130,
+                "name": "CutsceneActor11"
+            }, {
+                "id": 133,
+                "name": "PassportClosed"
+            }, {
+                "id": 134,
+                "name": "Map"
+            }, {
+                "id": 135,
+                "name": "Pistols"
+            }, {
+                "id": 136,
+                "name": "Shotgun"
+            }, {
+                "id": 137,
+                "name": "Auto pistols"
+            }, {
+                "id": 138,
+                "name": "Uzis"
+            }, {
+                "id": 139,
+                "name": "Harpoon Gun"
+            }, {
+                "id": 140,
+                "name": "M16"
+            }, {
+                "id": 141,
+                "name": "Grenade launcher"
+            }, {
+                "id": 142,
+                "name": "PistolAmmoSprite"
+            }, {
+                "id": 143,
+                "name": "Shotgun shells"
+            }, {
+                "id": 144,
+                "name": "Auto pistol ammo"
+            }, {
+                "id": 145,
+                "name": "Uzi ammo"
+            }, {
+                "id": 146,
+                "name": "Harpoons"
+            }, {
+                "id": 147,
+                "name": "M16 ammo"
+            }, {
+                "id": 148,
+                "name": "Grenades"
+            }, {
+                "id": 149,
+                "name": "Small medipack"
+            }, {
+                "id": 150,
+                "name": "Large medipack"
+            }, {
+                "id": 151,
+                "name": "Flares"
+            }, {
+                "id": 152,
+                "name": "Flare"
+            }, {
+                "id": 153,
+                "name": "Sunglasses"
+            }, {
+                "id": 154,
+                "name": "CassettePlayer"
+            }, {
+                "id": 155,
+                "name": "DirectionKeys"
+            }, {
+                "id": 157,
+                "name": "Pistols"
+            }, {
+                "id": 158,
+                "name": "Shotgun"
+            }, {
+                "id": 159,
+                "name": "Autopistols"
+            }, {
+                "id": 160,
+                "name": "Uzis"
+            }, {
+                "id": 161,
+                "name": "HarpoonGun"
+            }, {
+                "id": 162,
+                "name": "M16"
+            }, {
+                "id": 163,
+                "name": "GrenadeLauncher"
+            }, {
+                "id": 164,
+                "name": "PistolAmmo"
+            }, {
+                "id": 165,
+                "name": "ShotgunAmmo"
+            }, {
+                "id": 166,
+                "name": "AutopistolAmmo"
+            }, {
+                "id": 167,
+                "name": "UziAmmo"
+            }, {
+                "id": 168,
+                "name": "HarpoonGunAmmo"
+            }, {
+                "id": 169,
+                "name": "M16Ammo"
+            }, {
+                "id": 170,
+                "name": "GrenadeLauncherAmmo"
+            }, {
+                "id": 171,
+                "name": "SmallMedipack"
+            }, {
+                "id": 172,
+                "name": "LargeMedipack"
+            }, {
+                "id": 173,
+                "name": "Flares"
+            }, {
+                "id": 174,
+                "name": "Puzzle 1"
+            }, {
+                "id": 175,
+                "name": "Puzzle 2"
+            }, {
+                "id": 176,
+                "name": "Puzzle 3"
+            }, {
+                "id": 177,
+                "name": "Puzzle 4"
+            }, {
+                "id": 178,
+                "name": "Puzzle 1"
+            }, {
+                "id": 179,
+                "name": "Puzzle 2"
+            }, {
+                "id": 180,
+                "name": "Puzzle 3"
+            }, {
+                "id": 181,
+                "name": "Puzzle 4"
+            }, {
+                "id": 182,
+                "name": "Slot 1"
+            }, {
+                "id": 183,
+                "name": "Slot 2"
+            }, {
+                "id": 184,
+                "name": "Slot 3"
+            }, {
+                "id": 185,
+                "name": "Slot 4"
+            }, {
+                "id": 186,
+                "name": "Slot 1 Done"
+            }, {
+                "id": 187,
+                "name": "Slot 2 Done"
+            }, {
+                "id": 188,
+                "name": "Slot 3 Done"
+            }, {
+                "id": 189,
+                "name": "Slot 4 Done"
+            }, {
+                "id": 190,
+                "name": "Secret (Gold)"
+            }, {
+                "id": 191,
+                "name": "Secret (Jade)"
+            }, {
+                "id": 192,
+                "name": "Secret (Stone)"
+            }, {
+                "id": 193,
+                "name": "Key 1"
+            }, {
+                "id": 194,
+                "name": "Key 2"
+            }, {
+                "id": 195,
+                "name": "Key 3"
+            }, {
+                "id": 196,
+                "name": "Key 4"
+            }, {
+                "id": 197,
+                "name": "Key 1"
+            }, {
+                "id": 198,
+                "name": "Key 2"
+            }, {
+                "id": 199,
+                "name": "Key 3"
+            }, {
+                "id": 200,
+                "name": "Key 4"
+            }, {
+                "id": 201,
+                "name": "Keyhole 1"
+            }, {
+                "id": 202,
+                "name": "Keyhole 2"
+            }, {
+                "id": 203,
+                "name": "Keyhole 3"
+            }, {
+                "id": 204,
+                "name": "Keyhole 4"
+            }, {
+                "id": 205,
+                "name": "Quest Item 1"
+            }, {
+                "id": 206,
+                "name": "The Talion"
+            }, {
+                "id": 207,
+                "name": "QuestItem1"
+            }, {
+                "id": 208,
+                "name": "QuestItem2"
+            }, {
+                "id": 209,
+                "name": "DragonExplosionEffect"
+            }, {
+                "id": 210,
+                "name": "DragonExplosionEffect2"
+            }, {
+                "id": 211,
+                "name": "DragonExplosionEffect3"
+            }, {
+                "id": 212,
+                "name": "Alarm"
+            }, {
+                "id": 213,
+                "name": "Dripping Water"
+            }, {
+                "id": 214,
+                "name": "T-Rex"
+            }, {
+                "id": 215,
+                "name": "Singing Birds"
+            }, {
+                "id": 216,
+                "name": "BartoliHideoutClock"
+            }, {
+                "id": 217,
+                "name": "Placeholder"
+            }, {
+                "id": 218,
+                "name": "DragonBonesFront"
+            }, {
+                "id": 219,
+                "name": "DragonBonesBack"
+            }, {
+                "id": 220,
+                "name": "ExtraFire"
+            }, {
+                "id": 222,
+                "name": "Mine"
+            }, {
+                "id": 223,
+                "name": "MenuBackground"
+            }, {
+                "id": 224,
+                "name": "GrayDisk"
+            }, {
+                "id": 225,
+                "name": "GongStick"
+            }, {
+                "id": 226,
+                "name": "Gong"
+            }, {
+                "id": 227,
+                "name": "Detonator"
+            }, {
+                "id": 228,
+                "name": "Helicopter"
+            }, {
+                "id": 229,
+                "name": "Explosion"
+            }, {
+                "id": 230,
+                "name": "Splash"
+            }, {
+                "id": 231,
+                "name": "Bubbles"
+            }, {
+                "id": 233,
+                "name": "Blood"
+            }, {
+                "id": 235,
+                "name": "FlareSparkles"
+            }, {
+                "id": 236,
+                "name": "Glow"
+            }, {
+                "id": 238,
+                "name": "Ricochet"
+            }, {
+                "id": 240,
+                "name": "Gunflare"
+            }, {
+                "id": 241,
+                "name": "M16Gunflare"
+            }, {
+                "id": 243,
+                "name": "Camera Target"
+            }, {
+                "id": 244,
+                "name": "Waterfall Mist"
+            }, {
+                "id": 245,
+                "name": "Harpoon"
+            }, {
+                "id": 247,
+                "name": "Placeholder"
+            }, {
+                "id": 248,
+                "name": "GrenadeSingle"
+            }, {
+                "id": 249,
+                "name": "HarpoonFlying"
+            }, {
+                "id": 250,
+                "name": "LavaParticles"
+            }, {
+                "id": 251,
+                "name": "Lava Emitter"
+            }, {
+                "id": 252,
+                "name": "Flame"
+            }, {
+                "id": 253,
+                "name": "Flame Emitter"
+            }, {
+                "id": 254,
+                "name": "Skybox"
+            }, {
+                "id": 255,
+                "name": "FontGraphics"
+            }, {
+                "id": 256,
+                "name": "Monk"
+            }, {
+                "id": 257,
+                "name": "Doorbell"
+            }, {
+                "id": 258,
+                "name": "AlarmBell"
+            }, {
+                "id": 259,
+                "name": "Helicopter"
+            }, {
+                "id": 260,
+                "name": "Winston"
+            }, {
+                "id": 262,
+                "name": "LaraCutscenePlacement"
+            }, {
+                "id": 263,
+                "name": "ShotgunAnimation"
+            }, {
+                "id": 264,
+                "name": "Dragon (Emitter)"
+            }
+        ],
+        "tr3": [{
+                "id": 0,
+                "name": "Lara"
+            }, {
+                "id": 1,
+                "name": "LaraPistolsAnim"
+            }, {
+                "id": 2,
+                "name": "LaraPonytail"
+            }, {
+                "id": 3,
+                "name": "LaraShotgunAnim"
+            }, {
+                "id": 4,
+                "name": "LaraDesertEagleAnim"
+            }, {
+                "id": 5,
+                "name": "LaraUzisAnim"
+            }, {
+                "id": 6,
+                "name": "LaraMP5Anim"
+            }, {
+                "id": 7,
+                "name": "LaraRocketLauncherAnim"
+            }, {
+                "id": 8,
+                "name": "LaraGrenadeLauncherAnim"
+            }, {
+                "id": 9,
+                "name": "LaraHarpoonGunAnim"
+            }, {
+                "id": 10,
+                "name": "LaraFlareAnim"
+            }, {
+                "id": 11,
+                "name": "LaraUPVAnim"
+            }, {
+                "id": 12,
+                "name": "UPV"
+            }, {
+                "id": 14,
+                "name": "Kayak"
+            }, {
+                "id": 15,
+                "name": "Inflatable Boat"
+            }, {
+                "id": 16,
+                "name": "Quadbike"
+            }, {
+                "id": 17,
+                "name": "Minecart"
+            }, {
+                "id": 18,
+                "name": "Turret"
+            }, {
+                "id": 19,
+                "name": "UPV"
+            }, {
+                "id": 20,
+                "name": "Tribesman (Axe)"
+            }, {
+                "id": 21,
+                "name": "Tribesman (Dart)"
+            }, {
+                "id": 22,
+                "name": "Dog"
+            }, {
+                "id": 23,
+                "name": "Rat"
+            }, {
+                "id": 24,
+                "name": "Kill All Triggers"
+            }, {
+                "id": 25,
+                "name": "Killer Whale"
+            }, {
+                "id": 26,
+                "name": "Scuba Diver"
+            }, {
+                "id": 27,
+                "name": "Crow"
+            }, {
+                "id": 28,
+                "name": "Tiger"
+            }, {
+                "id": 29,
+                "name": "Vulture"
+            }, {
+                "id": 30,
+                "name": "Target"
+            }, {
+                "id": 31,
+                "name": "Crawler Mutant"
+            }, {
+                "id": 32,
+                "name": "Crocodile"
+            }, {
+                "id": 34,
+                "name": "Compsognathus"
+            }, {
+                "id": 35,
+                "name": "Lizard"
+            }, {
+                "id": 36,
+                "name": "Puna"
+            }, {
+                "id": 37,
+                "name": "Mercenary"
+            }, {
+                "id": 38,
+                "name": "Hanging Raptor"
+            }, {
+                "id": 39,
+                "name": "RX-Tech Guy (Red)"
+            }, {
+                "id": 40,
+                "name": "RX-Tech Guy (White)"
+            }, {
+                "id": 41,
+                "name": "Dog"
+            }, {
+                "id": 42,
+                "name": "Crawler Mutant"
+            }, {
+                "id": 44,
+                "name": "Wasp"
+            }, {
+                "id": 45,
+                "name": "Monster"
+            }, {
+                "id": 46,
+                "name": "Monster (Claw)"
+            }, {
+                "id": 47,
+                "name": "Wasp Spawn"
+            }, {
+                "id": 48,
+                "name": "Raptor Spawn"
+            }, {
+                "id": 49,
+                "name": "Willard"
+            }, {
+                "id": 50,
+                "name": "Flamethrower Guy"
+            }, {
+                "id": 51,
+                "name": "Guard (MP5)"
+            }, {
+                "id": 53,
+                "name": "Punk"
+            }, {
+                "id": 56,
+                "name": "Guard (Handgun)"
+            }, {
+                "id": 57,
+                "name": "Sophia Leigh"
+            }, {
+                "id": 58,
+                "name": "Cleaner Robot"
+            }, {
+                "id": 60,
+                "name": "MP (Baton)"
+            }, {
+                "id": 61,
+                "name": "MP (Handgun)"
+            }, {
+                "id": 62,
+                "name": "Prisoner"
+            }, {
+                "id": 63,
+                "name": "MP (MP5)"
+            }, {
+                "id": 64,
+                "name": "Gun Turret"
+            }, {
+                "id": 65,
+                "name": "Dam Guard"
+            }, {
+                "id": 66,
+                "name": "Tripwire"
+            }, {
+                "id": 67,
+                "name": "Electrified Wire"
+            }, {
+                "id": 68,
+                "name": "Killer Tripwire"
+            }, {
+                "id": 69,
+                "name": "Cobra"
+            }, {
+                "id": 70,
+                "name": "Shiva"
+            }, {
+                "id": 71,
+                "name": "Monkey"
+            }, {
+                "id": 73,
+                "name": "Tony"
+            }, {
+                "id": 74,
+                "name": "AI Guard"
+            }, {
+                "id": 75,
+                "name": "AI Ambush"
+            }, {
+                "id": 76,
+                "name": "AI Patrol 1"
+            }, {
+                "id": 77,
+                "name": "AI Modify"
+            }, {
+                "id": 78,
+                "name": "AI Follow"
+            }, {
+                "id": 79,
+                "name": "AI Patrol 2"
+            }, {
+                "id": 80,
+                "name": "AI Path"
+            }, {
+                "id": 81,
+                "name": "AI Check"
+            }, {
+                "id": 82,
+                "name": "Unknown"
+            }, {
+                "id": 83,
+                "name": "Breakable tile"
+            }, {
+                "id": 86,
+                "name": "Swinging Thing"
+            }, {
+                "id": 87,
+                "name": "Spikes"
+            }, {
+                "id": 88,
+                "name": "Boulder"
+            }, {
+                "id": 89,
+                "name": "Giant Boulder"
+            }, {
+                "id": 90,
+                "name": "Dart"
+            }, {
+                "id": 91,
+                "name": "Dart Emitter"
+            }, {
+                "id": 94,
+                "name": "Skeleton Trap"
+            }, {
+                "id": 97,
+                "name": "Pushable Block 1"
+            }, {
+                "id": 98,
+                "name": "Pushable Block 2"
+            }, {
+                "id": 101,
+                "name": "Breakable Window"
+            }, {
+                "id": 102,
+                "name": "Breakable Window"
+            }, {
+                "id": 106,
+                "name": "Hook"
+            }, {
+                "id": 107,
+                "name": "Falling Ceiling"
+            }, {
+                "id": 108,
+                "name": "Rolling Spindle"
+            }, {
+                "id": 110,
+                "name": "Train"
+            }, {
+                "id": 111,
+                "name": "Wall Blade"
+            }, {
+                "id": 113,
+                "name": "Icicles"
+            }, {
+                "id": 114,
+                "name": "Spike Wall"
+            }, {
+                "id": 116,
+                "name": "Spike Wall (Vertical)"
+            }, {
+                "id": 117,
+                "name": "Wheel Door"
+            }, {
+                "id": 118,
+                "name": "Small Switch"
+            }, {
+                "id": 119,
+                "name": "Propeller/Diver/Meteor"
+            }, {
+                "id": 120,
+                "name": "Fan"
+            }, {
+                "id": 121,
+                "name": "Stamper/Drum/Blades"
+            }, {
+                "id": 122,
+                "name": "Shiva"
+            }, {
+                "id": 123,
+                "name": "MonkeyMedipackMeshswap"
+            }, {
+                "id": 124,
+                "name": "MonkeyKeyMeshswap"
+            }, {
+                "id": 125,
+                "name": "UIFrame"
+            }, {
+                "id": 127,
+                "name": "Zipline"
+            }, {
+                "id": 128,
+                "name": "Button"
+            }, {
+                "id": 129,
+                "name": "Wall Switch"
+            }, {
+                "id": 130,
+                "name": "Underwater Lever"
+            }, {
+                "id": 131,
+                "name": "Door 1"
+            }, {
+                "id": 132,
+                "name": "Door 2"
+            }, {
+                "id": 133,
+                "name": "Door 3"
+            }, {
+                "id": 134,
+                "name": "Door 4"
+            }, {
+                "id": 135,
+                "name": "Door 5"
+            }, {
+                "id": 136,
+                "name": "Door 6"
+            }, {
+                "id": 137,
+                "name": "Door 7"
+            }, {
+                "id": 138,
+                "name": "Door 8"
+            }, {
+                "id": 139,
+                "name": "Trapdoor 1"
+            }, {
+                "id": 140,
+                "name": "Trapdoor 2"
+            }, {
+                "id": 141,
+                "name": "Trapdoor 3"
+            }, {
+                "id": 142,
+                "name": "Bridge (Flat)"
+            }, {
+                "id": 143,
+                "name": "Bridge (Tilt 1)"
+            }, {
+                "id": 144,
+                "name": "Bridge (Tilt 2)"
+            }, {
+                "id": 145,
+                "name": "PassportOpening"
+            }, {
+                "id": 146,
+                "name": "Compass"
+            }, {
+                "id": 147,
+                "name": "LarasHomePolaroid"
+            }, {
+                "id": 148,
+                "name": "CutsceneActor1"
+            }, {
+                "id": 149,
+                "name": "CutsceneActor2"
+            }, {
+                "id": 150,
+                "name": "CutsceneActor3"
+            }, {
+                "id": 151,
+                "name": "CutsceneActor4"
+            }, {
+                "id": 152,
+                "name": "CutsceneActor5"
+            }, {
+                "id": 153,
+                "name": "CutsceneActor6"
+            }, {
+                "id": 154,
+                "name": "CutsceneActor7"
+            }, {
+                "id": 155,
+                "name": "CutsceneActor8"
+            }, {
+                "id": 156,
+                "name": "CutsceneActor9"
+            }, {
+                "id": 158,
+                "name": "PassportClosed"
+            }, {
+                "id": 159,
+                "name": "Map"
+            }, {
+                "id": 160,
+                "name": "Pistols"
+            }, {
+                "id": 161,
+                "name": "Shotgun"
+            }, {
+                "id": 162,
+                "name": "Desert Eagle"
+            }, {
+                "id": 163,
+                "name": "Uzis"
+            }, {
+                "id": 164,
+                "name": "Harpoon Gun"
+            }, {
+                "id": 165,
+                "name": "MP5"
+            }, {
+                "id": 166,
+                "name": "Rocket Launcher"
+            }, {
+                "id": 167,
+                "name": "Grenade Launcher"
+            }, {
+                "id": 168,
+                "name": "PistolAmmoOnGround"
+            }, {
+                "id": 169,
+                "name": "Shotgun shells"
+            }, {
+                "id": 170,
+                "name": "Desert Eagle ammo"
+            }, {
+                "id": 171,
+                "name": "Uzi ammo"
+            }, {
+                "id": 172,
+                "name": "Harpoons"
+            }, {
+                "id": 173,
+                "name": "MP5 ammo"
+            }, {
+                "id": 174,
+                "name": "Rocket"
+            }, {
+                "id": 175,
+                "name": "Grenades"
+            }, {
+                "id": 176,
+                "name": "Small Medipack"
+            }, {
+                "id": 177,
+                "name": "Large Medipack"
+            }, {
+                "id": 178,
+                "name": "Flares"
+            }, {
+                "id": 179,
+                "name": "Flare"
+            }, {
+                "id": 180,
+                "name": "Savegame Crystal"
+            }, {
+                "id": 181,
+                "name": "Sunglasses"
+            }, {
+                "id": 182,
+                "name": "CassettePlayer"
+            }, {
+                "id": 183,
+                "name": "DirectionKeys"
+            }, {
+                "id": 184,
+                "name": "Globe"
+            }, {
+                "id": 185,
+                "name": "Pistols"
+            }, {
+                "id": 186,
+                "name": "Shotgun"
+            }, {
+                "id": 187,
+                "name": "Desert Eagle"
+            }, {
+                "id": 188,
+                "name": "Uzis"
+            }, {
+                "id": 189,
+                "name": "Harpoon Gun"
+            }, {
+                "id": 190,
+                "name": "MP5"
+            }, {
+                "id": 191,
+                "name": "Rocket Launcher"
+            }, {
+                "id": 192,
+                "name": "Grenade Launcher"
+            }, {
+                "id": 193,
+                "name": "PistolAmmo"
+            }, {
+                "id": 194,
+                "name": "ShotgunAmmo"
+            }, {
+                "id": 195,
+                "name": "DesertEagleAmmo"
+            }, {
+                "id": 196,
+                "name": "UziAmmo"
+            }, {
+                "id": 197,
+                "name": "HarpoonGunAmmo"
+            }, {
+                "id": 198,
+                "name": "MP5Ammo"
+            }, {
+                "id": 199,
+                "name": "RocketLauncherAmmo"
+            }, {
+                "id": 200,
+                "name": "GrenadeLauncherAmmo"
+            }, {
+                "id": 201,
+                "name": "SmallMedipack"
+            }, {
+                "id": 202,
+                "name": "LargeMedipack"
+            }, {
+                "id": 203,
+                "name": "Flares"
+            }, {
+                "id": 204,
+                "name": "SavegameCrystalInventory"
+            }, {
+                "id": 205,
+                "name": "Puzzle 1"
+            }, {
+                "id": 206,
+                "name": "Puzzle 2"
+            }, {
+                "id": 207,
+                "name": "Puzzle 3"
+            }, {
+                "id": 208,
+                "name": "Puzzle 4"
+            }, {
+                "id": 209,
+                "name": "Puzzle 1"
+            }, {
+                "id": 210,
+                "name": "Puzzle 2"
+            }, {
+                "id": 211,
+                "name": "Puzzle 3"
+            }, {
+                "id": 212,
+                "name": "Puzzle 4"
+            }, {
+                "id": 213,
+                "name": "Slot 1"
+            }, {
+                "id": 214,
+                "name": "Slot 2"
+            }, {
+                "id": 215,
+                "name": "Slot 3"
+            }, {
+                "id": 216,
+                "name": "Slot 4"
+            }, {
+                "id": 217,
+                "name": "Slot 1 Done"
+            }, {
+                "id": 218,
+                "name": "Slot 2 Done"
+            }, {
+                "id": 219,
+                "name": "Slot 3 Done"
+            }, {
+                "id": 220,
+                "name": "Slot 4 Done"
+            }, {
+                "id": 224,
+                "name": "Key 1"
+            }, {
+                "id": 225,
+                "name": "Key 2"
+            }, {
+                "id": 226,
+                "name": "Key 3"
+            }, {
+                "id": 227,
+                "name": "Key 4"
+            }, {
+                "id": 228,
+                "name": "Key 1"
+            }, {
+                "id": 229,
+                "name": "Key 2"
+            }, {
+                "id": 230,
+                "name": "Key 3"
+            }, {
+                "id": 231,
+                "name": "Key 4"
+            }, {
+                "id": 232,
+                "name": "Keyhole 1"
+            }, {
+                "id": 233,
+                "name": "Keyhole 2"
+            }, {
+                "id": 234,
+                "name": "Keyhole 3"
+            }, {
+                "id": 235,
+                "name": "Keyhole 4"
+            }, {
+                "id": 236,
+                "name": "Quest Item 1"
+            }, {
+                "id": 237,
+                "name": "Quest Item 2"
+            }, {
+                "id": 238,
+                "name": "QuestItem1"
+            }, {
+                "id": 239,
+                "name": "QuestItem2"
+            }, {
+                "id": 240,
+                "name": "Infada Stone"
+            }, {
+                "id": 241,
+                "name": "Element 115"
+            }, {
+                "id": 242,
+                "name": "Eye Of Isis"
+            }, {
+                "id": 243,
+                "name": "Ora Dagger"
+            }, {
+                "id": 244,
+                "name": "InfadaStone"
+            }, {
+                "id": 245,
+                "name": "Element115"
+            }, {
+                "id": 246,
+                "name": "EyeOfIsis"
+            }, {
+                "id": 247,
+                "name": "OraDagger"
+            }, {
+                "id": 272,
+                "name": "KeysSprite1"
+            }, {
+                "id": 273,
+                "name": "KeysSprite2"
+            }, {
+                "id": 276,
+                "name": "Infada Stone"
+            }, {
+                "id": 277,
+                "name": "Element 115"
+            }, {
+                "id": 278,
+                "name": "Eye Of Isis"
+            }, {
+                "id": 279,
+                "name": "Ora Dagger"
+            }, {
+                "id": 282,
+                "name": "FireBreathingDragonStatue"
+            }, {
+                "id": 285,
+                "name": "UnknownVisible285"
+            }, {
+                "id": 287,
+                "name": "T-Rex"
+            }, {
+                "id": 288,
+                "name": "Raptor"
+            }, {
+                "id": 291,
+                "name": "Moving Lasers"
+            }, {
+                "id": 292,
+                "name": "Electrified Field"
+            }, {
+                "id": 294,
+                "name": "Shadow Sprite"
+            }, {
+                "id": 295,
+                "name": "Detonator"
+            }, {
+                "id": 296,
+                "name": "Misc Sprites"
+            }, {
+                "id": 297,
+                "name": "Bubble"
+            }, {
+                "id": 299,
+                "name": "Glow"
+            }, {
+                "id": 300,
+                "name": "Gunflare"
+            }, {
+                "id": 301,
+                "name": "MP5Gunflare"
+            }, {
+                "id": 304,
+                "name": "Camera Target"
+            }, {
+                "id": 305,
+                "name": "Waterfall Mist"
+            }, {
+                "id": 306,
+                "name": "HarpoonFlying2"
+            }, {
+                "id": 309,
+                "name": "RocketSingle"
+            }, {
+                "id": 310,
+                "name": "HarpoonFlying"
+            }, {
+                "id": 311,
+                "name": "GrenadeSingle"
+            }, {
+                "id": 312,
+                "name": "Missile"
+            }, {
+                "id": 313,
+                "name": "Smoke"
+            }, {
+                "id": 314,
+                "name": "Movable Boom"
+            }, {
+                "id": 315,
+                "name": "LaraSkin"
+            }, {
+                "id": 316,
+                "name": "Glow 2"
+            }, {
+                "id": 317,
+                "name": "UnknownVisible317"
+            }, {
+                "id": 318,
+                "name": "Alarm Light"
+            }, {
+                "id": 319,
+                "name": "Light"
+            }, {
+                "id": 321,
+                "name": "Light 2"
+            }, {
+                "id": 322,
+                "name": "Pulsating Light"
+            }, {
+                "id": 324,
+                "name": "Red Light"
+            }, {
+                "id": 325,
+                "name": "Green Light"
+            }, {
+                "id": 326,
+                "name": "Blue Light"
+            }, {
+                "id": 327,
+                "name": "Light 3"
+            }, {
+                "id": 328,
+                "name": "Light 4"
+            }, {
+                "id": 330,
+                "name": "Fire"
+            }, {
+                "id": 331,
+                "name": "Alternate Fire"
+            }, {
+                "id": 332,
+                "name": "Alternate Fire 2"
+            }, {
+                "id": 333,
+                "name": "Fire 2"
+            }, {
+                "id": 334,
+                "name": "Smoke 2"
+            }, {
+                "id": 335,
+                "name": "Smoke 3"
+            }, {
+                "id": 336,
+                "name": "Smoke 4"
+            }, {
+                "id": 337,
+                "name": "Greenish Smoke"
+            }, {
+                "id": 338,
+                "name": "Piranhas"
+            }, {
+                "id": 339,
+                "name": "Fish"
+            }, {
+                "id": 347,
+                "name": "Bat Swarm"
+            }, {
+                "id": 349,
+                "name": "Animating 1"
+            }, {
+                "id": 350,
+                "name": "Animating 2"
+            }, {
+                "id": 351,
+                "name": "Animating 3"
+            }, {
+                "id": 352,
+                "name": "Animating 4"
+            }, {
+                "id": 353,
+                "name": "Animating 5"
+            }, {
+                "id": 354,
+                "name": "Animating 6"
+            }, {
+                "id": 355,
+                "name": "Skybox"
+            }, {
+                "id": 356,
+                "name": "FontGraphics"
+            }, {
+                "id": 357,
+                "name": "Doorbell"
+            }, {
+                "id": 358,
+                "name": "UnknownID358"
+            }, {
+                "id": 360,
+                "name": "Winston"
+            }, {
+                "id": 361,
+                "name": "Winston (Camo)"
+            }, {
+                "id": 362,
+                "name": "TimerFontGraphics"
+            }, {
+                "id": 365,
+                "name": "Earthquake"
+            }, {
+                "id": 366,
+                "name": "YellowShellCasing"
+            }, {
+                "id": 367,
+                "name": "RedShellCasing"
+            }, {
+                "id": 370,
+                "name": "Light Shaft"
+            }, {
+                "id": 373,
+                "name": "Electrical Switch Box"
+            }
+        ],
+        "tr4": [{
+                "id": 0,
+                "name": "Lara"
+            }, {
+                "id": 1,
+                "name": "LaraPistolsAnim"
+            }, {
+                "id": 2,
+                "name": "LaraUzisAnim"
+            }, {
+                "id": 3,
+                "name": "LaraShotgunAnim"
+            }, {
+                "id": 31,
+                "name": "Motorbike"
+            }, {
+                "id": 32,
+                "name": "Jeep"
+            }, {
+                "id": 34,
+                "name": "Enemy jeep"
+            }, {
+                "id": 35,
+                "name": "Skeleton"
+            }, {
+                "id": 37,
+                "name": "Guide"
+            }, {
+                "id": 39,
+                "name": "Von Croy"
+            }, {
+                "id": 41,
+                "name": "Enemy 1"
+            }, {
+                "id": 43,
+                "name": "Enemy 2"
+            }, {
+                "id": 45,
+                "name": "Horus"
+            }, {
+                "id": 47,
+                "name": "Mummy"
+            }, {
+                "id": 49,
+                "name": "Guardian"
+            }, {
+                "id": 51,
+                "name": "Crocodile"
+            }, {
+                "id": 53,
+                "name": "Horseman"
+            }, {
+                "id": 55,
+                "name": "Giant Scorpion"
+            }, {
+                "id": 57,
+                "name": "Jean Yves"
+            }, {
+                "id": 59,
+                "name": "Soldier"
+            }, {
+                "id": 61,
+                "name": "Knight Templar"
+            }, {
+                "id": 63,
+                "name": "Dragon"
+            }, {
+                "id": 65,
+                "name": "Horse"
+            }, {
+                "id": 67,
+                "name": "Monkey"
+            }, {
+                "id": 69,
+                "name": "Monkey (invisible)"
+            }, {
+                "id": 71,
+                "name": "Monkey (black)"
+            }, {
+                "id": 73,
+                "name": "Boar"
+            }, {
+                "id": 75,
+                "name": "Harpy"
+            }, {
+                "id": 77,
+                "name": "Demigod 1"
+            }, {
+                "id": 79,
+                "name": "Demigod 2"
+            }, {
+                "id": 81,
+                "name": "Demigod 3"
+            }, {
+                "id": 83,
+                "name": "Scarab"
+            }, {
+                "id": 84,
+                "name": "Giant Beetle"
+            }, {
+                "id": 86,
+                "name": "Wraith 1"
+            }, {
+                "id": 87,
+                "name": "Wraith 2"
+            }, {
+                "id": 88,
+                "name": "Wraith 3"
+            }, {
+                "id": 90,
+                "name": "Bat"
+            }, {
+                "id": 91,
+                "name": "Dog"
+            }, {
+                "id": 93,
+                "name": "Hammerhead"
+            }, {
+                "id": 95,
+                "name": "Soldier"
+            }, {
+                "id": 101,
+                "name": "Dead soldier"
+            }, {
+                "id": 102,
+                "name": "Ammit"
+            }, {
+                "id": 104,
+                "name": "Lara double"
+            }, {
+                "id": 106,
+                "name": "Scorpion"
+            }, {
+                "id": 107,
+                "name": "Fish"
+            }, {
+                "id": 108,
+                "name": "Senet (red)"
+            }, {
+                "id": 109,
+                "name": "Senet (green)"
+            }, {
+                "id": 110,
+                "name": "Senet (blue)"
+            }, {
+                "id": 111,
+                "name": "Senet (enemy)"
+            }, {
+                "id": 112,
+                "name": "Tile spinner"
+            }, {
+                "id": 113,
+                "name": "Scales"
+            }, {
+                "id": 114,
+                "name": "Dart"
+            }, {
+                "id": 115,
+                "name": "Dart Emitter"
+            }, {
+                "id": 117,
+                "name": "Falling Ceiling"
+            }, {
+                "id": 118,
+                "name": "Breakable Tile"
+            }, {
+                "id": 120,
+                "name": "Breakable wall"
+            }, {
+                "id": 121,
+                "name": "Breakable floor"
+            }, {
+                "id": 122,
+                "name": "Trapdoor 1"
+            }, {
+                "id": 123,
+                "name": "Trapdoor 2"
+            }, {
+                "id": 124,
+                "name": "Trapdoor 3"
+            }, {
+                "id": 125,
+                "name": "Floor Trapdoor 1"
+            }, {
+                "id": 126,
+                "name": "Floor Trapdoor 2"
+            }, {
+                "id": 127,
+                "name": "Ceiling trapdoor"
+            }, {
+                "id": 130,
+                "name": "Boulder"
+            }, {
+                "id": 132,
+                "name": "Spikes"
+            }, {
+                "id": 133,
+                "name": "Drill blades"
+            }, {
+                "id": 134,
+                "name": "Rolling Spikes"
+            }, {
+                "id": 135,
+                "name": "Flame emitter"
+            }, {
+                "id": 136,
+                "name": "Rotating blade"
+            }, {
+                "id": 137,
+                "name": "Blade ring"
+            }, {
+                "id": 138,
+                "name": "Hammer"
+            }, {
+                "id": 139,
+                "name": "Burning floor"
+            }, {
+                "id": 140,
+                "name": "Cog"
+            }, {
+                "id": 141,
+                "name": "Spike ball"
+            }, {
+                "id": 143,
+                "name": "Flame emitter"
+            }, {
+                "id": 144,
+                "name": "Flame emitter"
+            }, {
+                "id": 145,
+                "name": "Flame emitter"
+            }, {
+                "id": 146,
+                "name": "Rope"
+            }, {
+                "id": 147,
+                "name": "Fire rope"
+            }, {
+                "id": 148,
+                "name": "Pole"
+            }, {
+                "id": 150,
+                "name": "Platform"
+            }, {
+                "id": 151,
+                "name": "Raising block"
+            }, {
+                "id": 152,
+                "name": "Raising block"
+            }, {
+                "id": 153,
+                "name": "Expanding platform"
+            }, {
+                "id": 154,
+                "name": "Sliding block"
+            }, {
+                "id": 155,
+                "name": "Falling block"
+            }, {
+                "id": 156,
+                "name": "Pushable 1"
+            }, {
+                "id": 157,
+                "name": "Pushable 2"
+            }, {
+                "id": 158,
+                "name": "Pushable 3"
+            }, {
+                "id": 159,
+                "name": "Pushable 4"
+            }, {
+                "id": 160,
+                "name": "Pushable 5"
+            }, {
+                "id": 162,
+                "name": "Sentry Gun"
+            }, {
+                "id": 163,
+                "name": "Helicopter"
+            }, {
+                "id": 164,
+                "name": "Mapper"
+            }, {
+                "id": 165,
+                "name": "Obelisk"
+            }, {
+                "id": 166,
+                "name": "Blade trap"
+            }, {
+                "id": 168,
+                "name": "Bird blade"
+            }, {
+                "id": 169,
+                "name": "Blade trap"
+            }, {
+                "id": 170,
+                "name": "Wall blade"
+            }, {
+                "id": 171,
+                "name": "Pedestal blades"
+            }, {
+                "id": 172,
+                "name": "Blade"
+            }, {
+                "id": 173,
+                "name": "Lightning conductor"
+            }, {
+                "id": 174,
+                "name": "Element Puzzle"
+            }, {
+                "id": 175,
+                "name": "Puzzle 1",
+                "pickup": true
+            }, {
+                "id": 176,
+                "name": "Puzzle 2",
+                "pickup": true
+            }, {
+                "id": 177,
+                "name": "Puzzle 3",
+                "pickup": true
+            }, {
+                "id": 178,
+                "name": "Puzzle 4",
+                "pickup": true
+            }, {
+                "id": 179,
+                "name": "Puzzle 5",
+                "pickup": true
+            }, {
+                "id": 180,
+                "name": "Puzzle 6",
+                "pickup": true
+            }, {
+                "id": 181,
+                "name": "Puzzle 7",
+                "pickup": true
+            }, {
+                "id": 182,
+                "name": "Puzzle 8",
+                "pickup": true
+            }, {
+                "id": 183,
+                "name": "Puzzle 9",
+                "pickup": true
+            }, {
+                "id": 184,
+                "name": "Puzzle 10",
+                "pickup": true
+            }, {
+                "id": 185,
+                "name": "Puzzle 11",
+                "pickup": true
+            }, {
+                "id": 186,
+                "name": "Puzzle 12",
+                "pickup": true
+            }, {
+                "id": 187,
+                "name": "Puzzle 1 Combo 1",
+                "pickup": true
+            }, {
+                "id": 188,
+                "name": "Puzzle 1 Combo 2",
+                "pickup": true
+            }, {
+                "id": 189,
+                "name": "Puzzle 2 Combo 1",
+                "pickup": true
+            }, {
+                "id": 190,
+                "name": "Puzzle 2 Combo 2",
+                "pickup": true
+            }, {
+                "id": 193,
+                "name": "Puzzle 4 Combo 1",
+                "pickup": true
+            }, {
+                "id": 194,
+                "name": "Puzzle 4 Combo 2",
+                "pickup": true
+            }, {
+                "id": 195,
+                "name": "Puzzle 5 Combo 1",
+                "pickup": true
+            }, {
+                "id": 196,
+                "name": "Puzzle 5 Combo 2",
+                "pickup": true
+            }, {
+                "id": 197,
+                "name": "Puzzle 6 Combo 1",
+                "pickup": true
+            }, {
+                "id": 198,
+                "name": "Puzzle 6 Combo 2",
+                "pickup": true
+            }, {
+                "id": 199,
+                "name": "Puzzle 7 Combo 1",
+                "pickup": true
+            }, {
+                "id": 200,
+                "name": "Puzzle 7 Combo 2",
+                "pickup": true
+            }, {
+                "id": 201,
+                "name": "Puzzle 8 Combo 1",
+                "pickup": true
+            }, {
+                "id": 202,
+                "name": "Puzzle 8 Combo 2",
+                "pickup": true
+            }, {
+                "id": 203,
+                "name": "Key 1",
+                "pickup": true
+            }, {
+                "id": 204,
+                "name": "Key 2",
+                "pickup": true
+            }, {
+                "id": 205,
+                "name": "Key 3",
+                "pickup": true
+            }, {
+                "id": 206,
+                "name": "Key 4",
+                "pickup": true
+            }, {
+                "id": 207,
+                "name": "Key 5",
+                "pickup": true
+            }, {
+                "id": 208,
+                "name": "Key 6",
+                "pickup": true
+            }, {
+                "id": 209,
+                "name": "Key 7",
+                "pickup": true
+            }, {
+                "id": 210,
+                "name": "Key 8",
+                "pickup": true
+            }, {
+                "id": 211,
+                "name": "Key 9",
+                "pickup": true
+            }, {
+                "id": 212,
+                "name": "Key 10",
+                "pickup": true
+            }, {
+                "id": 213,
+                "name": "Key 11",
+                "pickup": true
+            }, {
+                "id": 214,
+                "name": "Key 12",
+                "pickup": true
+            }, {
+                "id": 231,
+                "name": "Item 1"
+            }, {
+                "id": 232,
+                "name": "Item 2"
+            }, {
+                "id": 243,
+                "name": "Examine 1"
+            }, {
+                "id": 244,
+                "name": "Examine 2"
+            }, {
+                "id": 245,
+                "name": "Examine 3"
+            }, {
+                "id": 246,
+                "name": "Crowbar",
+                "pickup": true
+            }, {
+                "id": 247,
+                "name": "Torch",
+                "pickup": true
+            }, {
+                "id": 249,
+                "name": "Winding Key"
+            }, {
+                "id": 250,
+                "name": "Mechanical Scarab"
+            }, {
+                "id": 252,
+                "name": "Quest Item 1"
+            }, {
+                "id": 253,
+                "name": "Quest Item 2"
+            }, {
+                "id": 254,
+                "name": "Quest Item 3"
+            }, {
+                "id": 255,
+                "name": "Quest Item 4"
+            }, {
+                "id": 256,
+                "name": "Quest Item 5"
+            }, {
+                "id": 257,
+                "name": "Quest Item 6"
+            }, {
+                "id": 260,
+                "name": "Slot 1"
+            }, {
+                "id": 261,
+                "name": "Slot 2"
+            }, {
+                "id": 262,
+                "name": "Slot 3"
+            }, {
+                "id": 263,
+                "name": "Slot 4"
+            }, {
+                "id": 264,
+                "name": "Slot 5"
+            }, {
+                "id": 265,
+                "name": "Slot 6"
+            }, {
+                "id": 266,
+                "name": "Slot 7"
+            }, {
+                "id": 267,
+                "name": "Slot 8"
+            }, {
+                "id": 268,
+                "name": "Slot 9"
+            }, {
+                "id": 269,
+                "name": "Slot 10"
+            }, {
+                "id": 270,
+                "name": "Slot 11"
+            }, {
+                "id": 271,
+                "name": "Slot 12"
+            }, {
+                "id": 284,
+                "name": "Lock 1"
+            }, {
+                "id": 285,
+                "name": "Lock 2"
+            }, {
+                "id": 286,
+                "name": "Lock 3"
+            }, {
+                "id": 287,
+                "name": "Lock 4"
+            }, {
+                "id": 288,
+                "name": "Lock 5"
+            }, {
+                "id": 289,
+                "name": "Lock 6"
+            }, {
+                "id": 290,
+                "name": "Lock 7"
+            }, {
+                "id": 291,
+                "name": "Lock 8"
+            }, {
+                "id": 292,
+                "name": "Lock 9"
+            }, {
+                "id": 293,
+                "name": "Lock 10"
+            }, {
+                "id": 294,
+                "name": "Lock 11"
+            }, {
+                "id": 295,
+                "name": "Lock 12"
+            }, {
+                "id": 296,
+                "name": "Waterskin 1",
+                "pickup": true
+            }, {
+                "id": 300,
+                "name": "Waterskin 2",
+                "pickup": true
+            }, {
+                "id": 306,
+                "name": "Switch 1"
+            }, {
+                "id": 307,
+                "name": "Switch 2"
+            }, {
+                "id": 308,
+                "name": "Switch 3"
+            }, {
+                "id": 309,
+                "name": "Switch 4"
+            }, {
+                "id": 310,
+                "name": "Switch 5"
+            }, {
+                "id": 311,
+                "name": "Switch 6"
+            }, {
+                "id": 312,
+                "name": "Switch 7"
+            }, {
+                "id": 313,
+                "name": "Switch 8"
+            }, {
+                "id": 315,
+                "name": "Lever (underwater)"
+            }, {
+                "id": 316,
+                "name": "Turn lever"
+            }, {
+                "id": 317,
+                "name": "Wheel lever"
+            }, {
+                "id": 318,
+                "name": "Lever"
+            }, {
+                "id": 319,
+                "name": "Jump lever"
+            }, {
+                "id": 320,
+                "name": "Crowbar lever"
+            }, {
+                "id": 321,
+                "name": "Pulley"
+            }, {
+                "id": 322,
+                "name": "Door 1"
+            }, {
+                "id": 323,
+                "name": "Door 2"
+            }, {
+                "id": 324,
+                "name": "Door 3"
+            }, {
+                "id": 325,
+                "name": "Door 4"
+            }, {
+                "id": 326,
+                "name": "Door 5"
+            }, {
+                "id": 327,
+                "name": "Door 6"
+            }, {
+                "id": 328,
+                "name": "Door 7"
+            }, {
+                "id": 329,
+                "name": "Door 8"
+            }, {
+                "id": 330,
+                "name": "Push/pull door 1"
+            }, {
+                "id": 332,
+                "name": "Kick door 1"
+            }, {
+                "id": 334,
+                "name": "Underwater door"
+            }, {
+                "id": 335,
+                "name": "Double doors"
+            }, {
+                "id": 336,
+                "name": "Bridge (flat)"
+            }, {
+                "id": 337,
+                "name": "Bridge (tilt)"
+            }, {
+                "id": 339,
+                "name": "Sarcophagus"
+            }, {
+                "id": 340,
+                "name": "Sequence Door 1"
+            }, {
+                "id": 341,
+                "name": "Sequence Button 3"
+            }, {
+                "id": 342,
+                "name": "Sequence Button 1"
+            }, {
+                "id": 343,
+                "name": "Sequence Button 2"
+            }, {
+                "id": 344,
+                "name": "Cutscene"
+            }, {
+                "id": 345,
+                "name": "Horus Statue"
+            }, {
+                "id": 346,
+                "name": "Face"
+            }, {
+                "id": 348,
+                "name": "Plinth"
+            }, {
+                "id": 349,
+                "name": "Pistols",
+                "pickup": true
+            }, {
+                "id": 350,
+                "name": "Pistol Ammo",
+                "pickup": true
+            }, {
+                "id": 351,
+                "name": "Uzis",
+                "pickup": true
+            }, {
+                "id": 352,
+                "name": "Uzi Ammo",
+                "pickup": true
+            }, {
+                "id": 353,
+                "name": "Shotgun",
+                "pickup": true
+            }, {
+                "id": 354,
+                "name": "Shotgun ammo (red)",
+                "pickup": true
+            }, {
+                "id": 355,
+                "name": "Shotgun ammo (blue)",
+                "pickup": true
+            }, {
+                "id": 356,
+                "name": "Crossbow",
+                "pickup": true
+            }, {
+                "id": 357,
+                "name": "Bolts",
+                "pickup": true
+            }, {
+                "id": 358,
+                "name": "Bolts (poison)",
+                "pickup": true
+            }, {
+                "id": 359,
+                "name": "Bolts (explosive)",
+                "pickup": true
+            }, {
+                "id": 361,
+                "name": "Grenade Launcher",
+                "pickup": true
+            }, {
+                "id": 362,
+                "name": "Grenades",
+                "pickup": true
+            }, {
+                "id": 363,
+                "name": "Grenades (super)",
+                "pickup": true
+            }, {
+                "id": 364,
+                "name": "Grenades (flash)",
+                "pickup": true
+            }, {
+                "id": 368,
+                "name": "Large medipack",
+                "pickup": true
+            }, {
+                "id": 366,
+                "name": "Revolver",
+                "pickup": true
+            }, {
+                "id": 367,
+                "name": "Revolver ammo",
+                "pickup": true
+            }, {
+                "id": 369,
+                "name": "Small medipack",
+                "pickup": true
+            }, {
+                "id": 370,
+                "name": "Lasersight",
+                "pickup": true
+            }, {
+                "id": 373,
+                "name": "Flares",
+                "pickup": true
+            }, {
+                "id": 375,
+                "name": "Compass"
+            }, {
+                "id": 380,
+                "name": "White smoke emitter"
+            }, {
+                "id": 381,
+                "name": "Black smoke emitter"
+            }, {
+                "id": 382,
+                "name": "Steam emitter"
+            }, {
+                "id": 383,
+                "name": "Earthquake"
+            }, {
+                "id": 385,
+                "name": "Waterfall Mist"
+            }, {
+                "id": 390,
+                "name": "Sprinkler"
+            }, {
+                "id": 394,
+                "name": "Amber light"
+            }, {
+                "id": 397,
+                "name": "Lens flare"
+            }, {
+                "id": 402,
+                "name": "AI Follow"
+            }, {
+                "id": 404,
+                "name": "AI X1"
+            }, {
+                "id": 405,
+                "name": "AI X2"
+            }, {
+                "id": 406,
+                "name": "Lara Start Pos"
+            }, {
+                "id": 408,
+                "name": "Trigger triggerer"
+            }, {
+                "id": 422,
+                "name": "Camera Target"
+            }, {
+                "id": 423,
+                "name": "Waterfall"
+            }, {
+                "id": 424,
+                "name": "Waterfall"
+            }, {
+                "id": 425,
+                "name": "Waterfall"
+            }, {
+                "id": 426,
+                "name": "Planet effect"
+            }, {
+                "id": 427,
+                "name": "Animating 1"
+            }, {
+                "id": 429,
+                "name": "Animating 2"
+            }, {
+                "id": 431,
+                "name": "Animating 3"
+            }, {
+                "id": 433,
+                "name": "Animating 4"
+            }, {
+                "id": 435,
+                "name": "Animating 5"
+            }, {
+                "id": 437,
+                "name": "Animating 6"
+            }, {
+                "id": 439,
+                "name": "Animating 7"
+            }, {
+                "id": 441,
+                "name": "Animating 8"
+            }, {
+                "id": 443,
+                "name": "Animating 9"
+            }, {
+                "id": 445,
+                "name": "Animating 10"
+            }, {
+                "id": 447,
+                "name": "Animating 11"
+            }, {
+                "id": 449,
+                "name": "Animating 12"
+            }, {
+                "id": 451,
+                "name": "Animating 13"
+            }, {
+                "id": 453,
+                "name": "Animating 14"
+            }, {
+                "id": 455,
+                "name": "Animating 15"
+            }, {
                 "id": 457,
                 "name" : "Animating 16"
             }
-		],
-		"tr5": [{
-				"id": 0,
-				"name": "Lara"
-			}, {
-				"id": 1,
-				"name": "LaraPistolsAnim"
-			}, {
-				"id": 2,
-				"name": "LaraUzisAnim"
-			}, {
-				"id": 3,
-				"name": "LaraShotgunAnim"
-			}, {
-				"id": 7,
-				"name": "LaraFlareAnim"
-			}, {
-				"id": 33,
-				"name": "SWAT"
-			}, {
-				"id": 35,
-				"name": "Advanced SWAT"
-			}, {
-				"id": 36,
-				"name": "Advanced SWAT mip"
-			}, {
-				"id": 37,
-				"name": "Guard"
-			}, {
-				"id": 38,
-				"name": "Blue Guard"
-			}, {
-				"id": 39,
-				"name": "Two Gun"
-			}, {
-				"id": 40,
-				"name": "Two gun mip"
-			}, {
-				"id": 41,
-				"name": "Dog"
-			}, {
-				"id": 42,
-				"name": "Dog mip"
-			}, {
-				"id": 43,
-				"name": "Crow"
-			}, {
-				"id": 44,
-				"name": "Crow mip"
-			}, {
-				"id": 45,
-				"name": "Larson"
-			}, {
-				"id": 46,
-				"name": "Larson mip"
-			}, {
-				"id": 48,
-				"name": "Pierre mip"
-			}, {
-				"id": 49,
-				"name": "Soldier (MG)"
-			}, {
-				"id": 50,
-				"name": "Soldier (MG) mip"
-			}, {
-				"id": 51,
-				"name": "Soldier (Pistols)"
-			}, {
-				"id": 54,
-				"name": "Sailor mip"
-			}, {
-				"id": 56,
-				"name": "Sub Captain"
-			}, {
-				"id": 57,
-				"name": "Lion"
-			}, {
-				"id": 59,
-				"name": "Gladiator"
-			}, {
-				"id": 61,
-				"name": "Soldier Statue"
-			}, {
-				"id": 63,
-				"name": "Hydra"
-			}, {
-				"id": 64,
-				"name": "Hydra mip"
-			}, {
-				"id": 65,
-				"name": "Guardian"
-			}, {
-				"id": 67,
-				"name": "Cyborg"
-			}, {
-				"id": 69,
-				"name": "Scientist"
-			}, {
-				"id": 71,
-				"name": "Will-o'-the-wisp"
-			}, {
-				"id": 73,
-				"name": "Skeleton"
-			}, {
-				"id": 77,
-				"name": "Maze Monster"
-			}, {
-				"id": 79,
-				"name": "Water Monster"
-			}, {
-				"id": 81,
-				"name": "Attack Sub"
-			}, {
-				"id": 83,
-				"name": "Sniper"
-			}, {
-				"id": 85,
-				"name": "Dog"
-			}, {
-				"id": 86,
-				"name": "Ventilator"
-			}, {
-				"id": 87,
-				"name": "Chef"
-			}, {
-				"id": 89,
-				"name": "Imp"
-			}, {
-				"id": 91,
-				"name": "Gunship"
-			}, {
-				"id": 93,
-				"name": "Bats"
-			}, {
-				"id": 94,
-				"name": "Rats"
-			}, {
-				"id": 95,
-				"name": "Spiders"
-			}, {
-				"id": 97,
-				"name": "Autogun"
-			}, {
-				"id": 98,
-				"name": "Cables"
-			}, {
-				"id": 99,
-				"name": "Dart"
-			}, {
-				"id": 100,
-				"name": "Dart Emitter"
-			}, {
-				"id": 102,
-				"name": "Falling Ceiling"
-			}, {
-				"id": 105,
-				"name": "Crumbling Floor"
-			}, {
-				"id": 106,
-				"name": "Trapdoor 1"
-			}, {
-				"id": 107,
-				"name": "Trapdoor 2"
-			}, {
-				"id": 108,
-				"name": "Trapdoor 3"
-			}, {
-				"id": 109,
-				"name": "Floor trapdoor 1"
-			}, {
-				"id": 110,
-				"name": "Floor trapdoor 2"
-			}, {
-				"id": 111,
-				"name": "Ceiling trapdoor"
-			}, {
-				"id": 114,
-				"name": "Boulder"
-			}, {
-				"id": 117,
-				"name": "Spikes"
-			}, {
-				"id": 118,
-				"name": "Ram"
-			}, {
-				"id": 121,
-				"name": "Flame"
-			}, {
-				"id": 122,
-				"name": "Flame"
-			}, {
-				"id": 123,
-				"name": "Flame"
-			}, {
-				"id": 124,
-				"name": "Cooker Flame"
-			}, {
-				"id": 125,
-				"name": "Roots"
-			}, {
-				"id": 126,
-				"name": "Rope"
-			}, {
-				"id": 128,
-				"name": "Pole"
-			}, {
-				"id": 129,
-				"name": "Propeller"
-			}, {
-				"id": 130,
-				"name": "Propeller"
-			}, {
-				"id": 131,
-				"name": "Grappling Target"
-			}, {
-				"id": 134,
-				"name": "Raising Block"
-			}, {
-				"id": 135,
-				"name": "Raising Block 2"
-			}, {
-				"id": 136,
-				"name": "Expanding Platform"
-			}, {
-				"id": 137,
-				"name": "Pushable 1"
-			}, {
-				"id": 138,
-				"name": "Pushable 2"
-			}, {
-				"id": 139,
-				"name": "Pushable 3"
-			}, {
-				"id": 140,
-				"name": "Pushable 4"
-			}, {
-				"id": 141,
-				"name": "Pushable 5"
-			}, {
-				"id": 142,
-				"name": "The Claw"
-			}, {
-				"id": 147,
-				"name": "Spark Emitter"
-			}, {
-				"id": 149,
-				"name": "Explosion"
-			}, {
-				"id": 150,
-				"name": "Iris Lightning"
-			}, {
-				"id": 151,
-				"name": "Monitor Screen"
-			}, {
-				"id": 152,
-				"name": "Security Screens"
-			}, {
-				"id": 153,
-				"name": "Motion Sensors"
-			}, {
-				"id": 154,
-				"name": "Tightrope"
-			}, {
-				"id": 155,
-				"name": "Horizontal Bar"
-			}, {
-				"id": 156,
-				"name": "X-Ray Controller"
-			}, {
-				"id": 158,
-				"name": "Portal"
-			}, {
-				"id": 159,
-				"name": "Generic Slot 1"
-			}, {
-				"id": 160,
-				"name": "Generic Slot 2"
-			}, {
-				"id": 161,
-				"name": "Generic Slot 3"
-			}, {
-				"id": 162,
-				"name": "Generic Slot 4"
-			}, {
-				"id": 164,
-				"name": "Cupboard"
-			}, {
-				"id": 166,
-				"name": "Drawer"
-			}, {
-				"id": 168,
-				"name": "Cupboard"
-			}, {
-				"id": 170,
-				"name": "Suitcase"
-			}, {
-				"id": 172,
-				"name": "Puzzle 1",
-				"pickup": true
-			}, {
-				"id": 173,
-				"name": "Puzzle 2",
-				"pickup": true
-			}, {
-				"id": 174,
-				"name": "Puzzle 3",
-				"pickup": true
-			}, {
-				"id": 175,
-				"name": "Puzzle 4",
-				"pickup": true
-			}, {
-				"id": 176,
-				"name": "Puzzle 5",
-				"pickup": true
-			}, {
-				"id": 180,
-				"name": "Puzzle 1 Combo 1",
-				"pickup": true
-			}, {
-				"id": 181,
-				"name": "Puzzle 1 Combo 2",
-				"pickup": true
-			}, {
-				"id": 182,
-				"name": "Puzzle 2 Combo 1",
-				"pickup": true
-			}, {
-				"id": 183,
-				"name": "Puzzle 2 Combo 2",
-				"pickup": true
-			}, {
-				"id": 184,
-				"name": "Puzzle 3 Combo 1",
-				"pickup": true
-			}, {
-				"id": 185,
-				"name": "Puzzle 3 Combo 2",
-				"pickup": true
-			}, {
-				"id": 186,
-				"name": "Puzzle 4 Combo 1",
-				"pickup": true
-			}, {
-				"id": 187,
-				"name": "Puzzle 4 Combo 2",
-				"pickup": true
-			}, {
-				"id": 196,
-				"name": "Key 1",
-				"pickup": true
-			}, {
-				"id": 197,
-				"name": "Key 2",
-				"pickup": true
-			}, {
-				"id": 198,
-				"name": "Key 3",
-				"pickup": true
-			}, {
-				"id": 199,
-				"name": "Key 4",
-				"pickup": true
-			}, {
-				"id": 200,
-				"name": "Key 5",
-				"pickup": true
-			}, {
-				"id": 201,
-				"name": "Key 6",
-				"pickup": true
-			}, {
-				"id": 202,
-				"name": "Key 7",
-				"pickup": true
-			}, {
-				"id": 203,
-				"name": "Key 8",
-				"pickup": true
-			}, {
-				"id": 220,
-				"name": "Pickup 1",
-				"pickup": true
-			}, {
-				"id": 221,
-				"name": "Pickup 2",
-				"pickup": true
-			}, {
-				"id": 222,
-				"name": "Pickup 3",
-				"pickup": true
-			}, {
-				"id": 223,
-				"name": "Secret",
-				"pickup": true
-			}, {
-				"id": 235,
-				"name": "Bottle",
-				"pickup": true
-			}, {
-				"id": 236,
-				"name": "Cloth",
-				"pickup": true
-			}, {
-				"id": 240,
-				"name": "Crowbar",
-				"pickup": true
-			}, {
-				"id": 241,
-				"name": "Torch",
-				"pickup": true
-			}, {
-				"id": 242,
-				"name": "Slot 1"
-			}, {
-				"id": 243,
-				"name": "Slot 2"
-			}, {
-				"id": 244,
-				"name": "Slot 3"
-			}, {
-				"id": 245,
-				"name": "Slot 4"
-			}, {
-				"id": 246,
-				"name": "Slot 5"
-			}, {
-				"id": 247,
-				"name": "Slot 6"
-			}, {
-				"id": 248,
-				"name": "Slot 7"
-			}, {
-				"id": 249,
-				"name": "Slot 8"
-			}, {
-				"id": 250,
-				"name": "Slot 1 Done"
-			}, {
-				"id": 251,
-				"name": "Slot 2 Done"
-			}, {
-				"id": 252,
-				"name": "Slot 3 Done"
-			}, {
-				"id": 253,
-				"name": "Slot 4 Done"
-			}, {
-				"id": 254,
-				"name": "Slot 5 Done"
-			}, {
-				"id": 255,
-				"name": "Slot 6 Done"
-			}, {
-				"id": 256,
-				"name": "Slot 7 Done"
-			}, {
-				"id": 257,
-				"name": "Slot 8 Done"
-			}, {
-				"id": 258,
-				"name": "Keyhole 1"
-			}, {
-				"id": 259,
-				"name": "Keyhole 2"
-			}, {
-				"id": 260,
-				"name": "Keyhole 3"
-			}, {
-				"id": 261,
-				"name": "Keyhole 4"
-			}, {
-				"id": 262,
-				"name": "Keyhole 5"
-			}, {
-				"id": 263,
-				"name": "Keyhole 6"
-			}, {
-				"id": 264,
-				"name": "Keyhole 7"
-			}, {
-				"id": 265,
-				"name": "Keyhole 8"
-			}, {
-				"id": 266,
-				"name": "Switch 1"
-			}, {
-				"id": 267,
-				"name": "Switch 2"
-			}, {
-				"id": 268,
-				"name": "Switch 3"
-			}, {
-				"id": 269,
-				"name": "Switch 4"
-			}, {
-				"id": 270,
-				"name": "Switch 5"
-			}, {
-				"id": 271,
-				"name": "Switch 6"
-			}, {
-				"id": 272,
-				"name": "Shoot switch 1"
-			}, {
-				"id": 273,
-				"name": "Shoot switch 2"
-			}, {
-				"id": 274,
-				"name": "Switch 7"
-			}, {
-				"id": 278,
-				"name": "Cog Switch"
-			}, {
-				"id": 280,
-				"name": "Jump Switch"
-			}, {
-				"id": 282,
-				"name": "Pole"
-			}, {
-				"id": 283,
-				"name": "Crow/Dove Switch"
-			}, {
-				"id": 284,
-				"name": "Door 1"
-			}, {
-				"id": 286,
-				"name": "Door 2"
-			}, {
-				"id": 288,
-				"name": "Door 3"
-			}, {
-				"id": 290,
-				"name": "Door 4"
-			}, {
-				"id": 292,
-				"name": "Door 5"
-			}, {
-				"id": 294,
-				"name": "Door 6"
-			}, {
-				"id": 296,
-				"name": "Door 7"
-			}, {
-				"id": 298,
-				"name": "Door 8"
-			}, {
-				"id": 300,
-				"name": "Closed Door 1"
-			}, {
-				"id": 302,
-				"name": "Closed Door 2"
-			}, {
-				"id": 304,
-				"name": "Closed Door 3"
-			}, {
-				"id": 306,
-				"name": "Closed Door 4"
-			}, {
-				"id": 308,
-				"name": "Closed Door 5"
-			}, {
-				"id": 310,
-				"name": "Closed Door 6"
-			}, {
-				"id": 312,
-				"name": "Lift Doors 1"
-			}, {
-				"id": 314,
-				"name": "Lift Doors 2"
-			}, {
-				"id": 320,
-				"name": "Kick Door 1"
-			}, {
-				"id": 326,
-				"name": "Double doors"
-			}, {
-				"id": 328,
-				"name": "Sequence Door 1"
-			}, {
-				"id": 329,
-				"name": "Sequence Switch 1"
-			}, {
-				"id": 330,
-				"name": "Sequence Switch 2"
-			}, {
-				"id": 331,
-				"name": "Sequence Switch 3"
-			}, {
-				"id": 332,
-				"name": "Steel Door"
-			}, {
-				"id": 334,
-				"name": "Pistols",
-				"pickup": true
-			}, {
-				"id": 335,
-				"name": "Pistol  Ammo",
-				"pickup": true
-			}, {
-				"id": 336,
-				"name": "Uzis",
-				"pickup": true
-			}, {
-				"id": 337,
-				"name": "Uzi Ammo",
-				"pickup": true
-			}, {
-				"id": 338,
-				"name": "Shotgun",
-				"pickup": true
-			}, {
-				"id": 339,
-				"name": "Shotgun ammo (red)",
-				"pickup": true
-			}, {
-				"id": 340,
-				"name": "Shotgun ammo (blue)",
-				"pickup": true
-			}, {
-				"id": 341,
-				"name": "Grappling Gun",
-				"pickup": true
-			}, {
-				"id": 342,
-				"name": "Grappling Ammo",
-				"pickup": true
-			}, {
-				"id": 345,
-				"name": "HK",
-				"pickup": true
-			}, {
-				"id": 346,
-				"name": "HK Ammo",
-				"pickup": true
-			}, {
-				"id": 347,
-				"name": "Revolver",
-				"pickup": true
-			}, {
-				"id": 348,
-				"name": "Revolver ammo",
-				"pickup": true
-			},  {
-				"id": 349,
-				"name": "Large medipack",
-				"pickup": true
-			}, {
-				"id": 350,
-				"name": "Small medipack",
-				"pickup": true
-			}, {
-				"id": 351,
-				"name": "Lasersight",
-				"pickup": true
-			}, {
-				"id": 354,
-				"name": "Flare",
-				"pickup": true
-			}, {
-				"id": 355,
-				"name": "Flares",
-				"pickup": true
-			}, {
-				"id": 356,
-				"name": "Compass"
-			}, {
-				"id": 363,
-				"name": "White smoke emitter"
-			}, {
-				"id": 364,
-				"name": "Black smoke emitter"
-			}, {
-				"id": 365,
-				"name": "Steam emitter"
-			}, {
-				"id": 366,
-				"name": "Earthquake"
-			}, {
-				"id": 367,
-				"name": "Bubbles"
-			}, {
-				"id": 368,
-				"name": "Waterfall Mist"
-			}, {
-				"id": 373,
-				"name": "Blinking Light"
-			}, {
-				"id": 374,
-				"name": "Pulsating Light"
-			}, {
-				"id": 375,
-				"name": "Strobe Light"
-			}, {
-				"id": 376,
-				"name": "Electrical Light"
-			}, {
-				"id": 378,
-				"name": "AIGuard"
-			}, {
-				"id": 379,
-				"name": "AIAmbush"
-			}, {
-				"id": 380,
-				"name": "AIPatrol1"
-			}, {
-				"id": 381,
-				"name": "AIModify"
-			}, {
-				"id": 382,
-				"name": "AIFollow"
-			}, {
-				"id": 383,
-				"name": "AIPatrol2"
-			}, {
-				"id": 384,
-				"name": "AI X1"
-			}, {
-				"id": 385,
-				"name": "AI X2"
-			}, {
-				"id": 386,
-				"name": "Lara Start Pos"
-			}, {
-				"id": 387,
-				"name": "Teleporter"
-			}, {
-				"id": 388,
-				"name": "Lift Teleporter"
-			}, {
-				"id": 389,
-				"name": "Raising Cog"
-			}, {
-				"id": 390,
-				"name": "Lasers"
-			}, {
-				"id": 391,
-				"name": "Steam lasers"
-			}, {
-				"id": 392,
-				"name": "Floor Lasers"
-			}, {
-				"id": 394,
-				"name": "Trigger triggerer"
-			}, {
-				"id": 395,
-				"name": "High Object 1"
-			}, {
-				"id": 396,
-				"name": "High Object 2"
-			}, {
-				"id": 397,
-				"name": "Smash Object 1"
-			}, {
-				"id": 398,
-				"name": "Smash Object 2"
-			}, {
-				"id": 409,
-				"name": "Camera Target"
-			}, {
-				"id": 410,
-				"name": "Waterfall 1"
-			}, {
-				"id": 411,
-				"name": "Waterfall 2"
-			}, {
-				"id": 412,
-				"name": "Waterfall 3"
-			}, {
-				"id": 413,
-				"name": "Fish tank"
-			}, {
-				"id": 414,
-				"name": "Waterfall 1"
-			}, {
-				"id": 415,
-				"name": "Waterfall 2"
-			}, {
-				"id": 416,
-				"name": "Animating 1"
-			}, {
-				"id": 417,
-				"name": "Animating 1 mip"
-			}, {
-				"id": 418,
-				"name": "Animating 2"
-			}, {
-				"id": 419,
-				"name": "Animating 2 mip"
-			}, {
-				"id": 420,
-				"name": "Animating 3"
-			}, {
-				"id": 421,
-				"name": "Animating 3 mip"
-			}, {
-				"id": 422,
-				"name": "Animating 4"
-			}, {
-				"id": 423,
-				"name": "Animating 4 mip"
-			}, {
-				"id": 424,
-				"name": "Animating 5"
-			}, {
-				"id": 425,
-				"name": "Animating 5 mip"
-			}, {
-				"id": 426,
-				"name": "Animating 6"
-			}, {
-				"id": 427,
-				"name": "Animating 6 mip"
-			}, {
-				"id": 428,
-				"name": "Animating 7"
-			}, {
-				"id": 429,
-				"name": "Animating 7 mip"
-			}, {
-				"id": 430,
-				"name": "Animating 8"
-			}, {
-				"id": 431,
-				"name": "Animating 8 mip"
-			}, {
-				"id": 432,
-				"name": "Animating 9"
-			}, {
-				"id": 433,
-				"name": "Animating 9 mip"
-			}, {
-				"id": 434,
-				"name": "Animating 10"
-			}, {
-				"id": 435,
-				"name": "Animating 10 mip"
-			}, {
-				"id": 436,
-				"name": "Animating 11"
-			}, {
-				"id": 437,
-				"name": "Animating 11 mip"
-			}, {
-				"id": 438,
-				"name": "Animating 12"
-			}, {
-				"id": 439,
-				"name": "Animating 12 mip"
-			}, {
-				"id": 440,
-				"name": "Animating 13"
-			}, {
-				"id": 441,
-				"name": "Animating 13 mip"
-			}, {
-				"id": 442,
-				"name": "Animating 14"
-			}, {
-				"id": 443,
-				"name": "Animating 14 mip"
-			}, {
-				"id": 444,
-				"name": "Animating 15"
-			}, {
-				"id": 445,
-				"name": "Animating 15 mip"
-			}, {
-				"id": 446,
-				"name": "Animating 16"
-			}, {
-				"id": 447,
-				"name": "Animating 16 mip"
-			}, {
-				"id": 448,
-				"name": "Bridge (Flat)"
-			}, {
-				"id": 450,
-				"name": "Bridge (Tilt 1)"
-			}, {
-				"id": 452,
-				"name": "Bridge (Tilt 2)"
-			}
-		]
-	}
+        ],
+        "tr5": [{
+                "id": 0,
+                "name": "Lara"
+            }, {
+                "id": 1,
+                "name": "LaraPistolsAnim"
+            }, {
+                "id": 2,
+                "name": "LaraUzisAnim"
+            }, {
+                "id": 3,
+                "name": "LaraShotgunAnim"
+            }, {
+                "id": 7,
+                "name": "LaraFlareAnim"
+            }, {
+                "id": 33,
+                "name": "SWAT"
+            }, {
+                "id": 35,
+                "name": "Advanced SWAT"
+            }, {
+                "id": 36,
+                "name": "Advanced SWAT mip"
+            }, {
+                "id": 37,
+                "name": "Guard"
+            }, {
+                "id": 38,
+                "name": "Blue Guard"
+            }, {
+                "id": 39,
+                "name": "Two Gun"
+            }, {
+                "id": 40,
+                "name": "Two gun mip"
+            }, {
+                "id": 41,
+                "name": "Dog"
+            }, {
+                "id": 42,
+                "name": "Dog mip"
+            }, {
+                "id": 43,
+                "name": "Crow"
+            }, {
+                "id": 44,
+                "name": "Crow mip"
+            }, {
+                "id": 45,
+                "name": "Larson"
+            }, {
+                "id": 46,
+                "name": "Larson mip"
+            }, {
+                "id": 48,
+                "name": "Pierre mip"
+            }, {
+                "id": 49,
+                "name": "Soldier (MG)"
+            }, {
+                "id": 50,
+                "name": "Soldier (MG) mip"
+            }, {
+                "id": 51,
+                "name": "Soldier (Pistols)"
+            }, {
+                "id": 54,
+                "name": "Sailor mip"
+            }, {
+                "id": 56,
+                "name": "Sub Captain"
+            }, {
+                "id": 57,
+                "name": "Lion"
+            }, {
+                "id": 59,
+                "name": "Gladiator"
+            }, {
+                "id": 61,
+                "name": "Soldier Statue"
+            }, {
+                "id": 63,
+                "name": "Hydra"
+            }, {
+                "id": 64,
+                "name": "Hydra mip"
+            }, {
+                "id": 65,
+                "name": "Guardian"
+            }, {
+                "id": 67,
+                "name": "Cyborg"
+            }, {
+                "id": 69,
+                "name": "Scientist"
+            }, {
+                "id": 71,
+                "name": "Will-o'-the-wisp"
+            }, {
+                "id": 73,
+                "name": "Skeleton"
+            }, {
+                "id": 77,
+                "name": "Maze Monster"
+            }, {
+                "id": 79,
+                "name": "Water Monster"
+            }, {
+                "id": 81,
+                "name": "Attack Sub"
+            }, {
+                "id": 83,
+                "name": "Sniper"
+            }, {
+                "id": 85,
+                "name": "Dog"
+            }, {
+                "id": 86,
+                "name": "Ventilator"
+            }, {
+                "id": 87,
+                "name": "Chef"
+            }, {
+                "id": 89,
+                "name": "Imp"
+            }, {
+                "id": 91,
+                "name": "Gunship"
+            }, {
+                "id": 93,
+                "name": "Bats"
+            }, {
+                "id": 94,
+                "name": "Rats"
+            }, {
+                "id": 95,
+                "name": "Spiders"
+            }, {
+                "id": 97,
+                "name": "Autogun"
+            }, {
+                "id": 98,
+                "name": "Cables"
+            }, {
+                "id": 99,
+                "name": "Dart"
+            }, {
+                "id": 100,
+                "name": "Dart Emitter"
+            }, {
+                "id": 102,
+                "name": "Falling Ceiling"
+            }, {
+                "id": 105,
+                "name": "Crumbling Floor"
+            }, {
+                "id": 106,
+                "name": "Trapdoor 1"
+            }, {
+                "id": 107,
+                "name": "Trapdoor 2"
+            }, {
+                "id": 108,
+                "name": "Trapdoor 3"
+            }, {
+                "id": 109,
+                "name": "Floor trapdoor 1"
+            }, {
+                "id": 110,
+                "name": "Floor trapdoor 2"
+            }, {
+                "id": 111,
+                "name": "Ceiling trapdoor"
+            }, {
+                "id": 114,
+                "name": "Boulder"
+            }, {
+                "id": 117,
+                "name": "Spikes"
+            }, {
+                "id": 118,
+                "name": "Ram"
+            }, {
+                "id": 121,
+                "name": "Flame"
+            }, {
+                "id": 122,
+                "name": "Flame"
+            }, {
+                "id": 123,
+                "name": "Flame"
+            }, {
+                "id": 124,
+                "name": "Cooker Flame"
+            }, {
+                "id": 125,
+                "name": "Roots"
+            }, {
+                "id": 126,
+                "name": "Rope"
+            }, {
+                "id": 128,
+                "name": "Pole"
+            }, {
+                "id": 129,
+                "name": "Propeller"
+            }, {
+                "id": 130,
+                "name": "Propeller"
+            }, {
+                "id": 131,
+                "name": "Grappling Target"
+            }, {
+                "id": 134,
+                "name": "Raising Block"
+            }, {
+                "id": 135,
+                "name": "Raising Block 2"
+            }, {
+                "id": 136,
+                "name": "Expanding Platform"
+            }, {
+                "id": 137,
+                "name": "Pushable 1"
+            }, {
+                "id": 138,
+                "name": "Pushable 2"
+            }, {
+                "id": 139,
+                "name": "Pushable 3"
+            }, {
+                "id": 140,
+                "name": "Pushable 4"
+            }, {
+                "id": 141,
+                "name": "Pushable 5"
+            }, {
+                "id": 142,
+                "name": "The Claw"
+            }, {
+                "id": 147,
+                "name": "Spark Emitter"
+            }, {
+                "id": 149,
+                "name": "Explosion"
+            }, {
+                "id": 150,
+                "name": "Iris Lightning"
+            }, {
+                "id": 151,
+                "name": "Monitor Screen"
+            }, {
+                "id": 152,
+                "name": "Security Screens"
+            }, {
+                "id": 153,
+                "name": "Motion Sensors"
+            }, {
+                "id": 154,
+                "name": "Tightrope"
+            }, {
+                "id": 155,
+                "name": "Horizontal Bar"
+            }, {
+                "id": 156,
+                "name": "X-Ray Controller"
+            }, {
+                "id": 158,
+                "name": "Portal"
+            }, {
+                "id": 159,
+                "name": "Generic Slot 1"
+            }, {
+                "id": 160,
+                "name": "Generic Slot 2"
+            }, {
+                "id": 161,
+                "name": "Generic Slot 3"
+            }, {
+                "id": 162,
+                "name": "Generic Slot 4"
+            }, {
+                "id": 164,
+                "name": "Cupboard"
+            }, {
+                "id": 166,
+                "name": "Drawer"
+            }, {
+                "id": 168,
+                "name": "Cupboard"
+            }, {
+                "id": 170,
+                "name": "Suitcase"
+            }, {
+                "id": 172,
+                "name": "Puzzle 1",
+                "pickup": true
+            }, {
+                "id": 173,
+                "name": "Puzzle 2",
+                "pickup": true
+            }, {
+                "id": 174,
+                "name": "Puzzle 3",
+                "pickup": true
+            }, {
+                "id": 175,
+                "name": "Puzzle 4",
+                "pickup": true
+            }, {
+                "id": 176,
+                "name": "Puzzle 5",
+                "pickup": true
+            }, {
+                "id": 180,
+                "name": "Puzzle 1 Combo 1",
+                "pickup": true
+            }, {
+                "id": 181,
+                "name": "Puzzle 1 Combo 2",
+                "pickup": true
+            }, {
+                "id": 182,
+                "name": "Puzzle 2 Combo 1",
+                "pickup": true
+            }, {
+                "id": 183,
+                "name": "Puzzle 2 Combo 2",
+                "pickup": true
+            }, {
+                "id": 184,
+                "name": "Puzzle 3 Combo 1",
+                "pickup": true
+            }, {
+                "id": 185,
+                "name": "Puzzle 3 Combo 2",
+                "pickup": true
+            }, {
+                "id": 186,
+                "name": "Puzzle 4 Combo 1",
+                "pickup": true
+            }, {
+                "id": 187,
+                "name": "Puzzle 4 Combo 2",
+                "pickup": true
+            }, {
+                "id": 196,
+                "name": "Key 1",
+                "pickup": true
+            }, {
+                "id": 197,
+                "name": "Key 2",
+                "pickup": true
+            }, {
+                "id": 198,
+                "name": "Key 3",
+                "pickup": true
+            }, {
+                "id": 199,
+                "name": "Key 4",
+                "pickup": true
+            }, {
+                "id": 200,
+                "name": "Key 5",
+                "pickup": true
+            }, {
+                "id": 201,
+                "name": "Key 6",
+                "pickup": true
+            }, {
+                "id": 202,
+                "name": "Key 7",
+                "pickup": true
+            }, {
+                "id": 203,
+                "name": "Key 8",
+                "pickup": true
+            }, {
+                "id": 220,
+                "name": "Pickup 1",
+                "pickup": true
+            }, {
+                "id": 221,
+                "name": "Pickup 2",
+                "pickup": true
+            }, {
+                "id": 222,
+                "name": "Pickup 3",
+                "pickup": true
+            }, {
+                "id": 223,
+                "name": "Secret",
+                "pickup": true
+            }, {
+                "id": 235,
+                "name": "Bottle",
+                "pickup": true
+            }, {
+                "id": 236,
+                "name": "Cloth",
+                "pickup": true
+            }, {
+                "id": 240,
+                "name": "Crowbar",
+                "pickup": true
+            }, {
+                "id": 241,
+                "name": "Torch",
+                "pickup": true
+            }, {
+                "id": 242,
+                "name": "Slot 1"
+            }, {
+                "id": 243,
+                "name": "Slot 2"
+            }, {
+                "id": 244,
+                "name": "Slot 3"
+            }, {
+                "id": 245,
+                "name": "Slot 4"
+            }, {
+                "id": 246,
+                "name": "Slot 5"
+            }, {
+                "id": 247,
+                "name": "Slot 6"
+            }, {
+                "id": 248,
+                "name": "Slot 7"
+            }, {
+                "id": 249,
+                "name": "Slot 8"
+            }, {
+                "id": 250,
+                "name": "Slot 1 Done"
+            }, {
+                "id": 251,
+                "name": "Slot 2 Done"
+            }, {
+                "id": 252,
+                "name": "Slot 3 Done"
+            }, {
+                "id": 253,
+                "name": "Slot 4 Done"
+            }, {
+                "id": 254,
+                "name": "Slot 5 Done"
+            }, {
+                "id": 255,
+                "name": "Slot 6 Done"
+            }, {
+                "id": 256,
+                "name": "Slot 7 Done"
+            }, {
+                "id": 257,
+                "name": "Slot 8 Done"
+            }, {
+                "id": 258,
+                "name": "Keyhole 1"
+            }, {
+                "id": 259,
+                "name": "Keyhole 2"
+            }, {
+                "id": 260,
+                "name": "Keyhole 3"
+            }, {
+                "id": 261,
+                "name": "Keyhole 4"
+            }, {
+                "id": 262,
+                "name": "Keyhole 5"
+            }, {
+                "id": 263,
+                "name": "Keyhole 6"
+            }, {
+                "id": 264,
+                "name": "Keyhole 7"
+            }, {
+                "id": 265,
+                "name": "Keyhole 8"
+            }, {
+                "id": 266,
+                "name": "Switch 1"
+            }, {
+                "id": 267,
+                "name": "Switch 2"
+            }, {
+                "id": 268,
+                "name": "Switch 3"
+            }, {
+                "id": 269,
+                "name": "Switch 4"
+            }, {
+                "id": 270,
+                "name": "Switch 5"
+            }, {
+                "id": 271,
+                "name": "Switch 6"
+            }, {
+                "id": 272,
+                "name": "Shoot switch 1"
+            }, {
+                "id": 273,
+                "name": "Shoot switch 2"
+            }, {
+                "id": 274,
+                "name": "Switch 7"
+            }, {
+                "id": 278,
+                "name": "Cog Switch"
+            }, {
+                "id": 280,
+                "name": "Jump Switch"
+            }, {
+                "id": 282,
+                "name": "Pole"
+            }, {
+                "id": 283,
+                "name": "Crow/Dove Switch"
+            }, {
+                "id": 284,
+                "name": "Door 1"
+            }, {
+                "id": 286,
+                "name": "Door 2"
+            }, {
+                "id": 288,
+                "name": "Door 3"
+            }, {
+                "id": 290,
+                "name": "Door 4"
+            }, {
+                "id": 292,
+                "name": "Door 5"
+            }, {
+                "id": 294,
+                "name": "Door 6"
+            }, {
+                "id": 296,
+                "name": "Door 7"
+            }, {
+                "id": 298,
+                "name": "Door 8"
+            }, {
+                "id": 300,
+                "name": "Closed Door 1"
+            }, {
+                "id": 302,
+                "name": "Closed Door 2"
+            }, {
+                "id": 304,
+                "name": "Closed Door 3"
+            }, {
+                "id": 306,
+                "name": "Closed Door 4"
+            }, {
+                "id": 308,
+                "name": "Closed Door 5"
+            }, {
+                "id": 310,
+                "name": "Closed Door 6"
+            }, {
+                "id": 312,
+                "name": "Lift Doors 1"
+            }, {
+                "id": 314,
+                "name": "Lift Doors 2"
+            }, {
+                "id": 320,
+                "name": "Kick Door 1"
+            }, {
+                "id": 326,
+                "name": "Double doors"
+            }, {
+                "id": 328,
+                "name": "Sequence Door 1"
+            }, {
+                "id": 329,
+                "name": "Sequence Switch 1"
+            }, {
+                "id": 330,
+                "name": "Sequence Switch 2"
+            }, {
+                "id": 331,
+                "name": "Sequence Switch 3"
+            }, {
+                "id": 332,
+                "name": "Steel Door"
+            }, {
+                "id": 334,
+                "name": "Pistols",
+                "pickup": true
+            }, {
+                "id": 335,
+                "name": "Pistol  Ammo",
+                "pickup": true
+            }, {
+                "id": 336,
+                "name": "Uzis",
+                "pickup": true
+            }, {
+                "id": 337,
+                "name": "Uzi Ammo",
+                "pickup": true
+            }, {
+                "id": 338,
+                "name": "Shotgun",
+                "pickup": true
+            }, {
+                "id": 339,
+                "name": "Shotgun ammo (red)",
+                "pickup": true
+            }, {
+                "id": 340,
+                "name": "Shotgun ammo (blue)",
+                "pickup": true
+            }, {
+                "id": 341,
+                "name": "Grappling Gun",
+                "pickup": true
+            }, {
+                "id": 342,
+                "name": "Grappling Ammo",
+                "pickup": true
+            }, {
+                "id": 345,
+                "name": "HK",
+                "pickup": true
+            }, {
+                "id": 346,
+                "name": "HK Ammo",
+                "pickup": true
+            }, {
+                "id": 347,
+                "name": "Revolver",
+                "pickup": true
+            }, {
+                "id": 348,
+                "name": "Revolver ammo",
+                "pickup": true
+            },  {
+                "id": 349,
+                "name": "Large medipack",
+                "pickup": true
+            }, {
+                "id": 350,
+                "name": "Small medipack",
+                "pickup": true
+            }, {
+                "id": 351,
+                "name": "Lasersight",
+                "pickup": true
+            }, {
+                "id": 354,
+                "name": "Flare",
+                "pickup": true
+            }, {
+                "id": 355,
+                "name": "Flares",
+                "pickup": true
+            }, {
+                "id": 356,
+                "name": "Compass"
+            }, {
+                "id": 363,
+                "name": "White smoke emitter"
+            }, {
+                "id": 364,
+                "name": "Black smoke emitter"
+            }, {
+                "id": 365,
+                "name": "Steam emitter"
+            }, {
+                "id": 366,
+                "name": "Earthquake"
+            }, {
+                "id": 367,
+                "name": "Bubbles"
+            }, {
+                "id": 368,
+                "name": "Waterfall Mist"
+            }, {
+                "id": 373,
+                "name": "Blinking Light"
+            }, {
+                "id": 374,
+                "name": "Pulsating Light"
+            }, {
+                "id": 375,
+                "name": "Strobe Light"
+            }, {
+                "id": 376,
+                "name": "Electrical Light"
+            }, {
+                "id": 378,
+                "name": "AIGuard"
+            }, {
+                "id": 379,
+                "name": "AIAmbush"
+            }, {
+                "id": 380,
+                "name": "AIPatrol1"
+            }, {
+                "id": 381,
+                "name": "AIModify"
+            }, {
+                "id": 382,
+                "name": "AIFollow"
+            }, {
+                "id": 383,
+                "name": "AIPatrol2"
+            }, {
+                "id": 384,
+                "name": "AI X1"
+            }, {
+                "id": 385,
+                "name": "AI X2"
+            }, {
+                "id": 386,
+                "name": "Lara Start Pos"
+            }, {
+                "id": 387,
+                "name": "Teleporter"
+            }, {
+                "id": 388,
+                "name": "Lift Teleporter"
+            }, {
+                "id": 389,
+                "name": "Raising Cog"
+            }, {
+                "id": 390,
+                "name": "Lasers"
+            }, {
+                "id": 391,
+                "name": "Steam lasers"
+            }, {
+                "id": 392,
+                "name": "Floor Lasers"
+            }, {
+                "id": 394,
+                "name": "Trigger triggerer"
+            }, {
+                "id": 395,
+                "name": "High Object 1"
+            }, {
+                "id": 396,
+                "name": "High Object 2"
+            }, {
+                "id": 397,
+                "name": "Smash Object 1"
+            }, {
+                "id": 398,
+                "name": "Smash Object 2"
+            }, {
+                "id": 409,
+                "name": "Camera Target"
+            }, {
+                "id": 410,
+                "name": "Waterfall 1"
+            }, {
+                "id": 411,
+                "name": "Waterfall 2"
+            }, {
+                "id": 412,
+                "name": "Waterfall 3"
+            }, {
+                "id": 413,
+                "name": "Fish tank"
+            }, {
+                "id": 414,
+                "name": "Waterfall 1"
+            }, {
+                "id": 415,
+                "name": "Waterfall 2"
+            }, {
+                "id": 416,
+                "name": "Animating 1"
+            }, {
+                "id": 417,
+                "name": "Animating 1 mip"
+            }, {
+                "id": 418,
+                "name": "Animating 2"
+            }, {
+                "id": 419,
+                "name": "Animating 2 mip"
+            }, {
+                "id": 420,
+                "name": "Animating 3"
+            }, {
+                "id": 421,
+                "name": "Animating 3 mip"
+            }, {
+                "id": 422,
+                "name": "Animating 4"
+            }, {
+                "id": 423,
+                "name": "Animating 4 mip"
+            }, {
+                "id": 424,
+                "name": "Animating 5"
+            }, {
+                "id": 425,
+                "name": "Animating 5 mip"
+            }, {
+                "id": 426,
+                "name": "Animating 6"
+            }, {
+                "id": 427,
+                "name": "Animating 6 mip"
+            }, {
+                "id": 428,
+                "name": "Animating 7"
+            }, {
+                "id": 429,
+                "name": "Animating 7 mip"
+            }, {
+                "id": 430,
+                "name": "Animating 8"
+            }, {
+                "id": 431,
+                "name": "Animating 8 mip"
+            }, {
+                "id": 432,
+                "name": "Animating 9"
+            }, {
+                "id": 433,
+                "name": "Animating 9 mip"
+            }, {
+                "id": 434,
+                "name": "Animating 10"
+            }, {
+                "id": 435,
+                "name": "Animating 10 mip"
+            }, {
+                "id": 436,
+                "name": "Animating 11"
+            }, {
+                "id": 437,
+                "name": "Animating 11 mip"
+            }, {
+                "id": 438,
+                "name": "Animating 12"
+            }, {
+                "id": 439,
+                "name": "Animating 12 mip"
+            }, {
+                "id": 440,
+                "name": "Animating 13"
+            }, {
+                "id": 441,
+                "name": "Animating 13 mip"
+            }, {
+                "id": 442,
+                "name": "Animating 14"
+            }, {
+                "id": 443,
+                "name": "Animating 14 mip"
+            }, {
+                "id": 444,
+                "name": "Animating 15"
+            }, {
+                "id": 445,
+                "name": "Animating 15 mip"
+            }, {
+                "id": 446,
+                "name": "Animating 16"
+            }, {
+                "id": 447,
+                "name": "Animating 16 mip"
+            }, {
+                "id": 448,
+                "name": "Bridge (Flat)"
+            }, {
+                "id": 450,
+                "name": "Bridge (Tilt 1)"
+            }, {
+                "id": 452,
+                "name": "Bridge (Tilt 2)"
+            }
+        ]
+    }
 
 }

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -302,16 +302,20 @@
                 "categories": [ "Scenery" ]
             }, {
                 "id": 77,
-                "name": "CutsceneActor1"
+                "name": "CutsceneActor1",
+                "categories": [ "Entity" ]
             }, {
                 "id": 78,
-                "name": "CutsceneActor2"
+                "name": "CutsceneActor2",
+                "categories": [ "Entity" ]
             }, {
                 "id": 79,
-                "name": "CutsceneActor3"
+                "name": "CutsceneActor3",
+                "categories": [ "Entity" ]
             }, {
                 "id": 80,
-                "name": "CutsceneActor4"
+                "name": "CutsceneActor4",
+                "categories": [ "Entity" ]
             }, {
                 "id": 81,
                 "name": "PassportClosed"
@@ -476,8 +480,7 @@
                 "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 127,
-                "name": "Lead Bar",
-                "categories": [ "Pickup", "Puzzle" ]
+                "name": "Lead Bar"
             }, {
                 "id": 128,
                 "name": "Midas Hand",
@@ -527,12 +530,21 @@
                 "name": "Keyhole 4",
                 "categories": [ "Keyhole" ]
             }, {
+                "id": 141,
+                "name": "Quest 1",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 142,
+                "name": "Quest 2",
+                "categories": [ "Pickup" ]
+            }, {
                 "id": 143,
                 "name": "Scion Piece",
                 "categories": [ "Pickup" ]
             }, {
                 "id": 144,
-                "name": "Scion Piece"
+                "name": "Scion Piece",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 145,
                 "name": "Scion",
@@ -545,6 +557,12 @@
                 "id": 147,
                 "name": "Scion Holder",
                 "categories": [ "Scenery" ]
+            }, {
+                "id": 148,
+                "name": "Quest 1"
+            }, {
+                "id": 149,
+                "name": "Quest 2"
             }, {
                 "id": 150,
                 "name": "ScionPiece2"
@@ -569,7 +587,8 @@
                 "categories": [ "Entity" ]
             }, {
                 "id": 162,
-                "name": "Suspended Shack"
+                "name": "Suspended Shack",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 163,
                 "name": "Mutant Egg (Big)",
@@ -2900,10 +2919,12 @@
                 "categories": [ "Entity" ]
             }, {
                 "id": 112,
-                "name": "Tile spinner"
+                "name": "Tile spinner",
+                "categories": [ "Puzzle" ]
             }, {
                 "id": 113,
-                "name": "Scales"
+                "name": "Scales",
+                "categories": [ "Slot" ]
             }, {
                 "id": 114,
                 "name": "Dart",
@@ -3010,13 +3031,16 @@
                 "categories": [ "Trap" ]
             }, {
                 "id": 146,
-                "name": "Rope"
+                "name": "Rope",
+                "categories": [ "Interactable" ]
             }, {
                 "id": 147,
-                "name": "Fire rope"
+                "name": "Fire rope",
+                "categories": [ "Puzzle" ]
             }, {
                 "id": 148,
-                "name": "Pole"
+                "name": "Pole",
+                "categories": [ "Interactable" ]
             }, {
                 "id": 150,
                 "name": "Platform"
@@ -3094,7 +3118,8 @@
                 "categories": [ "Trap" ]
             }, {
                 "id": 173,
-                "name": "Lightning conductor"
+                "name": "Lightning conductor",
+                "categories": [ "Trap" ]
             }, {
                 "id": 174,
                 "name": "Element Puzzle"
@@ -3252,19 +3277,24 @@
                 "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 231,
-                "name": "Item 1"
+                "name": "Item 1",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 232,
-                "name": "Item 2"
+                "name": "Item 2",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 243,
-                "name": "Examine 1"
+                "name": "Examine 1",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 244,
-                "name": "Examine 2"
+                "name": "Examine 2",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 245,
-                "name": "Examine 3"
+                "name": "Examine 3",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 246,
                 "name": "Crowbar",
@@ -3467,7 +3497,8 @@
                 "categories": [ "Switch" ]
             }, {
                 "id": 321,
-                "name": "Pulley"
+                "name": "Pulley",
+                "categories": [ "Switch" ]
             }, {
                 "id": 322,
                 "name": "Door 1",
@@ -3526,7 +3557,8 @@
                 "categories": [ "Scenery" ]
             }, {
                 "id": 339,
-                "name": "Sarcophagus"
+                "name": "Sarcophagus",
+                "categories": [ "Movable" ]
             }, {
                 "id": 340,
                 "name": "Sequence Door 1",

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -387,7 +387,7 @@
 				"name": "Midas Hand"
 			}, {
 				"id": 129,
-				"name": "Key 1"
+				"name": "Key 1",
 				"categories": [ "pickup", "key" ]
 			}, {
 				"id": 130,

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -2,7 +2,8 @@
 	"games": {
 		"tr1": [{
 				"id": 0,
-				"name": "Lara"
+				"name": "Lara",
+				"categories": [ "entity" ]
 			}, {
 				"id": 1,
 				"name": "LaraPistolsAnim"
@@ -387,6 +388,7 @@
 			}, {
 				"id": 129,
 				"name": "Key 1"
+				"categories": [ "pickup", "key" ]
 			}, {
 				"id": 130,
 				"name": "Key 2"

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -165,7 +165,8 @@
                 "categories": [ "Trap" ]
             }, {
                 "id": 41,
-                "name": "LiftingDoor"
+                "name": "LiftingDoor",
+                "categories": [ "Door", "Trapdoor" ]
             }, {
                 "id": 42,
                 "name": "Slamming Doors",
@@ -177,11 +178,11 @@
             }, {
                 "id": 44,
                 "name": "Hammer Handle",
-                "categories": [ "Puzzle" ]
+                "categories": [ "Trap" ]
             }, {
                 "id": 45,
                 "name": "Hammer Block",
-                "categories": [ "Puzzle" ]
+                "categories": [ "Trap" ]
             }, {
                 "id": 46,
                 "name": "Lightning Ball",
@@ -192,19 +193,19 @@
             }, {
                 "id": 48,
                 "name": "Pushable Block 1",
-                "categories": [ "Puzzle", "Movable" ]
+                "categories": [ "Movable" ]
             }, {
                 "id": 49,
                 "name": "Pushable Block 2",
-                "categories": [ "Puzzle", "Movable" ]
+                "categories": [ "Movable" ]
             }, {
                 "id": 50,
                 "name": "Pushable Block 3",
-                "categories": [ "Puzzle", "Movable" ]
+                "categories": [ "Movable" ]
             }, {
                 "id": 51,
                 "name": "Pushable Block 4",
-                "categories": [ "Puzzle", "Movable" ]
+                "categories": [ "Movable" ]
             }, {
                 "id": 52,
                 "name": "Moving Block"
@@ -406,16 +407,20 @@
                 "name": "Large medipack"
             }, {
                 "id": 110,
-                "name": "Puzzle 1"
+                "name": "Puzzle 1",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 111,
-                "name": "Puzzle 2"
+                "name": "Puzzle 2",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 112,
-                "name": "Puzzle 3"
+                "name": "Puzzle 3",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 113,
-                "name": "Puzzle 4"
+                "name": "Puzzle 4",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 114,
                 "name": "Puzzle 1"
@@ -430,37 +435,48 @@
                 "name": "Puzzle 4"
             }, {
                 "id": 118,
-                "name": "Slot 1"
+                "name": "Slot 1",
+                "categories": [ "Slot" ]
             }, {
                 "id": 119,
-                "name": "Slot 2"
+                "name": "Slot 2",
+                "categories": [ "Slot" ]
             }, {
                 "id": 120,
-                "name": "Slot 3"
+                "name": "Slot 3",
+                "categories": [ "Slot" ]
             }, {
                 "id": 121,
-                "name": "Slot 4"
+                "name": "Slot 4",
+                "categories": [ "Slot" ]
             }, {
                 "id": 122,
-                "name": "Slot 1 Done"
+                "name": "Slot 1 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 123,
-                "name": "Slot 2 Done"
+                "name": "Slot 2 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 124,
-                "name": "Slot 3 Done"
+                "name": "Slot 3 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 125,
-                "name": "Slot 4 Done"
+                "name": "Slot 4 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 126,
-                "name": "Lead Bar"
+                "name": "Lead Bar",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 127,
-                "name": "Lead Bar"
+                "name": "Lead Bar",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 128,
-                "name": "Midas Hand"
+                "name": "Midas Hand",
+                "categories": [ "Slot" ]
             }, {
                 "id": 129,
                 "name": "Key 1",
@@ -507,7 +523,8 @@
                 "categories": [ "Keyhole" ]
             }, {
                 "id": 143,
-                "name": "Scion Piece"
+                "name": "Scion Piece",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 144,
                 "name": "Scion Piece"
@@ -516,10 +533,12 @@
                 "name": "Scion"
             }, {
                 "id": 146,
-                "name": "Scion"
+                "name": "Scion",
+                "categories": [ "Entity" ]
             }, {
                 "id": 147,
-                "name": "Scion Holder"
+                "name": "Scion Holder",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 150,
                 "name": "ScionPiece2"
@@ -560,10 +579,12 @@
                 "name": "Gunflare"
             }, {
                 "id": 169,
-                "name": "Camera Target"
+                "name": "Camera Target",
+                "categories": [ "Effect" ]
             }, {
                 "id": 170,
-                "name": "Waterfall Mist"
+                "name": "Waterfall Mist",
+                "categories": [ "Effect", "Scenery" ]
             }, {
                 "id": 172,
                 "name": "MutantBullet"
@@ -592,13 +613,16 @@
                 "categories": [ "Trap" ]
             }, {
                 "id": 181,
-                "name": "MutantEggBig"
+                "name": "MutantEggBig",
+                "categories": [ "Entity" ]
             }, {
                 "id": 182,
-                "name": "Motorboat"
+                "name": "Motorboat",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 183,
-                "name": "Earthquake"
+                "name": "Earthquake",
+                "categories": [ "Effect" ]
             }, {
                 "id": 189,
                 "name": "LaraPonytail"

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -4567,28 +4567,36 @@
                 "name": "Electrical Light"
             }, {
                 "id": 378,
-                "name": "AIGuard"
+                "name": "AIGuard",
+                "categories": [ "AI" ]
             }, {
                 "id": 379,
-                "name": "AIAmbush"
+                "name": "AIAmbush",
+                "categories": [ "AI" ]
             }, {
                 "id": 380,
-                "name": "AIPatrol1"
+                "name": "AIPatrol1",
+                "categories": [ "AI" ]
             }, {
                 "id": 381,
-                "name": "AIModify"
+                "name": "AIModify",
+                "categories": [ "AI" ]
             }, {
                 "id": 382,
-                "name": "AIFollow"
+                "name": "AIFollow",
+                "categories": [ "AI" ]
             }, {
                 "id": 383,
-                "name": "AIPatrol2"
+                "name": "AIPatrol2",
+                "categories": [ "AI" ]
             }, {
                 "id": 384,
-                "name": "AI X1"
+                "name": "AI X1",
+                "categories": [ "AI" ]
             }, {
                 "id": 385,
-                "name": "AI X2"
+                "name": "AI X2",
+                "categories": [ "AI" ]
             }, {
                 "id": 386,
                 "name": "Lara Start Pos"

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -2659,7 +2659,8 @@
         ],
         "tr4": [{
                 "id": 0,
-                "name": "Lara"
+                "name": "Lara",
+                "categories": [ "Entity" ]
             }, {
                 "id": 1,
                 "name": "LaraPistolsAnim"
@@ -2671,139 +2672,184 @@
                 "name": "LaraShotgunAnim"
             }, {
                 "id": 31,
-                "name": "Motorbike"
+                "name": "Motorbike",
+                "categories": [ "Vehicle" ]
             }, {
                 "id": 32,
-                "name": "Jeep"
+                "name": "Jeep",
+                "categories": [ "Vehicle" ]
             }, {
                 "id": 34,
-                "name": "Enemy jeep"
+                "name": "Enemy jeep",
+                "categories": [ "Vehicle" ]
             }, {
                 "id": 35,
-                "name": "Skeleton"
+                "name": "Skeleton",
+                "categories": [ "Entity" ]
             }, {
                 "id": 37,
-                "name": "Guide"
+                "name": "Guide",
+                "categories": [ "Entity" ]
             }, {
                 "id": 39,
-                "name": "Von Croy"
+                "name": "Von Croy",
+                "categories": [ "Entity" ]
             }, {
                 "id": 41,
-                "name": "Enemy 1"
+                "name": "Enemy 1",
+                "categories": [ "Entity" ]
             }, {
                 "id": 43,
-                "name": "Enemy 2"
+                "name": "Enemy 2",
+                "categories": [ "Entity" ]
             }, {
                 "id": 45,
-                "name": "Horus"
+                "name": "Horus",
+                "categories": [ "Entity" ]
             }, {
                 "id": 47,
-                "name": "Mummy"
+                "name": "Mummy",
+                "categories": [ "Entity" ]
             }, {
                 "id": 49,
-                "name": "Guardian"
+                "name": "Guardian",
+                "categories": [ "Entity" ]
             }, {
                 "id": 51,
-                "name": "Crocodile"
+                "name": "Crocodile",
+                "categories": [ "Entity" ]
             }, {
                 "id": 53,
-                "name": "Horseman"
+                "name": "Horseman",
+                "categories": [ "Entity" ]
             }, {
                 "id": 55,
-                "name": "Giant Scorpion"
+                "name": "Giant Scorpion",
+                "categories": [ "Entity" ]
             }, {
                 "id": 57,
-                "name": "Jean Yves"
+                "name": "Jean Yves",
+                "categories": [ "Entity" ]
             }, {
                 "id": 59,
-                "name": "Soldier"
+                "name": "Soldier",
+                "categories": [ "Entity" ]
             }, {
                 "id": 61,
-                "name": "Knight Templar"
+                "name": "Knight Templar",
+                "categories": [ "Entity" ]
             }, {
                 "id": 63,
-                "name": "Dragon"
+                "name": "Dragon",
+                "categories": [ "Entity" ]
             }, {
                 "id": 65,
-                "name": "Horse"
+                "name": "Horse",
+                "categories": [ "Entity" ]
             }, {
                 "id": 67,
-                "name": "Monkey"
+                "name": "Monkey",
+                "categories": [ "Entity" ]
             }, {
                 "id": 69,
-                "name": "Monkey (invisible)"
+                "name": "Monkey (invisible)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 71,
-                "name": "Monkey (black)"
+                "name": "Monkey (black)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 73,
-                "name": "Boar"
+                "name": "Boar",
+                "categories": [ "Entity" ]
             }, {
                 "id": 75,
-                "name": "Harpy"
+                "name": "Harpy",
+                "categories": [ "Entity" ]
             }, {
                 "id": 77,
-                "name": "Demigod 1"
+                "name": "Demigod 1",
+                "categories": [ "Entity" ]
             }, {
                 "id": 79,
-                "name": "Demigod 2"
+                "name": "Demigod 2",
+                "categories": [ "Entity" ]
             }, {
                 "id": 81,
-                "name": "Demigod 3"
+                "name": "Demigod 3",
+                "categories": [ "Entity" ]
             }, {
                 "id": 83,
-                "name": "Scarab"
+                "name": "Scarab",
+                "categories": [ "Entity" ]
             }, {
                 "id": 84,
-                "name": "Giant Beetle"
+                "name": "Giant Beetle",
+                "categories": [ "Entity" ]
             }, {
                 "id": 86,
-                "name": "Wraith 1"
+                "name": "Wraith 1",
+                "categories": [ "Entity" ]
             }, {
                 "id": 87,
-                "name": "Wraith 2"
+                "name": "Wraith 2",
+                "categories": [ "Entity" ]
             }, {
                 "id": 88,
-                "name": "Wraith 3"
+                "name": "Wraith 3",
+                "categories": [ "Entity" ]
             }, {
                 "id": 90,
-                "name": "Bat"
+                "name": "Bat",
+                "categories": [ "Entity" ]
             }, {
                 "id": 91,
-                "name": "Dog"
+                "name": "Dog",
+                "categories": [ "Entity" ]
             }, {
                 "id": 93,
-                "name": "Hammerhead"
+                "name": "Hammerhead",
+                "categories": [ "Entity" ]
             }, {
                 "id": 95,
-                "name": "Soldier"
+                "name": "Soldier",
+                "categories": [ "Entity" ]
             }, {
                 "id": 101,
-                "name": "Dead soldier"
+                "name": "Dead soldier",
+                "categories": [ "Entity" ]
             }, {
                 "id": 102,
-                "name": "Ammit"
+                "name": "Ammit",
+                "categories": [ "Entity" ]
             }, {
                 "id": 104,
-                "name": "Lara double"
+                "name": "Lara double",
+                "categories": [ "Entity" ]
             }, {
                 "id": 106,
-                "name": "Scorpion"
+                "name": "Scorpion",
+                "categories": [ "Entity" ]
             }, {
                 "id": 107,
-                "name": "Fish"
+                "name": "Fish",
+                "categories": [ "Entity" ]
             }, {
                 "id": 108,
-                "name": "Senet (red)"
+                "name": "Senet (red)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 109,
-                "name": "Senet (green)"
+                "name": "Senet (green)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 110,
-                "name": "Senet (blue)"
+                "name": "Senet (blue)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 111,
-                "name": "Senet (enemy)"
+                "name": "Senet (enemy)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 112,
                 "name": "Tile spinner"
@@ -2812,82 +2858,108 @@
                 "name": "Scales"
             }, {
                 "id": 114,
-                "name": "Dart"
+                "name": "Dart",
+                "categories": [ "Trap" ]
             }, {
                 "id": 115,
-                "name": "Dart Emitter"
+                "name": "Dart Emitter",
+                "categories": [ "Trap" ]
             }, {
                 "id": 117,
-                "name": "Falling Ceiling"
+                "name": "Falling Ceiling",
+                "categories": [ "Trap" ]
             }, {
                 "id": 118,
-                "name": "Breakable Tile"
+                "name": "Breakable Tile",
+                "categories": [ "Trap" ]
             }, {
                 "id": 120,
-                "name": "Breakable wall"
+                "name": "Breakable wall",
+                "categories": [ "Trap" ]
             }, {
                 "id": 121,
-                "name": "Breakable floor"
+                "name": "Breakable floor",
+                "categories": [ "Trap" ]
             }, {
                 "id": 122,
-                "name": "Trapdoor 1"
+                "name": "Trapdoor 1",
+                "categories": [ "Trapdoor", "Door" ]
             }, {
                 "id": 123,
-                "name": "Trapdoor 2"
+                "name": "Trapdoor 2",
+                "categories": [ "Trapdoor", "Door" ]
             }, {
                 "id": 124,
-                "name": "Trapdoor 3"
+                "name": "Trapdoor 3",
+                "categories": [ "Trapdoor", "Door" ]
             }, {
                 "id": 125,
-                "name": "Floor Trapdoor 1"
+                "name": "Floor Trapdoor 1",
+                "categories": [ "Trapdoor", "Door" ]
             }, {
                 "id": 126,
-                "name": "Floor Trapdoor 2"
+                "name": "Floor Trapdoor 2",
+                "categories": [ "Trapdoor", "Door" ]
             }, {
                 "id": 127,
-                "name": "Ceiling trapdoor"
+                "name": "Ceiling trapdoor",
+                "categories": [ "Trapdoor", "Door" ]
             }, {
                 "id": 130,
-                "name": "Boulder"
+                "name": "Boulder",
+                "categories": [ "Trap" ]
             }, {
                 "id": 132,
-                "name": "Spikes"
+                "name": "Spikes",
+                "categories": [ "Trap" ]
             }, {
                 "id": 133,
-                "name": "Drill blades"
+                "name": "Drill blades",
+                "categories": [ "Trap" ]
             }, {
                 "id": 134,
-                "name": "Rolling Spikes"
+                "name": "Rolling Spikes",
+                "categories": [ "Trap" ]
             }, {
                 "id": 135,
-                "name": "Flame emitter"
+                "name": "Flame emitter",
+                "categories": [ "Trap" ]
             }, {
                 "id": 136,
-                "name": "Rotating blade"
+                "name": "Rotating blade",
+                "categories": [ "Trap" ]
             }, {
                 "id": 137,
-                "name": "Blade ring"
+                "name": "Blade ring",
+                "categories": [ "Trap" ]
             }, {
                 "id": 138,
-                "name": "Hammer"
+                "name": "Hammer",
+                "categories": [ "Trap" ]
             }, {
                 "id": 139,
-                "name": "Burning floor"
+                "name": "Burning floor",
+                "categories": [ "Trap" ]
             }, {
                 "id": 140,
-                "name": "Cog"
+                "name": "Cog",
+                "categories": [ "Trap" ]
             }, {
                 "id": 141,
-                "name": "Spike ball"
+                "name": "Spike ball",
+                "categories": [ "Trap" ]
             }, {
                 "id": 143,
-                "name": "Flame emitter"
+                "name": "Flame emitter",
+                "categories": [ "Trap" ]
             }, {
                 "id": 144,
-                "name": "Flame emitter"
+                "name": "Flame emitter",
+                "categories": [ "Trap" ]
             }, {
                 "id": 145,
-                "name": "Flame emitter"
+                "name": "Flame emitter",
+                "categories": [ "Trap" ]
             }, {
                 "id": 146,
                 "name": "Rope"
@@ -2917,22 +2989,28 @@
                 "name": "Falling block"
             }, {
                 "id": 156,
-                "name": "Pushable 1"
+                "name": "Pushable 1",
+                "categories": [ "Movable" ]
             }, {
                 "id": 157,
-                "name": "Pushable 2"
+                "name": "Pushable 2",
+                "categories": [ "Movable" ]
             }, {
                 "id": 158,
-                "name": "Pushable 3"
+                "name": "Pushable 3",
+                "categories": [ "Movable" ]
             }, {
                 "id": 159,
-                "name": "Pushable 4"
+                "name": "Pushable 4",
+                "categories": [ "Movable" ]
             }, {
                 "id": 160,
-                "name": "Pushable 5"
+                "name": "Pushable 5",
+                "categories": [ "Movable" ]
             }, {
                 "id": 162,
-                "name": "Sentry Gun"
+                "name": "Sentry Gun",
+                "categories": [ "Entity" ]
             }, {
                 "id": 163,
                 "name": "Helicopter"
@@ -2944,22 +3022,28 @@
                 "name": "Obelisk"
             }, {
                 "id": 166,
-                "name": "Blade trap"
+                "name": "Blade trap",
+                "categories": [ "Trap" ]
             }, {
                 "id": 168,
-                "name": "Bird blade"
+                "name": "Bird blade",
+                "categories": [ "Trap" ]
             }, {
                 "id": 169,
-                "name": "Blade trap"
+                "name": "Blade trap",
+                "categories": [ "Trap" ]
             }, {
                 "id": 170,
-                "name": "Wall blade"
+                "name": "Wall blade",
+                "categories": [ "Trap" ]
             }, {
                 "id": 171,
-                "name": "Pedestal blades"
+                "name": "Pedestal blades",
+                "categories": [ "Trap" ]
             }, {
                 "id": 172,
-                "name": "Blade"
+                "name": "Blade",
+                "categories": [ "Trap" ]
             }, {
                 "id": 173,
                 "name": "Lightning conductor"
@@ -2969,154 +3053,192 @@
             }, {
                 "id": 175,
                 "name": "Puzzle 1",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 176,
                 "name": "Puzzle 2",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 177,
                 "name": "Puzzle 3",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 178,
                 "name": "Puzzle 4",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 179,
                 "name": "Puzzle 5",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 180,
                 "name": "Puzzle 6",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 181,
                 "name": "Puzzle 7",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 182,
                 "name": "Puzzle 8",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 183,
                 "name": "Puzzle 9",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 184,
                 "name": "Puzzle 10",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 185,
                 "name": "Puzzle 11",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 186,
                 "name": "Puzzle 12",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 187,
                 "name": "Puzzle 1 Combo 1",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 188,
                 "name": "Puzzle 1 Combo 2",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 189,
                 "name": "Puzzle 2 Combo 1",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 190,
                 "name": "Puzzle 2 Combo 2",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 193,
                 "name": "Puzzle 4 Combo 1",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 194,
                 "name": "Puzzle 4 Combo 2",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 195,
                 "name": "Puzzle 5 Combo 1",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 196,
                 "name": "Puzzle 5 Combo 2",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 197,
                 "name": "Puzzle 6 Combo 1",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 198,
                 "name": "Puzzle 6 Combo 2",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 199,
                 "name": "Puzzle 7 Combo 1",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 200,
                 "name": "Puzzle 7 Combo 2",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 201,
                 "name": "Puzzle 8 Combo 1",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 202,
                 "name": "Puzzle 8 Combo 2",
+                "categories": [ "Pickup", "Puzzle" ],
                 "pickup": true
             }, {
                 "id": 203,
                 "name": "Key 1",
+                "categories": [ "Pickup", "Key" ],
                 "pickup": true
             }, {
                 "id": 204,
                 "name": "Key 2",
+                "categories": [ "Pickup", "Key" ],
                 "pickup": true
             }, {
                 "id": 205,
                 "name": "Key 3",
+                "categories": [ "Pickup", "Key" ],
                 "pickup": true
             }, {
                 "id": 206,
                 "name": "Key 4",
+                "categories": [ "Pickup", "Key" ],
                 "pickup": true
             }, {
                 "id": 207,
                 "name": "Key 5",
+                "categories": [ "Pickup", "Key" ],
                 "pickup": true
             }, {
                 "id": 208,
                 "name": "Key 6",
+                "categories": [ "Pickup", "Key" ],
                 "pickup": true
             }, {
                 "id": 209,
                 "name": "Key 7",
+                "categories": [ "Pickup", "Key" ],
                 "pickup": true
             }, {
                 "id": 210,
                 "name": "Key 8",
+                "categories": [ "Pickup", "Key" ],
                 "pickup": true
             }, {
                 "id": 211,
                 "name": "Key 9",
+                "categories": [ "Pickup", "Key" ],
                 "pickup": true
             }, {
                 "id": 212,
                 "name": "Key 10",
+                "categories": [ "Pickup", "Key" ],
                 "pickup": true
             }, {
                 "id": 213,
                 "name": "Key 11",
+                "categories": [ "Pickup", "Key" ],
                 "pickup": true
             }, {
                 "id": 214,
                 "name": "Key 12",
+                "categories": [ "Pickup", "Key" ],
                 "pickup": true
             }, {
                 "id": 231,
@@ -3136,217 +3258,285 @@
             }, {
                 "id": 246,
                 "name": "Crowbar",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 247,
                 "name": "Torch",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 249,
-                "name": "Winding Key"
+                "name": "Winding Key",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 250,
-                "name": "Mechanical Scarab"
+                "name": "Mechanical Scarab",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 252,
-                "name": "Quest Item 1"
+                "name": "Quest Item 1",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 253,
-                "name": "Quest Item 2"
+                "name": "Quest Item 2",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 254,
-                "name": "Quest Item 3"
+                "name": "Quest Item 3",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 255,
-                "name": "Quest Item 4"
+                "name": "Quest Item 4",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 256,
-                "name": "Quest Item 5"
+                "name": "Quest Item 5",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 257,
-                "name": "Quest Item 6"
+                "name": "Quest Item 6",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 260,
-                "name": "Slot 1"
+                "name": "Slot 1",
+                "categories": [ "Slot" ]
             }, {
                 "id": 261,
-                "name": "Slot 2"
+                "name": "Slot 2",
+                "categories": [ "Slot" ]
             }, {
                 "id": 262,
-                "name": "Slot 3"
+                "name": "Slot 3",
+                "categories": [ "Slot" ]
             }, {
                 "id": 263,
-                "name": "Slot 4"
+                "name": "Slot 4",
+                "categories": [ "Slot" ]
             }, {
                 "id": 264,
-                "name": "Slot 5"
+                "name": "Slot 5",
+                "categories": [ "Slot" ]
             }, {
                 "id": 265,
-                "name": "Slot 6"
+                "name": "Slot 6",
+                "categories": [ "Slot" ]
             }, {
                 "id": 266,
-                "name": "Slot 7"
+                "name": "Slot 7",
+                "categories": [ "Slot" ]
             }, {
                 "id": 267,
-                "name": "Slot 8"
+                "name": "Slot 8",
+                "categories": [ "Slot" ]
             }, {
                 "id": 268,
-                "name": "Slot 9"
+                "name": "Slot 9",
+                "categories": [ "Slot" ]
             }, {
                 "id": 269,
-                "name": "Slot 10"
+                "name": "Slot 10",
+                "categories": [ "Slot" ]
             }, {
                 "id": 270,
-                "name": "Slot 11"
+                "name": "Slot 11",
+                "categories": [ "Slot" ]
             }, {
                 "id": 271,
-                "name": "Slot 12"
+                "name": "Slot 12",
+                "categories": [ "Slot" ]
             }, {
                 "id": 284,
-                "name": "Lock 1"
+                "name": "Lock 1",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 285,
-                "name": "Lock 2"
+                "name": "Lock 2",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 286,
-                "name": "Lock 3"
+                "name": "Lock 3",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 287,
-                "name": "Lock 4"
+                "name": "Lock 4",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 288,
-                "name": "Lock 5"
+                "name": "Lock 5",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 289,
-                "name": "Lock 6"
+                "name": "Lock 6",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 290,
-                "name": "Lock 7"
+                "name": "Lock 7",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 291,
-                "name": "Lock 8"
+                "name": "Lock 8",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 292,
-                "name": "Lock 9"
+                "name": "Lock 9",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 293,
-                "name": "Lock 10"
+                "name": "Lock 10",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 294,
-                "name": "Lock 11"
+                "name": "Lock 11",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 295,
-                "name": "Lock 12"
+                "name": "Lock 12",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 296,
                 "name": "Waterskin 1",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 300,
                 "name": "Waterskin 2",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 306,
-                "name": "Switch 1"
+                "name": "Switch 1",
+                "categories": [ "Switch" ]
             }, {
                 "id": 307,
-                "name": "Switch 2"
+                "name": "Switch 2",
+                "categories": [ "Switch" ]
             }, {
                 "id": 308,
-                "name": "Switch 3"
+                "name": "Switch 3",
+                "categories": [ "Switch" ]
             }, {
                 "id": 309,
-                "name": "Switch 4"
+                "name": "Switch 4",
+                "categories": [ "Switch" ]
             }, {
                 "id": 310,
-                "name": "Switch 5"
+                "name": "Switch 5",
+                "categories": [ "Switch" ]
             }, {
                 "id": 311,
-                "name": "Switch 6"
+                "name": "Switch 6",
+                "categories": [ "Switch" ]
             }, {
                 "id": 312,
-                "name": "Switch 7"
+                "name": "Switch 7",
+                "categories": [ "Switch" ]
             }, {
                 "id": 313,
-                "name": "Switch 8"
+                "name": "Switch 8",
+                "categories": [ "Switch" ]
             }, {
                 "id": 315,
-                "name": "Lever (underwater)"
+                "name": "Lever (underwater)",
+                "categories": [ "Switch" ]
             }, {
                 "id": 316,
-                "name": "Turn lever"
+                "name": "Turn lever",
+                "categories": [ "Switch" ]
             }, {
                 "id": 317,
-                "name": "Wheel lever"
+                "name": "Wheel lever",
+                "categories": [ "Switch" ]
             }, {
                 "id": 318,
-                "name": "Lever"
+                "name": "Lever",
+                "categories": [ "Switch" ]
             }, {
                 "id": 319,
-                "name": "Jump lever"
+                "name": "Jump lever",
+                "categories": [ "Switch" ]
             }, {
                 "id": 320,
-                "name": "Crowbar lever"
+                "name": "Crowbar lever",
+                "categories": [ "Switch" ]
             }, {
                 "id": 321,
                 "name": "Pulley"
             }, {
                 "id": 322,
-                "name": "Door 1"
+                "name": "Door 1",
+                "categories": [ "Door" ]
             }, {
                 "id": 323,
-                "name": "Door 2"
+                "name": "Door 2",
+                "categories": [ "Door" ]
             }, {
                 "id": 324,
-                "name": "Door 3"
+                "name": "Door 3",
+                "categories": [ "Door" ]
             }, {
                 "id": 325,
-                "name": "Door 4"
+                "name": "Door 4",
+                "categories": [ "Door" ]
             }, {
                 "id": 326,
-                "name": "Door 5"
+                "name": "Door 5",
+                "categories": [ "Door" ]
             }, {
                 "id": 327,
-                "name": "Door 6"
+                "name": "Door 6",
+                "categories": [ "Door" ]
             }, {
                 "id": 328,
-                "name": "Door 7"
+                "name": "Door 7",
+                "categories": [ "Door" ]
             }, {
                 "id": 329,
-                "name": "Door 8"
+                "name": "Door 8",
+                "categories": [ "Door" ]
             }, {
                 "id": 330,
-                "name": "Push/pull door 1"
+                "name": "Push/pull door 1",
+                "categories": [ "Door" ]
             }, {
                 "id": 332,
-                "name": "Kick door 1"
+                "name": "Kick door 1",
+                "categories": [ "Door" ]
             }, {
                 "id": 334,
-                "name": "Underwater door"
+                "name": "Underwater door",
+                "categories": [ "Door" ]
             }, {
                 "id": 335,
-                "name": "Double doors"
+                "name": "Double doors",
+                "categories": [ "Door" ]
             }, {
                 "id": 336,
-                "name": "Bridge (flat)"
+                "name": "Bridge (flat)",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 337,
-                "name": "Bridge (tilt)"
+                "name": "Bridge (tilt)",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 339,
                 "name": "Sarcophagus"
             }, {
                 "id": 340,
-                "name": "Sequence Door 1"
+                "name": "Sequence Door 1",
+                "categories": [ "Door" ]
             }, {
                 "id": 341,
-                "name": "Sequence Button 3"
+                "name": "Sequence Button 3",
+                "categories": [ "Switch" ]
             }, {
                 "id": 342,
-                "name": "Sequence Button 1"
+                "name": "Sequence Button 1",
+                "categories": [ "Switch" ]
             }, {
                 "id": 343,
-                "name": "Sequence Button 2"
+                "name": "Sequence Button 2",
+                "categories": [ "Switch" ]
             }, {
                 "id": 344,
                 "name": "Cutscene"
@@ -3362,86 +3552,107 @@
             }, {
                 "id": 349,
                 "name": "Pistols",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 350,
                 "name": "Pistol Ammo",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 351,
                 "name": "Uzis",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 352,
                 "name": "Uzi Ammo",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 353,
                 "name": "Shotgun",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 354,
                 "name": "Shotgun ammo (red)",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 355,
                 "name": "Shotgun ammo (blue)",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 356,
                 "name": "Crossbow",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 357,
                 "name": "Bolts",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 358,
                 "name": "Bolts (poison)",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 359,
                 "name": "Bolts (explosive)",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 361,
                 "name": "Grenade Launcher",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 362,
                 "name": "Grenades",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 363,
                 "name": "Grenades (super)",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 364,
                 "name": "Grenades (flash)",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 368,
                 "name": "Large medipack",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 366,
                 "name": "Revolver",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 367,
                 "name": "Revolver ammo",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 369,
                 "name": "Small medipack",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 370,
                 "name": "Lasersight",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 373,
                 "name": "Flares",
+                "categories": [ "Pickup" ],
                 "pickup": true
             }, {
                 "id": 375,

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -208,7 +208,8 @@
                 "categories": [ "Movable" ]
             }, {
                 "id": 52,
-                "name": "Moving Block"
+                "name": "Moving Block",
+                "categories": [ "Movable" ]
             }, {
                 "id": 53,
                 "name": "Falling Ceiling",
@@ -1626,7 +1627,8 @@
         ],
         "tr3": [{
                 "id": 0,
-                "name": "Lara"
+                "name": "Lara",
+                "categories": [ "Entity" ]
             }, {
                 "id": 1,
                 "name": "LaraPistolsAnim"
@@ -1662,100 +1664,131 @@
                 "name": "LaraUPVAnim"
             }, {
                 "id": 12,
-                "name": "UPV"
+                "name": "UPV",
+                "categories": [ "Vehicle" ]
             }, {
                 "id": 14,
-                "name": "Kayak"
+                "name": "Kayak",
+                "categories": [ "Vehicle" ]
             }, {
                 "id": 15,
-                "name": "Inflatable Boat"
+                "name": "Inflatable Boat",
+                "categories": [ "Vehicle" ]
             }, {
                 "id": 16,
-                "name": "Quadbike"
+                "name": "Quadbike",
+                "categories": [ "Vehicle" ]
             }, {
                 "id": 17,
-                "name": "Minecart"
+                "name": "Minecart",
+                "categories": [ "Vehicle" ]
             }, {
                 "id": 18,
-                "name": "Turret"
+                "name": "Turret",
+                "categories": [ "Entity" ]
             }, {
                 "id": 19,
-                "name": "UPV"
+                "name": "UPV",
+                "categories": [ "Vehicle" ]
             }, {
                 "id": 20,
-                "name": "Tribesman (Axe)"
+                "name": "Tribesman (Axe)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 21,
-                "name": "Tribesman (Dart)"
+                "name": "Tribesman (Dart)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 22,
-                "name": "Dog"
+                "name": "Dog",
+                "categories": [ "Entity" ]
             }, {
                 "id": 23,
-                "name": "Rat"
+                "name": "Rat",
+                "categories": [ "Entity" ]
             }, {
                 "id": 24,
                 "name": "Kill All Triggers"
             }, {
                 "id": 25,
-                "name": "Killer Whale"
+                "name": "Killer Whale",
+                "categories": [ "Entity" ]
             }, {
                 "id": 26,
-                "name": "Scuba Diver"
+                "name": "Scuba Diver",
+                "categories": [ "Entity" ]
             }, {
                 "id": 27,
-                "name": "Crow"
+                "name": "Crow",
+                "categories": [ "Entity" ]
             }, {
                 "id": 28,
-                "name": "Tiger"
+                "name": "Tiger",
+                "categories": [ "Entity" ]
             }, {
                 "id": 29,
-                "name": "Vulture"
+                "name": "Vulture",
+                "categories": [ "Entity" ]
             }, {
                 "id": 30,
-                "name": "Target"
+                "name": "Target",
+                "categories": [ "Entity" ]
             }, {
                 "id": 31,
-                "name": "Crawler Mutant"
+                "name": "Crawler Mutant",
+                "categories": [ "Entity" ]
             }, {
                 "id": 32,
-                "name": "Crocodile"
+                "name": "Crocodile",
+                "categories": [ "Entity" ]
             }, {
                 "id": 34,
-                "name": "Compsognathus"
+                "name": "Compsognathus",
+                "categories": [ "Entity" ]
             }, {
                 "id": 35,
-                "name": "Lizard"
+                "name": "Lizard",
+                "categories": [ "Entity" ]
             }, {
                 "id": 36,
-                "name": "Puna"
+                "name": "Puna",
+                "categories": [ "Entity" ]
             }, {
                 "id": 37,
-                "name": "Mercenary"
+                "name": "Mercenary",
+                "categories": [ "Entity" ]
             }, {
                 "id": 38,
-                "name": "Hanging Raptor"
+                "name": "Hanging Raptor",
+                "categories": [ "Entity", "Scenery" ]
             }, {
                 "id": 39,
-                "name": "RX-Tech Guy (Red)"
+                "name": "RX-Tech Guy (Red)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 40,
-                "name": "RX-Tech Guy (White)"
+                "name": "RX-Tech Guy (White)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 41,
-                "name": "Dog"
+                "name": "Dog",
+                "categories": [ "Entity" ]
             }, {
                 "id": 42,
-                "name": "Crawler Mutant"
+                "name": "Crawler Mutant",
+                "categories": [ "Entity" ]
             }, {
                 "id": 44,
-                "name": "Wasp"
+                "name": "Wasp",
+                "categories": [ "Entity" ]
             }, {
                 "id": 45,
-                "name": "Monster"
+                "name": "Monster",
+                "categories": [ "Entity" ]
             }, {
                 "id": 46,
-                "name": "Monster (Claw)"
+                "name": "Monster (Claw)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 47,
                 "name": "Wasp Spawn"
@@ -1764,43 +1797,56 @@
                 "name": "Raptor Spawn"
             }, {
                 "id": 49,
-                "name": "Willard"
+                "name": "Willard",
+                "categories": [ "Entity" ]
             }, {
                 "id": 50,
-                "name": "Flamethrower Guy"
+                "name": "Flamethrower Guy",
+                "categories": [ "Entity" ]
             }, {
                 "id": 51,
-                "name": "Guard (MP5)"
+                "name": "Guard (MP5)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 53,
-                "name": "Punk"
+                "name": "Punk",
+                "categories": [ "Entity" ]
             }, {
                 "id": 56,
-                "name": "Guard (Handgun)"
+                "name": "Guard (Handgun)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 57,
-                "name": "Sophia Leigh"
+                "name": "Sophia Leigh",
+                "categories": [ "Entity" ]
             }, {
                 "id": 58,
-                "name": "Cleaner Robot"
+                "name": "Cleaner Robot",
+                "categories": [ "Entity" ]
             }, {
                 "id": 60,
-                "name": "MP (Baton)"
+                "name": "MP (Baton)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 61,
-                "name": "MP (Handgun)"
+                "name": "MP (Handgun)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 62,
-                "name": "Prisoner"
+                "name": "Prisoner",
+                "categories": [ "Entity" ]
             }, {
                 "id": 63,
-                "name": "MP (MP5)"
+                "name": "MP (MP5)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 64,
-                "name": "Gun Turret"
+                "name": "Gun Turret",
+                "categories": [ "Entity" ]
             }, {
                 "id": 65,
-                "name": "Dam Guard"
+                "name": "Dam Guard",
+                "categories": [ "Entity" ]
             }, {
                 "id": 66,
                 "name": "Tripwire"
@@ -1812,16 +1858,20 @@
                 "name": "Killer Tripwire"
             }, {
                 "id": 69,
-                "name": "Cobra"
+                "name": "Cobra",
+                "categories": [ "Entity" ]
             }, {
                 "id": 70,
-                "name": "Shiva"
+                "name": "Shiva",
+                "categories": [ "Entity" ]
             }, {
                 "id": 71,
-                "name": "Monkey"
+                "name": "Monkey",
+                "categories": [ "Entity" ]
             }, {
                 "id": 73,
-                "name": "Tony"
+                "name": "Tony",
+                "categories": [ "Entity" ]
             }, {
                 "id": 74,
                 "name": "AI Guard"
@@ -1851,34 +1901,44 @@
                 "name": "Unknown"
             }, {
                 "id": 83,
-                "name": "Breakable tile"
+                "name": "Breakable tile",
+                "categories": [ "Trap" ]
             }, {
                 "id": 86,
-                "name": "Swinging Thing"
+                "name": "Swinging Thing",
+                "categories": [ "Trap" ]
             }, {
                 "id": 87,
-                "name": "Spikes"
+                "name": "Spikes",
+                "categories": [ "Trap" ]
             }, {
                 "id": 88,
-                "name": "Boulder"
+                "name": "Boulder",
+                "categories": [ "Trap" ]
             }, {
                 "id": 89,
-                "name": "Giant Boulder"
+                "name": "Giant Boulder",
+                "categories": [ "Trap" ]
             }, {
                 "id": 90,
-                "name": "Dart"
+                "name": "Dart",
+                "categories": [ "Trap" ]
             }, {
                 "id": 91,
-                "name": "Dart Emitter"
+                "name": "Dart Emitter",
+                "categories": [ "Trap" ]
             }, {
                 "id": 94,
-                "name": "Skeleton Trap"
+                "name": "Skeleton Trap",
+                "categories": [ "Trap" ]
             }, {
                 "id": 97,
-                "name": "Pushable Block 1"
+                "name": "Pushable Block 1",
+                "categories": [ "Movable" ]
             }, {
                 "id": 98,
-                "name": "Pushable Block 2"
+                "name": "Pushable Block 2",
+                "categories": [ "Movable" ]
             }, {
                 "id": 101,
                 "name": "Breakable Window"
@@ -1887,46 +1947,60 @@
                 "name": "Breakable Window"
             }, {
                 "id": 106,
-                "name": "Hook"
+                "name": "Hook",
+                "categories": [ "Trap" ]
             }, {
                 "id": 107,
-                "name": "Falling Ceiling"
+                "name": "Falling Ceiling",
+                "categories": [ "Trap" ]
             }, {
                 "id": 108,
-                "name": "Rolling Spindle"
+                "name": "Rolling Spindle",
+                "categories": [ "Trap" ]
             }, {
                 "id": 110,
-                "name": "Train"
+                "name": "Train",
+                "categories": [ "Trap" ]
             }, {
                 "id": 111,
-                "name": "Wall Blade"
+                "name": "Wall Blade",
+                "categories": [ "Trap" ]
             }, {
                 "id": 113,
-                "name": "Icicles"
+                "name": "Icicles",
+                "categories": [ "Trap" ]
             }, {
                 "id": 114,
-                "name": "Spike Wall"
+                "name": "Spike Wall",
+                "categories": [ "Trap" ]
             }, {
                 "id": 116,
-                "name": "Spike Wall (Vertical)"
+                "name": "Spike Wall (Vertical)",
+                "categories": [ "Trap" ]
             }, {
                 "id": 117,
-                "name": "Wheel Door"
+                "name": "Wheel Door",
+                "categories": [ "Door" ]
             }, {
                 "id": 118,
-                "name": "Small Switch"
+                "name": "Small Switch",
+                "categories": [ "Switch" ]
             }, {
                 "id": 119,
-                "name": "Propeller/Diver/Meteor"
+                "name": "Propeller/Diver/Meteor",
+                "categories": [ "Trap" ]
             }, {
                 "id": 120,
-                "name": "Fan"
+                "name": "Fan",
+                "categories": [ "Trap" ]
             }, {
                 "id": 121,
-                "name": "Stamper/Drum/Blades"
+                "name": "Stamper/Drum/Blades",
+                "categories": [ "Trap" ]
             }, {
                 "id": 122,
-                "name": "Shiva"
+                "name": "Shiva",
+                "categories": [ "Entity" ]
             }, {
                 "id": 123,
                 "name": "MonkeyMedipackMeshswap"
@@ -1938,58 +2012,76 @@
                 "name": "UIFrame"
             }, {
                 "id": 127,
-                "name": "Zipline"
+                "name": "Zipline",
+                "categories": [ "Vehicle" ]
             }, {
                 "id": 128,
-                "name": "Button"
+                "name": "Button",
+                "categories": [ "Switch" ]
             }, {
                 "id": 129,
-                "name": "Wall Switch"
+                "name": "Wall Switch",
+                "categories": [ "Switch" ]
             }, {
                 "id": 130,
-                "name": "Underwater Lever"
+                "name": "Underwater Lever",
+                "categories": [ "Switch" ]
             }, {
                 "id": 131,
-                "name": "Door 1"
+                "name": "Door 1",
+                "categories": [ "Door" ]
             }, {
                 "id": 132,
-                "name": "Door 2"
+                "name": "Door 2",
+                "categories": [ "Door" ]
             }, {
                 "id": 133,
-                "name": "Door 3"
+                "name": "Door 3",
+                "categories": [ "Door" ]
             }, {
                 "id": 134,
-                "name": "Door 4"
+                "name": "Door 4",
+                "categories": [ "Door" ]
             }, {
                 "id": 135,
-                "name": "Door 5"
+                "name": "Door 5",
+                "categories": [ "Door" ]
             }, {
                 "id": 136,
-                "name": "Door 6"
+                "name": "Door 6",
+                "categories": [ "Door" ]
             }, {
                 "id": 137,
-                "name": "Door 7"
+                "name": "Door 7",
+                "categories": [ "Door" ]
             }, {
                 "id": 138,
-                "name": "Door 8"
+                "name": "Door 8",
+                "categories": [ "Door" ]
             }, {
                 "id": 139,
-                "name": "Trapdoor 1"
+                "name": "Trapdoor 1",
+                "categories": [ "Door", "Trapdoor" ]
             }, {
                 "id": 140,
-                "name": "Trapdoor 2"
+                "name": "Trapdoor 2",
+                "categories": [ "Door", "Trapdoor" ]
             }, {
                 "id": 141,
-                "name": "Trapdoor 3"
+                "name": "Trapdoor 3",
+                "categories": [ "Door", "Trapdoor" ]
             }, {
                 "id": 142,
-                "name": "Bridge (Flat)"
+                "name": "Bridge (Flat)",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 143,
-                "name": "Bridge (Tilt 1)"
+                "name": "Bridge (Tilt 1)",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 144,
-                "name": "Bridge (Tilt 2)"
+                "name": "Bridge (Tilt 2)",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 145,
                 "name": "PassportOpening"
@@ -2034,67 +2126,88 @@
                 "name": "Map"
             }, {
                 "id": 160,
-                "name": "Pistols"
+                "name": "Pistols",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 161,
-                "name": "Shotgun"
+                "name": "Shotgun",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 162,
-                "name": "Desert Eagle"
+                "name": "Desert Eagle",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 163,
-                "name": "Uzis"
+                "name": "Uzis",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 164,
-                "name": "Harpoon Gun"
+                "name": "Harpoon Gun",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 165,
-                "name": "MP5"
+                "name": "MP5",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 166,
-                "name": "Rocket Launcher"
+                "name": "Rocket Launcher",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 167,
-                "name": "Grenade Launcher"
+                "name": "Grenade Launcher",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 168,
-                "name": "PistolAmmoOnGround"
+                "name": "PistolAmmoOnGround",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 169,
-                "name": "Shotgun shells"
+                "name": "Shotgun shells",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 170,
-                "name": "Desert Eagle ammo"
+                "name": "Desert Eagle ammo",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 171,
-                "name": "Uzi ammo"
+                "name": "Uzi ammo",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 172,
-                "name": "Harpoons"
+                "name": "Harpoons",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 173,
-                "name": "MP5 ammo"
+                "name": "MP5 ammo",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 174,
-                "name": "Rocket"
+                "name": "Rocket",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 175,
-                "name": "Grenades"
+                "name": "Grenades",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 176,
-                "name": "Small Medipack"
+                "name": "Small Medipack",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 177,
-                "name": "Large Medipack"
+                "name": "Large Medipack",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 178,
-                "name": "Flares"
+                "name": "Flares",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 179,
-                "name": "Flare"
+                "name": "Flare",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 180,
-                "name": "Savegame Crystal"
+                "name": "Savegame Crystal",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 181,
                 "name": "Sunglasses"
@@ -2169,16 +2282,20 @@
                 "name": "SavegameCrystalInventory"
             }, {
                 "id": 205,
-                "name": "Puzzle 1"
+                "name": "Puzzle 1",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 206,
-                "name": "Puzzle 2"
+                "name": "Puzzle 2",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 207,
-                "name": "Puzzle 3"
+                "name": "Puzzle 3",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 208,
-                "name": "Puzzle 4"
+                "name": "Puzzle 4",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 209,
                 "name": "Puzzle 1"
@@ -2193,16 +2310,20 @@
                 "name": "Puzzle 4"
             }, {
                 "id": 213,
-                "name": "Slot 1"
+                "name": "Slot 1",
+                "categories": [ "Slot" ]
             }, {
                 "id": 214,
-                "name": "Slot 2"
+                "name": "Slot 2",
+                "categories": [ "Slot" ]
             }, {
                 "id": 215,
-                "name": "Slot 3"
+                "name": "Slot 3",
+                "categories": [ "Slot" ]
             }, {
                 "id": 216,
-                "name": "Slot 4"
+                "name": "Slot 4",
+                "categories": [ "Slot" ]
             }, {
                 "id": 217,
                 "name": "Slot 1 Done"
@@ -2217,16 +2338,20 @@
                 "name": "Slot 4 Done"
             }, {
                 "id": 224,
-                "name": "Key 1"
+                "name": "Key 1",
+                "categories": [ "Key" ]
             }, {
                 "id": 225,
-                "name": "Key 2"
+                "name": "Key 2",
+                "categories": [ "Key" ]
             }, {
                 "id": 226,
-                "name": "Key 3"
+                "name": "Key 3",
+                "categories": [ "Key" ]
             }, {
                 "id": 227,
-                "name": "Key 4"
+                "name": "Key 4",
+                "categories": [ "Key" ]
             }, {
                 "id": 228,
                 "name": "Key 1"
@@ -2241,22 +2366,28 @@
                 "name": "Key 4"
             }, {
                 "id": 232,
-                "name": "Keyhole 1"
+                "name": "Keyhole 1",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 233,
-                "name": "Keyhole 2"
+                "name": "Keyhole 2",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 234,
-                "name": "Keyhole 3"
+                "name": "Keyhole 3",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 235,
-                "name": "Keyhole 4"
+                "name": "Keyhole 4",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 236,
-                "name": "Quest Item 1"
+                "name": "Quest Item 1",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 237,
-                "name": "Quest Item 2"
+                "name": "Quest Item 2",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 238,
                 "name": "QuestItem1"
@@ -2265,16 +2396,20 @@
                 "name": "QuestItem2"
             }, {
                 "id": 240,
-                "name": "Infada Stone"
+                "name": "Infada Stone",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 241,
-                "name": "Element 115"
+                "name": "Element 115",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 242,
-                "name": "Eye Of Isis"
+                "name": "Eye Of Isis",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 243,
-                "name": "Ora Dagger"
+                "name": "Ora Dagger",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 244,
                 "name": "InfadaStone"
@@ -2307,28 +2442,34 @@
                 "name": "Ora Dagger"
             }, {
                 "id": 282,
-                "name": "FireBreathingDragonStatue"
+                "name": "FireBreathingDragonStatue",
+                "categories": [ "Trap" ]
             }, {
                 "id": 285,
                 "name": "UnknownVisible285"
             }, {
                 "id": 287,
-                "name": "T-Rex"
+                "name": "T-Rex",
+                "categories": [ "Entity" ]
             }, {
                 "id": 288,
-                "name": "Raptor"
+                "name": "Raptor",
+                "categories": [ "Entity" ]
             }, {
                 "id": 291,
-                "name": "Moving Lasers"
+                "name": "Moving Lasers",
+                "categories": [ "Trap" ]
             }, {
                 "id": 292,
-                "name": "Electrified Field"
+                "name": "Electrified Field",
+                "categories": [ "Trap" ]
             }, {
                 "id": 294,
                 "name": "Shadow Sprite"
             }, {
                 "id": 295,
-                "name": "Detonator"
+                "name": "Detonator",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 296,
                 "name": "Misc Sprites"
@@ -2346,10 +2487,12 @@
                 "name": "MP5Gunflare"
             }, {
                 "id": 304,
-                "name": "Camera Target"
+                "name": "Camera Target",
+                "categories": [ "Effect" ]
             }, {
                 "id": 305,
-                "name": "Waterfall Mist"
+                "name": "Waterfall Mist",
+                "categories": [ "Effect" ]
             }, {
                 "id": 306,
                 "name": "HarpoonFlying2"
@@ -2370,7 +2513,8 @@
                 "name": "Smoke"
             }, {
                 "id": 314,
-                "name": "Movable Boom"
+                "name": "Movable Boom",
+                "categories": [ "Trap" ]
             }, {
                 "id": 315,
                 "name": "LaraSkin"
@@ -2382,34 +2526,44 @@
                 "name": "UnknownVisible317"
             }, {
                 "id": 318,
-                "name": "Alarm Light"
+                "name": "Alarm Light",
+                "categories": [ "Effect" ]
             }, {
                 "id": 319,
-                "name": "Light"
+                "name": "Light",
+                "categories": [ "Effect" ]
             }, {
                 "id": 321,
-                "name": "Light 2"
+                "name": "Light 2",
+                "categories": [ "Effect" ]
             }, {
                 "id": 322,
-                "name": "Pulsating Light"
+                "name": "Pulsating Light",
+                "categories": [ "Effect" ]
             }, {
                 "id": 324,
-                "name": "Red Light"
+                "name": "Red Light",
+                "categories": [ "Effect" ]
             }, {
                 "id": 325,
-                "name": "Green Light"
+                "name": "Green Light",
+                "categories": [ "Effect" ]
             }, {
                 "id": 326,
-                "name": "Blue Light"
+                "name": "Blue Light",
+                "categories": [ "Effect" ]
             }, {
                 "id": 327,
-                "name": "Light 3"
+                "name": "Light 3",
+                "categories": [ "Effect" ]
             }, {
                 "id": 328,
-                "name": "Light 4"
+                "name": "Light 4",
+                "categories": [ "Effect" ]
             }, {
                 "id": 330,
-                "name": "Fire"
+                "name": "Fire",
+                "categories": [ "Trap" ]
             }, {
                 "id": 331,
                 "name": "Alternate Fire"
@@ -2433,13 +2587,16 @@
                 "name": "Greenish Smoke"
             }, {
                 "id": 338,
-                "name": "Piranhas"
+                "name": "Piranhas",
+                "categories": [ "Trap" ]
             }, {
                 "id": 339,
-                "name": "Fish"
+                "name": "Fish",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 347,
-                "name": "Bat Swarm"
+                "name": "Bat Swarm",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 349,
                 "name": "Animating 1"
@@ -2472,16 +2629,19 @@
                 "name": "UnknownID358"
             }, {
                 "id": 360,
-                "name": "Winston"
+                "name": "Winston",
+                "categories": [ "Entity" ]
             }, {
                 "id": 361,
-                "name": "Winston (Camo)"
+                "name": "Winston (Camo)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 362,
                 "name": "TimerFontGraphics"
             }, {
                 "id": 365,
-                "name": "Earthquake"
+                "name": "Earthquake",
+                "categories": [ "Effect" ]
             }, {
                 "id": 366,
                 "name": "YellowShellCasing"
@@ -2493,7 +2653,8 @@
                 "name": "Light Shaft"
             }, {
                 "id": 373,
-                "name": "Electrical Switch Box"
+                "name": "Electrical Switch Box",
+                "categories": [ "Effect", "Scenery" ]
             }
         ],
         "tr4": [{

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -709,7 +709,8 @@
         ],
         "tr2": [{
                 "id": 0,
-                "name": "Lara"
+                "name": "Lara",
+                "categories": [ "Entity" ]
             }, {
                 "id": 1,
                 "name": "LaraPistolsAnim"
@@ -748,220 +749,291 @@
                 "name": "AlternativeLara"
             }, {
                 "id": 13,
-                "name": "Skidoo"
+                "name": "Skidoo",
+                "categories": [ "Vehicle" ]
             }, {
                 "id": 14,
-                "name": "Boat"
+                "name": "Boat",
+                "categories": [ "Vehicle" ]
             }, {
                 "id": 15,
-                "name": "Dog"
+                "name": "Dog",
+                "categories": [ "Entity" ]
             }, {
                 "id": 16,
-                "name": "Masked Goon 1"
+                "name": "Masked Goon 1",
+                "categories": [ "Entity" ]
             }, {
                 "id": 17,
-                "name": "Masked Goon 2"
+                "name": "Masked Goon 2",
+                "categories": [ "Entity" ]
             }, {
                 "id": 18,
-                "name": "Masked Goon 3"
+                "name": "Masked Goon 3",
+                "categories": [ "Entity" ]
             }, {
                 "id": 19,
-                "name": "Knife thrower"
+                "name": "Knife thrower",
+                "categories": [ "Entity" ]
             }, {
                 "id": 20,
-                "name": "Shotgun Goon"
+                "name": "Shotgun Goon",
+                "categories": [ "Entity" ]
             }, {
                 "id": 21,
-                "name": "Rat"
+                "name": "Rat",
+                "categories": [ "Entity" ]
             }, {
                 "id": 22,
-                "name": "DragonFront"
+                "name": "DragonFront",
+                "categories": [ "Entity" ]
             }, {
                 "id": 23,
-                "name": "DragonBack"
+                "name": "DragonBack",
+                "categories": [ "Entity" ]
             }, {
                 "id": 24,
-                "name": "Gondola"
+                "name": "Gondola",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 25,
-                "name": "Shark"
+                "name": "Shark",
+                "categories": [ "Entity" ]
             }, {
                 "id": 26,
-                "name": "Yellow Eel"
+                "name": "Yellow Eel",
+                "categories": [ "Entity" ]
             }, {
                 "id": 27,
-                "name": "Black Eel"
+                "name": "Black Eel",
+                "categories": [ "Entity" ]
             }, {
                 "id": 28,
-                "name": "Barracuda"
+                "name": "Barracuda",
+                "categories": [ "Entity" ]
             }, {
                 "id": 29,
-                "name": "Scuba Diver"
+                "name": "Scuba Diver",
+                "categories": [ "Entity" ]
             }, {
                 "id": 30,
-                "name": "Shotgun Goon"
+                "name": "Shotgun Goon",
+                "categories": [ "Entity" ]
             }, {
                 "id": 31,
-                "name": "Rifle Goon"
+                "name": "Rifle Goon",
+                "categories": [ "Entity" ]
             }, {
                 "id": 32,
-                "name": "Stick Goon 1"
+                "name": "Stick Goon 1",
+                "categories": [ "Entity" ]
             }, {
                 "id": 33,
-                "name": "Stick Goon 2"
+                "name": "Stick Goon 2",
+                "categories": [ "Entity" ]
             }, {
                 "id": 34,
-                "name": "Flamethrower"
+                "name": "Flamethrower",
+                "categories": [ "Entity" ]
             }, {
                 "id": 36,
-                "name": "Spider"
+                "name": "Spider",
+                "categories": [ "Entity" ]
             }, {
                 "id": 37,
-                "name": "Giant Spider"
+                "name": "Giant Spider",
+                "categories": [ "Entity" ]
             }, {
                 "id": 38,
-                "name": "Crow"
+                "name": "Crow",
+                "categories": [ "Entity" ]
             }, {
                 "id": 39,
-                "name": "Tiger/Leopard"
+                "name": "Tiger/Leopard",
+                "categories": [ "Entity" ]
             }, {
                 "id": 40,
-                "name": "Bartoli"
+                "name": "Bartoli",
+                "categories": [ "Entity" ]
             }, {
                 "id": 41,
-                "name": "Guard (Spear)"
+                "name": "Guard (Spear)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 42,
-                "name": "XianGuardSpearStatue"
+                "name": "XianGuardSpearStatue",
+                "categories": [ "Entity" ]
             }, {
                 "id": 43,
-                "name": "Guard (Sword)"
+                "name": "Guard (Sword)",
+                "categories": [ "Entity" ]
             }, {
                 "id": 44,
-                "name": "XianGuardSwordStatue"
+                "name": "XianGuardSwordStatue",
+                "categories": [ "Entity" ]
             }, {
                 "id": 45,
-                "name": "Yeti"
+                "name": "Yeti",
+                "categories": [ "Entity" ]
             }, {
                 "id": 46,
-                "name": "Guardian"
+                "name": "Guardian",
+                "categories": [ "Entity" ]
             }, {
                 "id": 47,
-                "name": "Eagle"
+                "name": "Eagle",
+                "categories": [ "Entity" ]
             }, {
                 "id": 48,
-                "name": "Mercenary 1"
+                "name": "Mercenary 1",
+                "categories": [ "Entity" ]
             }, {
                 "id": 49,
-                "name": "Mercenary 2"
+                "name": "Mercenary 2",
+                "categories": [ "Entity" ]
             }, {
                 "id": 50,
-                "name": "Mercenary 3"
+                "name": "Mercenary 3",
+                "categories": [ "Entity" ]
             }, {
                 "id": 51,
-                "name": "Black Skidoo"
+                "name": "Black Skidoo",
+                "categories": [ "Entity" ]
             }, {
                 "id": 52,
-                "name": "Skidoo Driver"
+                "name": "Skidoo Driver",
+                "categories": [ "Entity" ]
             }, {
                 "id": 53,
-                "name": "Monk 1"
+                "name": "Monk 1",
+                "categories": [ "Entity" ]
             }, {
                 "id": 54,
-                "name": "Monk 2"
+                "name": "Monk 2",
+                "categories": [ "Entity" ]
             }, {
                 "id": 55,
-                "name": "Breakable Tile"
+                "name": "Breakable Tile",
+                "categories": [ "Trap" ]
             }, {
                 "id": 57,
-                "name": "Loose Boards"
+                "name": "Loose Boards",
+                "categories": [ "Trap" ]
             }, {
                 "id": 58,
-                "name": "Swinging Sandbag"
+                "name": "Swinging Sandbag",
+                "categories": [ "Trap" ]
             }, {
                 "id": 59,
-                "name": "Spikes"
+                "name": "Spikes",
+                "categories": [ "Trap" ]
             }, {
                 "id": 60,
-                "name": "Boulder"
+                "name": "Boulder",
+                "categories": [ "Trap" ]
             }, {
                 "id": 61,
-                "name": "Dart"
+                "name": "Dart",
+                "categories": [ "Trap" ]
             }, {
                 "id": 62,
-                "name": "Dart Emitter"
+                "name": "Dart Emitter",
+                "categories": [ "Trap" ]
             }, {
                 "id": 63,
-                "name": "Drawbridge"
+                "name": "Drawbridge",
+                "categories": [ "Trapdoor", "Door" ]
             }, {
                 "id": 64,
-                "name": "Slamming Doors"
+                "name": "Slamming Doors",
+                "categories": [ "Trap" ]
             }, {
                 "id": 65,
                 "name": "Elevator"
             }, {
                 "id": 66,
-                "name": "Minisub"
+                "name": "Minisub",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 67,
-                "name": "Pushable Block 1"
+                "name": "Pushable Block 1",
+                "categories": [ "Movable" ]
             }, {
                 "id": 68,
-                "name": "Pushable Block 2"
+                "name": "Pushable Block 2",
+                "categories": [ "Movable" ]
             }, {
                 "id": 69,
-                "name": "Pushable Block 3"
+                "name": "Pushable Block 3",
+                "categories": [ "Movable" ]
             }, {
                 "id": 70,
-                "name": "Pushable Block 4"
+                "name": "Pushable Block 4",
+                "categories": [ "Movable" ]
             }, {
                 "id": 71,
-                "name": "Lava bowl"
+                "name": "Lava bowl",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 72,
-                "name": "Breakable Window"
+                "name": "Breakable Window",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 73,
-                "name": "Breakable Window"
+                "name": "Breakable Window",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 76,
-                "name": "Propeller"
+                "name": "Propeller",
+                "categories": [ "Trap" ]
             }, {
                 "id": 77,
-                "name": "PowerSaw"
+                "name": "PowerSaw",
+                "categories": [ "Trap" ]
             }, {
                 "id": 78,
-                "name": "Hook"
+                "name": "Hook",
+                "categories": [ "Trap" ]
             }, {
                 "id": 79,
-                "name": "Falling Ceiling"
+                "name": "Falling Ceiling",
+                "categories": [ "Trap" ]
             }, {
                 "id": 80,
-                "name": "Rolling Spindle"
+                "name": "Rolling Spindle",
+                "categories": [ "Trap" ]
             }, {
                 "id": 81,
-                "name": "Wall Blade"
+                "name": "Wall Blade",
+                "categories": [ "Trap" ]
             }, {
                 "id": 82,
-                "name": "Statue Blade"
+                "name": "Statue Blade",
+                "categories": [ "Trap" ]
             }, {
                 "id": 83,
-                "name": "Boulders"
+                "name": "Boulders",
+                "categories": [ "Trap" ]
             }, {
                 "id": 84,
-                "name": "Icicles"
+                "name": "Icicles",
+                "categories": [ "Trap" ]
             }, {
                 "id": 85,
-                "name": "Spike Wall"
+                "name": "Spike Wall",
+                "categories": [ "Trap" ]
             }, {
                 "id": 86,
-                "name": "Springboard"
+                "name": "Springboard",
+                "categories": [ "Trap" ]
             }, {
                 "id": 87,
-                "name": "Spike Ceiling"
+                "name": "Spike Ceiling",
+                "categories": [ "Trap" ]
             }, {
                 "id": 88,
-                "name": "Bell"
+                "name": "Bell",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 89,
                 "name": "BoatWake"
@@ -973,88 +1045,114 @@
                 "name": "SnowmobileBelt"
             }, {
                 "id": 92,
-                "name": "Wheel Door"
+                "name": "Wheel Door",
+                "categories": [ "Door" ]
             }, {
                 "id": 93,
-                "name": "Small Switch"
+                "name": "Small Switch",
+                "categories": [ "Switch" ]
             }, {
                 "id": 94,
-                "name": "Underwater Fan"
+                "name": "Underwater Fan",
+                "categories": [ "Trap" ]
             }, {
                 "id": 95,
-                "name": "Fan"
+                "name": "Fan",
+                "categories": [ "Trap" ]
             }, {
                 "id": 96,
-                "name": "Swinging Box"
+                "name": "Swinging Box",
+                "categories": [ "Trap" ]
             }, {
                 "id": 97,
-                "name": "CutsceneActor1"
+                "name": "CutsceneActor1",
+                "categories": [ "Entity" ]
             }, {
                 "id": 98,
-                "name": "CutsceneActor2"
+                "name": "CutsceneActor2",
+                "categories": [ "Entity" ]
             }, {
                 "id": 99,
-                "name": "CutsceneActor3"
+                "name": "CutsceneActor3",
+                "categories": [ "Entity" ]
             }, {
                 "id": 100,
                 "name": "UIFrame"
             }, {
                 "id": 101,
-                "name": "Rolling Barrels"
+                "name": "Rolling Barrels",
+                "categories": [ "Trap" ]
             }, {
                 "id": 102,
                 "name": "Zipline"
             }, {
                 "id": 103,
-                "name": "Button"
+                "name": "Button",
+                "categories": [ "Switch" ]
             }, {
                 "id": 104,
-                "name": "Wall Switch"
+                "name": "Wall Switch",
+                "categories": [ "Switch" ]
             }, {
                 "id": 105,
-                "name": "Underwater Lever"
+                "name": "Underwater Lever",
+                "categories": [ "Switch" ]
             }, {
                 "id": 106,
-                "name": "Door 1"
+                "name": "Door 1",
+                "categories": [ "Door" ]
             }, {
                 "id": 107,
-                "name": "Door 2"
+                "name": "Door 2",
+                "categories": [ "Door" ]
             }, {
                 "id": 108,
-                "name": "Door 3"
+                "name": "Door 3",
+                "categories": [ "Door" ]
             }, {
                 "id": 109,
-                "name": "Door 4"
+                "name": "Door 4",
+                "categories": [ "Door" ]
             }, {
                 "id": 110,
-                "name": "Door 5"
+                "name": "Door 5",
+                "categories": [ "Door" ]
             }, {
                 "id": 111,
-                "name": "Door 6"
+                "name": "Door 6",
+                "categories": [ "Door" ]
             }, {
                 "id": 112,
-                "name": "Door 7"
+                "name": "Door 7",
+                "categories": [ "Door" ]
             }, {
                 "id": 113,
-                "name": "Door 8"
+                "name": "Door 8",
+                "categories": [ "Door" ]
             }, {
                 "id": 114,
-                "name": "Trapdoor 1"
+                "name": "Trapdoor 1",
+                "categories": [ "Door", "Trapdoor" ]
             }, {
                 "id": 115,
-                "name": "Trapdoor 2"
+                "name": "Trapdoor 2",
+                "categories": [ "Door", "Trapdoor" ]
             }, {
                 "id": 116,
-                "name": "Trapdoor 3"
+                "name": "Trapdoor 3",
+                "categories": [ "Door", "Trapdoor" ]
             }, {
                 "id": 117,
-                "name": "Bridge (Flat)"
+                "name": "Bridge (Flat)",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 118,
-                "name": "Bridge (Tilt 1)"
+                "name": "Bridge (Tilt 1)",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 119,
-                "name": "Bridge (Tilt 2)"
+                "name": "Bridge (Tilt 2)",
+                "categories": [ "Scenery" ]
             }, {
                 "id": 120,
                 "name": "PassportOpening"
@@ -1066,88 +1164,115 @@
                 "name": "LarasHomePolaroid"
             }, {
                 "id": 123,
-                "name": "CutsceneActor4"
+                "name": "CutsceneActor4",
+                "categories": [ "Entity" ]
             }, {
                 "id": 124,
-                "name": "CutsceneActor5"
+                "name": "CutsceneActor5",
+                "categories": [ "Entity" ]
             }, {
                 "id": 125,
-                "name": "CutsceneActor6"
+                "name": "CutsceneActor6",
+                "categories": [ "Entity" ]
             }, {
                 "id": 126,
-                "name": "CutsceneActor7"
+                "name": "CutsceneActor7",
+                "categories": [ "Entity" ]
             }, {
                 "id": 127,
-                "name": "CutsceneActor8"
+                "name": "CutsceneActor8",
+                "categories": [ "Entity" ]
             }, {
                 "id": 128,
-                "name": "CutsceneActor9"
+                "name": "CutsceneActor9",
+                "categories": [ "Entity" ]
             }, {
                 "id": 129,
-                "name": "CutsceneActor10"
+                "name": "CutsceneActor10",
+                "categories": [ "Entity" ]
             }, {
                 "id": 130,
-                "name": "CutsceneActor11"
+                "name": "CutsceneActor11",
+                "categories": [ "Entity" ]
             }, {
                 "id": 133,
-                "name": "PassportClosed"
+                "name": "PassportClosed",
+                "categories": [ "Entity" ]
             }, {
                 "id": 134,
                 "name": "Map"
             }, {
                 "id": 135,
-                "name": "Pistols"
+                "name": "Pistols",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 136,
-                "name": "Shotgun"
+                "name": "Shotgun",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 137,
-                "name": "Auto pistols"
+                "name": "Auto pistols",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 138,
-                "name": "Uzis"
+                "name": "Uzis",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 139,
-                "name": "Harpoon Gun"
+                "name": "Harpoon Gun",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 140,
-                "name": "M16"
+                "name": "M16",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 141,
-                "name": "Grenade launcher"
+                "name": "Grenade launcher",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 142,
-                "name": "PistolAmmoSprite"
+                "name": "PistolAmmoSprite",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 143,
-                "name": "Shotgun shells"
+                "name": "Shotgun shells",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 144,
-                "name": "Auto pistol ammo"
+                "name": "Auto pistol ammo",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 145,
-                "name": "Uzi ammo"
+                "name": "Uzi ammo",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 146,
-                "name": "Harpoons"
+                "name": "Harpoons",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 147,
-                "name": "M16 ammo"
+                "name": "M16 ammo",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 148,
-                "name": "Grenades"
+                "name": "Grenades",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 149,
-                "name": "Small medipack"
+                "name": "Small medipack",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 150,
-                "name": "Large medipack"
+                "name": "Large medipack",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 151,
-                "name": "Flares"
+                "name": "Flares",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 152,
-                "name": "Flare"
+                "name": "Flare",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 153,
                 "name": "Sunglasses"
@@ -1207,19 +1332,24 @@
                 "name": "LargeMedipack"
             }, {
                 "id": 173,
-                "name": "Flares"
+                "name": "Flares",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 174,
-                "name": "Puzzle 1"
+                "name": "Puzzle 1",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 175,
-                "name": "Puzzle 2"
+                "name": "Puzzle 2",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 176,
-                "name": "Puzzle 3"
+                "name": "Puzzle 3",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 177,
-                "name": "Puzzle 4"
+                "name": "Puzzle 4",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 178,
                 "name": "Puzzle 1"
@@ -1234,49 +1364,64 @@
                 "name": "Puzzle 4"
             }, {
                 "id": 182,
-                "name": "Slot 1"
+                "name": "Slot 1",
+                "categories": [ "Slot" ]
             }, {
                 "id": 183,
-                "name": "Slot 2"
+                "name": "Slot 2",
+                "categories": [ "Slot" ]
             }, {
                 "id": 184,
-                "name": "Slot 3"
+                "name": "Slot 3",
+                "categories": [ "Slot" ]
             }, {
                 "id": 185,
-                "name": "Slot 4"
+                "name": "Slot 4",
+                "categories": [ "Slot" ]
             }, {
                 "id": 186,
-                "name": "Slot 1 Done"
+                "name": "Slot 1 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 187,
-                "name": "Slot 2 Done"
+                "name": "Slot 2 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 188,
-                "name": "Slot 3 Done"
+                "name": "Slot 3 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 189,
-                "name": "Slot 4 Done"
+                "name": "Slot 4 Done",
+                "categories": [ "Slot" ]
             }, {
                 "id": 190,
-                "name": "Secret (Gold)"
+                "name": "Secret (Gold)",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 191,
-                "name": "Secret (Jade)"
+                "name": "Secret (Jade)",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 192,
-                "name": "Secret (Stone)"
+                "name": "Secret (Stone)",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 193,
-                "name": "Key 1"
+                "name": "Key 1",
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 194,
-                "name": "Key 2"
+                "name": "Key 2",
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 195,
-                "name": "Key 3"
+                "name": "Key 3",
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 196,
-                "name": "Key 4"
+                "name": "Key 4",
+                "categories": [ "Pickup", "Key" ]
             }, {
                 "id": 197,
                 "name": "Key 1"
@@ -1291,28 +1436,36 @@
                 "name": "Key 4"
             }, {
                 "id": 201,
-                "name": "Keyhole 1"
+                "name": "Keyhole 1",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 202,
-                "name": "Keyhole 2"
+                "name": "Keyhole 2",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 203,
-                "name": "Keyhole 3"
+                "name": "Keyhole 3",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 204,
-                "name": "Keyhole 4"
+                "name": "Keyhole 4",
+                "categories": [ "Keyhole" ]
             }, {
                 "id": 205,
-                "name": "Quest Item 1"
+                "name": "Quest Item 1",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 206,
-                "name": "The Talion"
+                "name": "The Talion",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 207,
-                "name": "QuestItem1"
+                "name": "QuestItem1",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 208,
-                "name": "QuestItem2"
+                "name": "QuestItem2",
+                "categories": [ "Pickup" ]
             }, {
                 "id": 209,
                 "name": "DragonExplosionEffect"
@@ -1324,16 +1477,20 @@
                 "name": "DragonExplosionEffect3"
             }, {
                 "id": 212,
-                "name": "Alarm"
+                "name": "Alarm",
+                "categories": [ "Effect" ]
             }, {
                 "id": 213,
-                "name": "Dripping Water"
+                "name": "Dripping Water",
+                "categories": [ "Effect" ]
             }, {
                 "id": 214,
-                "name": "T-Rex"
+                "name": "T-Rex",
+                "categories": [ "Entity" ]
             }, {
                 "id": 215,
-                "name": "Singing Birds"
+                "name": "Singing Birds",
+                "categories": [ "Effect" ]
             }, {
                 "id": 216,
                 "name": "BartoliHideoutClock"
@@ -1351,22 +1508,27 @@
                 "name": "ExtraFire"
             }, {
                 "id": 222,
-                "name": "Mine"
+                "name": "Mine",
+                "categories": [ "Trap" ]
             }, {
                 "id": 223,
                 "name": "MenuBackground"
             }, {
                 "id": 224,
-                "name": "GrayDisk"
+                "name": "GrayDisk",
+                "categories": [ "Trap" ]
             }, {
                 "id": 225,
-                "name": "GongStick"
+                "name": "GongStick",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 226,
-                "name": "Gong"
+                "name": "Gong",
+                "categories": [ "Slot" ]
             }, {
                 "id": 227,
-                "name": "Detonator"
+                "name": "Detonator",
+                "categories": [ "Pickup", "Puzzle" ]
             }, {
                 "id": 228,
                 "name": "Helicopter"
@@ -1399,10 +1561,12 @@
                 "name": "M16Gunflare"
             }, {
                 "id": 243,
-                "name": "Camera Target"
+                "name": "Camera Target",
+                "categories": [ "Effect" ]
             }, {
                 "id": 244,
-                "name": "Waterfall Mist"
+                "name": "Waterfall Mist",
+                "categories": [ "Effect" ]
             }, {
                 "id": 245,
                 "name": "Harpoon"
@@ -1447,7 +1611,8 @@
                 "name": "Helicopter"
             }, {
                 "id": 260,
-                "name": "Winston"
+                "name": "Winston",
+                "categories": [ "Entity" ]
             }, {
                 "id": 262,
                 "name": "LaraCutscenePlacement"

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -402,7 +402,6 @@ namespace trview
                 }
                 return results;
             });
-        _filters.add_getter<bool>("Is Pickup", [](auto&& item) { return item.is_pickup(); });
     }
 
     void ItemsWindow::set_level_version(trlevel::LevelVersion version)

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -242,20 +242,7 @@ namespace trview
                     add_stat("Invisible", item->invisible_flag());
                     add_stat("Flags", format_binary(item->activation_flags()));
                     add_stat("OCB", item->ocb());
-
-                    std::string category_text;
-                    auto categories = item->categories();
-                    auto iter = categories.begin();
-                    while (iter != categories.end())
-                    {
-                        category_text += *iter;
-                        ++iter;
-                        if (iter != categories.end())
-                        {
-                            category_text += ",";
-                        }
-                    }
-                    add_stat("Category", category_text);
+                    add_stat("Category", join(item->categories()));
                 }
 
                 ImGui::EndTable();

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -242,6 +242,7 @@ namespace trview
                     add_stat("Invisible", item->invisible_flag());
                     add_stat("Flags", format_binary(item->activation_flags()));
                     add_stat("OCB", item->ocb());
+                    add_stat("Is Pickup", item->is_pickup());
                 }
 
                 ImGui::EndTable();
@@ -390,6 +391,7 @@ namespace trview
                 }
                 return results;
             });
+        _filters.add_getter<bool>("Is Pickup", [](auto&& item) { return item.is_pickup(); });
     }
 
     void ItemsWindow::set_level_version(trlevel::LevelVersion version)

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -359,14 +359,25 @@ namespace trview
     {
         _filters.clear_all_getters();
         std::set<std::string> available_types;
+        std::set<std::string> available_categories;
         for (const auto& item : _all_items)
         {
             if (auto item_ptr = item.lock())
             {
                 available_types.insert(item_ptr->type());
+                available_categories.insert_range(item_ptr->categories());
             }
         }
         _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& item) { return item.type(); });
+        _filters.add_multi_getter<std::string>("Category", { available_categories.begin(), available_categories.end() }, [](auto&& item)
+            {
+                std::vector<std::string> results;
+                for (const auto& category : item.categories())
+                {
+                    results.push_back(category);
+                }
+                return results;
+            });
         _filters.add_getter<float>("#", [](auto&& item) { return static_cast<float>(item.number()); });
         _filters.add_getter<float>("X", [](auto&& item) { return item.position().x * trlevel::Scale_X; });
         _filters.add_getter<float>("Y", [](auto&& item) { return item.position().y * trlevel::Scale_Y; });

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -192,7 +192,7 @@ namespace trview
 
                 if (auto item = _selected_item.lock())
                 {
-                    auto add_stat = [&]<typename T>(const std::string& name, const T&& value)
+                    auto add_stat = [&]<typename T>(const std::string& name, T&& value)
                     {
                         const auto string_value = get_string(value);
                         ImGui::TableNextColumn();
@@ -242,7 +242,20 @@ namespace trview
                     add_stat("Invisible", item->invisible_flag());
                     add_stat("Flags", format_binary(item->activation_flags()));
                     add_stat("OCB", item->ocb());
-                    add_stat("Is Pickup", item->is_pickup());
+
+                    std::string category_text;
+                    auto categories = item->categories();
+                    auto iter = categories.begin();
+                    while (iter != categories.end())
+                    {
+                        category_text += *iter;
+                        ++iter;
+                        if (iter != categories.end())
+                        {
+                            category_text += ",";
+                        }
+                    }
+                    add_stat("Category", category_text);
                 }
 
                 ImGui::EndTable();

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -31,7 +31,7 @@
 #include <trview.app/Geometry/IPicking.h>
 #include <trview.app/Graphics/ISectorHighlight.h>
 #include <trview.app/UI/IViewerUI.h>
-#include <trview.app/Elements/ITypeNameLookup.h>
+#include "../Elements/ITypeInfoLookup.h"
 #include <trview.app/Menus/MenuDetector.h>
 #include <trview.app/Lua/Lua.h>
 #include <trview.common/Windows/Shortcuts.h>

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -47,7 +47,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Elements\Sector.cpp" />
     <ClCompile Include="Elements\StaticMesh.cpp" />
     <ClCompile Include="Elements\Trigger.cpp" />
-    <ClCompile Include="Elements\TypeNameLookup.cpp" />
+    <ClCompile Include="Elements\TypeInfoLookup.cpp" />
     <ClCompile Include="Geometry\IMesh.cpp" />
     <ClCompile Include="Geometry\IRenderable.cpp" />
     <ClCompile Include="Geometry\Matrix.cpp" />
@@ -208,7 +208,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Elements\ISector.h" />
     <ClInclude Include="Elements\IStaticMesh.h" />
     <ClInclude Include="Elements\ITrigger.h" />
-    <ClInclude Include="Elements\ITypeNameLookup.h" />
+    <ClInclude Include="Elements\ITypeInfoLookup.h" />
     <ClInclude Include="Elements\Level.h" />
     <ClInclude Include="Elements\Light.h" />
     <ClInclude Include="Elements\PickFilter.h" />
@@ -218,7 +218,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Elements\Sector.h" />
     <ClInclude Include="Elements\StaticMesh.h" />
     <ClInclude Include="Elements\Trigger.h" />
-    <ClInclude Include="Elements\TypeNameLookup.h" />
+    <ClInclude Include="Elements\TypeInfoLookup.h" />
     <ClInclude Include="Elements\Types.h" />
     <ClInclude Include="Filters\Filters.h" />
     <ClInclude Include="Filters\Filters.hpp" />
@@ -264,7 +264,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\Elements\ISector.h" />
     <ClInclude Include="Mocks\Elements\IStaticMesh.h" />
     <ClInclude Include="Mocks\Elements\ITrigger.h" />
-    <ClInclude Include="Mocks\Elements\ITypeNameLookup.h" />
+    <ClInclude Include="Mocks\Elements\ITypeInfoLookup.h" />
     <ClInclude Include="Mocks\Geometry\IMesh.h" />
     <ClInclude Include="Mocks\Geometry\IPicking.h" />
     <ClInclude Include="Mocks\Geometry\ITransparencyBuffer.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -113,6 +113,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Tools\Measure.cpp" />
     <ClCompile Include="Tools\Toolbar.cpp" />
     <ClInclude Include="Elements\ISector.hpp" />
+    <ClInclude Include="Elements\TypeInfo.h" />
     <ClInclude Include="Lua\BoundingBox.h" />
     <ClInclude Include="Lua\Colour.h" />
     <ClInclude Include="Lua\Elements\CameraSink\Lua_CameraSink.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -106,7 +106,7 @@
     <ClCompile Include="Graphics\MeshStorage.cpp">
       <Filter>Graphics</Filter>
     </ClCompile>
-    <ClCompile Include="Elements\TypeNameLookup.cpp">
+    <ClCompile Include="Elements\TypeInfoLookup.cpp">
       <Filter>Elements</Filter>
     </ClCompile>
     <ClCompile Include="Menus\MenuDetector.cpp">
@@ -451,10 +451,10 @@
     <ClInclude Include="Graphics\MeshStorage.h">
       <Filter>Graphics</Filter>
     </ClInclude>
-    <ClInclude Include="Elements\TypeNameLookup.h">
+    <ClInclude Include="Elements\TypeInfoLookup.h">
       <Filter>Elements</Filter>
     </ClInclude>
-    <ClInclude Include="Elements\ITypeNameLookup.h">
+    <ClInclude Include="Elements\ITypeInfoLookup.h">
       <Filter>Elements</Filter>
     </ClInclude>
     <ClInclude Include="Menus\MenuDetector.h">
@@ -573,7 +573,7 @@
     <ClInclude Include="Mocks\Geometry\ITransparencyBuffer.h">
       <Filter>Mocks\Geometry</Filter>
     </ClInclude>
-    <ClInclude Include="Mocks\Elements\ITypeNameLookup.h">
+    <ClInclude Include="Mocks\Elements\ITypeInfoLookup.h">
       <Filter>Mocks\Elements</Filter>
     </ClInclude>
     <ClInclude Include="Geometry\IMesh.h">

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -1033,6 +1033,9 @@
     <ClInclude Include="Mocks\Routing\IRandomizerRoute.h">
       <Filter>Mocks\Routing</Filter>
     </ClInclude>
+    <ClInclude Include="Elements\TypeInfo.h">
+      <Filter>Elements</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">

--- a/trview.common/Strings.h
+++ b/trview.common/Strings.h
@@ -36,6 +36,8 @@ namespace trview
     /// </summary>
     template <typename T>
     constexpr std::string get_string(T&& value);
+
+    std::string join(std::ranges::input_range auto&& range);
 }
 
 #include "Strings.inl"

--- a/trview.common/Strings.inl
+++ b/trview.common/Strings.inl
@@ -13,5 +13,20 @@ namespace trview
         }
         return std::format("{}", value);
     }
+
+    std::string join(std::ranges::input_range auto&& range)
+    {
+        std::string result;
+        auto iter = range.begin();
+        while (iter != range.end())
+        {
+            result += *iter;
+            if (++iter != range.end())
+            {
+                result += ",";
+            }
+        }
+        return result;
+    }
 }
 


### PR DESCRIPTION
Add a `Categories` property to `Item`. The user can see this category in the items window and is able to use filters against the category property. This will help for finding all pickups, all enemies or for excluding a certain type of item amongst other uses.

The `Categories` field is accessible from Lua so scripts can alter the categories on an item. The categories are taken as a copy of the initial category values from the type list so they can be safely changed by a script.

Closes #1200