### PR TITLE
Add explicit filters for known level entries

### DIFF
--- a/trview.app/Menus/FileMenu.cpp
+++ b/trview.app/Menus/FileMenu.cpp
@@ -160,7 +160,7 @@ namespace trview
 
     void FileMenu::choose_file()
     {
-        const auto filename = _dialogs->open_file(L"Open level", { { L"All Tomb Raider Files", { L"*.tr*", L"*.phd", L"*.psx" } } }, OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST);
+        const auto filename = _dialogs->open_file(L"Open level", { { L"All Tomb Raider Files", { L"*.tr2", L"*.tr4", L"*.trc", L"*.phd", L"*.psx" } } }, OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST);
         if (filename.has_value())
         {
             on_file_open(filename.value().filename);

--- a/trview.app/Menus/FileMenu.h
+++ b/trview.app/Menus/FileMenu.h
@@ -10,7 +10,7 @@ namespace trview
     class FileMenu final : public IFileMenu, public MessageHandler
     {
     public:
-        static const inline std::string default_file_pattern{ "\\*.TR*,\\*.PHD,\\*.PSX" };
+        static const inline std::string default_file_pattern{ "\\*.TR2*,\\*.TR4*,\\*.TRC*,\\*.PHD,\\*.PSX" };
 
         explicit FileMenu(
             const Window& window,


### PR DESCRIPTION
Search for TR2, TR4 and TRC instead of TR* as the TRG files from the remasters were being picked up.
Closes #1210