### PR TITLE
Show height difference on route

### DIFF
--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -23,6 +23,7 @@ namespace trlevel
         FogBulb = 4
     };
 
+    constexpr float Click{ 256.0f };
     constexpr float Scale { 1024.0f };
     constexpr float Scale_X { 1024.0f };
     constexpr float Scale_Y { 1024.0f };

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -502,7 +502,16 @@ namespace trview
             if (const auto waypoint = route->waypoint(i).lock())
             {
                 const auto notes = waypoint->notes();
-                if (notes.empty())
+                int diff = 0;
+                if (i > 0)
+                {
+                    if (const auto previous = route->waypoint(i - 1).lock())
+                    {
+                        diff = static_cast<int>((waypoint->position().y - previous->position().y) * trlevel::Scale);
+                    }
+                }
+
+                if (notes.empty() && diff == 0)
                 {
                     continue;
                 }
@@ -513,7 +522,16 @@ namespace trview
                     ImGui::SetNextWindowPos(vp->Pos + ImVec2(pos.x, pos.y));
                     if (ImGui::Begin(std::format("##waypoint{}", i).c_str(), nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoFocusOnAppearing))
                     {
-                        ImGui::Text(notes.c_str());
+                        if (diff != 0)
+                        {
+                            const std::string sign = diff <= 0 ? "+" : "-";
+                            const int clicks = static_cast<int>(round(diff / trlevel::Click));
+                            ImGui::Text(std::format("{}{} ({}{} clicks)", sign, abs(diff), sign, abs(clicks)).c_str());
+                        }
+                        if (!notes.empty())
+                        {
+                            ImGui::Text(notes.c_str());
+                        }
                     }
                     ImGui::End();
                 }


### PR DESCRIPTION
If notes are enabled show the height difference between waypoints in the viewer. Show in units and clicks.
Value is negated as negative to go up is probably not how people think about it.
Closes #1249