### PR TITLE
Reduce memory usage when loading levels

### DIFF
--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -184,9 +184,9 @@ namespace trlevel
         void generate_meshes(const std::vector<uint16_t>& mesh_data);
 
         // Load a Tomb Raider IV level.
-        void load_tr4(trview::Activity& activity, std::istream& file);
+        void load_tr4(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file);
 
-        void load_level_data(trview::Activity& activity, std::istream& file);
+        void load_level_data(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file);
 
         tr_colour4 colour_from_object_texture(uint32_t texture) const;
 


### PR DESCRIPTION
First steps in reducing memory usage when loading a level.
Use a spanstream instead of a stringstream with a copy - this more or less halves the memory usage, at least for the intial file contents.
Also discard 16 bit textures earlier if the 32 bit textures aren't all blank. This was being done before but after the 16 bit textures had been copied from the file.
#1255 