### PR TITLE
Add record count to filterable lists in windows

### DIFF
--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -1,6 +1,7 @@
 #include "CameraSinkWindow.h"
 #include "../../trview_imgui.h"
 #include "../../Elements/IRoom.h"
+#include "../RowCounter.h"
 
 namespace trview
 {
@@ -146,7 +147,7 @@ namespace trview
 
     void CameraSinkWindow::render_list()
     {
-        if (ImGui::BeginChild(Names::list_panel.c_str(), ImVec2(230, 0), true))
+        if (ImGui::BeginChild(Names::list_panel.c_str(), ImVec2(230, 0), true, ImGuiWindowFlags_NoScrollbar))
         {
             _filters.render();
             ImGui::SameLine();
@@ -159,7 +160,8 @@ namespace trview
                 set_sync(sync);
             }
 
-            if (ImGui::BeginTable(Names::camera_sink_list.c_str(), 4, ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(-1, -1)))
+            RowCounter counter{ "camera/sinks", _all_camera_sinks.size() };
+            if (ImGui::BeginTable(Names::camera_sink_list.c_str(), 4, ImGuiTableFlags_SizingFixedFit | ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(-1, -counter.height())))
             {
                 ImGui::TableSetupColumn("#");
                 ImGui::TableSetupColumn("Room");
@@ -185,6 +187,7 @@ namespace trview
                         continue;
                     }
 
+                    counter.count();
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
                     bool selected = _selected_camera_sink.lock() && _selected_camera_sink.lock()->number() == camera_sink->number();
@@ -236,6 +239,7 @@ namespace trview
                 }
 
                 ImGui::EndTable();
+                counter.render();
             }
         }
         ImGui::EndChild();

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -2,6 +2,7 @@
 #include <trview.common/Strings.h>
 #include <trview.common/Windows/Clipboard.h>
 #include "../trview_imgui.h"
+#include "RowCounter.h"
 
 namespace trview
 {
@@ -92,7 +93,7 @@ namespace trview
 
     void ItemsWindow::render_items_list()
     {
-        if (ImGui::BeginChild(Names::item_list_panel.c_str(), ImVec2(290, 0), true))
+        if (ImGui::BeginChild(Names::item_list_panel.c_str(), ImVec2(290, 0), true, ImGuiWindowFlags_NoScrollbar))
         {
             _filters.render();
 
@@ -106,7 +107,8 @@ namespace trview
                 set_sync_item(sync_item);
             }
 
-            if (ImGui::BeginTable(Names::items_list.c_str(), 5, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -1)))
+            RowCounter counter{ "items", _all_items.size() };
+            if (ImGui::BeginTable(Names::items_list.c_str(), 5, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -counter.height())))
             {
                 ImGui::TableSetupColumn("#");
                 ImGui::TableSetupColumn("Room");
@@ -133,6 +135,7 @@ namespace trview
                         continue;
                     }
 
+                    counter.count();
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
                     auto selected_item = _selected_item.lock();
@@ -183,6 +186,7 @@ namespace trview
                     ImGui::PopStyleVar();
                 }
                 ImGui::EndTable();
+                counter.render();
             }
         }
         ImGui::EndChild();

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -1,6 +1,7 @@
 #include "LightsWindow.h"
 #include "../trview_imgui.h"
 #include <format>
+#include "RowCounter.h"
 
 namespace trview
 {
@@ -78,7 +79,7 @@ namespace trview
 
     void LightsWindow::render_lights_list() 
     {
-        if (ImGui::BeginChild(Names::light_list_panel.c_str(), ImVec2(230, 0), true))
+        if (ImGui::BeginChild(Names::light_list_panel.c_str(), ImVec2(230, 0), true, ImGuiWindowFlags_NoScrollbar))
         {
             _filters.render();
             ImGui::SameLine();
@@ -91,7 +92,8 @@ namespace trview
                 set_sync_light(sync_light);
             }
 
-            if (ImGui::BeginTable(Names::lights_listbox.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -1)))
+            RowCounter counter{ "lights", _all_lights.size() };
+            if (ImGui::BeginTable(Names::lights_listbox.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -counter.height())))
             {
                 ImGui::TableSetupColumn("#");
                 ImGui::TableSetupColumn("Room");
@@ -116,6 +118,7 @@ namespace trview
                         continue;
                     }
 
+                    counter.count();
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
                     bool selected = _selected_light.lock() && _selected_light.lock()->number() == light->number();
@@ -155,6 +158,7 @@ namespace trview
                     ImGui::PopStyleVar();
                 }
                 ImGui::EndTable();
+                counter.render();
             }
         }
         ImGui::EndChild();

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -4,6 +4,7 @@
 #include <trview.common/Strings.h>
 #include "../trview_imgui.h"
 #include "../Elements/Floordata.h"
+#include "RowCounter.h"
 
 namespace trview
 {
@@ -280,7 +281,7 @@ namespace trview
 
     void RoomsWindow::render_rooms_list()
     {
-        if (ImGui::BeginChild(Names::rooms_panel.c_str(), ImVec2(270, 0), true))
+        if (ImGui::BeginChild(Names::rooms_panel.c_str(), ImVec2(270, 0), true, ImGuiWindowFlags_NoScrollbar))
         {
             _filters.render();
 
@@ -294,7 +295,8 @@ namespace trview
                 set_sync_room(sync_room);
             }
 
-            if (ImGui::BeginTable(Names::rooms_list.c_str(), 5, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -1)))
+            RowCounter counter{ "rooms", _all_rooms.size() };
+            if (ImGui::BeginTable(Names::rooms_list.c_str(), 5, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -counter.height())))
             {
                 ImGui::TableSetupColumn("#");
                 ImGui::TableSetupColumn("Items");
@@ -341,6 +343,7 @@ namespace trview
                         continue;
                     }
 
+                    counter.count();
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
                     bool selected = room_ptr->number() == _selected_room;
@@ -380,6 +383,7 @@ namespace trview
                     ImGui::PopStyleVar();
                 }
                 ImGui::EndTable();
+                counter.render();
             }
         }
         ImGui::EndChild();

--- a/trview.app/Windows/RowCounter.cpp
+++ b/trview.app/Windows/RowCounter.cpp
@@ -1,0 +1,36 @@
+#include "RowCounter.h"
+#include <format>
+
+namespace trview
+{
+    RowCounter::RowCounter(const std::string& entry_name, std::size_t maximum_size)
+        : _entry_name(entry_name), _maximum_size(maximum_size), _count(0)
+    {
+    }
+
+    float RowCounter::height() const
+    {
+        return ImGui::CalcTextSize(_entry_name.c_str()).y;
+    }
+
+    void RowCounter::count()
+    {
+        ++_count;
+    }
+
+    void RowCounter::set_count(std::size_t value)
+    {
+        _count = value;
+    }
+
+    void RowCounter::render()
+    {
+        const std::string text =
+            _count == _maximum_size ?
+            std::format("{} {}", _maximum_size, _entry_name) :
+            std::format("{} of {} {}", _count, _maximum_size, _entry_name);
+        const ImVec2 size = ImGui::CalcTextSize(text.c_str());
+        ImGui::SetCursorPosX(ImGui::GetWindowWidth() - size.x - 5);
+        ImGui::Text(text.c_str());
+    }
+}

--- a/trview.app/Windows/RowCounter.h
+++ b/trview.app/Windows/RowCounter.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace trview
+{
+    class RowCounter
+    {
+    public:
+        RowCounter(const std::string& entry_name, std::size_t maximum_size);
+        float height() const;
+        void count();
+        void set_count(std::size_t value);
+        void render();
+    private:
+        std::string _entry_name;
+        std::size_t _maximum_size;
+        std::size_t _count;
+    };
+}

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -2,6 +2,7 @@
 #include <trview.common/Strings.h>
 #include "../trview_imgui.h"
 #include <format>
+#include "RowCounter.h"
 
 namespace trview
 {
@@ -132,7 +133,7 @@ namespace trview
 
     void TriggersWindow::render_triggers_list()
     {
-        if (ImGui::BeginChild(Names::trigger_list_panel.c_str(), ImVec2(220, 0), true))
+        if (ImGui::BeginChild(Names::trigger_list_panel.c_str(), ImVec2(220, 0), true, ImGuiWindowFlags_NoScrollbar))
         {
             _filters.render();
             ImGui::SameLine();
@@ -177,7 +178,8 @@ namespace trview
                 ImGui::EndCombo();
             }
 
-            if (ImGui::BeginTable(Names::triggers_list.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -1)))
+            RowCounter counter{ "triggers", _all_triggers.size() };
+            if (ImGui::BeginTable(Names::triggers_list.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -counter.height())))
             {
                 ImGui::TableSetupColumn("#", ImGuiTableColumnFlags_WidthFixed, _required_number_width);
                 ImGui::TableSetupColumn("Room");
@@ -187,6 +189,7 @@ namespace trview
                 ImGui::TableHeadersRow();
 
                 filter_triggers();
+                counter.set_count(_filtered_triggers.size());
 
                 imgui_sort_weak(_filtered_triggers,
                     {
@@ -253,6 +256,7 @@ namespace trview
 
                 clipper.End();
                 ImGui::EndTable();
+                counter.render();
             }
         }
         ImGui::EndChild();

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -176,6 +176,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Windows\RoomsWindowManager.cpp" />
     <ClCompile Include="Windows\RouteWindow.cpp" />
     <ClCompile Include="Windows\RouteWindowManager.cpp" />
+    <ClCompile Include="Windows\RowCounter.cpp" />
     <ClCompile Include="Windows\Textures\TexturesWindow.cpp" />
     <ClCompile Include="Windows\Textures\TexturesWindowManager.cpp" />
     <ClCompile Include="Windows\TriggersWindow.cpp" />
@@ -385,6 +386,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Windows\RoomsWindowManager.h" />
     <ClInclude Include="Windows\RouteWindow.h" />
     <ClInclude Include="Windows\RouteWindowManager.h" />
+    <ClInclude Include="Windows\RowCounter.h" />
     <ClInclude Include="Windows\Textures\ITexturesWindow.h" />
     <ClInclude Include="Windows\Textures\ITexturesWindowManager.h" />
     <ClInclude Include="Windows\Textures\TexturesWindow.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -320,6 +320,9 @@
     <ClCompile Include="Routing\RandomizerRoute.cpp">
       <Filter>Routing</Filter>
     </ClCompile>
+    <ClCompile Include="Windows\RowCounter.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -1035,6 +1038,9 @@
     </ClInclude>
     <ClInclude Include="Elements\TypeInfo.h">
       <Filter>Elements</Filter>
+    </ClInclude>
+    <ClInclude Include="Windows\RowCounter.h">
+      <Filter>Windows</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Add a counter to show how many records are currently visible and how many there are for the main list in the various windows. If all records are visible it will show `y records`. If there is a filter it will show `x of y records`. `records` is replaced by the appropriate name in each window.

![image](https://github.com/chreden/trview/assets/4263940/70f9d868-7a43-4964-bef5-f69fa096ed2d)

Closes #1219