### PR TITLE
Use command type values for trigger command type filtering

### DIFF
--- a/trview.app/Elements/ITrigger.cpp
+++ b/trview.app/Elements/ITrigger.cpp
@@ -43,24 +43,6 @@ namespace trview
             { TriggerCommandType::Flyby, "Flyby" },
             { TriggerCommandType::Cutscene, "Cutscene" }
         };
-
-        const std::unordered_map<std::string, TriggerCommandType> command_type_lookup
-        {
-            { "Object", TriggerCommandType::Object },
-            { "Camera", TriggerCommandType::Camera },
-            { "Current", TriggerCommandType::UnderwaterCurrent },
-            { "Flip Map", TriggerCommandType::FlipMap },
-            { "Flip On", TriggerCommandType::FlipOn },
-            { "Flip Off", TriggerCommandType::FlipOff },
-            { "Look at Item", TriggerCommandType::LookAtItem },
-            { "End Level", TriggerCommandType::EndLevel },
-            { "Music", TriggerCommandType::PlaySoundtrack },
-            { "Flipeffect", TriggerCommandType::Flipeffect },
-            { "Secret", TriggerCommandType::SecretFound },
-            { "Clear Bodies", TriggerCommandType::ClearBodies },
-            { "Flyby", TriggerCommandType::Flyby },
-            { "Cutscene", TriggerCommandType::Cutscene }
-        };
     }
 
     ITrigger::~ITrigger()
@@ -93,19 +75,9 @@ namespace trview
         auto name = command_type_names.find(type);
         if (name == command_type_names.end())
         {
-            return "Unknown";
+            return std::format("Unknown ({})", static_cast<int>(type));
         }
         return name->second;
-    }
-
-    TriggerCommandType command_from_name(const std::string& name)
-    {
-        auto type = command_type_lookup.find(name);
-        if (type == command_type_lookup.end())
-        {
-            return TriggerCommandType::Object;
-        }
-        return type->second;
     }
 
     bool command_has_index(TriggerCommandType type)

--- a/trview.app/Elements/ITrigger.h
+++ b/trview.app/Elements/ITrigger.h
@@ -53,11 +53,6 @@ namespace trview
     /// @returns The string version of the enum.
     std::string command_type_name(TriggerCommandType type);
 
-    /// Get the trigger command type from a string.
-    /// @param name The string to convert.
-    /// @returns The trigger command type.
-    TriggerCommandType command_from_name(const std::string& name);
-
     bool has_command(const ITrigger& trigger, TriggerCommandType type);
     bool has_any_command(const ITrigger& trigger, const std::vector<TriggerCommandType>& type);
 

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -66,8 +66,15 @@ namespace trview
         bool _sync_trigger{ true };
         std::vector<TriggerCommandType> _selected_commands;
         std::shared_ptr<IClipboard> _clipboard;
-        std::vector<std::string> _all_commands;
-        uint32_t _selected_command{ 0u };
+
+        struct VirtualCommand
+        {
+            std::string        name;
+            TriggerCommandType type;
+            bool operator == (const VirtualCommand& other) const noexcept;
+        };
+        std::vector<VirtualCommand> _all_commands;
+        std::optional<VirtualCommand> _selected_command;
         std::weak_ptr<ITrigger> _selected_trigger;
         std::weak_ptr<ITrigger> _global_selected_trigger;
         bool _scroll_to_trigger{ false };


### PR DESCRIPTION
When using the command type filter in the triggers window use the value of the type, not the string. Information was being lost going from number to string and back so unknown command types were being mapped to object.
Closes #1229