### PR TITLE
Use room references instead of room numbers

### DIFF
--- a/trview.app.tests/CameraSinkWindowManagerTests.cpp
+++ b/trview.app.tests/CameraSinkWindowManagerTests.cpp
@@ -2,6 +2,7 @@
 #include <trview.app/Mocks/Windows/ICameraSinkWindow.h>
 #include <trview.app/Mocks/Elements/ICameraSink.h>
 #include <trview.app/Resources/resource.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -105,7 +106,7 @@ TEST(CameraSinkWindowManager, RoomForwarded)
 
     manager->create_window();
     EXPECT_CALL(*window, set_current_room).Times(1);
-    manager->set_room(0);
+    manager->set_room(mock_shared<MockRoom>());
 }
 
 TEST(CameraSinkWindowManager, SelectedSinkRaised)

--- a/trview.app.tests/ItemsWindowManagerTests.cpp
+++ b/trview.app.tests/ItemsWindowManagerTests.cpp
@@ -3,6 +3,7 @@
 #include <trview.app/Mocks/Windows/IItemsWindow.h>
 #include <trview.app/Elements/Types.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -154,7 +155,7 @@ TEST(ItemsWindowManager, SetRoomSetsRoomOnWindows)
     auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
-    manager->set_room(1);
+    manager->set_room(mock_shared<MockRoom>());
 }
 
 TEST(ItemsWindowManager, SetSelectedItemSetsSelectedItemOnWindows)

--- a/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
@@ -177,8 +177,7 @@ TEST(Lua_Level, SelectedRoom)
 {
     auto room = mock_shared<MockRoom>()->with_number(200);
     auto level = mock_shared<MockLevel>();
-    EXPECT_CALL(*level, room(200)).WillRepeatedly(Return(room));
-    EXPECT_CALL(*level, selected_room).WillRepeatedly(Return(200));
+    EXPECT_CALL(*level, selected_room).WillRepeatedly(Return(room));
 
     LuaState L;
     lua::create_level(L, level);
@@ -195,7 +194,8 @@ TEST(Lua_Level, SetSelectedRoom)
 {
     auto room = mock_shared<MockRoom>()->with_number(200);
     auto level = mock_shared<MockLevel>();
-    EXPECT_CALL(*level, set_selected_room(200));
+    std::weak_ptr<IRoom> called_room;
+    EXPECT_CALL(*level, set_selected_room).WillOnce(SaveArg<0>(&called_room));
 
     LuaState L;
     lua::create_level(L, level);
@@ -204,6 +204,7 @@ TEST(Lua_Level, SetSelectedRoom)
     lua_setglobal(L, "r");
 
     ASSERT_EQ(0, luaL_dostring(L, "l.selected_room = r"));
+    ASSERT_EQ(called_room.lock(), room);
 }
 
 TEST(Lua_Level, SelectedTrigger)

--- a/trview.app.tests/TriggersWindowManagerTests.cpp
+++ b/trview.app.tests/TriggersWindowManagerTests.cpp
@@ -3,6 +3,7 @@
 #include <trview.app/Mocks/Windows/ITriggersWindow.h>
 #include <trview.common/Mocks/Windows/IShortcuts.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 
 using namespace trview;
 using namespace trview::mocks;
@@ -212,7 +213,7 @@ TEST(TriggersWindowManager, SetRoomSetsRoomOnWindows)
     auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
     ASSERT_EQ(created_window, mock_window);
-    manager->set_room(1);
+    manager->set_room(mock_shared<MockRoom>());
 }
 
 TEST(TriggersWindowManager, SetSelectedTriggerSetsSelectedTriggerOnWindows)

--- a/trview.app.tests/Windows/LightsWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/LightsWindowManagerTests.cpp
@@ -1,6 +1,7 @@
 #include <trview.app/Windows/LightsWindowManager.h>
 #include <trview.app/Mocks/Windows/ILightsWindow.h>
 #include <trview.app/Mocks/Elements/ILight.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -163,21 +164,22 @@ TEST(LightsWindowManager, SetLevelVersionUpdatesNewWindows)
 TEST(LightsWindowManager, SetRoomUpdatesExistingWindows)
 {
     auto window = mock_shared<MockLightsWindow>();
-    EXPECT_CALL(*window, set_current_room(0)).Times(1);
-    EXPECT_CALL(*window, set_current_room(50)).Times(1);
+    auto room = mock_shared<MockRoom>();
+    EXPECT_CALL(*window, set_current_room).Times(2);
 
     auto manager = register_test_module().with_window_source([&]() { return window; }).build();
     manager->create_window();
-    manager->set_room(50);
+    manager->set_room(room);
 }
 
 TEST(LightsWindowManager, SetRoomUpdatesNewWindows)
 {
     auto window = mock_shared<MockLightsWindow>();
-    EXPECT_CALL(*window, set_current_room(50)).Times(1);
+    auto room = mock_shared<MockRoom>();
+    EXPECT_CALL(*window, set_current_room).Times(1);
 
     auto manager = register_test_module().with_window_source([&]() { return window; }).build();
-    manager->set_room(50);
+    manager->set_room(room);
     manager->create_window();
 }
 

--- a/trview.app.ui.tests/CameraSinkWindowTests.cpp
+++ b/trview.app.ui.tests/CameraSinkWindowTests.cpp
@@ -57,10 +57,11 @@ void register_camera_sink_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<CameraSinkWindowContext>();
             context.ptr = register_test_module().build();
 
+            auto room_78 = mock_shared<MockRoom>()->with_number(78);
             auto camera_sink1 = mock_shared<MockCameraSink>()->with_number(0)->with_room(mock_shared<MockRoom>()->with_number(56));
-            auto camera_sink2 = mock_shared<MockCameraSink>()->with_number(1)->with_room(mock_shared<MockRoom>()->with_number(78));
+            auto camera_sink2 = mock_shared<MockCameraSink>()->with_number(1)->with_room(room_78);
             context.ptr->set_camera_sinks({ camera_sink1, camera_sink2 });
-            context.ptr->set_current_room(78);
+            context.ptr->set_current_room(room_78);
             context.camera_sinks = { camera_sink1, camera_sink2 };
 
             ctx->ItemClick("/**/Track##track");

--- a/trview.app.ui.tests/ItemsWindowTests.cpp
+++ b/trview.app.ui.tests/ItemsWindowTests.cpp
@@ -156,13 +156,15 @@ void register_items_window_tests(ImGuiTestEngine* engine)
             std::shared_ptr<IItem> raised_item;
             auto token = context.ptr->on_item_selected += [&raised_item](const auto& item) { raised_item = item.lock(); };
 
+            auto room_78 = mock_shared<MockRoom>()->with_number(78);
+
             context.items =
             {
                 mock_shared<MockItem>()->with_number(0)->with_room(mock_shared<MockRoom>()->with_number(55)),
-                mock_shared<MockItem>()->with_number(1)->with_room(mock_shared<MockRoom>()->with_number(78))
+                mock_shared<MockItem>()->with_number(1)->with_room(room_78)
             };
             context.ptr->set_items({ std::from_range, context.items });
-            context.ptr->set_current_room(78);
+            context.ptr->set_current_room(room_78);
 
             ctx->ItemClick("Items 0/**/Track##track");
             ctx->ItemCheck("/**/Room");
@@ -184,13 +186,15 @@ void register_items_window_tests(ImGuiTestEngine* engine)
             std::shared_ptr<IItem> raised_item;
             auto token = context.ptr->on_item_selected += [&raised_item](const auto& item) { raised_item = item.lock(); };
 
+            auto room_78 = mock_shared<MockRoom>()->with_number(78);
+
             context.items =
             {
                 mock_shared<MockItem>()->with_number(0)->with_room(mock_shared<MockRoom>()->with_number(55)),
-                mock_shared<MockItem>()->with_number(1)->with_room(mock_shared<MockRoom>()->with_number(78))
+                mock_shared<MockItem>()->with_number(1)->with_room(room_78)
             };
             context.ptr->set_items({ std::from_range, context.items });
-            context.ptr->set_current_room(78);
+            context.ptr->set_current_room(room_78);
 
             ctx->ItemClick("Items 0/**/0##0");
 

--- a/trview.app.ui.tests/LightsWindowTests.cpp
+++ b/trview.app.ui.tests/LightsWindowTests.cpp
@@ -74,11 +74,12 @@ void register_lights_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<LightsWindowContext>();
             context.ptr = register_test_module().build();
 
+            auto room_78 = mock_shared<MockRoom>()->with_number(78);
             auto light1 = mock_shared<MockLight>()->with_number(0)->with_room(mock_shared<MockRoom>()->with_number(56));
-            auto light2 = mock_shared<MockLight>()->with_number(1)->with_room(mock_shared<MockRoom>()->with_number(78));
+            auto light2 = mock_shared<MockLight>()->with_number(1)->with_room(room_78);
             context.lights = { light1, light2 };
             context.ptr->set_lights({ light1, light2 });
-            context.ptr->set_current_room(78);
+            context.ptr->set_current_room(room_78);
 
             ctx->ItemClick("/**/Track##track");
             ctx->ItemCheck("/**/Room");
@@ -95,11 +96,12 @@ void register_lights_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<LightsWindowContext>();
             context.ptr = register_test_module().build();
 
+            auto room_78 = mock_shared<MockRoom>()->with_number(78);
             auto light1 = mock_shared<MockLight>()->with_number(0)->with_room(mock_shared<MockRoom>()->with_number(56));
-            auto light2 = mock_shared<MockLight>()->with_number(1)->with_room(mock_shared<MockRoom>()->with_number(78));
+            auto light2 = mock_shared<MockLight>()->with_number(1)->with_room(room_78);
             context.lights = { light1, light2 };
             context.ptr->set_lights({ light1, light2 });
-            context.ptr->set_current_room(78);
+            context.ptr->set_current_room(room_78);
 
             ctx->Yield();
 

--- a/trview.app.ui.tests/RoomsWindowTests.cpp
+++ b/trview.app.ui.tests/RoomsWindowTests.cpp
@@ -70,7 +70,7 @@ void register_rooms_window_tests(ImGuiTestEngine* engine)
 
             context.ptr->set_level_version(trlevel::LevelVersion::Tomb1);
             context.ptr->set_rooms({ room });
-            context.ptr->set_current_room(0);
+            context.ptr->set_current_room(room);
 
             ctx->Yield();
             IM_CHECK_EQ(ctx->ItemExists("/**/Bit 7"), true);
@@ -82,7 +82,7 @@ void register_rooms_window_tests(ImGuiTestEngine* engine)
 
             context.ptr->set_level_version(trlevel::LevelVersion::Tomb3);
             context.ptr->set_rooms({ room });
-            context.ptr->set_current_room(0);
+            context.ptr->set_current_room(room);
             ctx->Yield();
 
             IM_CHECK_EQ(ctx->ItemExists("/**/Bit 7"), false);
@@ -137,7 +137,7 @@ void register_rooms_window_tests(ImGuiTestEngine* engine)
 
             context.ptr->set_level_version(trlevel::LevelVersion::Tomb1);
             context.ptr->set_rooms({ normal_room, death_room });
-            context.ptr->set_current_room(0);
+            context.ptr->set_current_room(normal_room);
 
             ctx->Yield();
             IM_CHECK_EQ(ctx->ItemExists("/**/0##0"), true);

--- a/trview.app.ui.tests/TriggersWindowTests.cpp
+++ b/trview.app.ui.tests/TriggersWindowTests.cpp
@@ -215,10 +215,11 @@ void register_triggers_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<TriggersWindowContext>();
             context.ptr = register_test_module().build();
 
+            auto room_78 = mock_shared<MockRoom>()->with_number(78);
             auto trigger1 = mock_shared<MockTrigger>()->with_number(0);
             auto trigger2 = mock_shared<MockTrigger>()->with_number(1);
             context.ptr->set_triggers({ trigger1, trigger2 });
-            context.ptr->set_current_room(78);
+            context.ptr->set_current_room(room_78);
 
             ctx->Yield();
             IM_CHECK_EQ(ctx->ItemExists("/**/0##0"), true);
@@ -232,11 +233,12 @@ void register_triggers_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<TriggersWindowContext>();
             context.ptr = register_test_module().build();
 
+            auto room_78 = mock_shared<MockRoom>()->with_number(78);
             auto trigger1 = mock_shared<MockTrigger>()->with_number(0)->with_room(mock_shared<MockRoom>()->with_number(55));
-            auto trigger2 = mock_shared<MockTrigger>()->with_number(1)->with_room(mock_shared<MockRoom>()->with_number(78));
+            auto trigger2 = mock_shared<MockTrigger>()->with_number(1)->with_room(room_78);
             context.triggers = { trigger1, trigger2 };
             context.ptr->set_triggers({ trigger1, trigger2 });
-            context.ptr->set_current_room(78);
+            context.ptr->set_current_room(room_78);
 
             ctx->Yield();
             IM_CHECK_EQ(ctx->ItemExists("/**/0##0"), true);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -473,7 +473,10 @@ namespace trview
 
     void Application::select_room(std::weak_ptr<IRoom> room)
     {
-        _level->set_selected_room(room);
+        if (_level)
+        {
+            _level->set_selected_room(room);
+        }
         _viewer->select_room(room);
         _items_windows->set_room(room);
         _rooms_windows->set_room(room);

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -102,10 +102,11 @@ namespace trview
         void setup_camera_sink_windows();
         void setup_shortcuts();
         // Entity manipulation
+        void add_waypoint(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, std::weak_ptr<IRoom> room, IWaypoint::Type type, uint32_t index);
         void add_waypoint(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, IWaypoint::Type type, uint32_t index);
         void remove_waypoint(uint32_t index);
         void select_item(std::weak_ptr<IItem> item);
-        void select_room(uint32_t room);
+        void select_room(std::weak_ptr<IRoom> room);
         /// <summary>
         /// Select a trigger in the application. If the trigger is empty, nothing happens.
         /// </summary>

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -81,7 +81,7 @@ namespace trview
         virtual std::optional<uint32_t> selected_item() const = 0;
         virtual std::optional<uint32_t> selected_light() const = 0;
         virtual std::optional<uint32_t> selected_camera_sink() const = 0;
-        virtual uint16_t selected_room() const = 0;
+        virtual std::weak_ptr<IRoom> selected_room() const = 0;
         virtual std::optional<uint32_t> selected_trigger() const = 0;
         // Set whether to render the alternate mode (the flipmap) or the regular room.
         // enabled: Whether to render the flipmap.
@@ -109,7 +109,7 @@ namespace trview
         virtual void set_show_camera_sinks(bool show) = 0;
         virtual void set_trigger_visibility(uint32_t index, bool state) = 0;
         virtual void set_neighbour_depth(uint32_t depth) = 0;
-        virtual void set_selected_room(uint16_t index) = 0;
+        virtual void set_selected_room(const std::weak_ptr<IRoom>& room) = 0;
         virtual void set_selected_item(uint32_t index) = 0;
         virtual void set_light_visibility(uint32_t index, bool state) = 0;
         virtual void set_room_visibility(uint32_t index, bool state) = 0;
@@ -136,7 +136,7 @@ namespace trview
         virtual trlevel::LevelVersion version() const = 0;
         Event<std::weak_ptr<IItem>> on_item_selected;
         // Event raised when the level needs to change the selected room.
-        Event<uint32_t> on_room_selected;
+        Event<std::weak_ptr<IRoom>> on_room_selected;
         // Event raised when the level needs to change the alternate mode.
         Event<bool> on_alternate_mode_selected;
         /// Event raised when the level needs to change the alternate group mode.

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -39,7 +39,7 @@ namespace trview
         virtual ~Level() = default;
         virtual std::vector<graphics::Texture> level_textures() const override;
         virtual std::optional<uint32_t> selected_item() const override;
-        virtual uint16_t selected_room() const override;
+        std::weak_ptr<IRoom> selected_room() const override;
         virtual std::weak_ptr<IItem> item(uint32_t index) const override;
         virtual std::vector<std::weak_ptr<IItem>> items() const override;
         virtual uint32_t neighbour_depth() const override;
@@ -52,7 +52,7 @@ namespace trview
         virtual void render_transparency(const ICamera& camera) override;
         virtual void set_highlight_mode(RoomHighlightMode mode, bool enabled) override;
         virtual bool highlight_mode_enabled(RoomHighlightMode mode) const override;
-        virtual void set_selected_room(uint16_t index) override;
+        void set_selected_room(const std::weak_ptr<IRoom>& room) override;
         virtual void set_selected_item(uint32_t index) override;
         virtual void set_neighbour_depth(uint32_t depth) override;
         virtual void on_camera_moved() override;
@@ -174,7 +174,7 @@ namespace trview
 
         std::set<RoomHighlightMode> _room_highlight_modes;
         
-        uint16_t           _selected_room{ 0u };
+        std::weak_ptr<IRoom> _selected_room;
         std::weak_ptr<IItem> _selected_item;
         std::weak_ptr<ITrigger> _selected_trigger;
         std::weak_ptr<ILight> _selected_light;

--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -68,7 +68,7 @@ namespace trview
                 }
                 else if (key == "selected_room")
                 {
-                    return create_room(L, level->room(level->selected_room()).lock());
+                    return create_room(L, level->selected_room().lock());
                 }
                 else if (key == "selected_trigger")
                 {
@@ -118,7 +118,7 @@ namespace trview
                 {
                     if (auto room = to_room(L, -1))
                     {
-                        level->set_selected_room(static_cast<uint16_t>(room->number()));
+                        level->set_selected_room(room);
                     }
                 }
                 else if (key == "selected_trigger")

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -35,7 +35,7 @@ namespace trview
             MOCK_METHOD(std::vector<std::weak_ptr<IRoom>>, rooms, (), (const, override));
             MOCK_METHOD(std::optional<uint32_t>, selected_item, (), (const, override));
             MOCK_METHOD(std::optional<uint32_t>, selected_light, (), (const, override));
-            MOCK_METHOD(uint16_t, selected_room, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<IRoom>, selected_room, (), (const, override));
             MOCK_METHOD(std::optional<uint32_t>, selected_trigger, (), (const, override));
             MOCK_METHOD(void, set_alternate_mode, (bool), (override));
             MOCK_METHOD(void, set_alternate_group, (uint32_t, bool), (override));
@@ -56,7 +56,7 @@ namespace trview
             MOCK_METHOD(void, set_show_rooms, (bool), (override));
             MOCK_METHOD(void, set_trigger_visibility, (uint32_t, bool), (override));
             MOCK_METHOD(void, set_neighbour_depth, (uint32_t), (override));
-            MOCK_METHOD(void, set_selected_room, (uint16_t), (override));
+            MOCK_METHOD(void, set_selected_room, (const std::weak_ptr<IRoom>&), (override));
             MOCK_METHOD(void, set_selected_item, (uint32_t), (override));
             MOCK_METHOD(void, set_light_visibility, (uint32_t, bool), (override));
             MOCK_METHOD(void, set_room_visibility, (uint32_t, bool), (override));

--- a/trview.app/Mocks/Windows/ICameraSinkWindow.h
+++ b/trview.app/Mocks/Windows/ICameraSinkWindow.h
@@ -14,7 +14,7 @@ namespace trview
             MOCK_METHOD(void, set_camera_sinks, (const std::vector<std::weak_ptr<ICameraSink>>&), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));
             MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
-            MOCK_METHOD(void, set_current_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_current_room, (const std::weak_ptr<IRoom>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/ICameraSinkWindowManager.h
+++ b/trview.app/Mocks/Windows/ICameraSinkWindowManager.h
@@ -14,7 +14,7 @@ namespace trview
             MOCK_METHOD(std::weak_ptr<ICameraSinkWindow>, create_window, (), (override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
-            MOCK_METHOD(void, set_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_room, (const std::weak_ptr<IRoom>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IItemsWindow.h
+++ b/trview.app/Mocks/Windows/IItemsWindow.h
@@ -14,7 +14,7 @@ namespace trview
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(void, clear_selected_item, (), (override));
-            MOCK_METHOD(void, set_current_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_current_room, (const std::weak_ptr<IRoom>&), (override));
             MOCK_METHOD(void, set_selected_item, (const std::weak_ptr<IItem>&), (override));
             MOCK_METHOD(std::weak_ptr<IItem>, selected_item, (), (const, override));
             MOCK_METHOD(void, update, (float), (override));

--- a/trview.app/Mocks/Windows/IItemsWindowManager.h
+++ b/trview.app/Mocks/Windows/IItemsWindowManager.h
@@ -16,7 +16,7 @@ namespace trview
             MOCK_METHOD(void, set_level_version, (trlevel::LevelVersion), (override));
             MOCK_METHOD(void, set_model_checker, (const std::function<bool(uint32_t)>&), (override));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
-            MOCK_METHOD(void, set_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_room, (const std::weak_ptr<IRoom>&), (override));
             MOCK_METHOD(void, set_selected_item, (const std::weak_ptr<IItem>&), (override));
             MOCK_METHOD(std::weak_ptr<IItemsWindow>, create_window, (), (override));
             MOCK_METHOD(void, update, (float), (override));

--- a/trview.app/Mocks/Windows/ILightsWindow.h
+++ b/trview.app/Mocks/Windows/ILightsWindow.h
@@ -17,7 +17,7 @@ namespace trview
             MOCK_METHOD(void, set_selected_light, (const std::weak_ptr<ILight>&), (override));
             MOCK_METHOD(void, set_level_version, (trlevel::LevelVersion), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));
-            MOCK_METHOD(void, set_current_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_current_room, (const std::weak_ptr<IRoom>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/ILightsWindowManager.h
+++ b/trview.app/Mocks/Windows/ILightsWindowManager.h
@@ -16,7 +16,7 @@ namespace trview
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, set_selected_light, (const std::weak_ptr<ILight>&), (override));
             MOCK_METHOD(void, set_level_version, (trlevel::LevelVersion), (override));
-            MOCK_METHOD(void, set_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_room, (const std::weak_ptr<IRoom>&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRoomsWindow.h
+++ b/trview.app/Mocks/Windows/IRoomsWindow.h
@@ -12,7 +12,7 @@ namespace trview
             virtual ~MockRoomsWindow();
             MOCK_METHOD(void, clear_selected_trigger, (), (override));
             MOCK_METHOD(void, render, (), (override));
-            MOCK_METHOD(void, set_current_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_current_room, (const std::weak_ptr<IRoom>&), (override));
             MOCK_METHOD(void, set_items, (const std::vector<std::weak_ptr<IItem>>&), (override));
             MOCK_METHOD(void, set_level_version, (trlevel::LevelVersion), (override));
             MOCK_METHOD(void, set_map_colours, (const MapColours&), (override));

--- a/trview.app/Mocks/Windows/IRoomsWindowManager.h
+++ b/trview.app/Mocks/Windows/IRoomsWindowManager.h
@@ -15,7 +15,7 @@ namespace trview
             MOCK_METHOD(void, set_items, (const std::vector<std::weak_ptr<IItem>>&), (override));
             MOCK_METHOD(void, set_level_version, (trlevel::LevelVersion), (override));
             MOCK_METHOD(void, set_map_colours, (const MapColours&), (override));
-            MOCK_METHOD(void, set_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_room, (const std::weak_ptr<IRoom>&), (override));
             MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&), (override));
             MOCK_METHOD(void, set_selected_item, (const std::weak_ptr<IItem>&), (override));
             MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>& ), (override));

--- a/trview.app/Mocks/Windows/ITriggersWindow.h
+++ b/trview.app/Mocks/Windows/ITriggersWindow.h
@@ -13,7 +13,7 @@ namespace trview
             MOCK_METHOD(void, clear_selected_trigger, (), (override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(std::weak_ptr<ITrigger>, selected_trigger, (), (const, override));
-            MOCK_METHOD(void, set_current_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_current_room, (const std::weak_ptr<IRoom>&), (override));
             MOCK_METHOD(void, set_items, (const std::vector<std::weak_ptr<IItem>>&), (override));
             MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));

--- a/trview.app/Mocks/Windows/ITriggersWindowManager.h
+++ b/trview.app/Mocks/Windows/ITriggersWindowManager.h
@@ -13,7 +13,7 @@ namespace trview
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_items, (const std::vector<std::weak_ptr<IItem>>&), (override));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
-            MOCK_METHOD(void, set_room, (uint32_t), (override));
+            MOCK_METHOD(void, set_room, (const std::weak_ptr<IRoom>&), (override));
             MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&), (override));
             MOCK_METHOD(std::weak_ptr<ITriggersWindow>, create_window, (), (override));
             MOCK_METHOD(void, update, (float), (override));

--- a/trview.app/Mocks/Windows/IViewer.h
+++ b/trview.app/Mocks/Windows/IViewer.h
@@ -15,7 +15,7 @@ namespace trview
             MOCK_METHOD(void, open, (const std::weak_ptr<ILevel>&, ILevel::OpenMode), (override));
             MOCK_METHOD(void, set_settings, (const UserSettings&), (override));
             MOCK_METHOD(void, select_item, (const std::weak_ptr<IItem>&), (override));
-            MOCK_METHOD(void, select_room, (uint32_t), (override));
+            MOCK_METHOD(void, select_room, (const std::weak_ptr<IRoom>&), (override));
             MOCK_METHOD(void, select_light, (const std::weak_ptr<ILight>&), (override));
             MOCK_METHOD(void, select_sector, (const std::weak_ptr<ISector>&), (override));
             MOCK_METHOD(void, select_trigger, (const std::weak_ptr<ITrigger>&), (override));

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -7,26 +7,16 @@ namespace trview
 {
     namespace
     {
-        bool matching_room(ICameraSink& camera_sink, uint32_t room)
+        bool matching_room(ICameraSink& camera_sink, const std::weak_ptr<IRoom>& room)
         {
+            const auto room_ptr = room.lock();
             if (camera_sink.type() == ICameraSink::Type::Camera)
             {
-                if (auto camera_room = camera_sink.room().lock())
-                {
-                    return camera_room->number() == room;
-                }
-                return false;
+                return camera_sink.room().lock() == room_ptr;
             }
 
             const auto inferred = camera_sink.inferred_rooms();
-            return std::ranges::find_if(inferred, [=](auto&& r)
-                {
-                    if (auto inferred_room = r.lock())
-                    {
-                        return inferred_room->number() == room;
-                    }
-                    return false;
-                }) != inferred.end();
+            return std::ranges::find_if(inferred, [=](auto&& r) { return r.lock() == room_ptr; }) != inferred.end();
         }
 
         uint32_t primary_room(const ICameraSink& camera_sink)
@@ -372,7 +362,7 @@ namespace trview
         }
     }
 
-    void CameraSinkWindow::set_current_room(uint32_t room)
+    void CameraSinkWindow::set_current_room(const std::weak_ptr<IRoom>& room)
     {
         _current_room = room;
     }

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -27,7 +27,7 @@ namespace trview
         virtual void set_number(int32_t number) override;
         virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) override;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
-        virtual void set_current_room(uint32_t room) override;
+        void set_current_room(const std::weak_ptr<IRoom>& room) override;
     private:
         bool render_camera_sink_window();
         void set_sync(bool value);
@@ -46,7 +46,7 @@ namespace trview
         std::weak_ptr<ITrigger> _selected_trigger;
         bool _sync{ true };
         bool _scroll_to{ false };
-        uint32_t _current_room{ 0u };
+        std::weak_ptr<IRoom> _current_room;
         bool _force_sort{ false };
         std::vector<std::weak_ptr<ITrigger>> _triggered_by;
         Track<Type::Room> _track;

--- a/trview.app/Windows/CameraSink/CameraSinkWindowManager.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindowManager.cpp
@@ -58,7 +58,7 @@ namespace trview
         }
     }
 
-    void CameraSinkWindowManager::set_room(uint32_t room)
+    void CameraSinkWindowManager::set_room(const std::weak_ptr<IRoom>& room)
     {
         _current_room = room;
         for (auto& window : _windows)

--- a/trview.app/Windows/CameraSink/CameraSinkWindowManager.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindowManager.h
@@ -16,11 +16,11 @@ namespace trview
         virtual void render() override;
         virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) override;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
-        virtual void set_room(uint32_t room) override;
+        void set_room(const std::weak_ptr<IRoom>& room) override;
     private:
         ICameraSinkWindow::Source _camera_sink_window_source;
         std::vector<std::weak_ptr<ICameraSink>> _camera_sinks;
         std::weak_ptr<ICameraSink> _selected_camera_sink;
-        uint32_t _current_room{ 0u };
+        std::weak_ptr<IRoom> _current_room;
     };
 }

--- a/trview.app/Windows/CameraSink/ICameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/ICameraSinkWindow.h
@@ -14,7 +14,7 @@ namespace trview
         virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) = 0;
         virtual void set_number(int32_t number) = 0;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
-        virtual void set_current_room(uint32_t room) = 0;
+        virtual void set_current_room(const std::weak_ptr<IRoom>& room) = 0;
         /// <summary>
         /// Event raised when the window is closed.
         /// </summary>

--- a/trview.app/Windows/CameraSink/ICameraSinkWindowManager.h
+++ b/trview.app/Windows/CameraSink/ICameraSinkWindowManager.h
@@ -12,7 +12,7 @@ namespace trview
         virtual void render() = 0;
         virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) = 0;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
-        virtual void set_room(uint32_t room) = 0;
+        virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
         Event<std::weak_ptr<ICameraSink>, bool> on_camera_sink_visibility;

--- a/trview.app/Windows/IItemsWindow.h
+++ b/trview.app/Windows/IItemsWindow.h
@@ -43,9 +43,11 @@ namespace trview
         /// Clear the currently selected item from the details panel.
         virtual void clear_selected_item() = 0;
 
+        /// <summary>
         /// Set the current room. This will be used when the track room setting is on.
-        /// @param room The current room number.
-        virtual void set_current_room(uint32_t room) = 0;
+        /// </summary>
+        /// <param name="room">The current room.</param>
+        virtual void set_current_room(const std::weak_ptr<IRoom>& room) = 0;
 
         /// Set the selected item.
         /// @param item The selected item.

--- a/trview.app/Windows/IItemsWindowManager.h
+++ b/trview.app/Windows/IItemsWindowManager.h
@@ -35,9 +35,11 @@ namespace trview
         /// @param triggers The triggers in the level.
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
 
+        /// <summary>
         /// Set the current room to filter item windows.
-        /// @param room The current room.
-        virtual void set_room(uint32_t room) = 0;
+        /// </summary>
+        /// <param name="room">The current room.</param>
+        virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
 
         /// Set the currently selected item.
         /// @param item The selected item.

--- a/trview.app/Windows/ILightsWindow.h
+++ b/trview.app/Windows/ILightsWindow.h
@@ -17,7 +17,7 @@ namespace trview
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) = 0;
         virtual void set_level_version(trlevel::LevelVersion version) = 0;
         virtual void set_number(int32_t number) = 0;
-        virtual void set_current_room(uint32_t room) = 0;
+        virtual void set_current_room(const std::weak_ptr<IRoom>& room) = 0;
         /// <summary>
         /// Event raised when the window is closed.
         /// </summary>

--- a/trview.app/Windows/ILightsWindowManager.h
+++ b/trview.app/Windows/ILightsWindowManager.h
@@ -16,7 +16,7 @@ namespace trview
         virtual void update(float delta) = 0;
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) = 0;
         virtual void set_level_version(trlevel::LevelVersion version) = 0;
-        virtual void set_room(uint32_t room) = 0;
+        virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
 
         Event<std::weak_ptr<ILight>> on_light_selected;
         Event<std::weak_ptr<ILight>, bool> on_light_visibility;

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -18,7 +18,7 @@ namespace trview
         virtual ~IRoomsWindow() = 0;
 
         /// Event raised when the user has selected a room in the room window.
-        Event<uint32_t> on_room_selected;
+        Event<std::weak_ptr<IRoom>> on_room_selected;
 
         /// Event raised when the user has selected an item in the room window.
         Event<std::weak_ptr<IItem>> on_item_selected;
@@ -45,7 +45,7 @@ namespace trview
 
         /// Set the current room that the viewer is focusing on.
         /// @param room The current room.
-        virtual void set_current_room(uint32_t room) = 0;
+        virtual void set_current_room(const std::weak_ptr<IRoom>& room) = 0;
 
         /// Set the items in the level.
         /// @param items The items in the level.

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -9,7 +9,7 @@ namespace trview
         virtual ~IRoomsWindowManager() = 0;
 
         /// Event raised when the user has selected a room in the room window.
-        Event<uint32_t> on_room_selected;
+        Event<std::weak_ptr<IRoom>> on_room_selected;
 
         /// Event raised when the user has selected an item in the room window.
         Event<std::weak_ptr<IItem>> on_item_selected;
@@ -37,7 +37,7 @@ namespace trview
         virtual void set_map_colours(const MapColours& colours) = 0;
         /// Set the current room that the viewer is focusing on.
         /// @param room The current room.
-        virtual void set_room(uint32_t room) = 0;
+        virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
 
         /// Set the rooms to display in the window.
         /// @param rooms The rooms to show.

--- a/trview.app/Windows/ITriggersWindow.h
+++ b/trview.app/Windows/ITriggersWindow.h
@@ -41,9 +41,11 @@ namespace trview
 
         virtual std::weak_ptr<ITrigger> selected_trigger() const = 0;
 
+        /// <summary>
         /// Set the current room. This will be used when the track room setting is on.
-        /// @param room The current room number.
-        virtual void set_current_room(uint32_t room) = 0;
+        /// </summary>
+        /// <param name="room">The current room number</param>
+        virtual void set_current_room(const std::weak_ptr<IRoom>& room) = 0;
 
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) = 0;
 

--- a/trview.app/Windows/ITriggersWindowManager.h
+++ b/trview.app/Windows/ITriggersWindowManager.h
@@ -32,9 +32,11 @@ namespace trview
         /// @param triggers The triggers in the level.
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
 
+        /// <summary>
         /// Set the current room to filter trigger windows.
-        /// @param room The current room.
-        virtual void set_room(uint32_t room) = 0;
+        /// </summary>
+        /// <param name="room">The current room.</param>
+        virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
 
         /// Set the currently selected trigger.
         /// @param item The selected trigger.

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -47,7 +47,7 @@ namespace trview
         Event<std::weak_ptr<IItem>, bool> on_item_visibility;
 
         /// Event raised when the viewer wants to select a room.
-        Event<uint32_t> on_room_selected;
+        Event<std::weak_ptr<IRoom>> on_room_selected;
 
         /// Event raised when the viewer wants to select a trigger.
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
@@ -76,7 +76,7 @@ namespace trview
         Event<uint32_t> on_waypoint_removed;
 
         /// Event raised when the viewer wants to add a waypoint.
-        Event<DirectX::SimpleMath::Vector3, DirectX::SimpleMath::Vector3, uint32_t, IWaypoint::Type, uint32_t> on_waypoint_added;
+        Event<DirectX::SimpleMath::Vector3, DirectX::SimpleMath::Vector3, std::weak_ptr<IRoom>, IWaypoint::Type, uint32_t> on_waypoint_added;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
 
@@ -98,10 +98,12 @@ namespace trview
         /// @remarks This will not raise the on_item_selected event.
         virtual void select_item(const std::weak_ptr<IItem>& item) = 0;
 
+        /// <summary>
         /// Select the specified room.
-        /// @param room The room to select.
-        /// @remarks This will not raise the on_room_selected event.
-        virtual void select_room(uint32_t room) = 0;
+        /// </summary>
+        /// <param name="room">The room to select</param>
+        /// <remarks>This will not raise the on_room_selected event.</remarks>
+        virtual void select_room(const std::weak_ptr<IRoom>& room) = 0;
 
         /// Select the specified trigger.
         /// @param trigger The trigger to select.

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -58,7 +58,7 @@ namespace trview
         _triggered_by.clear();
     }
 
-    void ItemsWindow::set_current_room(uint32_t room)
+    void ItemsWindow::set_current_room(const std::weak_ptr<IRoom>& room)
     {
         _current_room = room;
     }
@@ -130,7 +130,7 @@ namespace trview
                 for (const auto& item : _all_items)
                 {
                     auto item_ptr = item.lock();
-                    if (!item_ptr || (_track.enabled<Type::Room>() && item_room(item_ptr) != _current_room || !_filters.match(*item_ptr)))
+                    if (!item_ptr || (_track.enabled<Type::Room>() && item_ptr->room().lock() != _current_room.lock() || !_filters.match(*item_ptr)))
                     {
                         continue;
                     }

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -33,7 +33,7 @@ namespace trview
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void clear_selected_item() override;
-        virtual void set_current_room(uint32_t room) override;
+        void set_current_room(const std::weak_ptr<IRoom>& room) override;
         virtual void set_selected_item(const std::weak_ptr<IItem>& item) override;
         virtual std::weak_ptr<IItem> selected_item() const override;
         virtual void update(float delta) override;
@@ -51,7 +51,7 @@ namespace trview
         std::string _id{ "Items 0" };
         std::vector<std::weak_ptr<IItem>> _all_items;
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;
-        uint32_t _current_room{ 0u };
+        std::weak_ptr<IRoom> _current_room;
         bool _sync_item{ true };
         std::shared_ptr<IClipboard> _clipboard;
         std::unordered_map<std::string, std::string> _tips;

--- a/trview.app/Windows/ItemsWindowManager.cpp
+++ b/trview.app/Windows/ItemsWindowManager.cpp
@@ -81,7 +81,7 @@ namespace trview
         }
     }
 
-    void ItemsWindowManager::set_room(uint32_t room)
+    void ItemsWindowManager::set_room(const std::weak_ptr<IRoom>& room)
     {
         _current_room = room;
         for (auto& window : _windows)

--- a/trview.app/Windows/ItemsWindowManager.h
+++ b/trview.app/Windows/ItemsWindowManager.h
@@ -30,14 +30,14 @@ namespace trview
         virtual void set_level_version(trlevel::LevelVersion version) override;
         virtual void set_model_checker(const std::function<bool(uint32_t)>& checker) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
-        virtual void set_room(uint32_t room) override;
+        void set_room(const std::weak_ptr<IRoom>& room) override;
         virtual void set_selected_item(const std::weak_ptr<IItem>& item) override;
         virtual std::weak_ptr<IItemsWindow> create_window() override;
         virtual void update(float delta) override;
     private:
         std::vector<std::weak_ptr<IItem>> _items;
         std::vector<std::weak_ptr<ITrigger>> _triggers;
-        uint32_t _current_room{ 0u };
+        std::weak_ptr<IRoom> _current_room;
         std::weak_ptr<IItem> _selected_item;
         IItemsWindow::Source _items_window_source;
         trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Unknown };

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -113,7 +113,7 @@ namespace trview
                 for (const auto& light_ptr : _all_lights)
                 {
                     const auto& light = light_ptr.lock();
-                    if (_track.enabled<Type::Room>() && light_room(light) != _current_room || !_filters.match(*light))
+                    if (_track.enabled<Type::Room>() && light->room().lock() != _current_room.lock() || !_filters.match(*light))
                     {
                         continue;
                     }
@@ -285,7 +285,7 @@ namespace trview
         _selected_light = light;
     }
 
-    void LightsWindow::set_current_room(uint32_t room)
+    void LightsWindow::set_current_room(const std::weak_ptr<IRoom>& room)
     {
         _current_room = room;
     }

--- a/trview.app/Windows/LightsWindow.h
+++ b/trview.app/Windows/LightsWindow.h
@@ -30,7 +30,7 @@ namespace trview
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) override;
         virtual void set_level_version(trlevel::LevelVersion version) override;
         virtual void set_number(int32_t number) override;
-        virtual void set_current_room(uint32_t room) override;
+        void set_current_room(const std::weak_ptr<IRoom>& room) override;
     private:
         void set_sync_light(bool value);
         void set_local_selected_light(const std::weak_ptr<ILight>& light);
@@ -48,7 +48,7 @@ namespace trview
         bool _scroll_to_light{ false };
         std::weak_ptr<ILight> _selected_light;
         std::weak_ptr<ILight> _global_selected_light;
-        uint32_t _current_room{ 0u };
+        std::weak_ptr<IRoom> _current_room;
         std::unordered_map<std::string, std::string> _tips;
         Filters<ILight> _filters;
         bool _force_sort{ false };

--- a/trview.app/Windows/LightsWindowManager.cpp
+++ b/trview.app/Windows/LightsWindowManager.cpp
@@ -73,7 +73,7 @@ namespace trview
         }
     }
 
-    void LightsWindowManager::set_room(uint32_t room)
+    void LightsWindowManager::set_room(const std::weak_ptr<IRoom>& room)
     {
         _current_room = room;
         for (auto& window : _windows)

--- a/trview.app/Windows/LightsWindowManager.h
+++ b/trview.app/Windows/LightsWindowManager.h
@@ -20,12 +20,12 @@ namespace trview
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) override;
         virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
         virtual std::weak_ptr<ILightsWindow> create_window() override;
-        virtual void set_room(uint32_t room) override;
+        void set_room(const std::weak_ptr<IRoom>& room) override;
     private:
         std::vector<std::weak_ptr<ILight>> _lights;
         ILightsWindow::Source _lights_window_source;
         std::weak_ptr<ILight> _selected_light;
         trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Tomb1 };
-        uint32_t _current_room{ 0u };
+        std::weak_ptr<IRoom> _current_room;
     };
 }

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -33,7 +33,7 @@ namespace trview
         virtual ~RoomsWindow() = default;
         virtual void clear_selected_trigger() override;
         virtual void render() override;
-        virtual void set_current_room(uint32_t room) override;
+        virtual void set_current_room(const std::weak_ptr<IRoom>& room) override;
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) override;
         virtual void set_level_version(trlevel::LevelVersion version) override;
         virtual void set_map_colours(const MapColours& colours) override;
@@ -52,7 +52,7 @@ namespace trview
         void render_rooms_list();
         void render_room_details();
         bool render_rooms_window();
-        void load_room_details(uint32_t room_number);
+        void load_room_details(std::weak_ptr<IRoom> room);
         void generate_filters();
         void render_properties_tab(const std::shared_ptr<IRoom>& room);
         void render_neighbours_tab(const std::shared_ptr<IRoom>& room);
@@ -65,7 +65,7 @@ namespace trview
         void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers);
         void set_lights(const std::vector<std::weak_ptr<ILight>>& lights);
         void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks);
-        void select_room(uint32_t room);
+        void select_room(std::weak_ptr<IRoom> room);
         void render_statics_tab();
         void set_static_meshes(const std::vector<std::weak_ptr<IStaticMesh>>& static_meshes);
 
@@ -97,8 +97,8 @@ namespace trview
         std::weak_ptr<IStaticMesh> _local_selected_static_mesh;
         bool _scroll_to_static_mesh{ false };
 
-        uint32_t _current_room{ 0u };
-        uint32_t _selected_room{ 0u };
+        std::weak_ptr<IRoom> _current_room;
+        std::weak_ptr<IRoom> _selected_room;
 
         TokenStore _token_store;
         std::unique_ptr<IMapRenderer> _map_renderer;

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -60,7 +60,7 @@ namespace trview
         }
     }
 
-    void RoomsWindowManager::set_room(uint32_t room)
+    void RoomsWindowManager::set_room(const std::weak_ptr<IRoom>& room)
     {
         _current_room = room;
         for (auto& window : _windows)

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -34,7 +34,7 @@ namespace trview
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) override;
         virtual void set_level_version(trlevel::LevelVersion version) override;
         virtual void set_map_colours(const MapColours& colours) override;
-        virtual void set_room(uint32_t room) override;
+        virtual void set_room(const std::weak_ptr<IRoom>& room) override;
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& items) override;
         virtual void set_selected_item(const std::weak_ptr<IItem>& item) override;
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
@@ -46,7 +46,7 @@ namespace trview
     private:
         std::vector<std::weak_ptr<IItem>> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
-        uint32_t _current_room{ 0u };
+        std::weak_ptr<IRoom> _current_room;
         std::weak_ptr<ITrigger> _selected_trigger;
         std::weak_ptr<IItem> _selected_item;
         IRoomsWindow::Source _rooms_window_source;

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -58,7 +58,7 @@ namespace trview
         _local_selected_trigger_commands.clear();
     }
 
-    void TriggersWindow::set_current_room(uint32_t room)
+    void TriggersWindow::set_current_room(const std::weak_ptr<IRoom>& room)
     {
         _current_room = room;
         _need_filtering = true;
@@ -497,7 +497,7 @@ namespace trview
             [&](const auto& trigger)
             {
                 const auto trigger_ptr = trigger.lock();
-                return !((_track.enabled<Type::Room>() && trigger_room(trigger_ptr) != _current_room || !_filters.match(*trigger_ptr)) ||
+                return !((_track.enabled<Type::Room>() && trigger_ptr->room().lock() != _current_room.lock() || !_filters.match(*trigger_ptr)) ||
                          (!_selected_commands.empty() && !has_any_command(*trigger_ptr, _selected_commands)));
             });
         _need_filtering = false;

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -36,7 +36,7 @@ namespace trview
         virtual void render() override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         virtual void clear_selected_trigger() override;
-        virtual void set_current_room(uint32_t room) override;
+        void set_current_room(const std::weak_ptr<IRoom>& room) override;
         virtual void set_number(int32_t number) override;
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) override;
@@ -59,8 +59,7 @@ namespace trview
         std::vector<std::weak_ptr<ITrigger>> _filtered_triggers;
 
         TokenStore _token_store;
-        /// The current room number selected for tracking.
-        uint32_t _current_room{ 0u };
+        std::weak_ptr<IRoom> _current_room;
         /// Whether the room tracking filter has been applied.
         bool _filter_applied{ false };
         bool _sync_trigger{ true };

--- a/trview.app/Windows/TriggersWindowManager.cpp
+++ b/trview.app/Windows/TriggersWindowManager.cpp
@@ -67,7 +67,7 @@ namespace trview
         }
     }
 
-    void TriggersWindowManager::set_room(uint32_t room)
+    void TriggersWindowManager::set_room(const std::weak_ptr<IRoom>& room)
     {
         _current_room = room;
         for (auto& window : _windows)

--- a/trview.app/Windows/TriggersWindowManager.h
+++ b/trview.app/Windows/TriggersWindowManager.h
@@ -26,14 +26,14 @@ namespace trview
         const std::weak_ptr<ITrigger> selected_trigger() const;
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
-        virtual void set_room(uint32_t room) override;
+        void set_room(const std::weak_ptr<IRoom>& room) override;
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual std::weak_ptr<ITriggersWindow> create_window() override;
         virtual void update(float delta) override;
     private:
         std::vector<std::weak_ptr<IItem>> _items;
         std::vector<std::weak_ptr<ITrigger>> _triggers;
-        uint32_t _current_room{ 0u };
+        std::weak_ptr<IRoom> _current_room;
         std::weak_ptr<ITrigger> _selected_trigger;
         ITriggersWindow::Source _triggers_window_source;
     };

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -494,14 +494,17 @@ namespace trview
                     const auto level = _level.lock();
                     if (level && !ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow))
                     {
-                        uint32_t room = room_number(sector->room());
-                        // Select the trigger (if it is a trigger).
+                        const auto room = sector->room().lock();
                         const auto triggers = level->triggers();
                         auto trigger = std::find_if(triggers.begin(), triggers.end(),
                             [&](auto t)
                             {
-                                const auto t_ptr = t.lock();
-                                return trigger_room(t_ptr) == room && t_ptr->sector_id() == sector->id();
+                                if (const auto t_ptr = t.lock())
+                                {
+                                    return t_ptr->sector_id() == sector->id() && t_ptr->room().lock() == room;
+                                }
+                                return false;
+                                
                             });
 
                         if (trigger == triggers.end() || (GetAsyncKeyState(VK_CONTROL) & 0x8000))

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -70,7 +70,7 @@ namespace trview
         void open(const std::weak_ptr<ILevel>& level, ILevel::OpenMode open_mode) override;
         virtual void set_settings(const UserSettings& settings) override;
         virtual void select_item(const std::weak_ptr<IItem>& item) override;
-        virtual void select_room(uint32_t room_number) override;
+        void select_room(const std::weak_ptr<IRoom>& room) override;
         virtual void select_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual void select_waypoint(const std::weak_ptr<IWaypoint>& waypoint) override;
         virtual void set_camera_mode(CameraMode camera_mode) override;
@@ -119,7 +119,7 @@ namespace trview
         void set_show_wireframe(bool show);
         void set_show_bounding_boxes(bool show);
         void set_show_lights(bool show);
-        uint32_t room_from_pick(const PickResult& pick) const;
+        std::weak_ptr<IRoom> room_from_pick(const PickResult& pick) const;
         void add_recent_orbit(const PickResult& pick);
         void select_previous_orbit();
         void select_next_orbit();


### PR DESCRIPTION
Convert almost everywhere to use room references instead of room numbers. This simplifies some code as there's fewer room lookups.
Only place remaining is waypoints - wasn't sure whether to change them yet.
Closes #1091 