### PR TITLE
Add background loading

### DIFF
--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -180,6 +180,12 @@ namespace trlevel
 
         virtual Platform platform() const = 0;
 
-        virtual void load() = 0;
+        struct LoadCallbacks
+        {
+            std::function<void(const std::string&)> on_progress;
+            std::function<void(const std::vector<uint32_t>&)> on_textile;
+        };
+
+        virtual void load(const LoadCallbacks& callbacks) = 0;
     };
 }

--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -179,5 +179,7 @@ namespace trlevel
         virtual tr_camera get_camera(uint32_t index) const = 0;
 
         virtual Platform platform() const = 0;
+
+        virtual void load() = 0;
     };
 }

--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -39,22 +39,6 @@ namespace trlevel
         // Returns: The palette colour.
         virtual tr_colour4 get_palette_entry(uint32_t index8, uint32_t index16) const = 0;
 
-        // Gets the number of textiles in the level.
-        // Returns: The number of textiles.
-        virtual uint32_t num_textiles() const = 0;
-
-        // Gets the 8 bit textile with the specified index.
-        // Returns: The textile for this index.
-        virtual tr_textile8 get_textile8(uint32_t index) const = 0;
-
-        // Gets the 16 bit textile with the specified index.
-        // Returns: The textile for this index.
-        virtual tr_textile16 get_textile16(uint32_t index) const = 0;
-
-        // Get the 8 or 16 bit textile with the specified index.
-        // Returns: The colours for this index.
-        virtual std::vector<uint32_t> get_textile(uint32_t index) const = 0;
-
         // Gets the number of rooms in the level.
         // Returns: The number of rooms.
         virtual uint32_t num_rooms() const = 0;
@@ -182,8 +166,11 @@ namespace trlevel
 
         struct LoadCallbacks
         {
-            std::function<void(const std::string&)> on_progress;
-            std::function<void(const std::vector<uint32_t>&)> on_textile;
+            std::function<void(const std::string&)> on_progress_callback;
+            std::function<void(const std::vector<uint32_t>&)> on_textile_callback;
+
+            void on_progress(const std::string& message) const;
+            void on_textile(const std::vector<uint32_t>& data) const;
         };
 
         virtual void load(const LoadCallbacks& callbacks) = 0;

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -180,14 +180,14 @@ namespace trlevel
         virtual uint32_t num_cameras() const override;
         virtual tr_camera get_camera(uint32_t index) const override;
         Platform platform() const override;
-        void load() override;
+        void load(const LoadCallbacks& callbacks) override;
     private:
         void generate_meshes(const std::vector<uint16_t>& mesh_data);
 
         // Load a Tomb Raider IV level.
-        void load_tr4(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file);
+        void load_tr4(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const LoadCallbacks& callbacks);
 
-        void load_level_data(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file);
+        void load_level_data(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const LoadCallbacks& callbacks);
 
         tr_colour4 colour_from_object_texture(uint32_t texture) const;
 

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -47,22 +47,6 @@ namespace trlevel
         // Returns: The palette colour.
         virtual tr_colour4 get_palette_entry(uint32_t index8, uint32_t index16) const override;
 
-        // Gets the number of textiles in the level.
-        // Returns: The number of textiles.
-        virtual uint32_t num_textiles() const override;
-
-        // Gets the 8 bit textile with the specified index.
-        // Returns: The textile for this index.
-        virtual tr_textile8 get_textile8(uint32_t index) const override;
-
-        // Gets the 16 bit textile with the specified index.
-        // Returns: The textile for this index.
-        virtual tr_textile16 get_textile16(uint32_t index) const override;
-
-        // Get the 8 or 16 bit textile with the specified index.
-        // Returns: The colours for this index.
-        virtual std::vector<uint32_t> get_textile(uint32_t index) const override;
-
         // Gets the number of rooms in the level.
         // Returns: The number of rooms.
         virtual uint32_t num_rooms() const override;
@@ -202,7 +186,6 @@ namespace trlevel
         std::vector<tr_textile4>  _textile4;
         std::vector<tr_textile8>  _textile8;
         std::vector<tr_textile16> _textile16;
-        std::vector<tr_textile32> _textile32;
         std::vector<tr_clut> _clut;
         std::vector<std::pair<uint16_t, uint16_t>> _converted_t16;
 

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -180,6 +180,7 @@ namespace trlevel
         virtual uint32_t num_cameras() const override;
         virtual tr_camera get_camera(uint32_t index) const override;
         Platform platform() const override;
+        void load() override;
     private:
         void generate_meshes(const std::vector<uint16_t>& mesh_data);
 
@@ -191,8 +192,6 @@ namespace trlevel
         tr_colour4 colour_from_object_texture(uint32_t texture) const;
 
         uint16_t convert_textile4(uint16_t tile, uint16_t clut_id);
-
-        std::shared_ptr<trview::ILog> _log;
 
         PlatformAndVersion _platform_and_version;
 
@@ -231,5 +230,10 @@ namespace trlevel
         std::string _name;
 
         std::vector<tr_camera> _cameras;
+
+        std::shared_ptr<trview::ILog>   _log;
+        std::shared_ptr<IDecrypter>     _decrypter;
+        std::string                     _filename;
+        std::shared_ptr<trview::IFiles> _files;
     };
 }

--- a/trlevel/Mocks/ILevel.h
+++ b/trlevel/Mocks/ILevel.h
@@ -15,10 +15,6 @@ namespace trlevel
             MOCK_METHOD(tr_colour4, get_palette_entry_16, (uint32_t), (const, override));
             MOCK_METHOD(tr_colour4, get_palette_entry, (uint32_t), (const, override));
             MOCK_METHOD(tr_colour4, get_palette_entry, (uint32_t, uint32_t), (const, override));
-            MOCK_METHOD(uint32_t, num_textiles, (), (const, override));
-            MOCK_METHOD(tr_textile8, get_textile8, (uint32_t), (const, override));
-            MOCK_METHOD(tr_textile16, get_textile16, (uint32_t), (const, override));
-            MOCK_METHOD(std::vector<uint32_t>, get_textile, (uint32_t), (const, override));
             MOCK_METHOD(uint32_t, num_rooms, (), (const, override));
             MOCK_METHOD(tr3_room, get_room, (uint32_t), (const, override));
             MOCK_METHOD(uint32_t, num_object_textures, (), (const, override));
@@ -48,6 +44,7 @@ namespace trlevel
             MOCK_METHOD(uint32_t, num_cameras, (), (const, override));
             MOCK_METHOD(tr_camera, get_camera, (uint32_t), (const, override));
             MOCK_METHOD(Platform, platform, (), (const, override));
+            MOCK_METHOD(void, load, (const LoadCallbacks&), (override));
         };
     }
 }

--- a/trlevel/trtypes.cpp
+++ b/trlevel/trtypes.cpp
@@ -43,6 +43,16 @@ namespace trlevel
         return a << 24 | b << 16 | g << 8 | r;
     }
 
+    std::vector<uint32_t> convert_textile(const tr_textile16& tile)
+    {
+        return tile.Tile | std::views::transform(convert_textile16) | std::ranges::to<std::vector>();
+    }
+
+    std::vector<uint32_t> convert_textile(const tr_textile32& tile)
+    {
+        return tile.Tile | std::views::transform(convert_textile32) | std::ranges::to<std::vector>();
+    }
+
     // Convert a set of Tomb Raider I static meshes into a format compatible
     // with Tomb Raider III (what the viewer is currently using).
     std::vector<tr3_room_staticmesh> convert_room_static_meshes(std::vector<tr_room_staticmesh> meshes)

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -796,6 +796,9 @@ namespace trlevel
     // Convert a 16 bit textile into a 32 bit argb value.
     uint32_t convert_textile16(uint16_t t);
 
+    std::vector<uint32_t> convert_textile(const tr_textile16& tile);
+    std::vector<uint32_t> convert_textile(const tr_textile32& tile);
+
     // Convert a set of Tomb Raider I static meshes into a format compatible
     // with Tomb Raider III (what the viewer is currently using).
     std::vector<tr3_room_staticmesh> convert_room_static_meshes(std::vector<tr_room_staticmesh> meshes);

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -99,7 +99,8 @@ namespace
                     std::move(items_window_manager), std::move(triggers_window_manager), std::move(route_window_manager), std::move(rooms_window_manager),
                     level_source, startup_options, dialogs, files, std::move(imgui_backend), std::move(lights_window_manager), std::move(log_window_manager),
                     std::move(textures_window_manager), std::move(camera_sink_window_manager), std::move(console_manager),
-                    plugins, std::move(plugins_window_manager), randomizer_route_source, fonts, std::move(statics_window_manager));
+                    plugins, std::move(plugins_window_manager), randomizer_route_source, fonts, std::move(statics_window_manager),
+                    Application::LoadMode::Sync);
             }
 
             test_module& with_dialogs(std::shared_ptr<IDialogs> dialogs)

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -52,11 +52,12 @@ namespace
             std::shared_ptr<ILog> log{ mock_shared<MockLog>() };
             graphics::IBuffer::ConstantSource buffer_source{ [](auto&&...) { return mock_unique<MockBuffer>(); } };
             ICameraSink::Source camera_sink_source{ [](auto&&...) { return mock_shared<MockCameraSink>(); } };
+            trlevel::ILevel::LoadCallbacks callbacks;
 
             std::shared_ptr<Level> build()
             {
                 auto new_level = std::make_shared<Level>(device, shader_storage, level_texture_storage, std::move(transparency_buffer), std::move(selection_renderer), log, buffer_source);
-                new_level->initialise(std::move(level), std::move(mesh_storage), entity_source, ai_source, room_source, trigger_source, light_source, camera_sink_source);
+                new_level->initialise(std::move(level), std::move(mesh_storage), entity_source, ai_source, room_source, trigger_source, light_source, camera_sink_source, callbacks);
                 return new_level;
             }
 

--- a/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
+++ b/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
@@ -22,7 +22,8 @@ TEST(LevelTextureStorage, PaletteLoadedTomb1)
     auto level = mock_shared<trlevel::mocks::MockLevel>();
     EXPECT_CALL(*level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb1));
     EXPECT_CALL(*level, get_palette_entry(_)).Times(AtLeast(1));
-    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>());
+    subject.load(level);
 }
 
 TEST(LevelTextureStorage, PaletteLoadedTomb2)
@@ -30,7 +31,8 @@ TEST(LevelTextureStorage, PaletteLoadedTomb2)
     auto level = mock_shared<trlevel::mocks::MockLevel>();
     EXPECT_CALL(*level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb2));
     EXPECT_CALL(*level, get_palette_entry(_)).Times(AtLeast(1));
-    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>());
+    subject.load(level);
 }
 
 TEST(LevelTextureStorage, PaletteLoadedTomb3)
@@ -38,7 +40,8 @@ TEST(LevelTextureStorage, PaletteLoadedTomb3)
     auto level = mock_shared<trlevel::mocks::MockLevel>();
     EXPECT_CALL(*level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb3));
     EXPECT_CALL(*level, get_palette_entry(_)).Times(AtLeast(1));
-    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>());
+    subject.load(level);
 }
 
 TEST(LevelTextureStorage, PaletteNotLoadedTomb4)
@@ -46,7 +49,8 @@ TEST(LevelTextureStorage, PaletteNotLoadedTomb4)
     auto level = mock_shared<trlevel::mocks::MockLevel>();
     EXPECT_CALL(*level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb4));
     EXPECT_CALL(*level, get_palette_entry(_)).Times(Exactly(0));
-    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>());
+    subject.load(level);
 }
 
 TEST(LevelTextureStorage, PaletteNotLoadedTomb5)
@@ -54,7 +58,8 @@ TEST(LevelTextureStorage, PaletteNotLoadedTomb5)
     auto level = mock_shared<trlevel::mocks::MockLevel>();
     EXPECT_CALL(*level, get_version()).WillRepeatedly(Return(LevelVersion::Tomb5));
     EXPECT_CALL(*level, get_palette_entry(_)).Times(Exactly(0));
-    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>());
+    subject.load(level);
 }
 
 TEST(LevelTextureStorage, TexturesGenerated)
@@ -62,28 +67,21 @@ TEST(LevelTextureStorage, TexturesGenerated)
     std::vector<uint32_t> data;
     data.resize(256 * 256, 0x000080ff);
 
-    auto level = mock_shared<trlevel::mocks::MockLevel>();
-    ON_CALL(*level, num_textiles).WillByDefault(Return(1));
-    EXPECT_CALL(*level, get_textile(0)).Times(1).WillRepeatedly(Return(data));
     auto device = mock_shared<MockDevice>();
 
     std::vector<std::vector<uint32_t>> saved_data;
-    EXPECT_CALL(*device, create_texture_2D).Times(3).WillRepeatedly(testing::Invoke(
+    EXPECT_CALL(*device, create_texture_2D).Times(1).WillRepeatedly(testing::Invoke(
         [&](auto&& desc, auto&& data)
         {
             const uint32_t* ptr = reinterpret_cast<const uint32_t*>(data.pSysMem);
             saved_data.push_back({ ptr, ptr + 256 * 256 });
             return nullptr;
         }));
-    EXPECT_CALL(*device, create_shader_resource_view).Times(3);
+    EXPECT_CALL(*device, create_shader_resource_view).Times(1);
 
-    LevelTextureStorage subject(device, mock_unique<MockTextureStorage>(), level);
+    LevelTextureStorage subject(device, mock_unique<MockTextureStorage>());
 
-    // 0: Tile, 1: Opaque tile, 2: TRLE
-    ASSERT_EQ(saved_data.size(), 3u);
+    // 0: TRLE
+    ASSERT_EQ(saved_data.size(), 1u);
     ASSERT_EQ(saved_data[0].size(), 65536u);
-    ASSERT_THAT(saved_data[0], testing::Each(testing::Eq(0x000080ff)));
-    ASSERT_EQ(saved_data[1].size(), 65536u);
-    ASSERT_THAT(saved_data[1], testing::Each(testing::Eq(0xff0080ff)));
-    ASSERT_EQ(saved_data[2].size(), 65536u);
 }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -741,6 +741,20 @@ namespace trview
 
         ImGui::PushFont(_fonts->font("Default"));
 
+
+        if (_load.valid())
+        {
+            const auto viewport = ImGui::GetMainViewport();
+            const ImVec2 size = ImGui::CalcTextSize(_progress.c_str());
+            ImGui::SetNextWindowPos(ImVec2(viewport->Pos.x + viewport->Size.x * 0.75f, viewport->Pos.y + viewport->Size.y), 0, ImVec2(0.5f, 1.0f));
+            ImGui::SetNextWindowSize(ImVec2(400, size.y));
+            if (ImGui::Begin("Load Progress", nullptr, ImGuiWindowFlags_NoTitleBar))
+            {
+                ImGui::Text(_progress.c_str());
+                ImGui::End();
+            }
+        }
+
         _viewer->render_ui();
         _items_windows->render();
         _triggers_windows->render();
@@ -970,7 +984,10 @@ namespace trview
 
     std::shared_ptr<ILevel> Application::load(const std::string& filename)
     {
-        auto level = _level_source(_trlevel_source(filename));
+        auto level = _level_source(_trlevel_source(filename), 
+            {
+                .on_progress = [&](auto&& p) { _progress = p; }
+            });
         level->set_filename(filename);
         return level;
     }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -746,9 +746,9 @@ namespace trview
         {
             const auto viewport = ImGui::GetMainViewport();
             const ImVec2 size = ImGui::CalcTextSize(_progress.c_str());
-            ImGui::SetNextWindowPos(ImVec2(viewport->Pos.x + viewport->Size.x * 0.75f, viewport->Pos.y + viewport->Size.y), 0, ImVec2(0.5f, 1.0f));
+            ImGui::SetNextWindowPos(ImVec2(viewport->Pos.x + viewport->Size.x * 0.75f, viewport->Pos.y), 0, ImVec2(0.5f, 0.0f));
             ImGui::SetNextWindowSize(ImVec2(400, size.y));
-            if (ImGui::Begin("Load Progress", nullptr, ImGuiWindowFlags_NoTitleBar))
+            if (ImGui::Begin("Load Progress", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove))
             {
                 ImGui::Text(_progress.c_str());
                 ImGui::End();
@@ -984,11 +984,11 @@ namespace trview
 
     std::shared_ptr<ILevel> Application::load(const std::string& filename)
     {
+        _progress = std::format("Loading {}", filename);
         auto level = _level_source(_trlevel_source(filename), 
             {
                 .on_progress_callback = [&](auto&& p) { _progress = p; }
             });
-        _progress = std::format("Loading {}", filename);
         level->set_filename(filename);
         return level;
     }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -988,6 +988,7 @@ namespace trview
             {
                 .on_progress = [&](auto&& p) { _progress = p; }
             });
+        _progress = std::format("Loading {}", filename);
         level->set_filename(filename);
         return level;
     }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -986,7 +986,7 @@ namespace trview
     {
         auto level = _level_source(_trlevel_source(filename), 
             {
-                .on_progress = [&](auto&& p) { _progress = p; }
+                .on_progress_callback = [&](auto&& p) { _progress = p; }
             });
         _progress = std::format("Loading {}", filename);
         level->set_filename(filename);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -66,14 +66,16 @@ namespace trview
         std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
         const IRandomizerRoute::Source& randomizer_route_source,
         std::shared_ptr<IFonts> fonts,
-        std::unique_ptr<IStaticsWindowManager> statics_window_manager)
+        std::unique_ptr<IStaticsWindowManager> statics_window_manager,
+        LoadMode load_mode)
         : MessageHandler(application_window), _instance(GetModuleHandle(nullptr)),
         _file_menu(std::move(file_menu)), _update_checker(std::move(update_checker)), _view_menu(window()), _settings_loader(settings_loader), _trlevel_source(trlevel_source),
         _viewer(std::move(viewer)), _route_source(route_source), _shortcuts(shortcuts), _items_windows(std::move(items_window_manager)),
         _triggers_windows(std::move(triggers_window_manager)), _route_window(std::move(route_window_manager)), _rooms_windows(std::move(rooms_window_manager)), _level_source(level_source),
         _dialogs(dialogs), _files(files), _timer(default_time_source()), _imgui_backend(std::move(imgui_backend)), _lights_windows(std::move(lights_window_manager)), _log_windows(std::move(log_window_manager)),
         _textures_windows(std::move(textures_window_manager)), _camera_sink_windows(std::move(camera_sink_window_manager)), _console_manager(std::move(console_manager)),
-        _plugins(plugins), _plugins_windows(std::move(plugins_window_manager)), _randomizer_route_source(randomizer_route_source), _fonts(fonts), _statics_windows(std::move(statics_window_manager))
+        _plugins(plugins), _plugins_windows(std::move(plugins_window_manager)), _randomizer_route_source(randomizer_route_source), _fonts(fonts), _statics_windows(std::move(statics_window_manager)),
+        _load_mode(load_mode)
     {
         SetWindowLongPtr(window(), GWLP_USERDATA, reinterpret_cast<LONG_PTR>(_imgui_backend.get()));
 
@@ -121,28 +123,37 @@ namespace trview
             return;
         }
 
-        try
+        _load = std::async(std::launch::async, [=]() -> LoadOperation
+            { 
+                LoadOperation operation
+                {
+                    .filename = filename,
+                    .open_mode = open_mode
+                };
+
+                try
+                {
+                    operation.level = load(filename);
+                }
+                catch (trlevel::LevelEncryptedException&)
+                {
+                    operation.error = "Level is encrypted and cannot be loaded";
+                }
+                catch (UserCancelledException&)
+                {
+                }
+                catch (std::exception& e)
+                {
+                    operation.error = std::format("Failed to load level : {}", e.what());
+                }
+
+                return operation;
+            });
+
+        if (_load_mode == LoadMode::Sync)
         {
-            auto level = load(filename);
-            _settings.add_recent_file(filename);
-            _file_menu->set_recent_files(_settings.recent_files);
-            _settings_loader->save_user_settings(_settings);
-            _viewer->set_settings(_settings);
-            set_current_level(level, open_mode, false);
-        }
-        catch (trlevel::LevelEncryptedException&)
-        {
-            _dialogs->message_box(L"Level is encrypted and cannot be loaded", L"Error", IDialogs::Buttons::OK);
-            return;
-        }
-        catch (UserCancelledException&)
-        {
-            return;
-        }
-        catch (std::exception& e)
-        {
-            _dialogs->message_box(to_utf16(std::format("Failed to load level : {}", e.what())), L"Error", IDialogs::Buttons::OK);
-            return;
+            _load.wait();
+            check_load();
         }
     }
 
@@ -701,6 +712,8 @@ namespace trview
             }
         }
 
+        check_load();
+
         _timer.update();
         const auto elapsed = _timer.elapsed();
         _items_windows->update(elapsed);
@@ -1103,5 +1116,33 @@ namespace trview
         select_room(static_mesh_ptr->room());
         _viewer->select_static_mesh(static_mesh_ptr);
         _statics_windows->select_static(static_mesh_ptr);
+    }
+
+    void Application::check_load()
+    {
+        if (!_load.valid() || _load.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready)
+        {
+            return;
+        }
+
+        const auto op = _load.get();
+        _load = {};
+
+        if (op.error)
+        {
+            _dialogs->message_box(to_utf16(op.error.value()), L"Error", IDialogs::Buttons::OK);
+            return;
+        }
+
+        if (!op.level)
+        {
+            return;
+        }
+
+        _settings.add_recent_file(op.filename);
+        _file_menu->set_recent_files(_settings.recent_files);
+        _settings_loader->save_user_settings(_settings);
+        _viewer->set_settings(_settings);
+        set_current_level(op.level, op.open_mode, false);
     }
 }

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <future>
+
 #include <trview.common/Window.h>
 #include <trview.common/Timer.h>
 
@@ -52,6 +54,12 @@ namespace trview
     class Application final : public IApplication, public MessageHandler
     {
     public:
+        enum class LoadMode
+        {
+            Async,
+            Sync
+        };
+
         explicit Application(
             const Window& application_window,
             std::unique_ptr<IUpdateChecker> update_checker,
@@ -79,7 +87,8 @@ namespace trview
             std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
             const IRandomizerRoute::Source& randomizer_route_source,
             std::shared_ptr<IFonts> fonts,
-            std::unique_ptr<IStaticsWindowManager> statics_window_manager);
+            std::unique_ptr<IStaticsWindowManager> statics_window_manager,
+            LoadMode load_mode);
         virtual ~Application();
         /// Attempt to open the specified level file.
         /// @param filename The level file to open.
@@ -139,6 +148,7 @@ namespace trview
         void open_recent_route();
         void save_window_placement();
         void select_static_mesh(const std::weak_ptr<IStaticMesh>& static_mesh);
+        void check_load();
 
         TokenStore _token_store;
 
@@ -187,6 +197,17 @@ namespace trview
 
         IRandomizerRoute::Source _randomizer_route_source;
         std::shared_ptr<IFonts> _fonts;
+
+        struct LoadOperation
+        {
+            std::shared_ptr<ILevel>     level;
+            std::string                 filename;
+            ILevel::OpenMode            open_mode;
+            std::optional<std::string>  error;
+        };
+
+        std::future<LoadOperation> _load;
+        LoadMode _load_mode;
     };
 
     std::unique_ptr<IApplication> create_application(HINSTANCE hInstance, int command_show, const std::wstring& command_line);

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -208,6 +208,7 @@ namespace trview
 
         std::future<LoadOperation> _load;
         LoadMode _load_mode;
+        std::string _progress{ "Nothing yet" };
     };
 
     std::unique_ptr<IApplication> create_application(HINSTANCE hInstance, int command_show, const std::wstring& command_line);

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -208,7 +208,7 @@ namespace trview
 
         std::future<LoadOperation> _load;
         LoadMode _load_mode;
-        std::string _progress{ "Nothing yet" };
+        std::string _progress;
     };
 
     std::unique_ptr<IApplication> create_application(HINSTANCE hInstance, int command_show, const std::wstring& command_line);

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -250,7 +250,7 @@ namespace trview
                 // TODO: Hook up callbacks for loading textures, other callbacks.
                 auto level_texture_storage = std::make_shared<LevelTextureStorage>(device, std::make_unique<TextureStorage>(device));
                 int count = 0;
-                callbacks.on_textile = [&](auto&& textile)
+                callbacks.on_textile_callback = [&](auto&& textile)
                     {
                         callbacks.on_progress(std::format("Loading texture {}", ++count));
                         level_texture_storage->add_textile(textile);

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -354,6 +354,7 @@ namespace trview
             std::make_unique<PluginsWindowManager>(window, shortcuts, plugins_window_source),
             randomizer_route_source,
             fonts,
-            std::make_unique<StaticsWindowManager>(window, shortcuts, statics_window_source));
+            std::make_unique<StaticsWindowManager>(window, shortcuts, statics_window_source),
+            Application::LoadMode::Async);
     }
 }

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -246,28 +246,30 @@ namespace trview
         auto camera_sink_source = [=](auto&&... args) { return std::make_shared<CameraSink>(camera_mesh, texture_storage, args...); };
 
         auto level_source = [=](auto&& level)
-        {
-            auto level_texture_storage = std::make_shared<LevelTextureStorage>(device, std::make_unique<TextureStorage>(device), level);
-            auto mesh_storage = std::make_unique<MeshStorage>(mesh_source, *level, *level_texture_storage);
-            auto new_level = std::make_shared<Level>(
-                device, 
-                shader_storage, 
-                level_texture_storage,
-                std::make_unique<TransparencyBuffer>(device),
-                std::make_unique<SelectionRenderer>(device, shader_storage, std::make_unique<TransparencyBuffer>(device), render_target_source),
-                log,
-                buffer_source);
-            new_level->initialise(
-                level,
-                std::move(mesh_storage),
-                entity_source,
-                ai_source,
-                room_source,
-                trigger_source,
-                light_source,
-                camera_sink_source);
-            return new_level;
-        };
+            {
+                // TODO: Hook up callbacks for loading textures, other callbacks.
+                level->load();
+
+                auto level_texture_storage = std::make_shared<LevelTextureStorage>(device, std::make_unique<TextureStorage>(device), level);
+                auto mesh_storage = std::make_unique<MeshStorage>(mesh_source, *level, *level_texture_storage);
+                auto new_level = std::make_shared<Level>(
+                    device, 
+                    shader_storage, 
+                    level_texture_storage,
+                    std::make_unique<TransparencyBuffer>(device),
+                    std::make_unique<SelectionRenderer>(device, shader_storage, std::make_unique<TransparencyBuffer>(device), render_target_source),
+                    log,
+                    buffer_source);
+                new_level->initialise(level,
+                    std::move(mesh_storage),
+                    entity_source,
+                    ai_source,
+                    room_source,
+                    trigger_source,
+                    light_source,
+                    camera_sink_source);
+                return new_level;
+            };
 
         auto dialogs = std::make_shared<Dialogs>(window);
         auto shell = std::make_shared<Shell>();

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -15,7 +15,7 @@ namespace trview
 {
     struct ILevel
     {
-        using Source = std::function<std::shared_ptr<ILevel>(std::shared_ptr<trlevel::ILevel>)>;
+        using Source = std::function<std::shared_ptr<ILevel>(std::shared_ptr<trlevel::ILevel>, trlevel::ILevel::LoadCallbacks)>;
 
         enum class OpenMode
         {

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1280,26 +1280,36 @@ namespace trview
         const IRoom::Source& room_source,
         const ITrigger::Source& trigger_source,
         const ILight::Source& light_source,
-        const ICameraSink::Source& camera_sink_source)
+        const ICameraSink::Source& camera_sink_source,
+        const trlevel::ILevel::LoadCallbacks callbacks)
     {
         _version = level->get_version();
         _floor_data = level->get_floor_data_all();
         _name = level->name();
 
         record_models(*level);
+        callbacks.on_progress("Generating rooms");
         generate_rooms(*level, room_source, *mesh_storage);
+        callbacks.on_progress("Generating triggers");
         generate_triggers(trigger_source);
+        callbacks.on_progress("Generating entities");
         generate_entities(*level, entity_source, ai_source, *mesh_storage);
+        callbacks.on_progress("Generating lights");
         generate_lights(*level, light_source);
+        callbacks.on_progress("Generating camera/sinks");
         generate_camera_sinks(*level, camera_sink_source);
 
+        callbacks.on_progress("Generating room bounding boxes");
         for (auto& room : _rooms)
         {
             room->update_bounding_box();
         }
 
         apply_ocb_adjustment();
+
+        callbacks.on_progress("Generating static meshes");
         record_static_meshes();
+        callbacks.on_progress("Done");
     }
 
     void Level::record_static_meshes()

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -111,7 +111,8 @@ namespace trview
             const IRoom::Source& room_source,
             const ITrigger::Source& trigger_source,
             const ILight::Source& light_source,
-            const ICameraSink::Source& camera_sink_source);
+            const ICameraSink::Source& camera_sink_source,
+            const trlevel::ILevel::LoadCallbacks callbacks);
         std::vector<std::weak_ptr<IStaticMesh>> static_meshes() const override;
         std::weak_ptr<IStaticMesh> static_mesh(uint32_t index) const override;
     private:

--- a/trview.app/Graphics/LevelTextureStorage.cpp
+++ b/trview.app/Graphics/LevelTextureStorage.cpp
@@ -7,37 +7,6 @@ namespace trview
     {
     }
 
-    LevelTextureStorage::LevelTextureStorage(const std::shared_ptr<graphics::IDevice>& device, std::unique_ptr<ITextureStorage> texture_storage, const std::shared_ptr<trlevel::ILevel>& level)
-        : _texture_storage(std::move(texture_storage)), _version(level->get_version()), _level(level), _platform(level->platform()), _device(device)
-    {
-        for (uint32_t i = 0; i < level->num_textiles(); ++i)
-        {
-            std::vector<uint32_t> data = level->get_textile(i);
-            _tiles.emplace_back(*_device, 256, 256, data);
-            for (auto& d : data)
-            {
-                d |= 0xff000000;
-            }
-            _opaque_tiles.emplace_back(*device, 256, 256, data);
-        }
-
-        // Generate the TRLE texture.
-        std::vector<uint32_t> pixels(256 * 256, 0xffffffff);
-        for (int x = 0; x < 256; ++x)
-        {
-            pixels[x] = 0xff000000;
-            pixels[x + 255 * 256] = 0xff000000;
-        }
-        for (int y = 0; y < 256; ++y)
-        {
-            pixels[y * 256] = 0xff000000;
-            pixels[y * 256 + 255] = 0xff000000;
-        }
-        _geometry_texture = graphics::Texture(*_device, 256, 256, pixels);
-
-        load(level);
-    }
-
     LevelTextureStorage::LevelTextureStorage(const std::shared_ptr<graphics::IDevice>& device, std::unique_ptr<ITextureStorage> texture_storage)
         : _device(device), _texture_storage(std::move(texture_storage))
     {

--- a/trview.app/Graphics/LevelTextureStorage.cpp
+++ b/trview.app/Graphics/LevelTextureStorage.cpp
@@ -8,33 +8,17 @@ namespace trview
     }
 
     LevelTextureStorage::LevelTextureStorage(const std::shared_ptr<graphics::IDevice>& device, std::unique_ptr<ITextureStorage> texture_storage, const std::shared_ptr<trlevel::ILevel>& level)
-        : _texture_storage(std::move(texture_storage)), _version(level->get_version()), _level(level), _platform(level->platform())
+        : _texture_storage(std::move(texture_storage)), _version(level->get_version()), _level(level), _platform(level->platform()), _device(device)
     {
         for (uint32_t i = 0; i < level->num_textiles(); ++i)
         {
             std::vector<uint32_t> data = level->get_textile(i);
-            _tiles.emplace_back(*device, 256, 256, data);
+            _tiles.emplace_back(*_device, 256, 256, data);
             for (auto& d : data)
             {
                 d |= 0xff000000;
             }
             _opaque_tiles.emplace_back(*device, 256, 256, data);
-        }
-
-        // Copy object textures locally from the level.
-        for (uint32_t i = 0; i < level->num_object_textures(); ++i)
-        {
-            _object_textures.push_back(level->get_object_texture(i));
-        }
-
-        if (_version < trlevel::LevelVersion::Tomb4)
-        {
-            using namespace DirectX::SimpleMath;
-            for (uint32_t i = 0; i < 256; ++i)
-            {
-                auto entry = level->get_palette_entry(i);
-                _palette[i] = Color(entry.Red / 255.f, entry.Green / 255.f, entry.Blue / 255.f, 1.0f);
-            }
         }
 
         // Generate the TRLE texture.
@@ -49,9 +33,27 @@ namespace trview
             pixels[y * 256] = 0xff000000;
             pixels[y * 256 + 255] = 0xff000000;
         }
-        _geometry_texture = graphics::Texture(*device, 256, 256, pixels);
+        _geometry_texture = graphics::Texture(*_device, 256, 256, pixels);
 
-        determine_texture_mode();
+        load(level);
+    }
+
+    LevelTextureStorage::LevelTextureStorage(const std::shared_ptr<graphics::IDevice>& device, std::unique_ptr<ITextureStorage> texture_storage)
+        : _device(device), _texture_storage(std::move(texture_storage))
+    {
+        // Generate the TRLE texture.
+        std::vector<uint32_t> pixels(256 * 256, 0xffffffff);
+        for (int x = 0; x < 256; ++x)
+        {
+            pixels[x] = 0xff000000;
+            pixels[x + 255 * 256] = 0xff000000;
+        }
+        for (int y = 0; y < 256; ++y)
+        {
+            pixels[y * 256] = 0xff000000;
+            pixels[y * 256 + 255] = 0xff000000;
+        }
+        _geometry_texture = graphics::Texture(*_device, 256, 256, pixels);
     }
 
     void LevelTextureStorage::determine_texture_mode()
@@ -166,5 +168,41 @@ namespace trview
     uint32_t LevelTextureStorage::num_object_textures() const
     {
         return static_cast<uint32_t>(_object_textures.size());
+    }
+
+    void LevelTextureStorage::load(const std::shared_ptr<trlevel::ILevel>& level)
+    {
+        _version = level->get_version();
+        _level = level;
+        _platform = level->platform();
+
+        // Copy object textures locally from the level.
+        for (uint32_t i = 0; i < level->num_object_textures(); ++i)
+        {
+            _object_textures.push_back(level->get_object_texture(i));
+        }
+
+        if (_version < trlevel::LevelVersion::Tomb4)
+        {
+            using namespace DirectX::SimpleMath;
+            for (uint32_t i = 0; i < 256; ++i)
+            {
+                auto entry = level->get_palette_entry(i);
+                _palette[i] = Color(entry.Red / 255.f, entry.Green / 255.f, entry.Blue / 255.f, 1.0f);
+            }
+        }
+
+        determine_texture_mode();
+    }
+
+    void LevelTextureStorage::add_textile(const std::vector<uint32_t>& textile)
+    {
+        _tiles.emplace_back(*_device, 256, 256, textile);
+        auto opaque = textile;
+        for (auto& d : opaque)
+        {
+            d |= 0xff000000;
+        }
+        _opaque_tiles.emplace_back(*_device, 256, 256, opaque);
     }
 }

--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -15,6 +15,7 @@ namespace trview
     {
     public:
         explicit LevelTextureStorage(const std::shared_ptr<graphics::IDevice>& device, std::unique_ptr<ITextureStorage> texture_storage, const std::shared_ptr<trlevel::ILevel>& level);
+        explicit LevelTextureStorage(const std::shared_ptr<graphics::IDevice>& device, std::unique_ptr<ITextureStorage> texture_storage);
         virtual ~LevelTextureStorage() = default;
         virtual graphics::Texture texture(uint32_t tile_index) const override;
         virtual graphics::Texture opaque_texture(uint32_t texture_index) const override;
@@ -29,11 +30,14 @@ namespace trview
         virtual DirectX::SimpleMath::Color palette_from_texture(uint32_t texture) const override;
         virtual graphics::Texture geometry_texture() const override;
         virtual uint32_t num_object_textures() const override;
+        void load(const std::shared_ptr<trlevel::ILevel>& level);
+        void add_textile(const std::vector<uint32_t>& textile);
     private:
         void determine_texture_mode();
 
         std::weak_ptr<trlevel::ILevel> _level;
 
+        std::shared_ptr<graphics::IDevice> _device;
         std::vector<graphics::Texture> _tiles;
         std::vector<graphics::Texture> _opaque_tiles;
         std::vector<trlevel::tr_object_texture> _object_textures;

--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -14,7 +14,6 @@ namespace trview
     class LevelTextureStorage final : public ILevelTextureStorage
     {
     public:
-        explicit LevelTextureStorage(const std::shared_ptr<graphics::IDevice>& device, std::unique_ptr<ITextureStorage> texture_storage, const std::shared_ptr<trlevel::ILevel>& level);
         explicit LevelTextureStorage(const std::shared_ptr<graphics::IDevice>& device, std::unique_ptr<ITextureStorage> texture_storage);
         virtual ~LevelTextureStorage() = default;
         virtual graphics::Texture texture(uint32_t tile_index) const override;
@@ -44,8 +43,8 @@ namespace trview
         std::unique_ptr<ITextureStorage> _texture_storage;
         mutable graphics::Texture _untextured_texture;
         std::array<DirectX::SimpleMath::Color, 256> _palette;
-        trlevel::LevelVersion _version;
-        trlevel::Platform _platform;
+        trlevel::LevelVersion _version{ trlevel::LevelVersion::Unknown };
+        trlevel::Platform _platform{ trlevel::Platform::Unknown };
 
         enum class TextureMode
         {


### PR DESCRIPTION
Load the next level in the background. Show progress at the top of the screen and switch to the next level once loading is complete. This stops the program from hanging during level loading which is particularly noticeable with custom levels.

Texture loading is also changed so that levels now output the textures as they are loaded (where possible - can't be done with TR4 at the moment due to the compressed data). This should cut down on the peak memory usage when loading a level as the raw data is discarded once the D3D texture has been created.

#1186 