### PR TITLE
Flip pickup sprites horizontally

### DIFF
--- a/trview.app/Geometry/IMesh.cpp
+++ b/trview.app/Geometry/IMesh.cpp
@@ -42,10 +42,10 @@ namespace trview
             using namespace DirectX::SimpleMath;
             std::vector<MeshVertex> vertices
             {
-                { Vector3(-0.5f, -0.5f, 0), Vector3::Zero, Vector2(u, v + height), Color(1,1,1,1)  },
-                { Vector3(0.5f, -0.5f, 0), Vector3::Zero, Vector2(u + width, v + height), Color(1,1,1,1) },
-                { Vector3(-0.5f, 0.5f, 0), Vector3::Zero, Vector2(u, v), Color(1,1,1,1) },
-                { Vector3(0.5f, 0.5f, 0), Vector3::Zero, Vector2(u + width, v), Color(1,1,1,1) },
+                { Vector3(-0.5f, -0.5f, 0), Vector3::Zero, Vector2(u + width, v + height), Color(1,1,1,1)  },
+                { Vector3(0.5f, -0.5f, 0), Vector3::Zero, Vector2(u, v + height), Color(1,1,1,1) },
+                { Vector3(-0.5f, 0.5f, 0), Vector3::Zero, Vector2(u + width, v), Color(1,1,1,1) },
+                { Vector3(0.5f, 0.5f, 0), Vector3::Zero, Vector2(u, v), Color(1,1,1,1) },
             };
 
             std::vector<TransparentTriangle> transparent_triangles


### PR DESCRIPTION
Sprites were flipped horizontally (left -> right) so flip them to make them the same as in-game.
Closes #1227