### PR TITLE
Fix sector highlight not appearing on hover

### DIFF
--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1419,7 +1419,7 @@ namespace trview
     void Viewer::set_sector_highlight(const std::shared_ptr<ISector>& sector)
     {
         const auto level = _level.lock();
-        if (level)
+        if (!level)
         {
             return;
         }


### PR DESCRIPTION
Sector highlight was checking if the level was loaded and if so, returning.
Should have been inverted. Add a test.
Closes #1204