### PR TITLE
Change "is not" on multi value filters to be "none of"

### DIFF
--- a/trview.app.tests/Filters/FiltersTests.cpp
+++ b/trview.app.tests/Filters/FiltersTests.cpp
@@ -342,3 +342,15 @@ TEST(Filters, NotPresentSingleWithPredicate)
     ASSERT_TRUE(filters.match(Object()));
     ASSERT_FALSE(filters.match(Object().with_option(1.0f)));
 }
+
+TEST(Filters, IsNotMultiValue)
+{
+    Filters<Object> filters;
+    filters.add_multi_getter<std::string>("value", [](auto&& o) { return o.texts; });
+
+    Filters<Object>::Filter is_not_string = make_filter().key("value").compare_op(CompareOp::NotEqual).value("first");
+    filters.set_filters({ is_not_string });
+
+    ASSERT_TRUE(filters.match(Object().with_texts({ "second", "third", "fourth" })));
+    ASSERT_FALSE(filters.match(Object().with_texts({ "second", "first", "third" })));
+}

--- a/trview.app/Filters/Filters.h
+++ b/trview.app/Filters/Filters.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <map>
 #include <variant>
+#include <ranges>
 
 namespace trview
 {
@@ -179,6 +180,7 @@ namespace trview
         bool is_match(const std::string& value, const Filter& filter) const;
         bool is_match(float value, const Filter& filter) const;
         bool is_match(bool value, const Filter& filter) const;
+        bool group_match(std::ranges::input_range auto&& results, const Filter& filter) const;
         std::vector<CompareOp> ops_for_key(const std::string& key) const;
         std::vector<std::string> options_for_key(const std::string& key) const;
         bool has_options(const std::string& key) const;

--- a/trview.app/Filters/Filters.hpp
+++ b/trview.app/Filters/Filters.hpp
@@ -228,6 +228,16 @@ namespace trview
     }
 
     template <typename T>
+    bool Filters<T>::group_match(std::ranges::input_range auto&& results, const Filter& filter) const
+    {
+        if (filter.compare == CompareOp::NotEqual)
+        {
+            return std::ranges::all_of(results, [](auto&& v) { return v; });
+        }
+        return std::ranges::any_of(results, [](auto&& v) { return v; });
+    }
+
+    template <typename T>
     bool Filters<T>::match(const T& value) const
     {
         if (!_enabled || empty())
@@ -262,7 +272,7 @@ namespace trview
                         const auto getter_values = multi_getter->second.function(value);
                         if (!getter_values.empty())
                         {
-                            filter_result = std::find_if(getter_values.begin(), getter_values.end(), [&](const auto& value) { return is_match(value, filter); }) != getter_values.end();
+                            filter_result = group_match(getter_values | std::views::transform([&](auto&& value) { return is_match(value, filter); }), filter);
                         }
                     }
                 }


### PR DESCRIPTION
For negative comparisons check that all of the matches are true - that is a 'none of'.
Closes #1225