### PR TITLE
Move windows to a window class

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -441,7 +441,7 @@ TEST(Application, WindowManagersAndViewerRendered)
 TEST(Application, SettingsSetOnWindow)
 {
     auto [windows_ptr, windows] = create_mock<MockWindows>();
-    EXPECT_CALL(windows, set_settings).Times(1);
+    EXPECT_CALL(windows, setup).Times(1);
 
     auto application = register_test_module()
         .with_windows(std::move(windows_ptr))
@@ -451,7 +451,7 @@ TEST(Application, SettingsSetOnWindow)
 TEST(Application, SettingsSetOnSettingsChanged)
 {
     auto [windows_ptr, windows] = create_mock<MockWindows>();
-    EXPECT_CALL(windows, set_settings).Times(2);
+    EXPECT_CALL(windows, set_settings).Times(1);
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
 
     auto application = register_test_module()
@@ -1058,7 +1058,6 @@ TEST(Application, OnStaticMeshSelected)
 {
     auto level = mock_shared<trview::mocks::MockLevel>();
     auto static_mesh = mock_shared<MockStaticMesh>();
-    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
     auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
     auto application = register_test_module()
@@ -1070,5 +1069,5 @@ TEST(Application, OnStaticMeshSelected)
 
     EXPECT_CALL(viewer, select_static_mesh).Times(1);
     EXPECT_CALL(windows, select(A<const std::weak_ptr<IStaticMesh>&>())).Times(1);
-    rooms_window_manager.on_static_mesh_selected(static_mesh);
+    windows.on_static_selected(static_mesh);
 }

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -11,13 +11,6 @@
 #include <trview.app/Mocks/Settings/IStartupOptions.h>
 #include <trview.app/Mocks/UI/IImGuiBackend.h>
 #include <trview.app/Mocks/Windows/IViewer.h>
-#include <trview.app/Mocks/Windows/IItemsWindowManager.h>
-#include <trview.app/Mocks/Windows/ITriggersWindowManager.h>
-#include <trview.app/Mocks/Windows/IRouteWindowManager.h>
-#include <trview.app/Mocks/Windows/IRoomsWindowManager.h>
-#include <trview.app/Mocks/Windows/ILightsWindowManager.h>
-#include <trview.app/Mocks/Windows/ILogWindowManager.h>
-#include <trview.app/Mocks/Windows/ITexturesWindowManager.h>
 #include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.common/Mocks/Windows/IShortcuts.h>
 #include <trview.common/Mocks/Windows/IDialogs.h>
@@ -27,7 +20,6 @@
 #include "NullImGuiBackend.h"
 #include <trview.common/Strings.h>
 #include <ranges>
-#include <trview.app/Mocks/Windows/IConsoleManager.h>
 #include <trview.app/Mocks/Lua/ILua.h>
 #include <trview.app/Mocks/Plugins/IPlugins.h>
 #include <trview.app/Mocks/UI/IFonts.h>
@@ -68,19 +60,11 @@ namespace
             std::unique_ptr<IViewer> viewer{ mock_unique<MockViewer>() };
             IRoute::Source route_source{ [](auto&&...) { return mock_shared<MockRoute>(); } };
             std::shared_ptr<MockShortcuts> shortcuts{ mock_shared<MockShortcuts>() };
-            std::unique_ptr<IItemsWindowManager> items_window_manager{ mock_unique<MockItemsWindowManager>() };
-            std::unique_ptr<ITriggersWindowManager> triggers_window_manager{ mock_unique<MockTriggersWindowManager>() };
-            std::unique_ptr<IRouteWindowManager> route_window_manager{ mock_unique<MockRouteWindowManager>() };
-            std::unique_ptr<IRoomsWindowManager> rooms_window_manager{ mock_unique<MockRoomsWindowManager>() };
             ILevel::Source level_source{ [](auto&&...) { return mock_unique<trview::mocks::MockLevel>(); } };
             std::shared_ptr<IStartupOptions> startup_options{ mock_shared<MockStartupOptions>() };
             std::shared_ptr<IDialogs> dialogs{ mock_shared<MockDialogs>() };
             std::shared_ptr<IFiles> files{ mock_shared<MockFiles>() };
             std::shared_ptr<IImGuiBackend> imgui_backend{ std::make_shared<NullImGuiBackend>() };
-            std::unique_ptr<ILightsWindowManager> lights_window_manager{ mock_unique<MockLightsWindowManager>() };
-            std::unique_ptr<ILogWindowManager> log_window_manager{ mock_unique<MockLogWindowManager>() };
-            std::unique_ptr<ITexturesWindowManager> textures_window_manager{ mock_unique<MockTexturesWindowManager>() };
-            std::unique_ptr<IConsoleManager> console_manager{ mock_unique<MockConsoleManager>() };
             std::shared_ptr<IPlugins> plugins{ mock_shared<MockPlugins>() };
             IRandomizerRoute::Source randomizer_route_source { [](auto&&...) { return mock_shared<MockRandomizerRoute>(); } };
             std::shared_ptr<IFonts> fonts { mock_shared<MockFonts>() };
@@ -89,23 +73,14 @@ namespace
             std::unique_ptr<Application> build()
             {
                 EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
-                return std::make_unique<Application>(window, std::move(update_checker), std::move(settings_loader),
-                    trlevel_source, std::move(file_menu), std::move(viewer), route_source, shortcuts,
-                    std::move(items_window_manager), std::move(triggers_window_manager), std::move(route_window_manager), std::move(rooms_window_manager),
-                    level_source, startup_options, dialogs, files, std::move(imgui_backend), std::move(lights_window_manager), std::move(log_window_manager),
-                    std::move(textures_window_manager), std::move(console_manager), plugins, randomizer_route_source, fonts, std::move(windows),
-                    Application::LoadMode::Sync);
+                return std::make_unique<Application>(window, std::move(update_checker), std::move(settings_loader), trlevel_source,
+                    std::move(file_menu), std::move(viewer), route_source, shortcuts, level_source, startup_options, dialogs, files,
+                    std::move(imgui_backend), plugins, randomizer_route_source, fonts, std::move(windows), Application::LoadMode::Sync);
             }
 
             test_module& with_dialogs(std::shared_ptr<IDialogs> dialogs)
             {
                 this->dialogs = dialogs;
-                return *this;
-            }
-
-            test_module& with_items_window_manager(std::unique_ptr<IItemsWindowManager> items_window_manager)
-            {
-                this->items_window_manager = std::move(items_window_manager);
                 return *this;
             }
 
@@ -121,12 +96,6 @@ namespace
                 return *this;
             }
 
-            test_module& with_rooms_window_manager(std::unique_ptr<IRoomsWindowManager> rooms_window_manager)
-            {
-                this->rooms_window_manager = std::move(rooms_window_manager);
-                return *this;
-            }
-
             test_module& with_route_source(IRoute::Source route_source)
             {
                 this->route_source = route_source;
@@ -139,12 +108,6 @@ namespace
                 return *this;
             }
 
-            test_module& with_route_window_manager(std::unique_ptr<IRouteWindowManager> route_window_manager)
-            {
-                this->route_window_manager = std::move(route_window_manager);
-                return *this;
-            }
-
             test_module& with_settings_loader(std::unique_ptr<ISettingsLoader> settings_loader)
             {
                 this->settings_loader = std::move(settings_loader);
@@ -154,18 +117,6 @@ namespace
             test_module& with_startup_options(std::shared_ptr<IStartupOptions> startup_options)
             {
                 this->startup_options = startup_options;
-                return *this;
-            }
-
-            test_module& with_triggers_window_manager(std::unique_ptr<ITriggersWindowManager> triggers_window_manager)
-            {
-                this->triggers_window_manager = std::move(triggers_window_manager);
-                return *this;
-            }
-
-            test_module& with_lights_window_manager(std::unique_ptr<ILightsWindowManager> lights_window_manager)
-            {
-                this->lights_window_manager = std::move(lights_window_manager);
                 return *this;
             }
 
@@ -196,24 +147,6 @@ namespace
             test_module& with_level_source(ILevel::Source level_source)
             {
                 this->level_source = level_source;
-                return *this;
-            }
-
-            test_module& with_log_window_manager(std::unique_ptr<ILogWindowManager> log_window_manager)
-            {
-                this->log_window_manager = std::move(log_window_manager);
-                return *this;
-            }
-
-            test_module& with_textures_window_manager(std::unique_ptr<ITexturesWindowManager> textures_window_manager)
-            {
-                this->textures_window_manager = std::move(textures_window_manager);
-                return *this;
-            }
-
-            test_module& with_console_manager(std::unique_ptr<IConsoleManager> console_manager)
-            {
-                this->console_manager = std::move(console_manager);
                 return *this;
             }
 
@@ -295,48 +228,20 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
     std::optional<std::string> called;
     auto trlevel_source = [&](auto&& filename) { called = filename; return mock_unique<trlevel::mocks::MockLevel>(); };
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
-    auto [items_window_manager_ptr, items_window_manager] = create_mock<MockItemsWindowManager>();
-    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
-    auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    auto [lights_window_manager_ptr, lights_window_manager] = create_mock<MockLightsWindowManager>();
-    auto [textures_window_manager_ptr, textures_window_manager] = create_mock<MockTexturesWindowManager>();
     auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto route = mock_shared<MockRoute>();
 
     std::vector<std::string> events;
 
-    EXPECT_CALL(items_window_manager, set_items(A<const std::vector<std::weak_ptr<IItem>>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_items"); });
-    EXPECT_CALL(items_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_triggers"); });
-    EXPECT_CALL(items_window_manager, set_level_version(A<trlevel::LevelVersion>())).Times(1).WillOnce([&](auto) { events.push_back("items_version"); });
-    EXPECT_CALL(items_window_manager, set_model_checker(A<const std::function<bool (uint32_t)>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_model_checker"); });
-    EXPECT_CALL(triggers_window_manager, set_items(A<const std::vector<std::weak_ptr<IItem>>&>())).Times(1).WillOnce([&](auto) { events.push_back("triggers_items"); });
-    EXPECT_CALL(triggers_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("triggers_triggers"); });
-    EXPECT_CALL(rooms_window_manager, set_level_version(A<trlevel::LevelVersion>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_version"); });
-    EXPECT_CALL(rooms_window_manager, set_items(A<const std::vector<std::weak_ptr<IItem>>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_items"); });
-    EXPECT_CALL(rooms_window_manager, set_floordata(A<const std::vector<uint16_t>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_floordata"); });
-    EXPECT_CALL(rooms_window_manager, set_rooms(A<const std::vector<std::weak_ptr<IRoom>>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_rooms"); });
-    EXPECT_CALL(route_window_manager, set_items(A<const std::vector<std::weak_ptr<IItem>>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_items"); });
-    EXPECT_CALL(route_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_triggers"); });
-    EXPECT_CALL(route_window_manager, set_rooms(A<const std::vector<std::weak_ptr<IRoom>>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_rooms"); });
-    EXPECT_CALL(route_window_manager, set_route(A<const std::weak_ptr<IRoute>&>())).Times(3).WillRepeatedly([&](auto) { events.push_back("route_route"); });
-    EXPECT_CALL(lights_window_manager, set_lights(A<const std::vector<std::weak_ptr<ILight>>&>())).Times(1).WillOnce([&](auto) { events.push_back("lights_lights"); });
     EXPECT_CALL(windows, set_level).Times(1).WillOnce([&](auto) { events.push_back("windows_level"); });
     EXPECT_CALL(*route, clear()).Times(1).WillOnce([&] { events.push_back("route_clear"); });
     EXPECT_CALL(*route, set_unsaved(false)).Times(1);
-    EXPECT_CALL(textures_window_manager, set_texture_storage).Times(1).WillOnce([&](auto) { events.push_back("textures"); });
     EXPECT_CALL(viewer, open(A<const std::weak_ptr<ILevel>&>(), ILevel::OpenMode::Full)).Times(1).WillOnce([&](auto&&...) { events.push_back("viewer"); });
 
     auto application = register_test_module()
         .with_trlevel_source(trlevel_source)
         .with_viewer(std::move(viewer_ptr))
         .with_route_source([&](auto&&...) {return route; })
-        .with_items_window_manager(std::move(items_window_manager_ptr))
-        .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
-        .with_route_window_manager(std::move(route_window_manager_ptr))
-        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
-        .with_lights_window_manager(std::move(lights_window_manager_ptr))
-        .with_textures_window_manager(std::move(textures_window_manager_ptr))
         .with_windows(std::move(windows_ptr))
         .build();
     application->open("test_path.tr2", ILevel::OpenMode::Full);
@@ -469,18 +374,18 @@ TEST(Application, ExportRouteSavesFile)
     auto dialogs = mock_shared<MockDialogs>();
     EXPECT_CALL(*dialogs, save_file).Times(1).WillRepeatedly(Return(IDialogs::FileResult{ "filename", 0 }));
 
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, save_as).Times(1);
     EXPECT_CALL(*route, set_unsaved(false)).Times(1);
 
     auto application = register_test_module()
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_route_source([&](auto&&...) {return route; })
         .with_dialogs(dialogs)
         .build();
 
-    route_window_manager.on_route_save_as();
+    windows.on_route_save_as();
 }
 
 TEST(Application, OpenRouteLoadsFile)
@@ -490,42 +395,27 @@ TEST(Application, OpenRouteLoadsFile)
 
     auto [viewer_ptr, viewer] = create_mock <MockViewer>();
     EXPECT_CALL(viewer, set_route).Times(2);
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    EXPECT_CALL(route_window_manager, set_route).Times(2);
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
+    EXPECT_CALL(windows, set_route).Times(2);
     auto files = mock_shared<MockFiles>();
     EXPECT_CALL(*files, load_file(A<const std::string&>())).Times(1).WillRepeatedly(Return<std::vector<uint8_t>>({ 0x7b, 0x7d }));;
 
     auto application = register_test_module()
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_viewer(std::move(viewer_ptr))
         .with_files(files)
         .with_dialogs(dialogs)
         .build();
 
-    route_window_manager.on_route_open();
+    windows.on_route_open();
 }
 
 TEST(Application, WindowManagersUpdated)
 {
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    EXPECT_CALL(route_window_manager, update).Times(1);
-    auto [items_window_manager_ptr, items_window_manager] = create_mock<MockItemsWindowManager>();
-    EXPECT_CALL(items_window_manager, update).Times(1);
-    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
-    EXPECT_CALL(rooms_window_manager, update).Times(1);
-    auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
-    EXPECT_CALL(triggers_window_manager, update).Times(1);
-    auto [lights_window_manager_ptr, lights_window_manager] = create_mock<MockLightsWindowManager>();
-    EXPECT_CALL(lights_window_manager, update).Times(1);
     auto [windows_ptr, windows] = create_mock<MockWindows>();
     EXPECT_CALL(windows, update).Times(1);
 
     auto application = register_test_module()
-        .with_route_window_manager(std::move(route_window_manager_ptr))
-        .with_items_window_manager(std::move(items_window_manager_ptr))
-        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
-        .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
-        .with_lights_window_manager(std::move(lights_window_manager_ptr))
         .with_windows(std::move(windows_ptr))
         .build();
     application->render();
@@ -533,39 +423,14 @@ TEST(Application, WindowManagersUpdated)
 
 TEST(Application, WindowManagersAndViewerRendered)
 {
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    EXPECT_CALL(route_window_manager, render).Times(1);
-    auto [items_window_manager_ptr, items_window_manager] = create_mock<MockItemsWindowManager>();
-    EXPECT_CALL(items_window_manager, render).Times(1);
-    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
-    EXPECT_CALL(rooms_window_manager, render).Times(1);
-    auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
-    EXPECT_CALL(triggers_window_manager, render).Times(1);
-    auto [lights_window_manager_ptr, lights_window_manager] = create_mock<MockLightsWindowManager>();
-    EXPECT_CALL(lights_window_manager, render).Times(1);
-    auto [log_window_manager_ptr, log_window_manager] = create_mock<MockLogWindowManager>();
-    EXPECT_CALL(log_window_manager, render).Times(1);
-    auto [textures_window_manager_ptr, textures_window_manager] = create_mock<MockTexturesWindowManager>();
-    EXPECT_CALL(textures_window_manager, render).Times(1);
-    auto [console_manager_ptr, console_manager] = create_mock<MockConsoleManager>();
-    EXPECT_CALL(console_manager, render).Times(1);
     auto [windows_ptr, windows] = create_mock<MockWindows>();
     EXPECT_CALL(windows, render).Times(1);
     auto plugins = mock_shared<MockPlugins>();
     EXPECT_CALL(*plugins, render_ui).Times(1);
-
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
     EXPECT_CALL(viewer, render).Times(1);
 
     auto application = register_test_module()
-        .with_route_window_manager(std::move(route_window_manager_ptr))
-        .with_items_window_manager(std::move(items_window_manager_ptr))
-        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
-        .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
-        .with_lights_window_manager(std::move(lights_window_manager_ptr))
-        .with_log_window_manager(std::move(log_window_manager_ptr))
-        .with_textures_window_manager(std::move(textures_window_manager_ptr))
-        .with_console_manager(std::move(console_manager_ptr))
         .with_windows(std::move(windows_ptr))
         .with_viewer(std::move(viewer_ptr))
         .with_plugins(plugins)
@@ -573,38 +438,24 @@ TEST(Application, WindowManagersAndViewerRendered)
     application->render();
 }
 
-TEST(Application, WaypointReorderedMovesWaypoint)
+TEST(Application, SettingsSetOnWindow)
 {
-    auto route = mock_shared<MockRoute>();
-    EXPECT_CALL(*route, move(1, 2)).Times(1);
-
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    auto application = register_test_module()
-        .with_route_window_manager(std::move(route_window_manager_ptr))
-        .with_route_source([&](auto&&...) {return route; })
-        .build();
-
-    route_window_manager.on_waypoint_reordered(1, 2);
-}
-
-TEST(Application, MapColoursSetOnRoomWindow)
-{
-    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
-    EXPECT_CALL(rooms_window_manager, set_map_colours).Times(1);
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
+    EXPECT_CALL(windows, set_settings).Times(1);
 
     auto application = register_test_module()
-        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .build();
 }
 
-TEST(Application, MapColoursSetOnSettingsChanged)
+TEST(Application, SettingsSetOnSettingsChanged)
 {
-    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
-    EXPECT_CALL(rooms_window_manager, set_map_colours).Times(2);
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
+    EXPECT_CALL(windows, set_settings).Times(2);
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
 
     auto application = register_test_module()
-        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_viewer(std::move(viewer_ptr))
         .build();
 
@@ -640,25 +491,6 @@ TEST(Application, ResetLayout)
         .build();
 
     application->process_message(WM_COMMAND, MAKEWPARAM(ID_WINDOWS_RESET_LAYOUT, 0), 0);
-}
-
-TEST(Application, RoomsWindowRoomVisibilityCaptured)
-{
-    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
-    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
-    EXPECT_CALL(level, set_room_visibility(0, true)).Times(1);
-
-    ILevel::Source level_source = [&](auto&&...) { return std::move(level_ptr); };
-
-    auto application = register_test_module()
-        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
-        .with_level_source(level_source)
-        .build();
-
-    application->open("", ILevel::OpenMode::Full);
-
-    auto room = mock_shared<MockRoom>();
-    rooms_window_manager.on_room_visibility(room, true);
 }
 
 TEST(Application, ViewerRoomVisibilityCaptured)
@@ -814,34 +646,6 @@ TEST(Application, RouteSetToDefaultColoursOnReset)
     application->open("test.tr2", ILevel::OpenMode::Full);
 }
 
-TEST(Application, RouteWindowCreatedOnStartup)
-{
-    UserSettings settings;
-    settings.route_startup = true;
-    auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
-    ON_CALL(settings_loader, load_user_settings).WillByDefault(Return(settings));
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    EXPECT_CALL(route_window_manager, create_window).Times(1);
-    auto application = register_test_module()
-        .with_settings_loader(std::move(settings_loader_ptr))
-        .with_route_window_manager(std::move(route_window_manager_ptr))
-        .build();
-}
-
-TEST(Application, RouteWindowNotCreatedOnStartup)
-{
-    UserSettings settings;
-    settings.route_startup = false;
-    auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
-    ON_CALL(settings_loader, load_user_settings).WillByDefault(Return(settings));
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    EXPECT_CALL(route_window_manager, create_window).Times(0);
-    auto application = register_test_module()
-        .with_settings_loader(std::move(settings_loader_ptr))
-        .with_route_window_manager(std::move(route_window_manager_ptr))
-        .build();
-}
-
 TEST(Application, RecentRouteLoaded)
 {
     UserSettings settings;
@@ -857,8 +661,8 @@ TEST(Application, RecentRouteLoaded)
     EXPECT_CALL(viewer, set_settings).Times(AtLeast(1)).WillRepeatedly(SaveArg<0>(&called_settings));
     auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
     ON_CALL(level, filename).WillByDefault(Return("test.tr2"));
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    ON_CALL(route_window_manager, is_window_open).WillByDefault(Return(true));
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
+    ON_CALL(windows, is_route_window_open).WillByDefault(Return(true));
 
     auto application = register_test_module()
         .with_settings_loader(std::move(settings_loader_ptr))
@@ -866,7 +670,7 @@ TEST(Application, RecentRouteLoaded)
         .with_viewer(std::move(viewer_ptr))
         .with_route_source([&](auto&&...) {return route; })
         .with_level_source([&](auto&&...) { return std::move(level_ptr); })
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .build();
     
     application->open("test.tr2", ILevel::OpenMode::Full);
@@ -887,15 +691,15 @@ TEST(Application, RecentRouteNotLoaded)
     EXPECT_CALL(viewer, set_settings).Times(AtLeast(1)).WillRepeatedly(SaveArg<0>(&called_settings));
     auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
     ON_CALL(level, filename).WillByDefault(Return("test.tr2"));
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    ON_CALL(route_window_manager, is_window_open).WillByDefault(Return(true));
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
+    ON_CALL(windows, is_route_window_open).WillByDefault(Return(true));
 
     auto application = register_test_module()
         .with_settings_loader(std::move(settings_loader_ptr))
         .with_dialogs(dialogs)
         .with_viewer(std::move(viewer_ptr))
         .with_level_source([&](auto&&...) { return std::move(level_ptr); })
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .build();
 
     application->open("test.tr2", ILevel::OpenMode::Full);
@@ -918,7 +722,7 @@ TEST(Application, RecentRouteLoadedOnWindowOpened)
     EXPECT_CALL(viewer, set_settings).Times(AtLeast(1)).WillRepeatedly(SaveArg<0>(&called_settings));
     auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
     ON_CALL(level, filename).WillByDefault(Return("test.tr2"));
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
 
     auto application = register_test_module()
         .with_settings_loader(std::move(settings_loader_ptr))
@@ -926,13 +730,13 @@ TEST(Application, RecentRouteLoadedOnWindowOpened)
         .with_viewer(std::move(viewer_ptr))
         .with_route_source([&](auto&&...) {return route; })
         .with_level_source([&](auto&&...) { return std::move(level_ptr); })
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .build();
 
     application->open("test.tr2", ILevel::OpenMode::Full);
 
-    ON_CALL(route_window_manager, is_window_open).WillByDefault(Return(true));
-    route_window_manager.on_window_created();
+    ON_CALL(windows, is_route_window_open).WillByDefault(Return(true));
+    windows.on_route_window_created();
 
     ASSERT_EQ(called_settings.recent_routes["test.tr2"].route_path, "test.tvr");
 }
@@ -942,40 +746,26 @@ TEST(Application, SectorHoverForwarded)
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
     EXPECT_CALL(viewer, select_sector).Times(1);
 
-    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
-
-    auto application = register_test_module()
-        .with_viewer(std::move(viewer_ptr))
-        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
-        .build();
-
-    rooms_window_manager.on_sector_hover(mock_shared<MockSector>());
-}
-
-TEST(Application, WaypointChangedUpdatesViewer)
-{
-    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
-    EXPECT_CALL(viewer, set_scene_changed).Times(1);
-
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-
-    auto application = register_test_module()
-        .with_viewer(std::move(viewer_ptr))
-        .with_route_window_manager(std::move(route_window_manager_ptr))
-        .build();
-
-    route_window_manager.on_waypoint_changed();
-}
-
-TEST(Application, ViewerUpdatedWhenCameraSinkTypeChanges)
-{
     auto [windows_ptr, windows] = create_mock<MockWindows>();
+
+    auto application = register_test_module()
+        .with_viewer(std::move(viewer_ptr))
+        .with_windows(std::move(windows_ptr))
+        .build();
+
+    windows.on_sector_hover(mock_shared<MockSector>());
+}
+
+TEST(Application, SceneChangedUpdatesViewer)
+{
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
     EXPECT_CALL(viewer, set_scene_changed).Times(1);
 
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
+
     auto application = register_test_module()
-        .with_windows(std::move(windows_ptr))
         .with_viewer(std::move(viewer_ptr))
+        .with_windows(std::move(windows_ptr))
         .build();
 
     windows.on_scene_changed();
@@ -996,24 +786,6 @@ TEST(Application, CameraSinkSelectedEventForwarded)
     windows.on_camera_sink_selected(mock_shared<MockCameraSink>());
 }
 
-/*
-* TODO: Remove visibility event.
-TEST(Application, CameraSinkVisibilityEventForwarded)
-{
-    auto [camera_sink_window_manager_ptr, camera_sink_window_manager] = create_mock<MockCameraSinkWindowManager>();
-    auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
-    EXPECT_CALL(level, set_camera_sink_visibility).Times(1);
-
-    auto application = register_test_module()
-        .with_camera_sink_window_manager(std::move(camera_sink_window_manager_ptr))
-        .with_level_source([&](auto&&...) { return std::move(level_ptr); })
-        .build();
-
-    application->open("test_path.tr2", ILevel::OpenMode::Full);
-    camera_sink_window_manager.on_camera_sink_visibility(mock_shared<MockCameraSink>(), true);
-}
-*/
-
 TEST(Application, TriggerSelectedFromWindows)
 {
     auto [windows_ptr, windows] = create_mock<MockWindows>();
@@ -1029,21 +801,20 @@ TEST(Application, TriggerSelectedFromWindows)
     windows.on_trigger_selected(mock_shared<MockTrigger>());
 }
 
-TEST(Application, CameraSinkSelectedFromTriggersWindow)
+TEST(Application, CameraSinkSelectedFromWindows)
 {
     auto sink = mock_shared<MockCameraSink>();
-    auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto [level_ptr, level] = create_mock<trview::mocks::MockLevel>();
     EXPECT_CALL(level, set_selected_camera_sink).Times(1);
-    ON_CALL(level, camera_sinks).WillByDefault(testing::Return(std::vector<std::weak_ptr<ICameraSink>>{ sink }));
 
     auto application = register_test_module()
-        .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_level_source([&](auto&&...) { return std::move(level_ptr); })
         .build();
 
     application->open("test_path.tr2", ILevel::OpenMode::Full);
-    triggers_window_manager.on_camera_sink_selected(0);
+    windows.on_camera_sink_selected(sink);
 }
 
 TEST(Application, SetCurrentLevelPrompt)
@@ -1114,18 +885,18 @@ TEST(Application, RouteOpen)
     ON_CALL(*files, load_file(A<const std::string&>())).WillByDefault(Return(std::vector<uint8_t>{0x7B, 0x7D}));
 
     auto route = mock_shared<MockRoute>();
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto dialogs = mock_shared<MockDialogs>();
     ON_CALL(*dialogs, open_file).WillByDefault(Return(IDialogs::FileResult{.filename = "test", .filter_index = 1 }));
     auto application = register_test_module()
         .with_settings_loader(std::move(settings_loader_ptr))
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_route_source([=](auto&&...) { return route; })
         .with_dialogs(dialogs)
         .with_files(files)
         .build();
 
-    route_window_manager.on_route_open();
+    windows.on_route_open();
 
     ASSERT_EQ(application->route(), route);
 }
@@ -1140,18 +911,18 @@ TEST(Application, RouteOpenRandomizer)
     ON_CALL(*files, load_file(A<const std::string&>())).WillByDefault(Return(std::vector<uint8_t>{0x7B, 0x7D}));
 
     auto route = mock_shared<MockRandomizerRoute>();
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto dialogs = mock_shared<MockDialogs>();
     ON_CALL(*dialogs, open_file).WillByDefault(Return(IDialogs::FileResult{.filename = "test.json", .filter_index = 2 }));
     auto application = register_test_module()
         .with_settings_loader(std::move(settings_loader_ptr))
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_randomizer_route_source([=](auto&&...) { return route; })
         .with_dialogs(dialogs)
         .with_files(files)
         .build();
 
-    route_window_manager.on_route_open();
+    windows.on_route_open();
 
     ASSERT_EQ(application->route(), route);
 }
@@ -1161,13 +932,13 @@ TEST(Application, RouteReload)
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, reload).Times(1);
 
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto application = register_test_module()
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_route_source([=](auto&&...) { return route; })
         .build();
 
-    route_window_manager.on_route_reload();
+    windows.on_route_reload();
 }
 
 TEST(Application, RouteSave)
@@ -1177,13 +948,13 @@ TEST(Application, RouteSave)
     EXPECT_CALL(*route, save).Times(1);
     EXPECT_CALL(*route, set_filename).Times(0);
 
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto application = register_test_module()
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_route_source([=](auto&&...) { return route; })
         .build();
 
-    route_window_manager.on_route_save();
+    windows.on_route_save();
 }
 
 TEST(Application, RouteSaveNoFilename)
@@ -1193,17 +964,17 @@ TEST(Application, RouteSaveNoFilename)
     EXPECT_CALL(*route, set_filename).Times(1);
     EXPECT_CALL(*route, set_unsaved(false)).Times(1);
 
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto dialogs = mock_shared<MockDialogs>();
     ON_CALL(*dialogs, save_file).WillByDefault(Return(IDialogs::FileResult{ .filename = "test", .filter_index = 1 }));
 
     auto application = register_test_module()
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_route_source([=](auto&&...) { return route; })
         .with_dialogs(dialogs)
         .build();
 
-    route_window_manager.on_route_save();
+    windows.on_route_save();
 }
 
 TEST(Application, RouteSaveAs)
@@ -1213,17 +984,17 @@ TEST(Application, RouteSaveAs)
     EXPECT_CALL(*route, set_filename).Times(1);
     EXPECT_CALL(*route, set_unsaved(false)).Times(1);
 
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto dialogs = mock_shared<MockDialogs>();
     ON_CALL(*dialogs, save_file).WillByDefault(Return(IDialogs::FileResult{.filename = "test", .filter_index = 1 }));
 
     auto application = register_test_module()
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_route_source([=](auto&&...) { return route; })
         .with_dialogs(dialogs)
         .build();
 
-    route_window_manager.on_route_save_as();
+    windows.on_route_save_as();
 }
 
 TEST(Application, RouteLevelSwitch)
@@ -1231,13 +1002,13 @@ TEST(Application, RouteLevelSwitch)
     auto [file_menu_ptr, file_menu] = create_mock<MockFileMenu>();
     EXPECT_CALL(file_menu, switch_to("test1"));
 
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto application = register_test_module()
         .with_file_menu(std::move(file_menu_ptr))
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .build();
       
-    route_window_manager.on_level_switch("test1");
+    windows.on_level_switch("test1");
 }
 
 TEST(Application, RouteNewRoute)
@@ -1249,10 +1020,10 @@ TEST(Application, RouteNewRoute)
         mock_shared<MockRoute>()
     };
 
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    EXPECT_CALL(route_window_manager, set_route).Times(2);
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
+    EXPECT_CALL(windows, set_route).Times(2);
     auto application = register_test_module()
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_route_source([&](auto&&...) -> std::shared_ptr<IRoute>
             {
                 if (index < routes.size())
@@ -1264,22 +1035,22 @@ TEST(Application, RouteNewRoute)
         .build();
 
     ASSERT_EQ(application->route(), routes[0]);
-    route_window_manager.on_new_route();
+    windows.on_new_route();
     ASSERT_EQ(application->route(), routes[1]);
 }
 
 TEST(Application, RouteNewRandomizerRoute)
 {
     auto route = mock_shared<MockRandomizerRoute>();
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    EXPECT_CALL(route_window_manager, set_route).Times(2);
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
+    EXPECT_CALL(windows, set_route).Times(2);
     auto application = register_test_module()
-        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_randomizer_route_source([&](auto&&...) { return route; })
         .build();
 
     ASSERT_NE(application->route(), route);
-    route_window_manager.on_new_randomizer_route();
+    windows.on_new_randomizer_route();
     ASSERT_EQ(application->route(), route);
 }
 
@@ -1291,7 +1062,6 @@ TEST(Application, OnStaticMeshSelected)
     auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
     auto application = register_test_module()
-        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
         .with_windows(std::move(windows_ptr))
         .with_viewer(std::move(viewer_ptr))
         .build();
@@ -1299,6 +1069,6 @@ TEST(Application, OnStaticMeshSelected)
     application->set_current_level(level, ILevel::OpenMode::Full, false);
 
     EXPECT_CALL(viewer, select_static_mesh).Times(1);
-    // EXPECT_CALL(windows, select(A<const std::weak_ptr<IStaticMesh>&>).Times(1);
+    EXPECT_CALL(windows, select(A<const std::weak_ptr<IStaticMesh>&>())).Times(1);
     rooms_window_manager.on_static_mesh_selected(static_mesh);
 }

--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -33,8 +33,7 @@
 #include <trview.app/Mocks/Plugins/IPlugins.h>
 #include <trview.app/Mocks/Windows/IPluginsWindowManager.h>
 #include <trview.app/Mocks/UI/IFonts.h>
-#include <trview.app/Mocks/Windows/IStaticsWindow.h>
-#include <trview.app/Mocks/Windows/IStaticsWindowManager.h>
+#include <trview.app/Mocks/Windows/IWindows.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -89,7 +88,7 @@ namespace
             std::unique_ptr<IPluginsWindowManager> plugins_window_manager{ mock_unique<MockPluginsWindowManager>() };
             IRandomizerRoute::Source randomizer_route_source { [](auto&&...) { return mock_shared<MockRandomizerRoute>(); } };
             std::shared_ptr<IFonts> fonts { mock_shared<MockFonts>() };
-            std::unique_ptr<IStaticsWindowManager> statics_window_manager{ mock_unique<MockStaticsWindowManager>() };
+            std::unique_ptr<IWindows> windows{ mock_unique<MockWindows>() };
 
             std::unique_ptr<Application> build()
             {
@@ -99,7 +98,7 @@ namespace
                     std::move(items_window_manager), std::move(triggers_window_manager), std::move(route_window_manager), std::move(rooms_window_manager),
                     level_source, startup_options, dialogs, files, std::move(imgui_backend), std::move(lights_window_manager), std::move(log_window_manager),
                     std::move(textures_window_manager), std::move(camera_sink_window_manager), std::move(console_manager),
-                    plugins, std::move(plugins_window_manager), randomizer_route_source, fonts, std::move(statics_window_manager),
+                    plugins, std::move(plugins_window_manager), randomizer_route_source, fonts, std::move(windows),
                     Application::LoadMode::Sync);
             }
 
@@ -241,9 +240,9 @@ namespace
                 return *this;
             }
 
-            test_module& with_statics_window_manager(std::unique_ptr<IStaticsWindowManager> statics_window_manager)
+            test_module& with_windows(std::unique_ptr<IWindows> windows)
             {
-                this->statics_window_manager = std::move(statics_window_manager);
+                this->windows = std::move(windows);
                 return *this;
             }
 
@@ -320,7 +319,7 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
     auto [lights_window_manager_ptr, lights_window_manager] = create_mock<MockLightsWindowManager>();
     auto [textures_window_manager_ptr, textures_window_manager] = create_mock<MockTexturesWindowManager>();
     auto [camera_sink_window_manager_ptr, camera_sink_window_manager] = create_mock<MockCameraSinkWindowManager>();
-    auto [statics_window_manager_ptr, statics_window_manager] = create_mock<MockStaticsWindowManager>();
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto route = mock_shared<MockRoute>();
 
     std::vector<std::string> events;
@@ -341,7 +340,7 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
     EXPECT_CALL(route_window_manager, set_route(A<const std::weak_ptr<IRoute>&>())).Times(3).WillRepeatedly([&](auto) { events.push_back("route_route"); });
     EXPECT_CALL(lights_window_manager, set_lights(A<const std::vector<std::weak_ptr<ILight>>&>())).Times(1).WillOnce([&](auto) { events.push_back("lights_lights"); });
     EXPECT_CALL(camera_sink_window_manager, set_camera_sinks).Times(1).WillOnce([&](auto) { events.push_back("camera_sinks_camera_sinks"); });
-    EXPECT_CALL(statics_window_manager, set_statics).Times(1).WillOnce([&](auto) { events.push_back("statics_statics"); });
+    EXPECT_CALL(windows, set_level).Times(1).WillOnce([&](auto) { events.push_back("windows_level"); });
     EXPECT_CALL(*route, clear()).Times(1).WillOnce([&] { events.push_back("route_clear"); });
     EXPECT_CALL(*route, set_unsaved(false)).Times(1);
     EXPECT_CALL(textures_window_manager, set_texture_storage).Times(1).WillOnce([&](auto) { events.push_back("textures"); });
@@ -358,7 +357,7 @@ TEST(Application, WindowContentsResetBeforeViewerLoaded)
         .with_lights_window_manager(std::move(lights_window_manager_ptr))
         .with_textures_window_manager(std::move(textures_window_manager_ptr))
         .with_camera_sink_window_manager(std::move(camera_sink_window_manager_ptr))
-        .with_statics_window_manager(std::move(statics_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .build();
     application->open("test_path.tr2", ILevel::OpenMode::Full);
 
@@ -538,8 +537,8 @@ TEST(Application, WindowManagersUpdated)
     EXPECT_CALL(triggers_window_manager, update).Times(1);
     auto [lights_window_manager_ptr, lights_window_manager] = create_mock<MockLightsWindowManager>();
     EXPECT_CALL(lights_window_manager, update).Times(1);
-    auto [statics_window_manager_ptr, statics_window_manager] = create_mock<MockStaticsWindowManager>();
-    EXPECT_CALL(statics_window_manager, update).Times(1);
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
+    EXPECT_CALL(windows, update).Times(1);
 
     auto application = register_test_module()
         .with_route_window_manager(std::move(route_window_manager_ptr))
@@ -547,7 +546,7 @@ TEST(Application, WindowManagersUpdated)
         .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
         .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
         .with_lights_window_manager(std::move(lights_window_manager_ptr))
-        .with_statics_window_manager(std::move(statics_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .build();
     application->render();
 }
@@ -574,8 +573,8 @@ TEST(Application, WindowManagersAndViewerRendered)
     EXPECT_CALL(console_manager, render).Times(1);
     auto [plugins_window_manager_ptr, plugins_window_manager] = create_mock<MockPluginsWindowManager>();
     EXPECT_CALL(plugins_window_manager, render).Times(1);
-    auto [statics_window_manager_ptr, statics_window_manager] = create_mock<MockStaticsWindowManager>();
-    EXPECT_CALL(statics_window_manager, render).Times(1);
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
+    EXPECT_CALL(windows, render).Times(1);
     auto plugins = mock_shared<MockPlugins>();
     EXPECT_CALL(*plugins, render_ui).Times(1);
 
@@ -593,7 +592,7 @@ TEST(Application, WindowManagersAndViewerRendered)
         .with_camera_sink_window_manager(std::move(camera_sink_window_manager_ptr))
         .with_console_manager(std::move(console_manager_ptr))
         .with_plugins_window_manager(std::move(plugins_window_manager_ptr))
-        .with_statics_window_manager(std::move(statics_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_viewer(std::move(viewer_ptr))
         .with_plugins(plugins)
         .build();
@@ -1326,17 +1325,17 @@ TEST(Application, OnStaticMeshSelected)
     auto level = mock_shared<trview::mocks::MockLevel>();
     auto static_mesh = mock_shared<MockStaticMesh>();
     auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
-    auto [statics_window_manager_ptr, statics_window_manager] = create_mock<MockStaticsWindowManager>();
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
     auto [viewer_ptr, viewer] = create_mock<MockViewer>();
     auto application = register_test_module()
         .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
-        .with_statics_window_manager(std::move(statics_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
         .with_viewer(std::move(viewer_ptr))
         .build();
 
     application->set_current_level(level, ILevel::OpenMode::Full, false);
 
     EXPECT_CALL(viewer, select_static_mesh).Times(1);
-    EXPECT_CALL(statics_window_manager, select_static).Times(1);
+    EXPECT_CALL(windows, select).Times(1);
     rooms_window_manager.on_static_mesh_selected(static_mesh);
 }

--- a/trview.app.tests/CameraSinkWindowManagerTests.cpp
+++ b/trview.app.tests/CameraSinkWindowManagerTests.cpp
@@ -131,27 +131,20 @@ TEST(CameraSinkWindowManager, SelectedSinkRaised)
     ASSERT_EQ(raised, sink);
 }
 
-TEST(CameraSinkWindowManager, SinkVisibilityRaised)
+TEST(CameraSinkWindowManager, SceneChangedRaised)
 {
     auto window = mock_shared<MockCameraSinkWindow>();
-    auto manager = register_test_module()
-        .with_window_source([&]() { return window; })
-        .build();
+    auto manager = register_test_module().with_window_source([&]() { return window; }).build();
 
-    std::optional<std::tuple<std::shared_ptr<ICameraSink>, bool>> raised;
-    auto token = manager->on_camera_sink_visibility += [&](auto sink, auto visibility)
-    {
-        raised = { sink.lock(), visibility };
-    };
+    bool raised = false;
+    auto token = manager->on_scene_changed += [&]() { raised = true; };
 
     manager->create_window();
 
     auto sink = mock_shared<MockCameraSink>();
-    manager->on_camera_sink_visibility(sink, true);
+    window->on_scene_changed();
 
     ASSERT_TRUE(raised);
-    ASSERT_EQ(std::get<0>(raised.value()), sink);
-    ASSERT_EQ(std::get<1>(raised.value()), true);
 }
 
 TEST(CameraSinkWindowManager, TriggerSelectedRaised)
@@ -174,26 +167,6 @@ TEST(CameraSinkWindowManager, TriggerSelectedRaised)
 
     ASSERT_TRUE(raised);
     ASSERT_EQ(raised, trigger);
-}
-
-TEST(CameraSinkWindowManager, CameraSinkTypeChangedRaised)
-{
-    auto window = mock_shared<MockCameraSinkWindow>();
-    auto manager = register_test_module()
-        .with_window_source([&]() { return window; })
-        .build();
-
-    bool raised = false;
-    auto token = manager->on_camera_sink_type_changed += [&]()
-    {
-        raised = true;
-    };
-
-    manager->create_window();
-    
-    manager->on_camera_sink_type_changed();
-
-    ASSERT_TRUE(raised);
 }
 
 TEST(CameraSinkWindowManager, CreateCameraSinkWindowKeyboardShortcut)

--- a/trview.app.tests/ItemsWindowManagerTests.cpp
+++ b/trview.app.tests/ItemsWindowManagerTests.cpp
@@ -83,22 +83,20 @@ TEST(ItemsWindowManager, ItemSelectedEventRaised)
     ASSERT_EQ(raised_item, test_item);
 }
 
-TEST(ItemsWindowManager, ItemVisibilityEventRaised)
+TEST(ItemsWindowManager, SceneChangedRaised)
 {
     auto manager = register_test_module().build();
 
-    std::optional<std::tuple<std::shared_ptr<IItem>, bool>> raised_item;
-    auto token = manager->on_item_visibility += [&raised_item](const auto& item, bool state) { raised_item = { item.lock(), state }; };
+    bool raised = false;
+    auto token = manager->on_scene_changed += [&raised]() { raised = true; };
 
     auto created_window = manager->create_window().lock();
     ASSERT_NE(created_window, nullptr);
 
     auto test_item = mock_shared<MockItem>();
-    created_window->on_item_visibility(test_item, true);
+    created_window->on_scene_changed();
 
-    ASSERT_TRUE(raised_item);
-    ASSERT_EQ(std::get<0>(raised_item.value()), test_item);
-    ASSERT_EQ(std::get<1>(raised_item.value()), true);
+    ASSERT_TRUE(raised);
 }
 
 TEST(ItemsWindowManager, TriggerSelectedEventRaised)

--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -96,24 +96,19 @@ TEST(RoomsWindowManager, MapColoursPassedToNewWindows)
     manager->create_window();
 }
 
-TEST(RoomsWindowManager, OnRoomVisibilityRaised)
+TEST(RoomsWindowManager, SceneChangedRaised)
 {
     auto manager = register_test_module().build();
     auto room = mock_shared<MockRoom>();
 
-    std::optional<std::tuple<std::weak_ptr<IRoom>, bool>> raised;
-    auto token = manager->on_room_visibility += [&](auto&& value, auto&& visible)
-    {
-        raised = { value, visible };
-    };
+    bool raised = false;
+    auto token = manager->on_scene_changed += [&]() { raised = true; };
 
     auto window = manager->create_window().lock();
     ASSERT_NE(window, nullptr);
 
-    window->on_room_visibility(room, true);
-    ASSERT_TRUE(raised.has_value());
-    ASSERT_EQ(std::get<0>(raised.value()).lock(), room);
-    ASSERT_TRUE(std::get<1>(raised.value()));
+    window->on_scene_changed();
+    ASSERT_TRUE(raised);
 }
 
 TEST(RoomsWindowManager, SetFloordataPassedToWindows)

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -288,6 +288,7 @@ TEST(Route, SelectedWaypoint)
     route->select_waypoint(wp1);
     ASSERT_FALSE(route->is_unsaved());
     ASSERT_EQ(route->selected_waypoint(), 1);
+    ASSERT_EQ(route->waypoint(route->selected_waypoint()).lock(), wp1);
 }
 
 TEST(Route, SelectedWaypointAdjustedByRemove)

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -209,9 +209,9 @@ TEST(Route, Insert)
     uint32_t test_index = 0;
     auto route = register_test_module().with_waypoint_source(indexed_source(test_index)).build();
     route->add(Vector3::Zero, Vector3::Down, 0);
-    route->add(Vector3::Zero, Vector3::Down, 1);
+    auto wp1 = route->add(Vector3::Zero, Vector3::Down, 1);
     route->set_unsaved(false);
-    route->select_waypoint(1);
+    route->select_waypoint(wp1);
     auto index = route->insert(Vector3(0, 1, 0), Vector3::Down, 2);
     ASSERT_EQ(index, 2);
     ASSERT_TRUE(route->is_unsaved());
@@ -283,9 +283,9 @@ TEST(Route, SelectedWaypoint)
 {
     auto route = register_test_module().build();
     route->add(Vector3::Zero, Vector3::Down, 0);
-    route->add(Vector3::Zero, Vector3::Down, 0);
+    auto wp1 = route->add(Vector3::Zero, Vector3::Down, 0);
     route->set_unsaved(false);
-    route->select_waypoint(1);
+    route->select_waypoint(wp1);
     ASSERT_FALSE(route->is_unsaved());
     ASSERT_EQ(route->selected_waypoint(), 1);
 }
@@ -294,9 +294,9 @@ TEST(Route, SelectedWaypointAdjustedByRemove)
 {
     auto route = register_test_module().build();
     route->add(Vector3::Zero, Vector3::Down, 0);
-    route->add(Vector3::Zero, Vector3::Down, 0);
+    auto wp1 = route->add(Vector3::Zero, Vector3::Down, 0);
     route->set_unsaved(false);
-    route->select_waypoint(1);
+    route->select_waypoint(wp1);
     ASSERT_FALSE(route->is_unsaved());
     ASSERT_EQ(route->selected_waypoint(), 1);
     route->remove(1);

--- a/trview.app.tests/Windows/LightsWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/LightsWindowManagerTests.cpp
@@ -61,24 +61,19 @@ TEST(LightsWindowManager, OnLightSelectedRaised)
     ASSERT_EQ(raised.lock(), light);
 }
 
-TEST(LightsWindowManager, OnLightVisibilityRaised)
+TEST(LightsWindowManager, SceneChangedRaised)
 {
     auto manager = register_test_module().build();
     auto light = mock_shared<MockLight>();
 
-    std::optional<std::tuple<std::weak_ptr<ILight>, bool>> raised;
-    auto token = manager->on_light_visibility += [&](auto&& value, auto&& visible) 
-    {
-        raised = { value, visible };
-    };
+    bool raised = false;
+    auto token = manager->on_scene_changed += [&]() { raised = true; };
 
     auto window = manager->create_window().lock();
     ASSERT_NE(window, nullptr);
 
-    window->on_light_visibility(light, true);
-    ASSERT_TRUE(raised.has_value());
-    ASSERT_EQ(std::get<0>(raised.value()).lock(), light);
-    ASSERT_TRUE(std::get<1>(raised.value()));
+    window->on_scene_changed();
+    ASSERT_TRUE(raised);
 }
 
 TEST(LightsWindowManager, SetLightsUpdatesExistingWindows)

--- a/trview.app.tests/Windows/RouteWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/RouteWindowManagerTests.cpp
@@ -94,56 +94,18 @@ TEST(RouteWindowManager, RandomizerSettingsPassedToNewWindow)
     manager->create_window();
 }
 
-TEST(RouteWindowManager, WaypointReorderedEventRaised)
-{
-    auto mock_window = mock_shared<MockRouteWindow>();
-    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
-    std::optional<std::tuple<int32_t, int32_t>> raised;
-    auto token = manager->on_waypoint_reordered += [&](int32_t from, int32_t to)
-    {
-        raised = { from, to };
-    };
-    manager->create_window();
-    mock_window->on_waypoint_reordered(1, 2);
-    ASSERT_TRUE(raised.has_value());
-    ASSERT_EQ(std::get<0>(raised.value()), 1);
-    ASSERT_EQ(std::get<1>(raised.value()), 2);
-}
-
-TEST(RouteWindowManager, OnColourChangeEventRaised)
+TEST(RouteWindowManager, OnSceneChangedEventRaised)
 {
     auto mock_window = mock_shared<MockRouteWindow>();
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
 
-    std::optional<Colour> raised;
-    auto token = manager->on_colour_changed += [&](const Colour& colour)
-    {
-        raised = colour;
-    };
+    bool raised = false;
+    auto token = manager->on_scene_changed += [&]() { raised = true; };
 
     manager->create_window();
-    mock_window->on_colour_changed(Colour::Yellow);
+    mock_window->on_scene_changed();
 
-    ASSERT_TRUE(raised.has_value());
-    ASSERT_EQ(raised.value(), Colour::Yellow);
-}
-
-TEST(RouteWindowManager, OnWaypointColourChangedEventRaised)
-{
-    auto mock_window = mock_shared<MockRouteWindow>();
-    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
-
-    std::optional<Colour> raised;
-    auto token = manager->on_waypoint_colour_changed += [&](const Colour& colour)
-    {
-        raised = colour;
-    };
-
-    manager->create_window();
-    mock_window->on_waypoint_colour_changed(Colour::Yellow);
-
-    ASSERT_TRUE(raised.has_value());
-    ASSERT_EQ(raised.value(), Colour::Yellow);
+    ASSERT_TRUE(raised);
 }
 
 TEST(RouteWindowManager, OnWindowCreatedEventRaised)
@@ -168,22 +130,6 @@ TEST(RouteWindowManager, IsWindowOpen)
     mock_window->on_window_closed();
     manager->render();
     ASSERT_FALSE(manager->is_window_open());
-}
-
-TEST(RouteWindowManager, WaypointChangedRaised)
-{
-    auto mock_window = mock_shared<MockRouteWindow>();
-    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
-
-    bool raised = false;
-    auto token = manager->on_waypoint_changed += [&]()
-    {
-        raised = true;
-    };
-
-    manager->create_window();
-    mock_window->on_waypoint_changed();
-    ASSERT_TRUE(raised);
 }
 
 TEST(RouteWindowManager, OnRouteOpenRaised)

--- a/trview.app.tests/Windows/WindowsTests.cpp
+++ b/trview.app.tests/Windows/WindowsTests.cpp
@@ -1,0 +1,34 @@
+#include <trview.app/Windows/Windows.h>
+
+#include <trview.app/Mocks/Windows/IPluginsWindowManager.h>
+#include <trview.app/Mocks/Windows/IStaticsWindowManager.h>
+
+using namespace trview;
+using namespace trview::tests;
+using namespace trview::mocks;
+
+namespace
+{
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            std::unique_ptr<IPluginsWindowManager> plugins{ mock_unique<MockPluginsWindowManager>() };
+            std::unique_ptr<IStaticsWindowManager> statics{ mock_unique<MockStaticsWindowManager>() };
+
+            std::unique_ptr<trview::Windows> build()
+            {
+                return std::make_unique<trview::Windows>(std::move(plugins), std::move(statics));
+            }
+        };
+        return test_module{};
+    }
+}
+
+TEST(Windows, Statics)
+{
+}
+
+TEST(Windows, Plugins)
+{
+}

--- a/trview.app.tests/Windows/WindowsTests.cpp
+++ b/trview.app.tests/Windows/WindowsTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Windows/Windows.h>
 
+#include <trview.app/Mocks/Windows/ICameraSinkWindowManager.h>
 #include <trview.app/Mocks/Windows/IPluginsWindowManager.h>
 #include <trview.app/Mocks/Windows/IStaticsWindowManager.h>
 
@@ -13,12 +14,13 @@ namespace
     {
         struct test_module
         {
+            std::unique_ptr<ICameraSinkWindowManager> camera_sinks{ mock_unique<MockCameraSinkWindowManager>() };
             std::unique_ptr<IPluginsWindowManager> plugins{ mock_unique<MockPluginsWindowManager>() };
             std::unique_ptr<IStaticsWindowManager> statics{ mock_unique<MockStaticsWindowManager>() };
 
             std::unique_ptr<trview::Windows> build()
             {
-                return std::make_unique<trview::Windows>(std::move(plugins), std::move(statics));
+                return std::make_unique<trview::Windows>(std::move(camera_sinks), std::move(plugins), std::move(statics));
             }
         };
         return test_module{};

--- a/trview.app.tests/Windows/WindowsTests.cpp
+++ b/trview.app.tests/Windows/WindowsTests.cpp
@@ -1,5 +1,10 @@
 #include <trview.app/Windows/Windows.h>
 
+#include <trview.app/Mocks/Elements/ICameraSink.h>
+#include <trview.app/Mocks/Elements/IItem.h>
+#include <trview.app/Mocks/Elements/ILight.h>
+#include <trview.app/Mocks/Elements/ITrigger.h>
+
 #include <trview.app/Mocks/Windows/ICameraSinkWindowManager.h>
 #include <trview.app/Mocks/Windows/IConsoleManager.h>
 #include <trview.app/Mocks/Windows/IItemsWindowManager.h>
@@ -49,19 +54,208 @@ namespace
                     std::move(textures),
                     std::move(triggers));
             }
+
+            test_module& with_camera_sinks(std::unique_ptr<ICameraSinkWindowManager> manager)
+            {
+                camera_sinks = std::move(manager);
+                return *this;
+            }
+
+            test_module& with_items(std::unique_ptr<IItemsWindowManager> manager)
+            {
+                items = std::move(manager);
+                return *this;
+            }
+
+            test_module& with_lights(std::unique_ptr<ILightsWindowManager> manager)
+            {
+                lights = std::move(manager);
+                return *this;
+            }
+
+            test_module& with_rooms(std::unique_ptr<IRoomsWindowManager> manager)
+            {
+                rooms = std::move(manager);
+                return *this;
+            }
         };
         return test_module{};
     }
 }
 
-/*
-TEST(Windows, Statics)
+TEST(Windows, CameraSinkEventsForwarded)
 {
+    auto [camera_sinks_ptr, camera_sinks] = create_mock<MockCameraSinkWindowManager>();
+    auto windows = register_test_module().with_camera_sinks(std::move(camera_sinks_ptr)).build();
+
+    std::shared_ptr<ICameraSink> raised_camera;
+    auto t1 = windows->on_camera_sink_selected += [&](auto s) { raised_camera = s.lock(); };
+
+    std::shared_ptr<ITrigger> raised_trigger;
+    auto t2 = windows->on_trigger_selected += [&](auto t) { raised_trigger = t.lock(); };
+
+    bool raised = false;
+    auto t3 = windows->on_scene_changed += [&]() { raised = true; };
+
+    auto camera = mock_shared<MockCameraSink>();
+    auto trigger = mock_shared<MockTrigger>();
+
+    camera_sinks.on_camera_sink_selected(camera);
+    camera_sinks.on_trigger_selected(trigger);
+    camera_sinks.on_scene_changed();
+
+    ASSERT_EQ(raised_camera, camera);
+    ASSERT_EQ(raised_trigger, trigger);
+    ASSERT_EQ(raised, true);
 }
 
-TEST(Windows, Plugins)
+TEST(Windows, ItemsEventsForwarded)
 {
+    auto [items_ptr, items] = create_mock<MockItemsWindowManager>();
+    auto windows = register_test_module().with_items(std::move(items_ptr)).build();
+
+    std::shared_ptr<IItem> raised_item;
+    auto t1 = windows->on_item_selected += [&](auto s) { raised_item = s.lock(); };
+
+    std::shared_ptr<ITrigger> raised_trigger;
+    auto t2 = windows->on_trigger_selected += [&](auto t) { raised_trigger = t.lock(); };
+
+    bool raised = false;
+    auto t3 = windows->on_scene_changed += [&]() { raised = true; };
+
+    auto item = mock_shared<MockItem>();
+    auto trigger = mock_shared<MockTrigger>();
+
+    items.on_item_selected(item);
+    items.on_trigger_selected(trigger);
+    items.on_scene_changed();
+
+    ASSERT_EQ(raised_item, item);
+    ASSERT_EQ(raised_trigger, trigger);
+    ASSERT_EQ(raised, true);
 }
+
+TEST(Windows, LightsEventsForwarded)
+{
+    auto [lights_ptr, lights] = create_mock<MockLightsWindowManager>();
+    auto windows = register_test_module().with_lights(std::move(lights_ptr)).build();
+
+    std::shared_ptr<ILight> raised_light;
+    auto t1 = windows->on_light_selected += [&](auto s) { raised_light = s.lock(); };
+
+    bool raised = false;
+    auto t2 = windows->on_scene_changed += [&]() { raised = true; };
+
+    auto light = mock_shared<MockLight>();
+    auto trigger = mock_shared<MockTrigger>();
+
+    lights.on_light_selected(light);
+    lights.on_scene_changed();
+
+    ASSERT_EQ(raised_light, light);
+    ASSERT_EQ(raised, true);
+}
+
+TEST(Windows, RoomsEventsForwarded)
+{
+    FAIL();
+}
+
+TEST(Windows, RouteEventsForwarded)
+{
+    FAIL();
+}
+
+TEST(Windows, SelectCameraSink)
+{
+    auto [camera_sinks_ptr, camera_sinks] = create_mock<MockCameraSinkWindowManager>();
+    auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
+
+    const auto camera = mock_shared<MockCameraSink>();
+    std::shared_ptr<ICameraSink> camera_sinks_camera;
+    EXPECT_CALL(camera_sinks, set_selected_camera_sink).Times(1).WillRepeatedly([&](auto c) { camera_sinks_camera = c.lock(); });
+    std::shared_ptr<ICameraSink> rooms_camera;
+    EXPECT_CALL(rooms, set_selected_camera_sink).Times(1).WillRepeatedly([&](auto c) { rooms_camera = c.lock(); });
+
+    auto windows = register_test_module().with_camera_sinks(std::move(camera_sinks_ptr)).with_rooms(std::move(rooms_ptr)).build();
+
+    windows->select(camera);
+
+    ASSERT_EQ(camera_sinks_camera, camera);
+    ASSERT_EQ(rooms_camera, camera);
+}
+
+TEST(Windows, SelectItem)
+{
+    FAIL();
+}
+
+TEST(Windows, SelectLight)
+{
+    FAIL();
+}
+
+TEST(Windows, SelectStaticMesh)
+{
+    FAIL();
+}
+
+TEST(Windows, SelectTrigger)
+{
+    FAIL();
+}
+
+TEST(Windows, SelectWaypoint)
+{
+    FAIL();
+}
+
+TEST(Windows, SetLevel)
+{
+    FAIL();
+}
+
+TEST(Windows, SetRoom)
+{
+    FAIL();
+}
+
+TEST(Windows, SetRoute)
+{
+    FAIL();
+}
+
+TEST(Windows, SetSettings)
+{
+    FAIL();
+}
+
+TEST(Windows, Setup)
+{
+    FAIL();
+}
+
+TEST(Windows, StaticsEventsForwarded)
+{
+    FAIL();
+}
+
+TEST(Windows, TriggersEventsForwarded)
+{
+    FAIL();
+}
+
+TEST(Windows, WindowsRendered)
+{
+    FAIL();
+}
+
+TEST(Windows, WindowsUpdated)
+{
+    FAIL();
+}
+
+/*
 
 TEST(Windows, MapColoursSetOnRoomWindow)
 {

--- a/trview.app.tests/Windows/WindowsTests.cpp
+++ b/trview.app.tests/Windows/WindowsTests.cpp
@@ -1,8 +1,12 @@
 #include <trview.app/Windows/Windows.h>
 
+#include <trview.common/TokenStore.h>
+
 #include <trview.app/Mocks/Elements/ICameraSink.h>
 #include <trview.app/Mocks/Elements/IItem.h>
 #include <trview.app/Mocks/Elements/ILight.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
+#include <trview.app/Mocks/Elements/ISector.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
 
 #include <trview.app/Mocks/Windows/ICameraSinkWindowManager.h>
@@ -20,6 +24,9 @@
 using namespace trview;
 using namespace trview::tests;
 using namespace trview::mocks;
+using namespace DirectX::SimpleMath;
+using testing::A;
+using testing::Return;
 
 namespace
 {
@@ -61,6 +68,12 @@ namespace
                 return *this;
             }
 
+            test_module& with_console(std::unique_ptr<IConsoleManager> manager)
+            {
+                console_manager = std::move(manager);
+                return *this;
+            }
+
             test_module& with_items(std::unique_ptr<IItemsWindowManager> manager)
             {
                 items = std::move(manager);
@@ -73,13 +86,66 @@ namespace
                 return *this;
             }
 
+            test_module& with_log(std::unique_ptr<ILogWindowManager> manager)
+            {
+                log = std::move(manager);
+                return *this;
+            }
+
+            test_module& with_plugins(std::unique_ptr<IPluginsWindowManager> manager)
+            {
+                plugins = std::move(manager);
+                return *this;
+            }
+
             test_module& with_rooms(std::unique_ptr<IRoomsWindowManager> manager)
             {
                 rooms = std::move(manager);
                 return *this;
             }
+
+            test_module& with_route(std::unique_ptr<IRouteWindowManager> manager)
+            {
+                route = std::move(manager);
+                return *this;
+            }
+
+            test_module& with_statics(std::unique_ptr<IStaticsWindowManager> manager)
+            {
+                statics = std::move(manager);
+                return *this;
+            }
+
+            test_module& with_textures(std::unique_ptr<ITexturesWindowManager> manager)
+            {
+                textures = std::move(manager);
+                return *this;
+            }
+
+            test_module& with_triggers(std::unique_ptr<ITriggersWindowManager> manager)
+            {
+                triggers = std::move(manager);
+                return *this;
+            }
         };
         return test_module{};
+    }
+
+    template <int index = 0, typename T>
+    auto capture(std::shared_ptr<T>& out)
+    {
+        return [&](auto... in) { out = std::get<index>(std::tie(in...)).lock(); };
+    }
+
+    template <int index = 0, typename T>
+    auto capture(T& out)
+    {
+        return [&](auto... in) { out = std::get<index>(std::tie(in...)); };
+    }
+
+    auto capture_called(bool& out)
+    {
+        return [&](auto&&...) { out = true; };
     }
 }
 
@@ -88,14 +154,15 @@ TEST(Windows, CameraSinkEventsForwarded)
     auto [camera_sinks_ptr, camera_sinks] = create_mock<MockCameraSinkWindowManager>();
     auto windows = register_test_module().with_camera_sinks(std::move(camera_sinks_ptr)).build();
 
+    TokenStore store;
     std::shared_ptr<ICameraSink> raised_camera;
-    auto t1 = windows->on_camera_sink_selected += [&](auto s) { raised_camera = s.lock(); };
+    store += windows->on_camera_sink_selected += capture(raised_camera);
 
     std::shared_ptr<ITrigger> raised_trigger;
-    auto t2 = windows->on_trigger_selected += [&](auto t) { raised_trigger = t.lock(); };
+    store += windows->on_trigger_selected += capture(raised_trigger);
 
     bool raised = false;
-    auto t3 = windows->on_scene_changed += [&]() { raised = true; };
+    store += windows->on_scene_changed += capture_called(raised);
 
     auto camera = mock_shared<MockCameraSink>();
     auto trigger = mock_shared<MockTrigger>();
@@ -109,30 +176,62 @@ TEST(Windows, CameraSinkEventsForwarded)
     ASSERT_EQ(raised, true);
 }
 
+TEST(Windows, CameraSinkStartup)
+{
+    auto [camera_sinks_ptr, camera_sinks] = create_mock<MockCameraSinkWindowManager>();
+    EXPECT_CALL(camera_sinks, create_window).Times(1);
+
+    auto windows = register_test_module().with_camera_sinks(std::move(camera_sinks_ptr)).build();
+
+    windows->setup({ .camera_sink_startup = true });
+}
+
 TEST(Windows, ItemsEventsForwarded)
 {
     auto [items_ptr, items] = create_mock<MockItemsWindowManager>();
+    auto waypoint = mock_shared<MockWaypoint>();
+    auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, insert(A<const Vector3&>(), A<const Vector3&>(), A<uint32_t>(), IWaypoint::Type::Entity, A<uint32_t>())).Times(1).WillRepeatedly(Return(100));
+    EXPECT_CALL(*route, waypoint(100)).Times(1).WillRepeatedly(Return(waypoint));
+
     auto windows = register_test_module().with_items(std::move(items_ptr)).build();
+    windows->set_route(route);
+
+    TokenStore store;
+    std::shared_ptr<IWaypoint> raised_waypoint;
+    store += windows->on_waypoint_selected += capture(raised_waypoint);
 
     std::shared_ptr<IItem> raised_item;
-    auto t1 = windows->on_item_selected += [&](auto s) { raised_item = s.lock(); };
+    store += windows->on_item_selected += capture(raised_item);
 
     std::shared_ptr<ITrigger> raised_trigger;
-    auto t2 = windows->on_trigger_selected += [&](auto t) { raised_trigger = t.lock(); };
+    store += windows->on_trigger_selected += capture(raised_trigger);
 
     bool raised = false;
-    auto t3 = windows->on_scene_changed += [&]() { raised = true; };
+    store += windows->on_scene_changed += capture_called(raised);
 
     auto item = mock_shared<MockItem>();
     auto trigger = mock_shared<MockTrigger>();
 
+    items.on_add_to_route(item);
     items.on_item_selected(item);
     items.on_trigger_selected(trigger);
     items.on_scene_changed();
 
+    ASSERT_EQ(raised_waypoint, waypoint);
     ASSERT_EQ(raised_item, item);
     ASSERT_EQ(raised_trigger, trigger);
     ASSERT_EQ(raised, true);
+}
+
+TEST(Windows, ItemsStartup)
+{
+    auto [items_ptr, items] = create_mock<MockItemsWindowManager>();
+    EXPECT_CALL(items, create_window).Times(1);
+
+    auto windows = register_test_module().with_items(std::move(items_ptr)).build();
+
+    windows->setup({ .items_startup = true });
 }
 
 TEST(Windows, LightsEventsForwarded)
@@ -140,11 +239,12 @@ TEST(Windows, LightsEventsForwarded)
     auto [lights_ptr, lights] = create_mock<MockLightsWindowManager>();
     auto windows = register_test_module().with_lights(std::move(lights_ptr)).build();
 
+    TokenStore store;
     std::shared_ptr<ILight> raised_light;
-    auto t1 = windows->on_light_selected += [&](auto s) { raised_light = s.lock(); };
+    store += windows->on_light_selected += [&](auto s) { raised_light = s.lock(); };
 
     bool raised = false;
-    auto t2 = windows->on_scene_changed += [&]() { raised = true; };
+    store += windows->on_scene_changed += [&]() { raised = true; };
 
     auto light = mock_shared<MockLight>();
     auto trigger = mock_shared<MockTrigger>();
@@ -158,12 +258,137 @@ TEST(Windows, LightsEventsForwarded)
 
 TEST(Windows, RoomsEventsForwarded)
 {
-    FAIL();
+    auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
+
+    auto windows = register_test_module().with_rooms(std::move(rooms_ptr)).build();
+
+    TokenStore store;
+    std::shared_ptr<ICameraSink> raised_camera;
+    store += windows->on_camera_sink_selected += capture(raised_camera);
+    std::shared_ptr<IItem> raised_item;
+    store += windows->on_item_selected += capture(raised_item);
+    std::shared_ptr<ILight> raised_light;
+    store += windows->on_light_selected += capture(raised_light);
+    std::shared_ptr<IRoom> raised_room;
+    store += windows->on_room_selected += capture(raised_room);
+    bool scene_changed = false;
+    store += windows->on_scene_changed += capture_called(scene_changed);
+    std::shared_ptr<ISector> raised_sector;
+    store += windows->on_sector_hover += capture(raised_sector);
+    std::shared_ptr<IStaticMesh> raised_static;
+    store += windows->on_static_selected += capture(raised_static);
+    std::shared_ptr<ITrigger> raised_trigger;
+    store += windows->on_trigger_selected += capture(raised_trigger);
+
+    auto camera = mock_shared<MockCameraSink>();
+    rooms.on_camera_sink_selected(camera);
+
+    auto item = mock_shared<MockItem>();
+    rooms.on_item_selected(item);
+
+    auto light = mock_shared<MockLight>();
+    rooms.on_light_selected(light);
+
+    auto room = mock_shared<MockRoom>();
+    rooms.on_room_selected(room);
+
+    rooms.on_scene_changed();
+
+    auto sector = mock_shared<MockSector>();
+    rooms.on_sector_hover(sector);
+
+    auto static_mesh = mock_shared<MockStaticMesh>();
+    rooms.on_static_mesh_selected(static_mesh);
+
+    auto trigger = mock_shared<MockTrigger>();
+    rooms.on_trigger_selected(trigger);
+
+    ASSERT_EQ(raised_camera, camera);
+    ASSERT_EQ(raised_item, item);
+    ASSERT_EQ(raised_light, light);
+    ASSERT_EQ(raised_room, room);
+    ASSERT_EQ(scene_changed, true);
+    ASSERT_EQ(raised_sector, sector);
+    ASSERT_EQ(raised_static, static_mesh);
+    ASSERT_EQ(raised_trigger, trigger);
+}
+
+TEST(Windows, RoomsStartup)
+{
+    auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
+    EXPECT_CALL(rooms, create_window).Times(1);
+
+    auto windows = register_test_module().with_rooms(std::move(rooms_ptr)).build();
+
+    windows->setup({ .rooms_startup = true });
 }
 
 TEST(Windows, RouteEventsForwarded)
 {
-    FAIL();
+    auto [route_ptr, route] = create_mock<MockRouteWindowManager>();
+    auto windows = register_test_module().with_route(std::move(route_ptr)).build();
+
+    TokenStore store;
+
+    std::shared_ptr<IWaypoint> raised_waypoint;
+    store += route.on_waypoint_selected += capture(raised_waypoint);
+    std::shared_ptr<IItem> raised_item;
+    store += route.on_item_selected += capture(raised_item);
+    bool scene_changed = false;
+    store += route.on_scene_changed += capture_called(scene_changed);
+    std::shared_ptr<ITrigger> raised_trigger;
+    store += route.on_trigger_selected += capture(raised_trigger);
+    bool route_open = false;
+    store += route.on_route_open += capture_called(route_open);
+    bool route_reload = false;
+    store += route.on_route_reload += capture_called(route_reload);
+    bool route_save = false;
+    store += route.on_route_save += capture_called(route_save);
+    bool route_save_as = false;
+    store += route.on_route_save_as += capture_called(route_save_as);
+    std::optional<std::string> level_switch_raised;
+    store += route.on_level_switch += capture(level_switch_raised);
+    bool new_route = false;
+    store += route.on_new_route += capture_called(new_route);
+    bool new_randomizer_route = false;
+    store += route.on_new_randomizer_route += capture_called(new_randomizer_route);
+
+    auto waypoint = mock_shared<MockWaypoint>();
+    route.on_waypoint_selected(waypoint);
+    auto item = mock_shared<MockItem>();
+    route.on_item_selected(item);
+    route.on_scene_changed();
+    auto trigger = mock_shared<MockTrigger>();
+    route.on_trigger_selected(trigger);
+    route.on_route_open();
+    route.on_route_reload();
+    route.on_route_save();
+    route.on_route_save_as();
+    route.on_level_switch("test");
+    route.on_new_route();
+    route.on_new_randomizer_route();
+
+    ASSERT_EQ(raised_waypoint, waypoint);
+    ASSERT_EQ(raised_item, item);
+    ASSERT_EQ(scene_changed, true);
+    ASSERT_EQ(raised_trigger, trigger);
+    ASSERT_EQ(route_open, true);
+    ASSERT_EQ(route_reload, true);
+    ASSERT_EQ(route_save, true);
+    ASSERT_EQ(route_save_as, true);
+    ASSERT_EQ(level_switch_raised, "test");
+    ASSERT_EQ(new_route, true);
+    ASSERT_EQ(new_randomizer_route, true);
+}
+
+TEST(Windows, RouteStartup)
+{
+    auto [route_ptr, route] = create_mock<MockRouteWindowManager>();
+    EXPECT_CALL(route, create_window).Times(1);
+
+    auto windows = register_test_module().with_route(std::move(route_ptr)).build();
+
+    windows->setup({ .route_startup = true });
 }
 
 TEST(Windows, SelectCameraSink)
@@ -187,250 +412,375 @@ TEST(Windows, SelectCameraSink)
 
 TEST(Windows, SelectItem)
 {
-    FAIL();
+    auto [items_ptr, items] = create_mock<MockItemsWindowManager>();
+    auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
+    auto windows = register_test_module()
+        .with_items(std::move(items_ptr))
+        .with_rooms(std::move(rooms_ptr))
+        .build();
+
+    std::shared_ptr<IItem> items_item;
+    EXPECT_CALL(items, set_selected_item).Times(1).WillRepeatedly([&](auto i) { items_item = i.lock(); });
+    std::shared_ptr<IItem> rooms_item;
+    EXPECT_CALL(rooms, set_selected_item).Times(1).WillRepeatedly([&](auto i) { rooms_item = i.lock(); });
+
+    const auto item = mock_shared<MockItem>();
+    windows->select(item);
+
+    ASSERT_EQ(items_item, item);
+    ASSERT_EQ(rooms_item, item);
 }
 
 TEST(Windows, SelectLight)
 {
-    FAIL();
+    auto [lights_ptr, lights] = create_mock<MockLightsWindowManager>();
+    auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
+    auto windows = register_test_module()
+        .with_lights(std::move(lights_ptr))
+        .with_rooms(std::move(rooms_ptr))
+        .build();
+
+    std::shared_ptr<ILight> lights_light;
+    EXPECT_CALL(lights, set_selected_light).Times(1).WillRepeatedly([&](auto l) { lights_light = l.lock(); });
+    std::shared_ptr<ILight> rooms_light;
+    EXPECT_CALL(rooms, set_selected_light).Times(1).WillRepeatedly([&](auto l) { rooms_light = l.lock(); });
+
+    const auto light = mock_shared<MockLight>();
+    windows->select(light);
+
+    ASSERT_EQ(lights_light, light);
+    ASSERT_EQ(rooms_light, light);
 }
 
 TEST(Windows, SelectStaticMesh)
 {
-    FAIL();
+    auto [statics_ptr, statics] = create_mock<MockStaticsWindowManager>();
+    auto windows = register_test_module().with_statics(std::move(statics_ptr)).build();
+
+    std::shared_ptr<IStaticMesh> statics_static;
+    EXPECT_CALL(statics, select_static).Times(1).WillRepeatedly([&](auto s) { statics_static = s.lock(); });
+
+    const auto static_mesh = mock_shared<MockStaticMesh>();
+    windows->select(static_mesh);
+
+    ASSERT_EQ(statics_static, static_mesh);
 }
 
 TEST(Windows, SelectTrigger)
 {
-    FAIL();
+    auto [triggers_ptr, triggers] = create_mock<MockTriggersWindowManager>();
+    auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
+    auto windows = register_test_module()
+        .with_triggers(std::move(triggers_ptr))
+        .with_rooms(std::move(rooms_ptr))
+        .build();
+
+    std::shared_ptr<ITrigger> triggers_trigger;
+    EXPECT_CALL(triggers, set_selected_trigger).Times(1).WillRepeatedly([&](auto t) { triggers_trigger = t.lock(); });
+    std::shared_ptr<ITrigger> rooms_trigger;
+    EXPECT_CALL(rooms, set_selected_trigger).Times(1).WillRepeatedly([&](auto t) { rooms_trigger = t.lock(); });
+
+    const auto trigger = mock_shared<MockTrigger>();
+    windows->select(trigger);
+
+    ASSERT_EQ(triggers_trigger, trigger);
+    ASSERT_EQ(rooms_trigger, trigger);
 }
 
 TEST(Windows, SelectWaypoint)
 {
-    FAIL();
+    auto [route_ptr, route] = create_mock<MockRouteWindowManager>();
+    auto windows = register_test_module().with_route(std::move(route_ptr)).build();
+
+    std::shared_ptr<IWaypoint> route_waypoint;
+    EXPECT_CALL(route, select_waypoint).Times(1).WillRepeatedly([&](auto w) { route_waypoint = w.lock(); });
+
+    const auto waypoint = mock_shared<MockWaypoint>();
+    windows->select(waypoint);
+
+    ASSERT_EQ(route_waypoint, waypoint);
 }
 
 TEST(Windows, SetLevel)
 {
-    FAIL();
+    auto [cameras_ptr, cameras] = create_mock<MockCameraSinkWindowManager>();
+    EXPECT_CALL(cameras, set_camera_sinks).Times(1);
+    auto [items_ptr, items] = create_mock<MockItemsWindowManager>();
+    EXPECT_CALL(items, set_items).Times(1);
+    EXPECT_CALL(items, set_triggers).Times(1);
+    EXPECT_CALL(items, set_level_version).Times(1);
+    EXPECT_CALL(items, set_model_checker).Times(1);
+    auto [lights_ptr, lights] = create_mock<MockLightsWindowManager>();
+    EXPECT_CALL(lights, set_level_version).Times(1);
+    EXPECT_CALL(lights, set_lights).Times(1);
+    auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
+    EXPECT_CALL(rooms, set_level_version).Times(1);
+    EXPECT_CALL(rooms, set_items).Times(1);
+    EXPECT_CALL(rooms, set_floordata).Times(1);
+    EXPECT_CALL(rooms, set_rooms).Times(1);
+    auto [route_ptr, route] = create_mock<MockRouteWindowManager>();
+    EXPECT_CALL(route, set_items).Times(1);
+    EXPECT_CALL(route, set_triggers).Times(1);
+    EXPECT_CALL(route, set_rooms).Times(1);
+    auto [statics_ptr, statics] = create_mock<MockStaticsWindowManager>();
+    EXPECT_CALL(statics, set_statics).Times(1);
+    auto [triggers_ptr, triggers] = create_mock<MockTriggersWindowManager>();
+    EXPECT_CALL(triggers, set_items).Times(1);
+    EXPECT_CALL(triggers, set_triggers).Times(1);
+    auto [textures_ptr, textures] = create_mock<MockTexturesWindowManager>();
+    EXPECT_CALL(textures, set_texture_storage).Times(1);
+    auto windows = register_test_module()
+        .with_camera_sinks(std::move(cameras_ptr))
+        .with_items(std::move(items_ptr))
+        .with_lights(std::move(lights_ptr))
+        .with_rooms(std::move(rooms_ptr))
+        .with_route(std::move(route_ptr))
+        .with_statics(std::move(statics_ptr))
+        .with_textures(std::move(textures_ptr))
+        .with_triggers(std::move(triggers_ptr))
+        .build();
+
+    windows->set_level(mock_shared<MockLevel>());
 }
 
 TEST(Windows, SetRoom)
 {
-    FAIL();
+    auto [cameras_ptr, cameras] = create_mock<MockCameraSinkWindowManager>();
+    auto [lights_ptr, lights] = create_mock<MockLightsWindowManager>();
+    auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
+    auto [statics_ptr, statics] = create_mock<MockStaticsWindowManager>();
+    auto [triggers_ptr, triggers] = create_mock<MockTriggersWindowManager>();
+    auto windows = register_test_module()
+        .with_camera_sinks(std::move(cameras_ptr))
+        .with_lights(std::move(lights_ptr))
+        .with_rooms(std::move(rooms_ptr))
+        .with_statics(std::move(statics_ptr))
+        .with_triggers(std::move(triggers_ptr))
+        .build();
+
+    std::shared_ptr<IRoom> cameras_room;
+    EXPECT_CALL(cameras, set_room).Times(1).WillRepeatedly([&](auto r) { cameras_room = r.lock(); });
+    std::shared_ptr<IRoom> lights_room;
+    EXPECT_CALL(lights, set_room).Times(1).WillRepeatedly([&](auto r) { lights_room = r.lock(); });
+    std::shared_ptr<IRoom> rooms_room;
+    EXPECT_CALL(rooms, set_room).Times(1).WillRepeatedly([&](auto r) { rooms_room = r.lock(); });
+    std::shared_ptr<IRoom> statics_room;
+    EXPECT_CALL(statics, set_room).Times(1).WillRepeatedly([&](auto r) { statics_room = r.lock(); });
+    std::shared_ptr<IRoom> triggers_room;
+    EXPECT_CALL(triggers, set_room).Times(1).WillRepeatedly([&](auto r) { triggers_room = r.lock(); });
+
+    const auto room = mock_shared<MockRoom>();
+    windows->set_room(room);
+
+    ASSERT_EQ(cameras_room, room);
+    ASSERT_EQ(lights_room, room);
+    ASSERT_EQ(rooms_room, room);
+    ASSERT_EQ(statics_room, room);
+    ASSERT_EQ(triggers_room, room);
 }
 
 TEST(Windows, SetRoute)
 {
-    FAIL();
+    auto [route_ptr, route] = create_mock<MockRouteWindowManager>();
+    auto windows = register_test_module().with_route(std::move(route_ptr)).build();
+
+    std::shared_ptr<IRoute> route_route;
+    EXPECT_CALL(route, set_route).Times(1).WillRepeatedly([&](auto r) { route_route = r.lock(); });
+
+    const auto real_route = mock_shared<MockRoute>();
+    windows->set_route(real_route);
+
+    ASSERT_EQ(route_route, real_route);
 }
 
 TEST(Windows, SetSettings)
 {
-    FAIL();
+    auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
+    auto [route_ptr, route] = create_mock<MockRouteWindowManager>();
+    auto windows = register_test_module().with_rooms(std::move(rooms_ptr)).with_route(std::move(route_ptr)).build();
+
+    EXPECT_CALL(rooms, set_map_colours).Times(1);
+    EXPECT_CALL(route, set_randomizer_enabled(true)).Times(1);
+    EXPECT_CALL(route, set_randomizer_settings).Times(1);
+
+    windows->set_settings({ .randomizer_tools = true });
 }
 
 TEST(Windows, Setup)
 {
-    FAIL();
+    auto [cameras_ptr, cameras] = create_mock<MockCameraSinkWindowManager>();
+    auto [items_ptr, items] = create_mock<MockItemsWindowManager>();
+    auto [lights_ptr, lights] = create_mock<MockLightsWindowManager>();
+    auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
+    auto [route_ptr, route] = create_mock<MockRouteWindowManager>();
+    auto [statics_ptr, statics] = create_mock<MockStaticsWindowManager>();
+    auto [triggers_ptr, triggers] = create_mock<MockTriggersWindowManager>();
+    auto windows = register_test_module()
+        .with_camera_sinks(std::move(cameras_ptr))
+        .with_items(std::move(items_ptr))
+        .with_lights(std::move(lights_ptr))
+        .with_rooms(std::move(rooms_ptr))
+        .with_route(std::move(route_ptr))
+        .with_statics(std::move(statics_ptr))
+        .with_triggers(std::move(triggers_ptr))
+        .build();
+
+    EXPECT_CALL(cameras, create_window).Times(0);
+    EXPECT_CALL(items, create_window).Times(0);
+    EXPECT_CALL(lights, create_window).Times(0);
+    EXPECT_CALL(rooms, create_window).Times(0);
+    EXPECT_CALL(route, create_window).Times(0);
+    EXPECT_CALL(statics, create_window).Times(0);
+    EXPECT_CALL(triggers, create_window).Times(0);
+
+    EXPECT_CALL(rooms, set_map_colours).Times(1);
+    EXPECT_CALL(route, set_randomizer_enabled(true)).Times(1);
+    EXPECT_CALL(route, set_randomizer_settings).Times(1);
+
+    windows->setup({ .randomizer_tools = true });
 }
 
 TEST(Windows, StaticsEventsForwarded)
 {
-    FAIL();
+    auto [statics_ptr, statics] = create_mock<MockStaticsWindowManager>();
+
+    auto windows = register_test_module().with_statics(std::move(statics_ptr)).build();
+
+    std::shared_ptr<IStaticMesh> raised_static;
+    auto t1 = windows->on_static_selected += capture(raised_static);
+
+    auto static_mesh = mock_shared<MockStaticMesh>();
+    statics.on_static_selected(static_mesh);
+
+    ASSERT_EQ(raised_static, static_mesh);
+}
+
+TEST(Windows, StaticsStartup)
+{
+    auto [statics_ptr, statics] = create_mock<MockStaticsWindowManager>();
+    EXPECT_CALL(statics, create_window).Times(1);
+
+    auto windows = register_test_module().with_statics(std::move(statics_ptr)).build();
+
+    windows->setup({ .statics_startup = true });
 }
 
 TEST(Windows, TriggersEventsForwarded)
 {
-    FAIL();
-}
-
-TEST(Windows, WindowsRendered)
-{
-    FAIL();
-}
-
-TEST(Windows, WindowsUpdated)
-{
-    FAIL();
-}
-
-/*
-
-TEST(Windows, MapColoursSetOnRoomWindow)
-{
-    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
-    EXPECT_CALL(rooms_window_manager, set_map_colours).Times(1);
-
-    auto windows = register_test_module()
-        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
-        .build();
-}
-
-TEST(Windows, MapColoursSetOnSettingsChanged)
-{
-    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
-    EXPECT_CALL(rooms_window_manager, set_map_colours).Times(2);
-    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
-
-    auto application = register_test_module()
-        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
-        .with_viewer(std::move(viewer_ptr))
-        .build();
-
-    viewer.on_settings(UserSettings());
-}
-
-TEST(Windows, SetLevel)
-{
-    std::optional<std::string> called;
-    auto trlevel_source = [&](auto&& filename) { called = filename; return mock_unique<trlevel::mocks::MockLevel>(); };
-    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
-    auto [items_window_manager_ptr, items_window_manager] = create_mock<MockItemsWindowManager>();
-    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
-    auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    auto [lights_window_manager_ptr, lights_window_manager] = create_mock<MockLightsWindowManager>();
-    auto [textures_window_manager_ptr, textures_window_manager] = create_mock<MockTexturesWindowManager>();
-    auto [windows_ptr, windows] = create_mock<MockWindows>();
+    auto [triggers_ptr, triggers] = create_mock<MockTriggersWindowManager>();
+    auto waypoint = mock_shared<MockWaypoint>();
     auto route = mock_shared<MockRoute>();
+    EXPECT_CALL(*route, insert(A<const Vector3&>(), A<const Vector3&>(), A<uint32_t>(), IWaypoint::Type::Trigger, A<uint32_t>())).Times(1).WillRepeatedly(Return(100));
+    EXPECT_CALL(*route, waypoint(100)).Times(1).WillRepeatedly(Return(waypoint));
 
-    std::vector<std::string> events;
+    auto windows = register_test_module().with_triggers(std::move(triggers_ptr)).build();
+    windows->set_route(route);
 
-    EXPECT_CALL(items_window_manager, set_items(A<const std::vector<std::weak_ptr<IItem>>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_items"); });
-    EXPECT_CALL(items_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_triggers"); });
-    EXPECT_CALL(items_window_manager, set_level_version(A<trlevel::LevelVersion>())).Times(1).WillOnce([&](auto) { events.push_back("items_version"); });
-    EXPECT_CALL(items_window_manager, set_model_checker(A<const std::function<bool(uint32_t)>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_model_checker"); });
-    EXPECT_CALL(triggers_window_manager, set_items(A<const std::vector<std::weak_ptr<IItem>>&>())).Times(1).WillOnce([&](auto) { events.push_back("triggers_items"); });
-    EXPECT_CALL(triggers_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("triggers_triggers"); });
-    EXPECT_CALL(rooms_window_manager, set_level_version(A<trlevel::LevelVersion>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_version"); });
-    EXPECT_CALL(rooms_window_manager, set_items(A<const std::vector<std::weak_ptr<IItem>>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_items"); });
-    EXPECT_CALL(rooms_window_manager, set_floordata(A<const std::vector<uint16_t>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_floordata"); });
-    EXPECT_CALL(rooms_window_manager, set_rooms(A<const std::vector<std::weak_ptr<IRoom>>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_rooms"); });
-    EXPECT_CALL(route_window_manager, set_items(A<const std::vector<std::weak_ptr<IItem>>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_items"); });
-    EXPECT_CALL(route_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_triggers"); });
-    EXPECT_CALL(route_window_manager, set_rooms(A<const std::vector<std::weak_ptr<IRoom>>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_rooms"); });
-    EXPECT_CALL(route_window_manager, set_route(A<const std::weak_ptr<IRoute>&>())).Times(3).WillRepeatedly([&](auto) { events.push_back("route_route"); });
-    EXPECT_CALL(lights_window_manager, set_lights(A<const std::vector<std::weak_ptr<ILight>>&>())).Times(1).WillOnce([&](auto) { events.push_back("lights_lights"); });
-    EXPECT_CALL(windows, set_level).Times(1).WillOnce([&](auto) { events.push_back("windows_level"); });
-    EXPECT_CALL(*route, clear()).Times(1).WillOnce([&] { events.push_back("route_clear"); });
-    EXPECT_CALL(*route, set_unsaved(false)).Times(1);
-    EXPECT_CALL(textures_window_manager, set_texture_storage).Times(1).WillOnce([&](auto) { events.push_back("textures"); });
-    EXPECT_CALL(viewer, open(A<const std::weak_ptr<ILevel>&>(), ILevel::OpenMode::Full)).Times(1).WillOnce([&](auto&&...) { events.push_back("viewer"); });
+    TokenStore store;
+    std::shared_ptr<IItem> raised_item;
+    store += windows->on_item_selected += capture(raised_item);
+    std::shared_ptr<ITrigger> raised_trigger;
+    store += windows->on_trigger_selected += capture(raised_trigger);
+    std::shared_ptr<IWaypoint> raised_waypoint;
+    store += windows->on_waypoint_selected += capture(raised_waypoint);
+    std::shared_ptr<ICameraSink> raised_camera_sink;
+    store += windows->on_camera_sink_selected += capture(raised_camera_sink);
+    bool raised = false;
+    store += windows->on_scene_changed += capture_called(raised);
 
-    auto application = register_test_module()
-        .with_trlevel_source(trlevel_source)
-        .with_viewer(std::move(viewer_ptr))
-        .with_route_source([&](auto&&...) {return route; })
-        .with_items_window_manager(std::move(items_window_manager_ptr))
-        .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
-        .with_route_window_manager(std::move(route_window_manager_ptr))
-        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
-        .with_lights_window_manager(std::move(lights_window_manager_ptr))
-        .with_textures_window_manager(std::move(textures_window_manager_ptr))
-        .with_windows(std::move(windows_ptr))
-        .build();
-    application->open("test_path.tr2", ILevel::OpenMode::Full);
+    auto item = mock_shared<MockItem>();
+    auto trigger = mock_shared<MockTrigger>();
+    auto camera_sink = mock_shared<MockCameraSink>();
 
-    ASSERT_TRUE(called.has_value());
-    ASSERT_EQ(called.value(), "test_path.tr2");
+    triggers.on_add_to_route(trigger);
+    triggers.on_item_selected(item);
+    triggers.on_trigger_selected(trigger);
+    triggers.on_scene_changed();
+    triggers.on_camera_sink_selected(camera_sink);
 
-    ASSERT_EQ(events.back(), "viewer");
+    ASSERT_EQ(raised_item, item);
+    ASSERT_EQ(raised_trigger, trigger);
+    ASSERT_EQ(raised_waypoint, waypoint);
+    ASSERT_EQ(raised, true);
+    ASSERT_EQ(raised_camera_sink, camera_sink);
+}
+
+TEST(Windows, TriggersStartup)
+{
+    auto [triggers_ptr, triggers] = create_mock<MockTriggersWindowManager>();
+    EXPECT_CALL(triggers, create_window).Times(1);
+
+    auto windows = register_test_module().with_triggers(std::move(triggers_ptr)).build();
+
+    windows->setup({ .triggers_startup = true });
 }
 
 TEST(Windows, WindowsRendered)
 {
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    EXPECT_CALL(route_window_manager, render).Times(1);
-    auto [items_window_manager_ptr, items_window_manager] = create_mock<MockItemsWindowManager>();
-    EXPECT_CALL(items_window_manager, render).Times(1);
-    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
-    EXPECT_CALL(rooms_window_manager, render).Times(1);
-    auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
-    EXPECT_CALL(triggers_window_manager, render).Times(1);
-    auto [lights_window_manager_ptr, lights_window_manager] = create_mock<MockLightsWindowManager>();
-    EXPECT_CALL(lights_window_manager, render).Times(1);
-    auto [log_window_manager_ptr, log_window_manager] = create_mock<MockLogWindowManager>();
-    EXPECT_CALL(log_window_manager, render).Times(1);
-    auto [textures_window_manager_ptr, textures_window_manager] = create_mock<MockTexturesWindowManager>();
-    EXPECT_CALL(textures_window_manager, render).Times(1);
-    auto [console_manager_ptr, console_manager] = create_mock<MockConsoleManager>();
-    EXPECT_CALL(console_manager, render).Times(1);
-    auto [windows_ptr, windows] = create_mock<MockWindows>();
-    EXPECT_CALL(windows, render).Times(1);
-    auto plugins = mock_shared<MockPlugins>();
-    EXPECT_CALL(*plugins, render_ui).Times(1);
-
-    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
-    EXPECT_CALL(viewer, render).Times(1);
-
-    auto application = register_test_module()
-        .with_route_window_manager(std::move(route_window_manager_ptr))
-        .with_items_window_manager(std::move(items_window_manager_ptr))
-        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
-        .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
-        .with_lights_window_manager(std::move(lights_window_manager_ptr))
-        .with_log_window_manager(std::move(log_window_manager_ptr))
-        .with_textures_window_manager(std::move(textures_window_manager_ptr))
-        .with_console_manager(std::move(console_manager_ptr))
-        .with_windows(std::move(windows_ptr))
-        .with_viewer(std::move(viewer_ptr))
-        .with_plugins(plugins)
+    auto [cameras_ptr, cameras] = create_mock<MockCameraSinkWindowManager>();
+    EXPECT_CALL(cameras, render).Times(1);
+    auto [console_ptr, console] = create_mock<MockConsoleManager>();
+    EXPECT_CALL(console, render).Times(1);
+    auto [items_ptr, items] = create_mock<MockItemsWindowManager>();
+    EXPECT_CALL(items, render).Times(1);
+    auto [lights_ptr, lights] = create_mock<MockLightsWindowManager>();
+    EXPECT_CALL(lights, render).Times(1);
+    auto [log_ptr, log] = create_mock<MockLogWindowManager>();
+    EXPECT_CALL(log, render).Times(1);
+    auto [plugins_ptr, plugins] = create_mock<MockPluginsWindowManager>();
+    EXPECT_CALL(plugins, render).Times(1);
+    auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
+    EXPECT_CALL(rooms, render).Times(1);
+    auto [route_ptr, route] = create_mock<MockRouteWindowManager>();
+    EXPECT_CALL(route, render).Times(1);
+    auto [statics_ptr, statics] = create_mock<MockStaticsWindowManager>();
+    EXPECT_CALL(statics, render).Times(1);
+    auto [textures_ptr, textures] = create_mock<MockTexturesWindowManager>();
+    EXPECT_CALL(textures, render).Times(1);
+    auto [triggers_ptr, triggers] = create_mock<MockTriggersWindowManager>();
+    EXPECT_CALL(triggers, render).Times(1);
+    auto windows = register_test_module()
+        .with_camera_sinks(std::move(cameras_ptr))
+        .with_console(std::move(console_ptr))
+        .with_items(std::move(items_ptr))
+        .with_lights(std::move(lights_ptr))
+        .with_log(std::move(log_ptr))
+        .with_plugins(std::move(plugins_ptr))
+        .with_rooms(std::move(rooms_ptr))
+        .with_route(std::move(route_ptr))
+        .with_statics(std::move(statics_ptr))
+        .with_textures(std::move(textures_ptr))
+        .with_triggers(std::move(triggers_ptr))
         .build();
-    application->render();
+
+    windows->render();
 }
 
 TEST(Windows, WindowsUpdated)
 {
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    EXPECT_CALL(route_window_manager, update).Times(1);
-    auto [items_window_manager_ptr, items_window_manager] = create_mock<MockItemsWindowManager>();
-    EXPECT_CALL(items_window_manager, update).Times(1);
-    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
-    EXPECT_CALL(rooms_window_manager, update).Times(1);
-    auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
-    EXPECT_CALL(triggers_window_manager, update).Times(1);
-    auto [lights_window_manager_ptr, lights_window_manager] = create_mock<MockLightsWindowManager>();
-    EXPECT_CALL(lights_window_manager, update).Times(1);
-    auto [windows_ptr, windows] = create_mock<MockWindows>();
-    EXPECT_CALL(windows, update).Times(1);
-
-    auto application = register_test_module()
-        .with_route_window_manager(std::move(route_window_manager_ptr))
-        .with_items_window_manager(std::move(items_window_manager_ptr))
-        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
-        .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
-        .with_lights_window_manager(std::move(lights_window_manager_ptr))
-        .with_windows(std::move(windows_ptr))
+    auto [items_ptr, items] = create_mock<MockItemsWindowManager>();
+    EXPECT_CALL(items, update).Times(1);
+    auto [lights_ptr, lights] = create_mock<MockLightsWindowManager>();
+    EXPECT_CALL(lights, update).Times(1);
+    auto [plugins_ptr, plugins] = create_mock<MockPluginsWindowManager>();
+    EXPECT_CALL(plugins, update).Times(1);
+    auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
+    EXPECT_CALL(rooms, update).Times(1);
+    auto [route_ptr, route] = create_mock<MockRouteWindowManager>();
+    EXPECT_CALL(route, update).Times(1);
+    auto [statics_ptr, statics] = create_mock<MockStaticsWindowManager>();
+    EXPECT_CALL(statics, update).Times(1);
+    auto [triggers_ptr, triggers] = create_mock<MockTriggersWindowManager>();
+    EXPECT_CALL(triggers, update).Times(1);
+    auto windows = register_test_module()
+        .with_items(std::move(items_ptr))
+        .with_lights(std::move(lights_ptr))
+        .with_plugins(std::move(plugins_ptr))
+        .with_rooms(std::move(rooms_ptr))
+        .with_route(std::move(route_ptr))
+        .with_statics(std::move(statics_ptr))
+        .with_triggers(std::move(triggers_ptr))
         .build();
-    application->render();
-}
 
-TEST(Windows, RouteWindowCreatedOnStartup)
-{
-    UserSettings settings;
-    settings.route_startup = true;
-    auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
-    ON_CALL(settings_loader, load_user_settings).WillByDefault(Return(settings));
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    EXPECT_CALL(route_window_manager, create_window).Times(1);
-    auto application = register_test_module()
-        .with_settings_loader(std::move(settings_loader_ptr))
-        .with_route_window_manager(std::move(route_window_manager_ptr))
-        .build();
+    windows->update(1.0f);
 }
-
-TEST(Windows, RouteWindowNotCreatedOnStartup)
-{
-    UserSettings settings;
-    settings.route_startup = false;
-    auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
-    ON_CALL(settings_loader, load_user_settings).WillByDefault(Return(settings));
-    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
-    EXPECT_CALL(route_window_manager, create_window).Times(0);
-    auto application = register_test_module()
-        .with_settings_loader(std::move(settings_loader_ptr))
-        .with_route_window_manager(std::move(route_window_manager_ptr))
-        .build();
-}
-*/

--- a/trview.app.tests/Windows/WindowsTests.cpp
+++ b/trview.app.tests/Windows/WindowsTests.cpp
@@ -21,6 +21,8 @@
 #include <trview.app/Mocks/Windows/ITexturesWindowManager.h>
 #include <trview.app/Mocks/Windows/ITriggersWindowManager.h>
 
+#include <trview.tests.common/Event.h>
+
 using namespace trview;
 using namespace trview::tests;
 using namespace trview::mocks;
@@ -129,23 +131,6 @@ namespace
             }
         };
         return test_module{};
-    }
-
-    template <int index = 0, typename T>
-    auto capture(std::shared_ptr<T>& out)
-    {
-        return [&](auto... in) { out = std::get<index>(std::tie(in...)).lock(); };
-    }
-
-    template <int index = 0, typename T>
-    auto capture(T& out)
-    {
-        return [&](auto... in) { out = std::get<index>(std::tie(in...)); };
-    }
-
-    auto capture_called(bool& out)
-    {
-        return [&](auto&&...) { out = true; };
     }
 }
 

--- a/trview.app.tests/Windows/WindowsTests.cpp
+++ b/trview.app.tests/Windows/WindowsTests.cpp
@@ -1,8 +1,16 @@
 #include <trview.app/Windows/Windows.h>
 
 #include <trview.app/Mocks/Windows/ICameraSinkWindowManager.h>
+#include <trview.app/Mocks/Windows/IConsoleManager.h>
+#include <trview.app/Mocks/Windows/IItemsWindowManager.h>
+#include <trview.app/Mocks/Windows/ILightsWindowManager.h>
+#include <trview.app/Mocks/Windows/ILogWindowManager.h>
+#include <trview.app/Mocks/Windows/IRoomsWindowManager.h>
+#include <trview.app/Mocks/Windows/IRouteWindowManager.h>
 #include <trview.app/Mocks/Windows/IPluginsWindowManager.h>
 #include <trview.app/Mocks/Windows/IStaticsWindowManager.h>
+#include <trview.app/Mocks/Windows/ITexturesWindowManager.h>
+#include <trview.app/Mocks/Windows/ITriggersWindowManager.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -15,18 +23,38 @@ namespace
         struct test_module
         {
             std::unique_ptr<ICameraSinkWindowManager> camera_sinks{ mock_unique<MockCameraSinkWindowManager>() };
+            std::unique_ptr<IConsoleManager> console_manager{ mock_unique<MockConsoleManager>() };
+            std::unique_ptr<IItemsWindowManager> items{ mock_unique<MockItemsWindowManager>() };
+            std::unique_ptr<ILogWindowManager> log{ mock_unique<MockLogWindowManager>() };
+            std::unique_ptr<ILightsWindowManager> lights{ mock_unique<MockLightsWindowManager>() };
             std::unique_ptr<IPluginsWindowManager> plugins{ mock_unique<MockPluginsWindowManager>() };
+            std::unique_ptr<IRoomsWindowManager> rooms{ mock_unique<MockRoomsWindowManager>() };
+            std::unique_ptr<IRouteWindowManager> route{ mock_unique<MockRouteWindowManager>() };
             std::unique_ptr<IStaticsWindowManager> statics{ mock_unique<MockStaticsWindowManager>() };
+            std::unique_ptr<ITexturesWindowManager> textures{ mock_unique<MockTexturesWindowManager>() };
+            std::unique_ptr<ITriggersWindowManager> triggers{ mock_unique<MockTriggersWindowManager>() };
 
             std::unique_ptr<trview::Windows> build()
             {
-                return std::make_unique<trview::Windows>(std::move(camera_sinks), std::move(plugins), std::move(statics));
+                return std::make_unique<trview::Windows>(
+                    std::move(camera_sinks),
+                    std::move(console_manager),
+                    std::move(items),
+                    std::move(lights),
+                    std::move(log),
+                    std::move(plugins),
+                    std::move(rooms),
+                    std::move(route),
+                    std::move(statics),
+                    std::move(textures),
+                    std::move(triggers));
             }
         };
         return test_module{};
     }
 }
 
+/*
 TEST(Windows, Statics)
 {
 }
@@ -34,3 +62,181 @@ TEST(Windows, Statics)
 TEST(Windows, Plugins)
 {
 }
+
+TEST(Windows, MapColoursSetOnRoomWindow)
+{
+    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
+    EXPECT_CALL(rooms_window_manager, set_map_colours).Times(1);
+
+    auto windows = register_test_module()
+        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
+        .build();
+}
+
+TEST(Windows, MapColoursSetOnSettingsChanged)
+{
+    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
+    EXPECT_CALL(rooms_window_manager, set_map_colours).Times(2);
+    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
+
+    auto application = register_test_module()
+        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
+        .with_viewer(std::move(viewer_ptr))
+        .build();
+
+    viewer.on_settings(UserSettings());
+}
+
+TEST(Windows, SetLevel)
+{
+    std::optional<std::string> called;
+    auto trlevel_source = [&](auto&& filename) { called = filename; return mock_unique<trlevel::mocks::MockLevel>(); };
+    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
+    auto [items_window_manager_ptr, items_window_manager] = create_mock<MockItemsWindowManager>();
+    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
+    auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    auto [lights_window_manager_ptr, lights_window_manager] = create_mock<MockLightsWindowManager>();
+    auto [textures_window_manager_ptr, textures_window_manager] = create_mock<MockTexturesWindowManager>();
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
+    auto route = mock_shared<MockRoute>();
+
+    std::vector<std::string> events;
+
+    EXPECT_CALL(items_window_manager, set_items(A<const std::vector<std::weak_ptr<IItem>>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_items"); });
+    EXPECT_CALL(items_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_triggers"); });
+    EXPECT_CALL(items_window_manager, set_level_version(A<trlevel::LevelVersion>())).Times(1).WillOnce([&](auto) { events.push_back("items_version"); });
+    EXPECT_CALL(items_window_manager, set_model_checker(A<const std::function<bool(uint32_t)>&>())).Times(1).WillOnce([&](auto) { events.push_back("items_model_checker"); });
+    EXPECT_CALL(triggers_window_manager, set_items(A<const std::vector<std::weak_ptr<IItem>>&>())).Times(1).WillOnce([&](auto) { events.push_back("triggers_items"); });
+    EXPECT_CALL(triggers_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("triggers_triggers"); });
+    EXPECT_CALL(rooms_window_manager, set_level_version(A<trlevel::LevelVersion>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_version"); });
+    EXPECT_CALL(rooms_window_manager, set_items(A<const std::vector<std::weak_ptr<IItem>>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_items"); });
+    EXPECT_CALL(rooms_window_manager, set_floordata(A<const std::vector<uint16_t>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_floordata"); });
+    EXPECT_CALL(rooms_window_manager, set_rooms(A<const std::vector<std::weak_ptr<IRoom>>&>())).Times(1).WillOnce([&](auto) { events.push_back("rooms_rooms"); });
+    EXPECT_CALL(route_window_manager, set_items(A<const std::vector<std::weak_ptr<IItem>>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_items"); });
+    EXPECT_CALL(route_window_manager, set_triggers(A<const std::vector<std::weak_ptr<ITrigger>>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_triggers"); });
+    EXPECT_CALL(route_window_manager, set_rooms(A<const std::vector<std::weak_ptr<IRoom>>&>())).Times(1).WillOnce([&](auto) { events.push_back("route_rooms"); });
+    EXPECT_CALL(route_window_manager, set_route(A<const std::weak_ptr<IRoute>&>())).Times(3).WillRepeatedly([&](auto) { events.push_back("route_route"); });
+    EXPECT_CALL(lights_window_manager, set_lights(A<const std::vector<std::weak_ptr<ILight>>&>())).Times(1).WillOnce([&](auto) { events.push_back("lights_lights"); });
+    EXPECT_CALL(windows, set_level).Times(1).WillOnce([&](auto) { events.push_back("windows_level"); });
+    EXPECT_CALL(*route, clear()).Times(1).WillOnce([&] { events.push_back("route_clear"); });
+    EXPECT_CALL(*route, set_unsaved(false)).Times(1);
+    EXPECT_CALL(textures_window_manager, set_texture_storage).Times(1).WillOnce([&](auto) { events.push_back("textures"); });
+    EXPECT_CALL(viewer, open(A<const std::weak_ptr<ILevel>&>(), ILevel::OpenMode::Full)).Times(1).WillOnce([&](auto&&...) { events.push_back("viewer"); });
+
+    auto application = register_test_module()
+        .with_trlevel_source(trlevel_source)
+        .with_viewer(std::move(viewer_ptr))
+        .with_route_source([&](auto&&...) {return route; })
+        .with_items_window_manager(std::move(items_window_manager_ptr))
+        .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
+        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
+        .with_lights_window_manager(std::move(lights_window_manager_ptr))
+        .with_textures_window_manager(std::move(textures_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
+        .build();
+    application->open("test_path.tr2", ILevel::OpenMode::Full);
+
+    ASSERT_TRUE(called.has_value());
+    ASSERT_EQ(called.value(), "test_path.tr2");
+
+    ASSERT_EQ(events.back(), "viewer");
+}
+
+TEST(Windows, WindowsRendered)
+{
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    EXPECT_CALL(route_window_manager, render).Times(1);
+    auto [items_window_manager_ptr, items_window_manager] = create_mock<MockItemsWindowManager>();
+    EXPECT_CALL(items_window_manager, render).Times(1);
+    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
+    EXPECT_CALL(rooms_window_manager, render).Times(1);
+    auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
+    EXPECT_CALL(triggers_window_manager, render).Times(1);
+    auto [lights_window_manager_ptr, lights_window_manager] = create_mock<MockLightsWindowManager>();
+    EXPECT_CALL(lights_window_manager, render).Times(1);
+    auto [log_window_manager_ptr, log_window_manager] = create_mock<MockLogWindowManager>();
+    EXPECT_CALL(log_window_manager, render).Times(1);
+    auto [textures_window_manager_ptr, textures_window_manager] = create_mock<MockTexturesWindowManager>();
+    EXPECT_CALL(textures_window_manager, render).Times(1);
+    auto [console_manager_ptr, console_manager] = create_mock<MockConsoleManager>();
+    EXPECT_CALL(console_manager, render).Times(1);
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
+    EXPECT_CALL(windows, render).Times(1);
+    auto plugins = mock_shared<MockPlugins>();
+    EXPECT_CALL(*plugins, render_ui).Times(1);
+
+    auto [viewer_ptr, viewer] = create_mock<MockViewer>();
+    EXPECT_CALL(viewer, render).Times(1);
+
+    auto application = register_test_module()
+        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_items_window_manager(std::move(items_window_manager_ptr))
+        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
+        .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
+        .with_lights_window_manager(std::move(lights_window_manager_ptr))
+        .with_log_window_manager(std::move(log_window_manager_ptr))
+        .with_textures_window_manager(std::move(textures_window_manager_ptr))
+        .with_console_manager(std::move(console_manager_ptr))
+        .with_windows(std::move(windows_ptr))
+        .with_viewer(std::move(viewer_ptr))
+        .with_plugins(plugins)
+        .build();
+    application->render();
+}
+
+TEST(Windows, WindowsUpdated)
+{
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    EXPECT_CALL(route_window_manager, update).Times(1);
+    auto [items_window_manager_ptr, items_window_manager] = create_mock<MockItemsWindowManager>();
+    EXPECT_CALL(items_window_manager, update).Times(1);
+    auto [rooms_window_manager_ptr, rooms_window_manager] = create_mock<MockRoomsWindowManager>();
+    EXPECT_CALL(rooms_window_manager, update).Times(1);
+    auto [triggers_window_manager_ptr, triggers_window_manager] = create_mock<MockTriggersWindowManager>();
+    EXPECT_CALL(triggers_window_manager, update).Times(1);
+    auto [lights_window_manager_ptr, lights_window_manager] = create_mock<MockLightsWindowManager>();
+    EXPECT_CALL(lights_window_manager, update).Times(1);
+    auto [windows_ptr, windows] = create_mock<MockWindows>();
+    EXPECT_CALL(windows, update).Times(1);
+
+    auto application = register_test_module()
+        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .with_items_window_manager(std::move(items_window_manager_ptr))
+        .with_rooms_window_manager(std::move(rooms_window_manager_ptr))
+        .with_triggers_window_manager(std::move(triggers_window_manager_ptr))
+        .with_lights_window_manager(std::move(lights_window_manager_ptr))
+        .with_windows(std::move(windows_ptr))
+        .build();
+    application->render();
+}
+
+TEST(Windows, RouteWindowCreatedOnStartup)
+{
+    UserSettings settings;
+    settings.route_startup = true;
+    auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
+    ON_CALL(settings_loader, load_user_settings).WillByDefault(Return(settings));
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    EXPECT_CALL(route_window_manager, create_window).Times(1);
+    auto application = register_test_module()
+        .with_settings_loader(std::move(settings_loader_ptr))
+        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .build();
+}
+
+TEST(Windows, RouteWindowNotCreatedOnStartup)
+{
+    UserSettings settings;
+    settings.route_startup = false;
+    auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
+    ON_CALL(settings_loader, load_user_settings).WillByDefault(Return(settings));
+    auto [route_window_manager_ptr, route_window_manager] = create_mock<MockRouteWindowManager>();
+    EXPECT_CALL(route_window_manager, create_window).Times(0);
+    auto application = register_test_module()
+        .with_settings_loader(std::move(settings_loader_ptr))
+        .with_route_window_manager(std::move(route_window_manager_ptr))
+        .build();
+}
+*/

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -86,6 +86,7 @@
     <ClCompile Include="Windows\RouteWindowManagerTests.cpp" />
     <ClCompile Include="Windows\StaticsWindowManagerTests.cpp" />
     <ClCompile Include="Windows\ViewerTests.cpp" />
+    <ClCompile Include="Windows\WindowsTests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\external\DirectXTK\DirectXTK_Desktop.vcxproj">

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -203,6 +203,9 @@
     <ClCompile Include="Windows\StaticsWindowManagerTests.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
+    <ClCompile Include="Windows\WindowsTests.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app.ui.tests/CameraSinkWindowTests.cpp
+++ b/trview.app.ui.tests/CameraSinkWindowTests.cpp
@@ -168,7 +168,7 @@ void register_camera_sink_window_tests(ImGuiTestEngine* engine)
             auto token = context.ptr->on_scene_changed += [&raised]() { raised = true; };
 
             auto camera_sink1 = mock_shared<MockCameraSink>()->with_number(0);
-            auto camera_sink2 = mock_shared<MockCameraSink>()->with_number(1);
+            auto camera_sink2 = mock_shared<MockCameraSink>()->with_number(1)->with_updating_visible(true);
             ON_CALL(*camera_sink2, visible).WillByDefault(testing::Return(true));
             EXPECT_CALL(*camera_sink2, set_visible(false)).Times(1);
             context.camera_sinks = { camera_sink1, camera_sink2 };

--- a/trview.app.ui.tests/ItemsWindowTests.cpp
+++ b/trview.app.ui.tests/ItemsWindowTests.cpp
@@ -254,7 +254,7 @@ void register_items_window_tests(ImGuiTestEngine* engine)
             auto token = context.ptr->on_scene_changed += [&raised]() { raised = true; };
 
             auto item1 = mock_shared<MockItem>()->with_number(0)->with_visible(true);
-            auto item2 = mock_shared<MockItem>()->with_number(1)->with_visible(true);
+            auto item2 = mock_shared<MockItem>()->with_number(1)->with_updating_visible(true);
             EXPECT_CALL(*item2, set_visible(false)).Times(1);
 
             context.items = { item1, item2 };

--- a/trview.app.ui.tests/ItemsWindowTests.cpp
+++ b/trview.app.ui.tests/ItemsWindowTests.cpp
@@ -250,25 +250,20 @@ void register_items_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<ItemsWindowContext>();
             context.ptr = register_test_module().build();
 
-            std::optional<std::tuple<std::shared_ptr<IItem>, bool>> raised_item;
-            auto token = context.ptr->on_item_visibility += [&raised_item](const auto& item, bool state) 
-            {
-                auto i = std::static_pointer_cast<MockItem>(item.lock());
-                ON_CALL(*i, visible).WillByDefault(Return(false));
-                raised_item = { item.lock(), state }; 
-            };
+            bool raised = false;
+            auto token = context.ptr->on_scene_changed += [&raised]() { raised = true; };
 
-            context.items =
-            {
-                mock_shared<MockItem>()->with_number(0)->with_visible(true),
-                mock_shared<MockItem>()->with_number(1)->with_visible(true)
-            };
+            auto item1 = mock_shared<MockItem>()->with_number(0)->with_visible(true);
+            auto item2 = mock_shared<MockItem>()->with_number(1)->with_visible(true);
+            EXPECT_CALL(*item2, set_visible(false)).Times(1);
+
+            context.items = { item1, item2 };
             context.ptr->set_items({ std::from_range, context.items });
 
             ctx->ItemCheck("Items 0/**/##hide-1");
-            IM_CHECK_EQ(raised_item.has_value(), true);
-            IM_CHECK_EQ(std::get<1>(raised_item.value()), false);
-            IM_CHECK_EQ(std::get<0>(raised_item.value()), context.items[1]);
+
+            IM_CHECK_EQ(raised, true);
+            IM_CHECK_EQ(Mock::VerifyAndClearExpectations(context.items[1].get()), true);
         });
 
     test<ItemsWindowContext>(engine, "Items Window", "Trigger Selected Event Raised",

--- a/trview.app.ui.tests/LightsWindowTests.cpp
+++ b/trview.app.ui.tests/LightsWindowTests.cpp
@@ -161,7 +161,8 @@ void register_lights_window_tests(ImGuiTestEngine* engine)
             auto token = context.ptr->on_scene_changed += [&raised]() { raised = true; };
 
             auto light1 = mock_shared<MockLight>()->with_number(0);
-            auto light2 = mock_shared<MockLight>()->with_number(1);
+            auto light2 = mock_shared<MockLight>()->with_number(1)->with_updating_visible(false);
+            EXPECT_CALL(*light2, set_visible(true)).Times(1);
 
             context.lights = { light1, light2 };
             context.ptr->set_lights({ light1, light2 });

--- a/trview.app.ui.tests/RoomsWindowTests.cpp
+++ b/trview.app.ui.tests/RoomsWindowTests.cpp
@@ -90,7 +90,7 @@ void register_rooms_window_tests(ImGuiTestEngine* engine)
             IM_CHECK_EQ(ctx->ItemExists("Quicksand \\/ 7"), false);
         });
 
-    test<RoomsWindowContext>(engine, "Rooms Window", "On Room Visiblity Raised",
+    test<RoomsWindowContext>(engine, "Rooms Window", "On Room Visibility Raised",
         [](ImGuiTestContext* ctx) { ctx->GetVars<RoomsWindowContext>().render(); },
         [](ImGuiTestContext* ctx)
         {
@@ -101,8 +101,8 @@ void register_rooms_window_tests(ImGuiTestEngine* engine)
             auto token = context.ptr->on_scene_changed += [&raised]() { raised = true; };
 
             auto room1 = mock_shared<MockRoom>()->with_number(0);
-            auto room2 = mock_shared<MockRoom>()->with_number(1);
-            EXPECT_CALL(*room2, set_visible(false)).Times(1);
+            auto room2 = mock_shared<MockRoom>()->with_number(1)->with_updating_visible(false);
+            EXPECT_CALL(*room2, set_visible(true)).Times(1);
             context.ptr->set_rooms({ room1, room2 });
 
             ctx->ItemUncheck("/**/##hide-1");

--- a/trview.app.ui.tests/RouteWindowTests.cpp
+++ b/trview.app.ui.tests/RouteWindowTests.cpp
@@ -180,7 +180,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<RouteWindowContext>();
             context.ptr = register_test_module().build();
             context.ptr->set_route(route);
-            context.ptr->select_waypoint(0);
+            context.ptr->select_waypoint(waypoint);
             context.route = route;
 
             ctx->ItemInputValue("/**/Notes##notes", "Test");
@@ -209,7 +209,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             EXPECT_CALL(*route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
             EXPECT_CALL(*waypoint, set_randomizer_settings(An<const IWaypoint::WaypointRandomizerSettings&>())).WillRepeatedly(SaveArg<0>(&new_settings));
             context.ptr->set_route(route);
-            context.ptr->select_waypoint(0);
+            context.ptr->select_waypoint(waypoint);
             context.route = route;
 
             ctx->Yield();
@@ -259,7 +259,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<RouteWindowContext>();
             context.ptr = register_test_module().build();
             context.ptr->set_route(route);
-            context.ptr->select_waypoint(0);
+            context.ptr->select_waypoint(waypoint);
 
             ctx->MouseMoveToVoid();
             IM_CHECK_EQ(ctx->ItemExists("/**/##Tooltip_00"), false);
@@ -283,7 +283,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             EXPECT_CALL(*route, waypoints).WillRepeatedly(Return(1));
             EXPECT_CALL(*route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
             context.ptr->set_route(route);
-            context.ptr->select_waypoint(0);
+            context.ptr->select_waypoint(waypoint);
 
             std::optional<uint32_t> raised;
             auto token = context.ptr->on_waypoint_deleted += [&](const auto& waypoint)
@@ -495,7 +495,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             EXPECT_CALL(*route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
             context.route = route;
             context.ptr->set_route(route);
-            context.ptr->select_waypoint(0);
+            context.ptr->select_waypoint(waypoint);
 
             RandomizerSettings settings;
             settings.settings["test1"] = { "Test 1", RandomizerSettings::Setting::Type::Boolean };
@@ -530,7 +530,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             EXPECT_CALL(*route, waypoints).WillRepeatedly(Return(1));
             EXPECT_CALL(*route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
             context.ptr->set_route(route);
-            context.ptr->select_waypoint(0);
+            context.ptr->select_waypoint(waypoint);
 
             ctx->Yield();
             IM_CHECK_EQ(ctx->ItemExists("/**/Test"), false);
@@ -590,7 +590,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             EXPECT_CALL(*route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
 
             context.ptr->set_route(route);
-            context.ptr->select_waypoint(0);
+            context.ptr->select_waypoint(waypoint);
 
             ctx->ItemClick("/**/Room Position");
 
@@ -657,7 +657,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             EXPECT_CALL(*route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
             EXPECT_CALL(*waypoint, set_randomizer_settings(An<const IWaypoint::WaypointRandomizerSettings&>())).WillRepeatedly(SaveArg<0>(&new_settings));
             context.ptr->set_route(route);
-            context.ptr->select_waypoint(0);
+            context.ptr->select_waypoint(waypoint);
 
             ctx->ItemInputValue("/**/Test 1", "2");
 
@@ -688,7 +688,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             EXPECT_CALL(*route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
             EXPECT_CALL(*waypoint, set_randomizer_settings(An<const IWaypoint::WaypointRandomizerSettings&>())).WillRepeatedly(SaveArg<0>(&new_settings));
             context.ptr->set_route(route);
-            context.ptr->select_waypoint(0);
+            context.ptr->select_waypoint(waypoint);
 
             ctx->ItemInputValue("/**/Test 1", "Two");
 
@@ -718,7 +718,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             context.ptr = register_test_module().build();
             context.route = route;
             context.ptr->set_route(route);
-            context.ptr->select_waypoint(0);
+            context.ptr->select_waypoint(waypoint);
             context.ptr->set_randomizer_settings(settings);
             context.ptr->set_randomizer_enabled(true);
 
@@ -756,7 +756,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
 
             context.ptr->set_rooms({ room });
             context.ptr->set_route(route);
-            context.ptr->select_waypoint(0);
+            context.ptr->select_waypoint(waypoint);
             context.route = route;
             context.room = room;
             ctx->Yield();

--- a/trview.app.ui.tests/RouteWindowTests.cpp
+++ b/trview.app.ui.tests/RouteWindowTests.cpp
@@ -91,6 +91,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<RouteWindowContext>();
             context.ptr = register_test_module().with_dialogs(dialogs).with_files(files).build();
             context.ptr->set_route(route);
+            context.ptr->select_waypoint(waypoint);
             context.route = route;
 
             ctx->ItemClick("/**/Attach Save");
@@ -123,6 +124,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<RouteWindowContext>();
             context.ptr = register_test_module().with_dialogs(dialogs).with_files(files).build();
             context.ptr->set_route(route);
+            context.ptr->select_waypoint(waypoint);
 
             ctx->ItemClick("/**/Attach Save");
 
@@ -152,6 +154,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<RouteWindowContext>();
             context.ptr = register_test_module().with_dialogs(dialogs).with_files(files).build();
             context.ptr->set_route(route);
+            context.ptr->select_waypoint(waypoint);
 
             ctx->ItemClick("/**/Attach Save");
 
@@ -239,6 +242,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<RouteWindowContext>();
             context.ptr = register_test_module().build();
             context.ptr->set_route(route);
+            context.ptr->select_waypoint(waypoint);
 
             ctx->ItemClick("/**/SAVEGAME.0", ImGuiMouseButton_Right);
             ctx->ItemClick("/**/Remove");
@@ -282,20 +286,21 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             auto route = mock_shared<MockRoute>();
             EXPECT_CALL(*route, waypoints).WillRepeatedly(Return(1));
             EXPECT_CALL(*route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
+
+            std::shared_ptr<IWaypoint> removed;
+            EXPECT_CALL(*route, remove(A<const std::shared_ptr<IWaypoint>&>()))
+                .Times(1)
+                .WillRepeatedly([&](auto w) { removed = w; });
             context.ptr->set_route(route);
             context.ptr->select_waypoint(waypoint);
 
-            std::optional<uint32_t> raised;
-            auto token = context.ptr->on_waypoint_deleted += [&](const auto& waypoint)
-            {
-                raised = waypoint;
-            };
+            bool raised = false;
+            auto token = context.ptr->on_scene_changed += [&]() { raised = true; };
 
             ctx->ItemClick("/**/Delete Waypoint");
 
-            IM_CHECK_EQ(raised.has_value(), true);
-            IM_CHECK_EQ(raised.value(), 0);
-
+            IM_CHECK_EQ(raised, true);
+            IM_CHECK_EQ(waypoint, removed);
             IM_CHECK_EQ(Mock::VerifyAndClearExpectations(route.get()), true);
             IM_CHECK_EQ(Mock::VerifyAndClearExpectations(waypoint.get()), true);
         });
@@ -321,6 +326,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             context.ptr = register_test_module().with_dialogs(dialogs).with_files(files).build();
             context.route = route;
             context.ptr->set_route(route);
+            context.ptr->select_waypoint(waypoint);
 
             ctx->ItemClick("/**/SAVEGAME.0");
 
@@ -352,6 +358,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             context.ptr = register_test_module().with_dialogs(dialogs).with_files(files).build();
             context.route = route;
             context.ptr->set_route(route);
+            context.ptr->select_waypoint(waypoint);
 
             ctx->ItemClick("/**/SAVEGAME.0");
 
@@ -383,6 +390,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             context.ptr = register_test_module().with_dialogs(dialogs).with_files(files).build();
             context.route = route;
             context.ptr->set_route(route);
+            context.ptr->select_waypoint(waypoint);
 
             ctx->ItemClick("/**/SAVEGAME.0");
 
@@ -539,6 +547,7 @@ void register_route_window_tests(ImGuiTestEngine* engine)
             EXPECT_CALL(*rando_route, waypoints).WillRepeatedly(Return(1));
             EXPECT_CALL(*rando_route, waypoint(An<uint32_t>())).WillRepeatedly(Return(waypoint));
             context.ptr->set_route(rando_route);
+            context.ptr->select_waypoint(waypoint);
             context.route = route;
 
             ctx->Yield();

--- a/trview.app.ui.tests/TriggersWindowTests.cpp
+++ b/trview.app.ui.tests/TriggersWindowTests.cpp
@@ -84,7 +84,7 @@ void register_triggers_window_tests(ImGuiTestEngine* engine)
             auto level = mock_shared<MockLevel>();
             ON_CALL(*level, camera_sink(100)).WillByDefault(Return(cam));
 
-            auto trigger = mock_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Camera, 100) });
+            auto trigger = mock_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Camera, 100) })->with_level(level);
             context.triggers = { trigger };
             context.ptr->set_triggers({ trigger });
             context.ptr->set_selected_trigger(trigger);
@@ -310,7 +310,7 @@ void register_triggers_window_tests(ImGuiTestEngine* engine)
             bool raised = false;
             auto token = context.ptr->on_scene_changed += [&raised]() { raised = true; };
 
-            auto trigger = mock_shared<MockTrigger>()->with_visible(true);
+            auto trigger = mock_shared<MockTrigger>()->with_updating_visible(true);
             context.triggers = { trigger };
             context.ptr->set_triggers({ trigger });
             EXPECT_CALL(*trigger, set_visible(false)).Times(1);

--- a/trview.app.ui.tests/pch.h
+++ b/trview.app.ui.tests/pch.h
@@ -31,3 +31,5 @@ void render(const MockWrapper<T>& wrapper)
         wrapper.ptr->render();
     }
 }
+
+#include <external/DirectXTK/Inc/SimpleMath.h>

--- a/trview.app.ui.tests/pch.h
+++ b/trview.app.ui.tests/pch.h
@@ -33,3 +33,4 @@ void render(const MockWrapper<T>& wrapper)
 }
 
 #include <external/DirectXTK/Inc/SimpleMath.h>
+#include <trview.app/Routing/Waypoint.h>

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -61,10 +61,8 @@ namespace trview
         LoadMode load_mode)
         : MessageHandler(application_window), _instance(GetModuleHandle(nullptr)),
         _file_menu(std::move(file_menu)), _update_checker(std::move(update_checker)), _view_menu(window()), _settings_loader(settings_loader), _trlevel_source(trlevel_source),
-        _viewer(std::move(viewer)), _route_source(route_source), _shortcuts(shortcuts),
-        _level_source(level_source),
-        _dialogs(dialogs), _files(files), _timer(default_time_source()), _imgui_backend(std::move(imgui_backend)),
-        _plugins(plugins), _randomizer_route_source(randomizer_route_source), _fonts(fonts), _load_mode(load_mode),
+        _viewer(std::move(viewer)), _route_source(route_source), _shortcuts(shortcuts), _level_source(level_source), _dialogs(dialogs), _files(files), _timer(default_time_source()),
+        _imgui_backend(std::move(imgui_backend)), _plugins(plugins), _randomizer_route_source(randomizer_route_source), _fonts(fonts), _load_mode(load_mode),
         _windows(std::move(windows))
     {
         SetWindowLongPtr(window(), GWLP_USERDATA, reinterpret_cast<LONG_PTR>(_imgui_backend.get()));
@@ -82,18 +80,13 @@ namespace trview
         setup_shortcuts();
         setup_view_menu();
 
-        // Camera Sink
         _token_store += _windows->on_camera_sink_selected += [this](const auto& sink) {  select_camera_sink(sink); };
         _token_store += _windows->on_trigger_selected += [this](const auto& trigger) { select_trigger(trigger); };
         _token_store += _windows->on_scene_changed += [this]() { _viewer->set_scene_changed(); };
-        // Items
         _token_store += _windows->on_item_selected += [this](const auto& item) { select_item(item); };
-        // Lights
         _token_store += _windows->on_light_selected += [this](const auto& light) { select_light(light); };
-        // Rooms
         _token_store += _windows->on_room_selected += [this](const auto& room) { select_room(room); };
         _token_store += _windows->on_sector_hover += [this](const auto& sector) { select_sector(sector); };
-        // Route
         _token_store += _windows->on_waypoint_selected += [&](const auto& waypoint) { select_waypoint(waypoint); };
         _token_store += _windows->on_route_open += [&]() { this->open_route(); };
         _token_store += _windows->on_route_reload += [&]() { this->reload_route(); };
@@ -103,7 +96,6 @@ namespace trview
         _token_store += _windows->on_level_switch += [&](const auto& level) { _file_menu->switch_to(level); };
         _token_store += _windows->on_new_route += [&]() { if (should_discard_changes()) { set_route(_route_source(std::nullopt)); } };
         _token_store += _windows->on_new_randomizer_route += [&]() { if (should_discard_changes()) { set_route(_randomizer_route_source(std::nullopt)); } };
-        // Statics
         _token_store += _windows->on_static_selected += [this](const auto& stat) { select_static_mesh(stat); };
 
         _windows->setup(_settings);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -919,7 +919,6 @@ namespace trview
     void Application::setup_camera_sink_windows()
     {
         _token_store += _windows->on_camera_sink_selected += [this](const auto& sink) {  select_camera_sink(sink); };
-        // _token_store += _windows->on_camera_sink_visibility += [this](const auto& cs, bool value) { set_camera_sink_visibility(cs, value); };
         _token_store += _windows->on_trigger_selected += [this](const auto& trigger) { select_trigger(trigger); };
         _token_store += _windows->on_scene_changed += [this]() { _viewer->set_scene_changed(); };
     }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -54,9 +54,6 @@ namespace trview
         std::shared_ptr<IDialogs> dialogs,
         std::shared_ptr<IFiles> files,
         std::shared_ptr<IImGuiBackend> imgui_backend,
-        std::unique_ptr<ILogWindowManager> log_window_manager,
-        std::unique_ptr<ITexturesWindowManager> textures_window_manager,
-        std::unique_ptr<IConsoleManager> console_manager,
         std::shared_ptr<IPlugins> plugins,
         const IRandomizerRoute::Source& randomizer_route_source,
         std::shared_ptr<IFonts> fonts,
@@ -66,8 +63,8 @@ namespace trview
         _file_menu(std::move(file_menu)), _update_checker(std::move(update_checker)), _view_menu(window()), _settings_loader(settings_loader), _trlevel_source(trlevel_source),
         _viewer(std::move(viewer)), _route_source(route_source), _shortcuts(shortcuts),
         _level_source(level_source),
-        _dialogs(dialogs), _files(files), _timer(default_time_source()), _imgui_backend(std::move(imgui_backend)), _log_windows(std::move(log_window_manager)),
-        _textures_windows(std::move(textures_window_manager)), _console_manager(std::move(console_manager)), _plugins(plugins), _randomizer_route_source(randomizer_route_source), _fonts(fonts), _load_mode(load_mode),
+        _dialogs(dialogs), _files(files), _timer(default_time_source()), _imgui_backend(std::move(imgui_backend)),
+        _plugins(plugins), _randomizer_route_source(randomizer_route_source), _fonts(fonts), _load_mode(load_mode),
         _windows(std::move(windows))
     {
         SetWindowLongPtr(window(), GWLP_USERDATA, reinterpret_cast<LONG_PTR>(_imgui_backend.get()));
@@ -627,9 +624,6 @@ namespace trview
         }
 
         _viewer->render_ui();
-        _log_windows->render();
-        _textures_windows->render();
-        _console_manager->render();
         _windows->render();
         _plugins->render_ui();
 
@@ -766,8 +760,7 @@ namespace trview
 
     void Application::open_recent_route()
     {
-        // TODO:
-        if (!_level || _recent_route_prompted /* || !_route_window->is_window_open() */ || std::dynamic_pointer_cast<IRandomizerRoute>(_route) != nullptr)
+        if (!_level || _recent_route_prompted  || !_windows->is_route_window_open() || std::dynamic_pointer_cast<IRandomizerRoute>(_route) != nullptr)
         {
             return;
         }
@@ -863,10 +856,7 @@ namespace trview
             {
                 _route->set_unsaved(false);
             }
-            // TODO:
-            // _route_window->set_route(_route);
         }
-        _textures_windows->set_texture_storage(_level->texture_storage());
 
         set_route(_route);
         _viewer->open(level, open_mode);

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -64,7 +64,6 @@ namespace trview
         std::unique_ptr<ICameraSinkWindowManager> camera_sink_window_manager,
         std::unique_ptr<IConsoleManager> console_manager,
         std::shared_ptr<IPlugins> plugins,
-        std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
         const IRandomizerRoute::Source& randomizer_route_source,
         std::shared_ptr<IFonts> fonts,
         std::unique_ptr<IWindows> windows,
@@ -75,7 +74,7 @@ namespace trview
         _triggers_windows(std::move(triggers_window_manager)), _route_window(std::move(route_window_manager)), _rooms_windows(std::move(rooms_window_manager)), _level_source(level_source),
         _dialogs(dialogs), _files(files), _timer(default_time_source()), _imgui_backend(std::move(imgui_backend)), _lights_windows(std::move(lights_window_manager)), _log_windows(std::move(log_window_manager)),
         _textures_windows(std::move(textures_window_manager)), _camera_sink_windows(std::move(camera_sink_window_manager)), _console_manager(std::move(console_manager)),
-        _plugins(plugins), _plugins_windows(std::move(plugins_window_manager)), _randomizer_route_source(randomizer_route_source), _fonts(fonts), _load_mode(load_mode), _windows(std::move(windows))
+        _plugins(plugins), _randomizer_route_source(randomizer_route_source), _fonts(fonts), _load_mode(load_mode), _windows(std::move(windows))
     {
         SetWindowLongPtr(window(), GWLP_USERDATA, reinterpret_cast<LONG_PTR>(_imgui_backend.get()));
 
@@ -722,7 +721,6 @@ namespace trview
         _rooms_windows->update(elapsed);
         _route_window->update(elapsed);
         _lights_windows->update(elapsed);
-        _plugins_windows->update(elapsed);
         _windows->update(elapsed);
 
         _viewer->render();
@@ -766,7 +764,6 @@ namespace trview
         _textures_windows->render();
         _camera_sink_windows->render();
         _console_manager->render();
-        _plugins_windows->render();
         _windows->render();
         _plugins->render_ui();
 

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -81,7 +81,6 @@ namespace trview
             std::unique_ptr<ILightsWindowManager> lights_window_manager,
             std::unique_ptr<ILogWindowManager> log_window_manager,
             std::unique_ptr<ITexturesWindowManager> textures_window_manager,
-            std::unique_ptr<ICameraSinkWindowManager> camera_sink_window_manager,
             std::unique_ptr<IConsoleManager> console_manager,
             std::shared_ptr<IPlugins> plugins,
             const IRandomizerRoute::Source& randomizer_route_source,
@@ -189,7 +188,6 @@ namespace trview
         bool _recent_route_prompted{ false };
 
         std::unique_ptr<ITexturesWindowManager> _textures_windows;
-        std::unique_ptr<ICameraSinkWindowManager> _camera_sink_windows;
         std::unique_ptr<IConsoleManager> _console_manager;
         std::shared_ptr<IPlugins> _plugins;
 

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -15,10 +15,7 @@
 #include "Routing/IRandomizerRoute.h"
 #include <trview.app/Settings/ISettingsLoader.h>
 #include <trview.app/Settings/IStartupOptions.h>
-#include <trview.app/Windows/IRoomsWindowManager.h>
 #include <trview.app/Windows/IRouteWindowManager.h>
-#include <trview.app/Windows/ITriggersWindowManager.h>
-#include <trview.app/Windows/ILightsWindowManager.h>
 #include <trview.app/Windows/IViewer.h>
 #include <trview.common/Windows/IDialogs.h>
 #include <trview.common/Windows/IShortcuts.h>
@@ -68,7 +65,6 @@ namespace trview
             const IRoute::Source& route_source,
             std::shared_ptr<IShortcuts> shortcuts,
             std::unique_ptr<IRouteWindowManager> route_window_manager,
-            std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
             const ILevel::Source& level_source,
             std::shared_ptr<IStartupOptions> startup_options,
             std::shared_ptr<IDialogs> dialogs,
@@ -100,9 +96,7 @@ namespace trview
         // Window setup functions.
         void setup_view_menu();
         void setup_viewer(const IStartupOptions& startup_options);
-        void setup_rooms_windows();
         void setup_route_window();
-        void setup_lights_windows();
         void setup_shortcuts();
         // Entity manipulation
         void add_waypoint(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, std::weak_ptr<IRoom> room, IWaypoint::Type type, uint32_t index);
@@ -166,7 +160,6 @@ namespace trview
         std::unique_ptr<IViewer> _viewer;
         std::unique_ptr<IWindows> _windows;
         std::unique_ptr<IRouteWindowManager> _route_window;
-        std::unique_ptr<IRoomsWindowManager> _rooms_windows;
         Timer _timer;
         std::optional<std::pair<std::string, FontSetting>> _new_font;
 

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -20,7 +20,6 @@
 #include <trview.common/Windows/IDialogs.h>
 #include <trview.common/Windows/IShortcuts.h>
 #include "Windows/Log/ILogWindowManager.h"
-#include "Windows/Textures/ITexturesWindowManager.h"
 #include "UI/IImGuiBackend.h"
 #include "Windows/Console/IConsoleManager.h"
 #include "Plugins/IPlugins.h"
@@ -69,9 +68,6 @@ namespace trview
             std::shared_ptr<IDialogs> dialogs,
             std::shared_ptr<IFiles> files,
             std::shared_ptr<IImGuiBackend> imgui_backend,
-            std::unique_ptr<ILogWindowManager> log_window_manager,
-            std::unique_ptr<ITexturesWindowManager> textures_window_manager,
-            std::unique_ptr<IConsoleManager> console_manager,
             std::shared_ptr<IPlugins> plugins,
             const IRandomizerRoute::Source& randomizer_route_source,
             std::shared_ptr<IFonts> fonts,
@@ -162,11 +158,8 @@ namespace trview
 
         std::shared_ptr<IImGuiBackend> _imgui_backend;
         std::string _imgui_ini_filename;
-        std::unique_ptr<ILogWindowManager> _log_windows;
         bool _recent_route_prompted{ false };
 
-        std::unique_ptr<ITexturesWindowManager> _textures_windows;
-        std::unique_ptr<IConsoleManager> _console_manager;
         std::shared_ptr<IPlugins> _plugins;
 
         IRandomizerRoute::Source _randomizer_route_source;

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -26,7 +26,6 @@
 #include "Windows/Log/ILogWindowManager.h"
 #include "Windows/Textures/ITexturesWindowManager.h"
 #include "UI/IImGuiBackend.h"
-#include "Windows/CameraSink/ICameraSinkWindowManager.h"
 #include "Windows/Console/IConsoleManager.h"
 #include "Plugins/IPlugins.h"
 #include "UI/Fonts/IFonts.h"

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -31,12 +31,13 @@
 #include "Plugins/IPlugins.h"
 #include "Windows/Plugins/IPluginsWindowManager.h"
 #include "UI/Fonts/IFonts.h"
-#include "Windows/Statics/IStaticsWindowManager.h"
 
 struct ImFont;
 
 namespace trview
 {
+    struct IWindows;
+
     struct IApplication
     {
         virtual ~IApplication() = 0;
@@ -87,7 +88,7 @@ namespace trview
             std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
             const IRandomizerRoute::Source& randomizer_route_source,
             std::shared_ptr<IFonts> fonts,
-            std::unique_ptr<IStaticsWindowManager> statics_window_manager,
+            std::unique_ptr<IWindows> windows,
             LoadMode load_mode);
         virtual ~Application();
         /// Attempt to open the specified level file.
@@ -175,6 +176,7 @@ namespace trview
 
         // Windows
         std::unique_ptr<IViewer> _viewer;
+        std::unique_ptr<IWindows> _windows;
         std::unique_ptr<IItemsWindowManager> _items_windows;
         std::unique_ptr<ITriggersWindowManager> _triggers_windows;
         std::unique_ptr<IRouteWindowManager> _route_window;
@@ -193,7 +195,6 @@ namespace trview
         std::unique_ptr<IConsoleManager> _console_manager;
         std::shared_ptr<IPlugins> _plugins;
         std::unique_ptr<IPluginsWindowManager> _plugins_windows;
-        std::unique_ptr<IStaticsWindowManager> _statics_windows;
 
         IRandomizerRoute::Source _randomizer_route_source;
         std::shared_ptr<IFonts> _fonts;

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -15,7 +15,6 @@
 #include "Routing/IRandomizerRoute.h"
 #include <trview.app/Settings/ISettingsLoader.h>
 #include <trview.app/Settings/IStartupOptions.h>
-#include <trview.app/Windows/IItemsWindowManager.h>
 #include <trview.app/Windows/IRoomsWindowManager.h>
 #include <trview.app/Windows/IRouteWindowManager.h>
 #include <trview.app/Windows/ITriggersWindowManager.h>
@@ -68,8 +67,6 @@ namespace trview
             std::unique_ptr<IViewer> viewer,
             const IRoute::Source& route_source,
             std::shared_ptr<IShortcuts> shortcuts,
-            std::unique_ptr<IItemsWindowManager> items_window_manager,
-            std::unique_ptr<ITriggersWindowManager> triggers_window_manager,
             std::unique_ptr<IRouteWindowManager> route_window_manager,
             std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
             const ILevel::Source& level_source,
@@ -77,7 +74,6 @@ namespace trview
             std::shared_ptr<IDialogs> dialogs,
             std::shared_ptr<IFiles> files,
             std::shared_ptr<IImGuiBackend> imgui_backend,
-            std::unique_ptr<ILightsWindowManager> lights_window_manager,
             std::unique_ptr<ILogWindowManager> log_window_manager,
             std::unique_ptr<ITexturesWindowManager> textures_window_manager,
             std::unique_ptr<IConsoleManager> console_manager,
@@ -104,13 +100,9 @@ namespace trview
         // Window setup functions.
         void setup_view_menu();
         void setup_viewer(const IStartupOptions& startup_options);
-        void setup_items_windows();
-        void setup_triggers_windows();
         void setup_rooms_windows();
         void setup_route_window();
         void setup_lights_windows();
-        void setup_camera_sink_windows();
-        void setup_statics_window();
         void setup_shortcuts();
         // Entity manipulation
         void add_waypoint(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, std::weak_ptr<IRoom> room, IWaypoint::Type type, uint32_t index);
@@ -173,11 +165,8 @@ namespace trview
         // Windows
         std::unique_ptr<IViewer> _viewer;
         std::unique_ptr<IWindows> _windows;
-        std::unique_ptr<IItemsWindowManager> _items_windows;
-        std::unique_ptr<ITriggersWindowManager> _triggers_windows;
         std::unique_ptr<IRouteWindowManager> _route_window;
         std::unique_ptr<IRoomsWindowManager> _rooms_windows;
-        std::unique_ptr<ILightsWindowManager> _lights_windows;
         Timer _timer;
         std::optional<std::pair<std::string, FontSetting>> _new_font;
 

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -12,16 +12,14 @@
 #include <trview.app/Menus/IFileMenu.h>
 #include <trview.app/Menus/IUpdateChecker.h>
 #include <trview.app/Menus/ViewMenu.h>
-#include <trview.app/Routing/Route.h>
+#include <trview.app/Routing/IRoute.h>
 #include "Routing/IRandomizerRoute.h"
 #include <trview.app/Settings/ISettingsLoader.h>
 #include <trview.app/Settings/IStartupOptions.h>
 #include <trview.app/Windows/IViewer.h>
 #include <trview.common/Windows/IDialogs.h>
 #include <trview.common/Windows/IShortcuts.h>
-#include "Windows/Log/ILogWindowManager.h"
 #include "UI/IImGuiBackend.h"
-#include "Windows/Console/IConsoleManager.h"
 #include "Plugins/IPlugins.h"
 #include "UI/Fonts/IFonts.h"
 

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -4,6 +4,7 @@
 
 #include <trview.common/Window.h>
 #include <trview.common/Timer.h>
+#include <trview.common/TokenStore.h>
 
 #include <trlevel/ILevel.h>
 
@@ -15,7 +16,6 @@
 #include "Routing/IRandomizerRoute.h"
 #include <trview.app/Settings/ISettingsLoader.h>
 #include <trview.app/Settings/IStartupOptions.h>
-#include <trview.app/Windows/IRouteWindowManager.h>
 #include <trview.app/Windows/IViewer.h>
 #include <trview.common/Windows/IDialogs.h>
 #include <trview.common/Windows/IShortcuts.h>
@@ -64,7 +64,6 @@ namespace trview
             std::unique_ptr<IViewer> viewer,
             const IRoute::Source& route_source,
             std::shared_ptr<IShortcuts> shortcuts,
-            std::unique_ptr<IRouteWindowManager> route_window_manager,
             const ILevel::Source& level_source,
             std::shared_ptr<IStartupOptions> startup_options,
             std::shared_ptr<IDialogs> dialogs,
@@ -96,7 +95,6 @@ namespace trview
         // Window setup functions.
         void setup_view_menu();
         void setup_viewer(const IStartupOptions& startup_options);
-        void setup_route_window();
         void setup_shortcuts();
         // Entity manipulation
         void add_waypoint(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, std::weak_ptr<IRoom> room, IWaypoint::Type type, uint32_t index);
@@ -109,7 +107,7 @@ namespace trview
         /// </summary>
         /// <param name="trigger">The trigger.</param>
         void select_trigger(const std::weak_ptr<ITrigger>& trigger);
-        void select_waypoint(uint32_t index);
+        void select_waypoint(const std::weak_ptr<IWaypoint>& waypoint);
         void select_next_waypoint();
         void select_previous_waypoint();
         void select_light(const std::weak_ptr<ILight>& light);
@@ -159,7 +157,6 @@ namespace trview
         // Windows
         std::unique_ptr<IViewer> _viewer;
         std::unique_ptr<IWindows> _windows;
-        std::unique_ptr<IRouteWindowManager> _route_window;
         Timer _timer;
         std::optional<std::pair<std::string, FontSetting>> _new_font;
 

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -29,7 +29,6 @@
 #include "Windows/CameraSink/ICameraSinkWindowManager.h"
 #include "Windows/Console/IConsoleManager.h"
 #include "Plugins/IPlugins.h"
-#include "Windows/Plugins/IPluginsWindowManager.h"
 #include "UI/Fonts/IFonts.h"
 
 struct ImFont;
@@ -85,7 +84,6 @@ namespace trview
             std::unique_ptr<ICameraSinkWindowManager> camera_sink_window_manager,
             std::unique_ptr<IConsoleManager> console_manager,
             std::shared_ptr<IPlugins> plugins,
-            std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
             const IRandomizerRoute::Source& randomizer_route_source,
             std::shared_ptr<IFonts> fonts,
             std::unique_ptr<IWindows> windows,
@@ -194,7 +192,6 @@ namespace trview
         std::unique_ptr<ICameraSinkWindowManager> _camera_sink_windows;
         std::unique_ptr<IConsoleManager> _console_manager;
         std::shared_ptr<IPlugins> _plugins;
-        std::unique_ptr<IPluginsWindowManager> _plugins_windows;
 
         IRandomizerRoute::Source _randomizer_route_source;
         std::shared_ptr<IFonts> _fonts;

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -348,7 +348,6 @@ namespace trview
             std::move(viewer),
             route_source,
             shortcuts,
-            std::make_unique<RouteWindowManager>(window, shortcuts, route_window_source),
             level_source,
             std::make_shared<StartupOptions>(command_line),
             dialogs,
@@ -366,6 +365,7 @@ namespace trview
                 std::make_unique<LightsWindowManager>(window, shortcuts, lights_window_source),
                 std::make_unique<PluginsWindowManager>(window, shortcuts, plugins_window_source),
                 std::make_unique<RoomsWindowManager>(window, shortcuts, rooms_window_source),
+                std::make_unique<RouteWindowManager>(window, shortcuts, route_window_source),
                 std::make_unique<StaticsWindowManager>(window, shortcuts, statics_window_source),
                 std::make_unique<TriggersWindowManager>(window, shortcuts, triggers_window_source)),
             Application::LoadMode::Async);

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -362,10 +362,11 @@ namespace trview
             std::make_unique<CameraSinkWindowManager>(window, shortcuts, camera_sink_window_source),
             std::make_unique<ConsoleManager>(window, shortcuts, console_source, files),
             plugins,
-            std::make_unique<PluginsWindowManager>(window, shortcuts, plugins_window_source),
             randomizer_route_source,
             fonts,
-            std::make_unique<Windows>(std::make_unique<StaticsWindowManager>(window, shortcuts, statics_window_source)),
+            std::make_unique<Windows>(
+                std::make_unique<PluginsWindowManager>(window, shortcuts, plugins_window_source),
+                std::make_unique<StaticsWindowManager>(window, shortcuts, statics_window_source)),
             Application::LoadMode::Async);
     }
 }

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -349,7 +349,6 @@ namespace trview
             route_source,
             shortcuts,
             std::make_unique<RouteWindowManager>(window, shortcuts, route_window_source),
-            std::make_unique<RoomsWindowManager>(window, shortcuts, rooms_window_source),
             level_source,
             std::make_shared<StartupOptions>(command_line),
             dialogs,
@@ -366,6 +365,7 @@ namespace trview
                 std::make_unique<ItemsWindowManager>(window, shortcuts, items_window_source),
                 std::make_unique<LightsWindowManager>(window, shortcuts, lights_window_source),
                 std::make_unique<PluginsWindowManager>(window, shortcuts, plugins_window_source),
+                std::make_unique<RoomsWindowManager>(window, shortcuts, rooms_window_source),
                 std::make_unique<StaticsWindowManager>(window, shortcuts, statics_window_source),
                 std::make_unique<TriggersWindowManager>(window, shortcuts, triggers_window_source)),
             Application::LoadMode::Async);

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -53,6 +53,7 @@
 #include "Windows/RouteWindowManager.h"
 #include "Windows/RoomsWindowManager.h"
 #include "Windows/TriggersWindowManager.h"
+#include "Windows/TriggersWindow.h"
 #include "Windows/Viewer.h"
 #include "Windows/Log/LogWindow.h"
 #include "Windows/Log/LogWindowManager.h"
@@ -347,8 +348,6 @@ namespace trview
             std::move(viewer),
             route_source,
             shortcuts,
-            std::make_unique<ItemsWindowManager>(window, shortcuts, items_window_source),
-            std::make_unique<TriggersWindowManager>(window, shortcuts, triggers_window_source),
             std::make_unique<RouteWindowManager>(window, shortcuts, route_window_source),
             std::make_unique<RoomsWindowManager>(window, shortcuts, rooms_window_source),
             level_source,
@@ -356,7 +355,6 @@ namespace trview
             dialogs,
             files,
             imgui_backend,
-            std::make_unique<LightsWindowManager>(window, shortcuts, lights_window_source),
             std::make_unique<LogWindowManager>(window, log_window_source),
             std::make_unique<TexturesWindowManager>(window, textures_window_source),
             std::make_unique<ConsoleManager>(window, shortcuts, console_source, files),
@@ -365,8 +363,11 @@ namespace trview
             fonts,
             std::make_unique<Windows>(
                 std::make_unique<CameraSinkWindowManager>(window, shortcuts, camera_sink_window_source),
+                std::make_unique<ItemsWindowManager>(window, shortcuts, items_window_source),
+                std::make_unique<LightsWindowManager>(window, shortcuts, lights_window_source),
                 std::make_unique<PluginsWindowManager>(window, shortcuts, plugins_window_source),
-                std::make_unique<StaticsWindowManager>(window, shortcuts, statics_window_source)),
+                std::make_unique<StaticsWindowManager>(window, shortcuts, statics_window_source),
+                std::make_unique<TriggersWindowManager>(window, shortcuts, triggers_window_source)),
             Application::LoadMode::Async);
     }
 }

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -359,12 +359,12 @@ namespace trview
             std::make_unique<LightsWindowManager>(window, shortcuts, lights_window_source),
             std::make_unique<LogWindowManager>(window, log_window_source),
             std::make_unique<TexturesWindowManager>(window, textures_window_source),
-            std::make_unique<CameraSinkWindowManager>(window, shortcuts, camera_sink_window_source),
             std::make_unique<ConsoleManager>(window, shortcuts, console_source, files),
             plugins,
             randomizer_route_source,
             fonts,
             std::make_unique<Windows>(
+                std::make_unique<CameraSinkWindowManager>(window, shortcuts, camera_sink_window_source),
                 std::make_unique<PluginsWindowManager>(window, shortcuts, plugins_window_source),
                 std::make_unique<StaticsWindowManager>(window, shortcuts, statics_window_source)),
             Application::LoadMode::Async);

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -71,6 +71,7 @@
 #include "UI/Fonts/Fonts.h"
 #include "Windows/Statics/StaticsWindowManager.h"
 #include "Windows/Statics/StaticsWindow.h"
+#include "Windows/Windows.h"
 
 namespace trview
 {
@@ -364,7 +365,7 @@ namespace trview
             std::make_unique<PluginsWindowManager>(window, shortcuts, plugins_window_source),
             randomizer_route_source,
             fonts,
-            std::make_unique<StaticsWindowManager>(window, shortcuts, statics_window_source),
+            std::make_unique<Windows>(std::make_unique<StaticsWindowManager>(window, shortcuts, statics_window_source)),
             Application::LoadMode::Async);
     }
 }

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -353,20 +353,20 @@ namespace trview
             dialogs,
             files,
             imgui_backend,
-            std::make_unique<LogWindowManager>(window, log_window_source),
-            std::make_unique<TexturesWindowManager>(window, textures_window_source),
-            std::make_unique<ConsoleManager>(window, shortcuts, console_source, files),
             plugins,
             randomizer_route_source,
             fonts,
             std::make_unique<Windows>(
                 std::make_unique<CameraSinkWindowManager>(window, shortcuts, camera_sink_window_source),
+                std::make_unique<ConsoleManager>(window, shortcuts, console_source, files),
                 std::make_unique<ItemsWindowManager>(window, shortcuts, items_window_source),
                 std::make_unique<LightsWindowManager>(window, shortcuts, lights_window_source),
+                std::make_unique<LogWindowManager>(window, log_window_source),
                 std::make_unique<PluginsWindowManager>(window, shortcuts, plugins_window_source),
                 std::make_unique<RoomsWindowManager>(window, shortcuts, rooms_window_source),
                 std::make_unique<RouteWindowManager>(window, shortcuts, route_window_source),
                 std::make_unique<StaticsWindowManager>(window, shortcuts, statics_window_source),
+                std::make_unique<TexturesWindowManager>(window, textures_window_source),
                 std::make_unique<TriggersWindowManager>(window, shortcuts, triggers_window_source)),
             Application::LoadMode::Async);
     }

--- a/trview.app/Mocks/Elements/ICameraSink.h
+++ b/trview.app/Mocks/Elements/ICameraSink.h
@@ -30,6 +30,8 @@ namespace trview
             MOCK_METHOD(bool, visible, (), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<ITrigger>>, triggers, (), (const, override));
 
+            bool _visible_state{ false };
+
             std::shared_ptr<MockCameraSink> with_number(uint32_t number)
             {
                 ON_CALL(*this, number).WillByDefault(testing::Return(number));
@@ -51,6 +53,14 @@ namespace trview
             std::shared_ptr<MockCameraSink> with_room(std::shared_ptr<IRoom> room)
             {
                 ON_CALL(*this, room).WillByDefault(testing::Return(room));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockCameraSink> with_updating_visible(bool value)
+            {
+                _visible_state = value;
+                ON_CALL(*this, visible).WillByDefault([&]() { return _visible_state; });
+                ON_CALL(*this, set_visible).WillByDefault([&](auto v) { _visible_state = v; });
                 return shared_from_this();
             }
         };

--- a/trview.app/Mocks/Elements/IItem.h
+++ b/trview.app/Mocks/Elements/IItem.h
@@ -34,6 +34,8 @@ namespace trview
             MOCK_METHOD(std::unordered_set<std::string>, categories, (), (const, override));
             MOCK_METHOD(void, set_categories, (const std::unordered_set<std::string>&), (override));
 
+            bool _visible_state;
+
             std::shared_ptr<MockItem> with_number(uint32_t number)
             {
                 ON_CALL(*this, number).WillByDefault(testing::Return(number));
@@ -67,6 +69,14 @@ namespace trview
             std::shared_ptr<MockItem> with_visible(bool value)
             {
                 ON_CALL(*this, visible).WillByDefault(testing::Return(value));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockItem> with_updating_visible(bool value)
+            {
+                _visible_state = value;
+                ON_CALL(*this, visible).WillByDefault([&]() { return _visible_state; });
+                ON_CALL(*this, set_visible).WillByDefault([&](auto v) { _visible_state = v; });
                 return shared_from_this();
             }
         };

--- a/trview.app/Mocks/Elements/ILight.h
+++ b/trview.app/Mocks/Elements/ILight.h
@@ -37,6 +37,8 @@ namespace trview
             MOCK_METHOD(void, render_direction, (const ICamera&, const ILevelTextureStorage&), (override));
             MOCK_METHOD(trlevel::LevelVersion, level_version, (), (const, override));
 
+            bool _visible_state{ false };
+
             std::shared_ptr<MockLight> with_number(uint32_t number)
             {
                 ON_CALL(*this, number).WillByDefault(testing::Return(number));
@@ -58,6 +60,14 @@ namespace trview
             std::shared_ptr<MockLight> with_level_version(trlevel::LevelVersion version)
             {
                 ON_CALL(*this, level_version).WillByDefault(testing::Return(version));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockLight> with_updating_visible(bool value)
+            {
+                _visible_state = value;
+                ON_CALL(*this, visible).WillByDefault([&]() { return _visible_state; });
+                ON_CALL(*this, set_visible).WillByDefault([&](auto v) { _visible_state = v; });
                 return shared_from_this();
             }
         };

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -63,6 +63,7 @@ namespace trview
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<IStaticMesh>>, static_meshes, (), (const));
 
+            bool _visible_state{ false };
 
             std::shared_ptr<MockRoom> with_number(uint32_t number)
             {
@@ -109,6 +110,14 @@ namespace trview
             std::shared_ptr<MockRoom> with_room_info(const RoomInfo& info)
             {
                 ON_CALL(*this, info).WillByDefault(testing::Return(info));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockRoom> with_updating_visible(bool value)
+            {
+                _visible_state = value;
+                ON_CALL(*this, visible).WillByDefault([&]() { return _visible_state; });
+                ON_CALL(*this, set_visible).WillByDefault([&](auto v) { _visible_state = v; });
                 return shared_from_this();
             }
         };

--- a/trview.app/Mocks/Elements/ITrigger.h
+++ b/trview.app/Mocks/Elements/ITrigger.h
@@ -33,6 +33,8 @@ namespace trview
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
 
+            bool _visible_state{ false };
+
             std::shared_ptr<MockTrigger> with_number(uint32_t number)
             {
                 ON_CALL(*this, number).WillByDefault(testing::Return(number));
@@ -60,6 +62,20 @@ namespace trview
             std::shared_ptr<MockTrigger> with_visible(const std::function<bool()>& visible)
             {
                 ON_CALL(*this, visible).WillByDefault(visible);
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockTrigger> with_updating_visible(bool value)
+            {
+                _visible_state = value;
+                ON_CALL(*this, visible).WillByDefault([&]() { return _visible_state; });
+                ON_CALL(*this, set_visible).WillByDefault([&](auto v) { _visible_state = v; });
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockTrigger> with_level(std::shared_ptr<ILevel> level)
+            {
+                ON_CALL(*this, level).WillByDefault(testing::Return(level));
                 return shared_from_this();
             }
         };

--- a/trview.app/Mocks/Mocks.cpp
+++ b/trview.app/Mocks/Mocks.cpp
@@ -63,6 +63,7 @@
 #include "Mocks/Tools/IToolbar.h"
 #include "Mocks/Windows/IStaticsWindow.h"
 #include "Mocks/Windows/IStaticsWindowManager.h"
+#include "Mocks/Windows/IWindows.h"
 
 namespace trview
 {
@@ -253,5 +254,8 @@ namespace trview
 
         MockToolbar::MockToolbar() {}
         MockToolbar::~MockToolbar() {}
+
+        MockWindows::MockWindows() {}
+        MockWindows::~MockWindows() {}
     }
 }

--- a/trview.app/Mocks/Routing/IRandomizerRoute.h
+++ b/trview.app/Mocks/Routing/IRandomizerRoute.h
@@ -33,7 +33,7 @@ namespace trview
             MOCK_METHOD(void, save, (const std::shared_ptr<IFiles>&, const UserSettings&), (override));
             MOCK_METHOD(void, save_as, (const std::shared_ptr<IFiles>&, const std::string&, const UserSettings&), (override));
             MOCK_METHOD(uint32_t, selected_waypoint, (), (const, override));
-            MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
+            MOCK_METHOD(void, select_waypoint, (const std::weak_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, set_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_filename, (const std::string&), (override));
             MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -31,7 +31,7 @@ namespace trview
             MOCK_METHOD(void, save, (const std::shared_ptr<IFiles>&, const UserSettings&), (override));
             MOCK_METHOD(void, save_as, (const std::shared_ptr<IFiles>&, const std::string&, const UserSettings&), (override));
             MOCK_METHOD(uint32_t, selected_waypoint, (), (const, override));
-            MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
+            MOCK_METHOD(void, select_waypoint, (const std::weak_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, set_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_filename, (const std::string&), (override));
             MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));

--- a/trview.app/Mocks/Windows/IRouteWindow.h
+++ b/trview.app/Mocks/Windows/IRouteWindow.h
@@ -12,7 +12,7 @@ namespace trview
             virtual ~MockRouteWindow();
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_route, (const std::weak_ptr<IRoute>&), (override));
-            MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
+            MOCK_METHOD(void, select_waypoint, (const std::weak_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, set_items, (const std::vector<std::weak_ptr<IItem>>&), (override));
             MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&), (override));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));

--- a/trview.app/Mocks/Windows/IRouteWindowManager.h
+++ b/trview.app/Mocks/Windows/IRouteWindowManager.h
@@ -16,7 +16,7 @@ namespace trview
             MOCK_METHOD(void, set_items, (const std::vector<std::weak_ptr<IItem>>&), (override));
             MOCK_METHOD(void, set_rooms, (const std::vector<std::weak_ptr<IRoom>>&), (override));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
-            MOCK_METHOD(void, select_waypoint, (uint32_t), (override));
+            MOCK_METHOD(void, select_waypoint, (const std::weak_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, set_randomizer_enabled, (bool), (override));
             MOCK_METHOD(void, set_randomizer_settings, (const RandomizerSettings&), (override));

--- a/trview.app/Mocks/Windows/IWindows.h
+++ b/trview.app/Mocks/Windows/IWindows.h
@@ -12,6 +12,7 @@ namespace trview
             virtual ~MockWindows();
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, render, (), (override));
+            MOCK_METHOD(void, select, (const std::weak_ptr<ICameraSink>&), (override));
             MOCK_METHOD(void, select, (const std::weak_ptr<IStaticMesh>&), (override));
             MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
             MOCK_METHOD(void, set_room, (const std::weak_ptr<IRoom>&), (override));

--- a/trview.app/Mocks/Windows/IWindows.h
+++ b/trview.app/Mocks/Windows/IWindows.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "../../Windows/IWindows.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockWindows : public IWindows
+        {
+            MockWindows();
+            virtual ~MockWindows();
+            MOCK_METHOD(void, update, (float), (override));
+            MOCK_METHOD(void, render, (), (override));
+            MOCK_METHOD(void, select, (const std::weak_ptr<IStaticMesh>&), (override));
+            MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
+            MOCK_METHOD(void, set_room, (const std::weak_ptr<IRoom>&), (override));
+            MOCK_METHOD(void, setup, (const UserSettings&), (override));
+        };
+    }
+}

--- a/trview.app/Mocks/Windows/IWindows.h
+++ b/trview.app/Mocks/Windows/IWindows.h
@@ -10,12 +10,19 @@ namespace trview
         {
             MockWindows();
             virtual ~MockWindows();
+            MOCK_METHOD(bool, is_route_window_open, (), (const, override));
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, select, (const std::weak_ptr<ICameraSink>&), (override));
+            MOCK_METHOD(void, select, (const std::weak_ptr<IItem>&), (override));
+            MOCK_METHOD(void, select, (const std::weak_ptr<ILight>&), (override));
             MOCK_METHOD(void, select, (const std::weak_ptr<IStaticMesh>&), (override));
+            MOCK_METHOD(void, select, (const std::weak_ptr<ITrigger>&), (override));
+            MOCK_METHOD(void, select, (const std::weak_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
             MOCK_METHOD(void, set_room, (const std::weak_ptr<IRoom>&), (override));
+            MOCK_METHOD(void, set_route, (const std::weak_ptr<IRoute>&), (override));
+            MOCK_METHOD(void, set_settings, (const UserSettings&), (override));
             MOCK_METHOD(void, setup, (const UserSettings&), (override));
         };
     }

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -133,11 +133,7 @@ namespace trview
         /// </summary>
         /// <returns>The index of the currently selected waypoint.</returns>
         virtual uint32_t selected_waypoint() const = 0;
-        /// <summary>
-        /// Set the specified waypoint index to be the selected waypoint.
-        /// </summary>
-        /// <param name="index">The index to select.</param>
-        virtual void select_waypoint(uint32_t index) = 0;
+        virtual void select_waypoint(const std::weak_ptr<IWaypoint>& waypoint) = 0;
         /// <summary>
         /// Set the colour for the route.
         /// </summary>

--- a/trview.app/Routing/IWaypoint.h
+++ b/trview.app/Routing/IWaypoint.h
@@ -4,7 +4,7 @@
 #include <variant>
 #include <SimpleMath.h>
 #include <trview.common/Colour.h>
-#include <trview.app/Geometry/IRenderable.h>
+#include "../Geometry/IRenderable.h"
 #include <trview.common/Event.h>
 
 namespace trview

--- a/trview.app/Routing/RandomizerRoute.cpp
+++ b/trview.app/Routing/RandomizerRoute.cpp
@@ -323,9 +323,9 @@ namespace trview
         return _route->selected_waypoint();
     }
 
-    void RandomizerRoute::select_waypoint(uint32_t index)
+    void RandomizerRoute::select_waypoint(const std::weak_ptr<IWaypoint>& waypoint)
     {
-        return _route->select_waypoint(index);
+        return _route->select_waypoint(waypoint);
     }
 
     void RandomizerRoute::set_colour(const Colour& colour)

--- a/trview.app/Routing/RandomizerRoute.h
+++ b/trview.app/Routing/RandomizerRoute.h
@@ -40,7 +40,7 @@ namespace trview
         void save(const std::shared_ptr<IFiles>& files, const UserSettings& settings) override;
         void save_as(const std::shared_ptr<IFiles>& files, const std::string& filename, const UserSettings& settings) override;
         uint32_t selected_waypoint() const override;
-        void select_waypoint(uint32_t index) override;
+        void select_waypoint(const std::weak_ptr<IWaypoint>& waypoint) override;
         void set_colour(const Colour& colour) override;
         void set_filename(const std::string& filename) override;
         void set_level(const std::weak_ptr<ILevel>& level) override;

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -359,9 +359,16 @@ namespace trview
         return _selected_index;
     }
 
-    void Route::select_waypoint(uint32_t index)
+    void Route::select_waypoint(const std::weak_ptr<IWaypoint>& waypoint)
     {
-        _selected_index = index;
+        if (const auto waypoint_ptr = waypoint.lock())
+        {
+            const auto iter = std::ranges::find(_waypoints, waypoint_ptr);
+            if (iter != _waypoints.end())
+            {
+                _selected_index = static_cast<uint32_t>(std::distance(_waypoints.begin(), iter));
+            }
+        }
     }
 
     void Route::set_colour(const Colour& colour)

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -39,7 +39,7 @@ namespace trview
         void save(const std::shared_ptr<IFiles>& files, const UserSettings& settings) override;
         void save_as(const std::shared_ptr<IFiles>& files, const std::string& filename, const UserSettings& settings) override;
         virtual uint32_t selected_waypoint() const override;
-        virtual void select_waypoint(uint32_t index) override;
+        void select_waypoint(const std::weak_ptr<IWaypoint>& waypoint) override;
         virtual void set_colour(const Colour& colour) override;
         void set_filename(const std::string& filename) override;
         void set_level(const std::weak_ptr<ILevel>& level) override;

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -224,7 +224,8 @@ namespace trview
                     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
                     if (ImGui::Checkbox(std::format("##hide-{}", camera_sink->number()).c_str(), &hidden))
                     {
-                        on_camera_sink_visibility(camera_sink, !hidden);
+                        camera_sink->set_visible(!hidden);
+                        on_scene_changed();
                     }
                     ImGui::PopStyleVar();
                 }
@@ -270,13 +271,13 @@ namespace trview
                 if (ImGui::Selectable("Camera##type", &camera_selected))
                 {
                     selected->set_type(ICameraSink::Type::Camera);
-                    on_camera_sink_type_changed();
+                    on_scene_changed();
                 }
                 bool sink_selected = selected->type() == ICameraSink::Type::Sink;
                 if (ImGui::Selectable("Sink##type", &sink_selected))
                 {
                     selected->set_type(ICameraSink::Type::Sink);
-                    on_camera_sink_type_changed();
+                    on_scene_changed();
                 }
                 ImGui::EndCombo();
             }

--- a/trview.app/Windows/CameraSink/CameraSinkWindowManager.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindowManager.cpp
@@ -20,9 +20,9 @@ namespace trview
         window->set_selected_camera_sink(_selected_camera_sink);
         window->set_current_room(_current_room);
         window->on_camera_sink_selected += on_camera_sink_selected;
-        window->on_camera_sink_visibility += on_camera_sink_visibility;
         window->on_trigger_selected += on_trigger_selected;
-        window->on_camera_sink_type_changed += on_camera_sink_type_changed;
+        window->on_scene_changed += on_scene_changed;
+        
         return add_window(window);
     }
 

--- a/trview.app/Windows/CameraSink/ICameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/ICameraSinkWindow.h
@@ -21,8 +21,7 @@ namespace trview
         Event<> on_window_closed;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
-        Event<std::weak_ptr<ICameraSink>, bool> on_camera_sink_visibility;
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
-        Event<> on_camera_sink_type_changed;
+        Event<> on_scene_changed;
     };
 }

--- a/trview.app/Windows/CameraSink/ICameraSinkWindowManager.h
+++ b/trview.app/Windows/CameraSink/ICameraSinkWindowManager.h
@@ -15,8 +15,7 @@ namespace trview
         virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
-        Event<std::weak_ptr<ICameraSink>, bool> on_camera_sink_visibility;
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
-        Event<> on_camera_sink_type_changed;
+        Event<> on_scene_changed;
     };
 }

--- a/trview.app/Windows/IItemsWindow.h
+++ b/trview.app/Windows/IItemsWindow.h
@@ -17,8 +17,7 @@ namespace trview
         /// Event raised when an item is selected in the list.
         Event<std::weak_ptr<IItem>> on_item_selected;
 
-        /// Event raised when an item visibility is changed.
-        Event<std::weak_ptr<IItem>, bool> on_item_visibility;
+        Event<> on_scene_changed;
 
         /// Event raised when a trigger is selected in the list.
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;

--- a/trview.app/Windows/IItemsWindowManager.h
+++ b/trview.app/Windows/IItemsWindowManager.h
@@ -12,7 +12,7 @@ namespace trview
         /// Event raised when an item is selected in one of the item windows.
         Event<std::weak_ptr<IItem>> on_item_selected;
 
-        Event<std::weak_ptr<IItem>, bool> on_item_visibility;
+        Event<> on_scene_changed;
 
         /// Event raised when a trigger is selected in one of the item windows.
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;

--- a/trview.app/Windows/ILightsWindow.h
+++ b/trview.app/Windows/ILightsWindow.h
@@ -26,9 +26,6 @@ namespace trview
         /// Event raised when a light is selected in the list.
         /// </summary>
         Event<std::weak_ptr<ILight>> on_light_selected;
-        /// <summary>
-        /// Event raised when the visibility of a light is changed.
-        /// </summary>
-        Event<std::weak_ptr<ILight>, bool> on_light_visibility;
+        Event<> on_scene_changed;
     };
 }

--- a/trview.app/Windows/ILightsWindowManager.h
+++ b/trview.app/Windows/ILightsWindowManager.h
@@ -19,6 +19,6 @@ namespace trview
         virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
 
         Event<std::weak_ptr<ILight>> on_light_selected;
-        Event<std::weak_ptr<ILight>, bool> on_light_visibility;
+        Event<> on_scene_changed;
     };
 }

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -29,7 +29,7 @@ namespace trview
         /// Event raised when the window is closed.
         Event<> on_window_closed;
 
-        Event<std::weak_ptr<IRoom>, bool> on_room_visibility;
+        Event<> on_scene_changed;
 
         Event<std::weak_ptr<ISector>> on_sector_hover;
 

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -17,7 +17,7 @@ namespace trview
         /// Event raised when the user has selected a trigger in the room window.
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
-        Event<std::weak_ptr<IRoom>, bool> on_room_visibility;
+        Event<> on_scene_changed;
 
         Event<std::weak_ptr<ISector>> on_sector_hover;
         Event<std::weak_ptr<ILight>> on_light_selected;

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -35,9 +35,6 @@ namespace trview
         /// Event raised when a route is exported.
         Event<> on_route_save_as;
 
-        /// Event raised when a waypoint is deleted.
-        Event<uint32_t> on_waypoint_deleted;
-
         /// Event raised when the window is closed.
         Event<> on_window_closed;
 

--- a/trview.app/Windows/IRouteWindow.h
+++ b/trview.app/Windows/IRouteWindow.h
@@ -16,7 +16,7 @@ namespace trview
         virtual ~IRouteWindow() = 0;
 
         /// Event raised when a waypoint is selected.
-        Event<uint32_t> on_waypoint_selected;
+        Event<std::weak_ptr<IWaypoint>> on_waypoint_selected;
 
         /// Event raised when an item is selected.
         Event<std::weak_ptr<IItem>> on_item_selected;
@@ -24,20 +24,7 @@ namespace trview
         /// Event raised when a trigger is selected.
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
-        /// Event raised when the route colour has been changed.
-        Event<Colour> on_colour_changed;
-
-        /// <summary>
-        /// Event raised when the route stick colour has been changed.
-        /// </summary>
-        Event<Colour> on_waypoint_colour_changed;
-
-        Event<> on_waypoint_changed;
-
-        /// <summary>
-        /// Event raised when a waypoint has moved from one index to another.
-        /// </summary>
-        Event<int32_t, int32_t> on_waypoint_reordered;
+        Event<> on_scene_changed;
 
         /// Event raised when a route file is opened.
         Event<> on_route_open;
@@ -58,7 +45,6 @@ namespace trview
 
         Event<> on_new_route;
         Event<> on_new_randomizer_route;
-        Event<std::string, std::string> on_level_reordered;
 
         /// Render the window.
         virtual void render() = 0;
@@ -68,8 +54,7 @@ namespace trview
         virtual void set_route(const std::weak_ptr<IRoute>& route) = 0;
 
         /// Select the specified waypoint.
-        /// @param index The index of the waypoint to select.
-        virtual void select_waypoint(uint32_t index) = 0;
+        virtual void select_waypoint(const std::weak_ptr<IWaypoint>& waypoint) = 0;
 
         /// Set the items to that are in the level.
         /// @param items The items to show.

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -9,9 +9,6 @@ namespace trview
     {
         virtual ~IRouteWindowManager() = 0;
 
-        /// Event raised when the route colour has changed.
-        Event<Colour> on_colour_changed;
-
         /// Event raised when a route is imported.
         Event<> on_route_open;
 
@@ -21,13 +18,8 @@ namespace trview
         /// Event raised when a route is exported.
         Event<> on_route_save_as;
 
-        /// <summary>
-        /// Event raised when the route stick colour has changed.
-        /// </summary>
-        Event<Colour> on_waypoint_colour_changed;
-
         /// Event raised when a waypoint is selected.
-        Event<uint32_t> on_waypoint_selected;
+        Event<std::weak_ptr<IWaypoint>> on_waypoint_selected;
 
         /// Event raised when an item is selected.
         Event<std::weak_ptr<IItem>> on_item_selected;
@@ -38,7 +30,7 @@ namespace trview
         /// Event raised when a waypoint is deleted.
         Event<uint32_t> on_waypoint_deleted;
 
-        Event<> on_waypoint_changed;
+        Event<> on_scene_changed;
 
         /// <summary>
         /// Event raised when a waypoint has moved from one index to another.
@@ -72,7 +64,7 @@ namespace trview
         /// @param triggers The triggers.
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
 
-        virtual void select_waypoint(uint32_t index) = 0;
+        virtual void select_waypoint(const std::weak_ptr<IWaypoint>& waypoint) = 0;
         /// <summary>
         /// Update the windows.
         /// </summary>

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -32,11 +32,6 @@ namespace trview
 
         Event<> on_scene_changed;
 
-        /// <summary>
-        /// Event raised when a waypoint has moved from one index to another.
-        /// </summary>
-        Event<int32_t, int32_t> on_waypoint_reordered;
-
         Event<> on_window_created;
 
         Event<std::string> on_level_switch;

--- a/trview.app/Windows/IRouteWindowManager.h
+++ b/trview.app/Windows/IRouteWindowManager.h
@@ -27,9 +27,6 @@ namespace trview
         /// Event raised when a trigger is selected.
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
-        /// Event raised when a waypoint is deleted.
-        Event<uint32_t> on_waypoint_deleted;
-
         Event<> on_scene_changed;
 
         Event<> on_window_created;

--- a/trview.app/Windows/ITriggersWindow.h
+++ b/trview.app/Windows/ITriggersWindow.h
@@ -4,6 +4,7 @@
 #include <trview.common/Event.h>
 #include "../Elements/IItem.h"
 #include "../Elements/ITrigger.h"
+#include "../Elements/CameraSink/ICameraSink.h"
 
 namespace trview
 {
@@ -16,8 +17,7 @@ namespace trview
         /// Event raised when a trigger is selected in the list.
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
 
-        /// Event raised when the visibility of a trigger is changed.
-        Event<std::weak_ptr<ITrigger>, bool> on_trigger_visibility;
+        Event<> on_scene_changed;
 
         /// Event raised when an item is selected in the list.
         Event<std::weak_ptr<IItem>> on_item_selected;
@@ -31,7 +31,7 @@ namespace trview
         /// <summary>
         /// Event raised when a camera/sinkm is selected in the list.
         /// </summary>
-        Event<uint32_t> on_camera_sink_selected;
+        Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
 
         /// Clear the currently selected trigger from the details panel.
         virtual void clear_selected_trigger() = 0;

--- a/trview.app/Windows/ITriggersWindowManager.h
+++ b/trview.app/Windows/ITriggersWindowManager.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "TriggersWindow.h"
+#include "ITriggersWindow.h"
 
 namespace trview
 {
@@ -11,7 +11,7 @@ namespace trview
         /// Event raised when an item is selected in one of the trigger windows.
         Event<std::weak_ptr<IItem>> on_item_selected;
 
-        Event<std::weak_ptr<ITrigger>, bool> on_trigger_visibility;
+        Event<> on_scene_changed;
 
         /// Event raised when a trigger is selected in one of the trigger windows.
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
@@ -19,7 +19,7 @@ namespace trview
         /// Event raised when the 'add to route' button is pressed in one of the trigger windows.
         Event<std::weak_ptr<ITrigger>> on_add_to_route;
 
-        Event<uint32_t> on_camera_sink_selected;
+        Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
 
         /// Render all of the triggers windows.
         virtual void render() = 0;

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -70,7 +70,7 @@ namespace trview
         Event<std::weak_ptr<ICameraSink>, bool> on_camera_sink_visibility;
 
         /// Event raised when the viewer wants to select a waypoint.
-        Event<uint32_t> on_waypoint_selected;
+        Event<std::weak_ptr<IWaypoint>> on_waypoint_selected;
 
         /// Event raised when the viewer wants to remove a waypoint.
         Event<uint32_t> on_waypoint_removed;

--- a/trview.app/Windows/IWindows.h
+++ b/trview.app/Windows/IWindows.h
@@ -20,6 +20,7 @@ namespace trview
     struct IWindows
     {
         virtual ~IWindows() = 0;
+        virtual bool is_route_window_open() const = 0;
         virtual void update(float elapsed) = 0;
         virtual void render() = 0;
         virtual void select(const std::weak_ptr<ICameraSink>& camera_sink) = 0;

--- a/trview.app/Windows/IWindows.h
+++ b/trview.app/Windows/IWindows.h
@@ -10,9 +10,11 @@ namespace trview
     struct ILevel;
     struct ILight;
     struct IRoom;
+    struct IRoute;
     struct ISector;
     struct IStaticMesh;
     struct ITrigger;
+    struct IWaypoint;
     struct UserSettings;
 
     struct IWindows
@@ -25,18 +27,29 @@ namespace trview
         virtual void select(const std::weak_ptr<ILight>& light) = 0;
         virtual void select(const std::weak_ptr<IStaticMesh>& static_mesh) = 0;
         virtual void select(const std::weak_ptr<ITrigger>& trigger) = 0;
+        virtual void select(const std::weak_ptr<IWaypoint>& waypoint) = 0;
         virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
         virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
+        virtual void set_route(const std::weak_ptr<IRoute>& route) = 0;
         virtual void set_settings(const UserSettings& settings) = 0;
         virtual void setup(const UserSettings& settings) = 0;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
         Event<std::weak_ptr<IItem>> on_item_selected;
+        Event<std::string> on_level_switch;
         Event<std::weak_ptr<ILight>> on_light_selected;
+        Event<> on_new_route;
+        Event<> on_new_randomizer_route;
         Event<std::weak_ptr<IRoom>> on_room_selected;
+        Event<> on_route_open;
+        Event<> on_route_reload;
+        Event<> on_route_save;
+        Event<> on_route_save_as;
         Event<std::weak_ptr<ISector>> on_sector_hover;
         Event<std::weak_ptr<IStaticMesh>> on_static_selected;
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
+        Event<std::weak_ptr<IWaypoint>> on_waypoint_selected;
+        Event<> on_route_window_created;
         Event<> on_scene_changed;
     };
 }

--- a/trview.app/Windows/IWindows.h
+++ b/trview.app/Windows/IWindows.h
@@ -5,9 +5,11 @@
 
 namespace trview
 {
+    struct ICameraSink;
     struct ILevel;
     struct IRoom;
     struct IStaticMesh;
+    struct ITrigger;
     struct UserSettings;
 
     struct IWindows
@@ -15,10 +17,15 @@ namespace trview
         virtual ~IWindows() = 0;
         virtual void update(float elapsed) = 0;
         virtual void render() = 0;
+        virtual void select(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
         virtual void select(const std::weak_ptr<IStaticMesh>& static_mesh) = 0;
         virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
         virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
         virtual void setup(const UserSettings& settings) = 0;
+
+        Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
         Event<std::weak_ptr<IStaticMesh>> on_static_selected;
+        Event<std::weak_ptr<ITrigger>> on_trigger_selected;
+        Event<> on_scene_changed;
     };
 }

--- a/trview.app/Windows/IWindows.h
+++ b/trview.app/Windows/IWindows.h
@@ -6,6 +6,7 @@
 namespace trview
 {
     struct ICameraSink;
+    struct IItem;
     struct ILevel;
     struct IRoom;
     struct IStaticMesh;
@@ -18,12 +19,17 @@ namespace trview
         virtual void update(float elapsed) = 0;
         virtual void render() = 0;
         virtual void select(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
+        virtual void select(const std::weak_ptr<IItem>& item) = 0;
+        virtual void select(const std::weak_ptr<ILight>& light) = 0;
         virtual void select(const std::weak_ptr<IStaticMesh>& static_mesh) = 0;
+        virtual void select(const std::weak_ptr<ITrigger>& trigger) = 0;
         virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
         virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
         virtual void setup(const UserSettings& settings) = 0;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
+        Event<std::weak_ptr<IItem>> on_item_selected;
+        Event<std::weak_ptr<ILight>> on_light_selected;
         Event<std::weak_ptr<IStaticMesh>> on_static_selected;
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
         Event<> on_scene_changed;

--- a/trview.app/Windows/IWindows.h
+++ b/trview.app/Windows/IWindows.h
@@ -8,7 +8,9 @@ namespace trview
     struct ICameraSink;
     struct IItem;
     struct ILevel;
+    struct ILight;
     struct IRoom;
+    struct ISector;
     struct IStaticMesh;
     struct ITrigger;
     struct UserSettings;
@@ -25,11 +27,14 @@ namespace trview
         virtual void select(const std::weak_ptr<ITrigger>& trigger) = 0;
         virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
         virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
+        virtual void set_settings(const UserSettings& settings) = 0;
         virtual void setup(const UserSettings& settings) = 0;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
         Event<std::weak_ptr<IItem>> on_item_selected;
         Event<std::weak_ptr<ILight>> on_light_selected;
+        Event<std::weak_ptr<IRoom>> on_room_selected;
+        Event<std::weak_ptr<ISector>> on_sector_hover;
         Event<std::weak_ptr<IStaticMesh>> on_static_selected;
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
         Event<> on_scene_changed;

--- a/trview.app/Windows/IWindows.h
+++ b/trview.app/Windows/IWindows.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <memory>
+#include <trview.common/Event.h>
+
+namespace trview
+{
+    struct ILevel;
+    struct IRoom;
+    struct IStaticMesh;
+    struct UserSettings;
+
+    struct IWindows
+    {
+        virtual ~IWindows() = 0;
+        virtual void update(float elapsed) = 0;
+        virtual void render() = 0;
+        virtual void select(const std::weak_ptr<IStaticMesh>& static_mesh) = 0;
+        virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
+        virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
+        virtual void setup(const UserSettings& settings) = 0;
+        Event<std::weak_ptr<IStaticMesh>> on_static_selected;
+    };
+}

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -183,7 +183,8 @@ namespace trview
                     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
                     if (ImGui::Checkbox(std::format("##hide-{}", item_ptr->number()).c_str(), &hidden))
                     {
-                        on_item_visibility(item, !hidden);
+                        item_ptr->set_visible(!hidden);
+                        on_scene_changed();
                     }
                     ImGui::PopStyleVar();
                 }

--- a/trview.app/Windows/ItemsWindowManager.cpp
+++ b/trview.app/Windows/ItemsWindowManager.cpp
@@ -31,7 +31,7 @@ namespace trview
     {
         auto items_window = _items_window_source();
         items_window->on_item_selected += on_item_selected;
-        items_window->on_item_visibility += on_item_visibility;
+        items_window->on_scene_changed += on_scene_changed;
         items_window->on_trigger_selected += on_trigger_selected;
         items_window->on_add_to_route += on_add_to_route;
         items_window->set_items(_items);

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -155,7 +155,8 @@ namespace trview
                     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
                     if (ImGui::Checkbox(std::format("##hide-{}", light->number()).c_str(), &hidden))
                     {
-                        on_light_visibility(light, !hidden);
+                        light->set_visible(!hidden);
+                        on_scene_changed();
                     }
                     ImGui::PopStyleVar();
                 }

--- a/trview.app/Windows/LightsWindowManager.cpp
+++ b/trview.app/Windows/LightsWindowManager.cpp
@@ -50,7 +50,7 @@ namespace trview
         lights_window->set_selected_light(_selected_light);
         lights_window->set_current_room(_current_room);
         lights_window->on_light_selected += on_light_selected;
-        lights_window->on_light_visibility += on_light_visibility;
+        lights_window->on_scene_changed += on_scene_changed;
         return add_window(lights_window);
     }
 

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -374,7 +374,8 @@ namespace trview
                     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
                     if (ImGui::Checkbox(std::format("##hide-{}", room_ptr->number()).c_str(), &hidden))
                     {
-                        on_room_visibility(room, !hidden);
+                        room_ptr->set_visible(!hidden);
+                        on_scene_changed();
                     }
                     ImGui::PopStyleVar();
                 }

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -102,7 +102,7 @@ namespace trview
         rooms_window->on_room_selected += on_room_selected;
         rooms_window->on_item_selected += on_item_selected;
         rooms_window->on_trigger_selected += on_trigger_selected;
-        rooms_window->on_room_visibility += on_room_visibility;
+        rooms_window->on_scene_changed += on_scene_changed;
         rooms_window->on_sector_hover += on_sector_hover;
         rooms_window->on_light_selected += on_light_selected;
         rooms_window->on_camera_sink_selected += on_camera_sink_selected;

--- a/trview.app/Windows/RouteWindow.h
+++ b/trview.app/Windows/RouteWindow.h
@@ -36,7 +36,7 @@ namespace trview
         virtual ~RouteWindow() = default;
         virtual void render() override;
         virtual void set_route(const std::weak_ptr<IRoute>& route) override;
-        virtual void select_waypoint(uint32_t index) override;
+        void select_waypoint(const std::weak_ptr<IWaypoint>& waypoint) override;
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) override;
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& rooms) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
@@ -57,7 +57,7 @@ namespace trview
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;
         IWaypoint::Type _selected_type{ IWaypoint::Type::Position };
-        uint32_t       _selected_index{ 0u };
+        std::weak_ptr<IWaypoint> _selected_waypoint;
         std::shared_ptr<IClipboard> _clipboard;
         std::shared_ptr<IDialogs> _dialogs;
         std::shared_ptr<IFiles> _files;

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -40,7 +40,6 @@ namespace trview
         _route_window->on_item_selected += on_item_selected;
         _route_window->on_trigger_selected += on_trigger_selected;
         _route_window->on_waypoint_selected += on_waypoint_selected;
-        _route_window->on_waypoint_deleted += on_waypoint_deleted;
         _route_window->on_scene_changed += on_scene_changed;
         _route_window->on_level_switch += on_level_switch;
         _route_window->on_new_route += on_new_route;

--- a/trview.app/Windows/RouteWindowManager.cpp
+++ b/trview.app/Windows/RouteWindowManager.cpp
@@ -33,22 +33,18 @@ namespace trview
 
         // Otherwise create the window.
         _route_window = _route_window_source();
-        _route_window->on_colour_changed += on_colour_changed;
         _route_window->on_route_open += on_route_open;
         _route_window->on_route_reload += on_route_reload;
         _route_window->on_route_save += on_route_save;
         _route_window->on_route_save_as += on_route_save_as;
         _route_window->on_item_selected += on_item_selected;
-        _route_window->on_waypoint_colour_changed += on_waypoint_colour_changed;
         _route_window->on_trigger_selected += on_trigger_selected;
         _route_window->on_waypoint_selected += on_waypoint_selected;
         _route_window->on_waypoint_deleted += on_waypoint_deleted;
-        _route_window->on_waypoint_reordered += on_waypoint_reordered;
-        _route_window->on_waypoint_changed += on_waypoint_changed;
+        _route_window->on_scene_changed += on_scene_changed;
         _route_window->on_level_switch += on_level_switch;
         _route_window->on_new_route += on_new_route;
         _route_window->on_new_randomizer_route += on_new_randomizer_route;
-        _route_window->on_level_reordered += on_level_reordered;
         _token_store += _route_window->on_window_closed += [&]() { _closing = true; };
 
         _route_window->set_randomizer_settings(_randomizer_settings);
@@ -112,13 +108,12 @@ namespace trview
         }
     }
 
-    void RouteWindowManager::select_waypoint(uint32_t index)
+    void RouteWindowManager::select_waypoint(const std::weak_ptr<IWaypoint>& waypoint)
     {
-        _selected_waypoint = index;
-
+        _selected_waypoint = waypoint;
         if (_route_window)
         {
-            _route_window->select_waypoint(index);
+            _route_window->select_waypoint(waypoint);
         }
     }
 

--- a/trview.app/Windows/RouteWindowManager.h
+++ b/trview.app/Windows/RouteWindowManager.h
@@ -20,7 +20,7 @@ namespace trview
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) override;
         virtual void set_rooms(const std::vector<std::weak_ptr<IRoom>>& rooms) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
-        virtual void select_waypoint(uint32_t index) override;
+        void select_waypoint(const std::weak_ptr<IWaypoint>& waypoint) override;
         virtual void update(float delta) override;
         virtual void set_randomizer_enabled(bool value) override;
         virtual void set_randomizer_settings(const RandomizerSettings& settings) override;
@@ -33,7 +33,7 @@ namespace trview
         std::vector<std::weak_ptr<IItem>> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
         std::vector<std::weak_ptr<ITrigger>> _all_triggers;
-        uint32_t _selected_waypoint{ 0u };
+        std::weak_ptr<IWaypoint> _selected_waypoint;
         IRouteWindow::Source _route_window_source;
         bool _randomizer_enabled{ false };
         RandomizerSettings _randomizer_settings;

--- a/trview.app/Windows/TriggersWindowManager.cpp
+++ b/trview.app/Windows/TriggersWindowManager.cpp
@@ -32,7 +32,7 @@ namespace trview
         auto triggers_window = _triggers_window_source();
         triggers_window->on_item_selected += on_item_selected;
         triggers_window->on_trigger_selected += on_trigger_selected;
-        triggers_window->on_trigger_visibility += on_trigger_visibility;
+        triggers_window->on_scene_changed += on_scene_changed;
         triggers_window->on_add_to_route += on_add_to_route;
         triggers_window->on_camera_sink_selected += on_camera_sink_selected;
         triggers_window->set_items(_items);

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1323,7 +1323,7 @@ namespace trview
         }
         case PickResult::Type::Waypoint:
         {
-            if (level)
+            if (_route)
             {
                 on_waypoint_selected(_route->waypoint(pick.index));
             }

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1325,7 +1325,7 @@ namespace trview
         {
             if (level)
             {
-                on_waypoint_selected(pick.index);
+                on_waypoint_selected(_route->waypoint(pick.index));
             }
             break;
         }

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -21,7 +21,7 @@ namespace trview
     {
         _camera_sink_windows->on_camera_sink_selected += on_camera_sink_selected;
         _camera_sink_windows->on_trigger_selected += on_trigger_selected;
-        _camera_sink_windows->on_camera_sink_type_changed += on_scene_changed;
+        _camera_sink_windows->on_scene_changed += on_scene_changed;
 
         _statics_windows->on_static_selected += on_static_selected;
     }

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -3,6 +3,7 @@
 #include "Elements/IRoom.h"
 #include "Settings/UserSettings.h"
 
+#include "CameraSink/ICameraSinkWindowManager.h"
 #include "Plugins/IPluginsWindowManager.h"
 #include "Statics/IStaticsWindowManager.h"
 
@@ -13,10 +14,15 @@ namespace trview
     }
 
     Windows::Windows(
+        std::unique_ptr<ICameraSinkWindowManager> camera_sink_windows,
         std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
         std::unique_ptr<IStaticsWindowManager> statics_window_manager)
-        : _plugins_windows(std::move(plugins_window_manager)), _statics_windows(std::move(statics_window_manager))
+        : _camera_sink_windows(std::move(camera_sink_windows)), _plugins_windows(std::move(plugins_window_manager)), _statics_windows(std::move(statics_window_manager))
     {
+        _camera_sink_windows->on_camera_sink_selected += on_camera_sink_selected;
+        _camera_sink_windows->on_trigger_selected += on_trigger_selected;
+        _camera_sink_windows->on_camera_sink_type_changed += on_scene_changed;
+
         _statics_windows->on_static_selected += on_static_selected;
     }
 
@@ -28,8 +34,14 @@ namespace trview
 
     void Windows::render()
     {
+        _camera_sink_windows->render();
         _plugins_windows->render();
         _statics_windows->render();
+    }
+
+    void Windows::select(const std::weak_ptr<ICameraSink>& camera_sink)
+    {
+        _camera_sink_windows->set_selected_camera_sink(camera_sink);
     }
 
     void Windows::select(const std::weak_ptr<IStaticMesh>& static_mesh)
@@ -41,6 +53,7 @@ namespace trview
     {
         if (auto new_level = level.lock())
         {
+            _camera_sink_windows->set_camera_sinks(new_level->camera_sinks());
             _statics_windows->set_statics(new_level->static_meshes());
         }
         else
@@ -51,11 +64,17 @@ namespace trview
 
     void Windows::set_room(const std::weak_ptr<IRoom>& room)
     {
+        _camera_sink_windows->set_room(room);
         _statics_windows->set_room(room);
     }
 
     void Windows::setup(const UserSettings& settings)
     {
+        if (settings.camera_sink_startup)
+        {
+            _camera_sink_windows->create_window();
+        }
+
         if (settings.statics_startup)
         {
             _statics_windows->create_window();

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -162,31 +162,30 @@ namespace trview
 
     void Windows::set_level(const std::weak_ptr<ILevel>& level)
     {
-        if (auto new_level = level.lock())
+        const auto new_level = level.lock();
+        if (!new_level)
         {
-            _camera_sink_windows->set_camera_sinks(new_level->camera_sinks());
-            _items_windows->set_items(new_level->items());
-            _items_windows->set_triggers(new_level->triggers());
-            _items_windows->set_level_version(new_level->version());
-            _items_windows->set_model_checker([=](uint32_t id) { return new_level->has_model(id); });
-            _lights_windows->set_level_version(new_level->version());
-            _lights_windows->set_lights(new_level->lights());
-            _rooms_windows->set_level_version(new_level->version());
-            _rooms_windows->set_items(new_level->items());
-            _rooms_windows->set_floordata(new_level->floor_data());
-            _rooms_windows->set_rooms(new_level->rooms());
-            _route_window->set_items(new_level->items());
-            _route_window->set_triggers(new_level->triggers());
-            _route_window->set_rooms(new_level->rooms());
-            _statics_windows->set_statics(new_level->static_meshes());
-            _triggers_windows->set_items(new_level->items());
-            _triggers_windows->set_triggers(new_level->triggers());
-            _textures_windows->set_texture_storage(new_level->texture_storage());
+            return;
         }
-        else
-        {
-            // TODO: Clear data?
-        }
+
+        _camera_sink_windows->set_camera_sinks(new_level->camera_sinks());
+        _items_windows->set_items(new_level->items());
+        _items_windows->set_triggers(new_level->triggers());
+        _items_windows->set_level_version(new_level->version());
+        _items_windows->set_model_checker([=](uint32_t id) { return new_level->has_model(id); });
+        _lights_windows->set_level_version(new_level->version());
+        _lights_windows->set_lights(new_level->lights());
+        _rooms_windows->set_level_version(new_level->version());
+        _rooms_windows->set_items(new_level->items());
+        _rooms_windows->set_floordata(new_level->floor_data());
+        _rooms_windows->set_rooms(new_level->rooms());
+        _route_window->set_items(new_level->items());
+        _route_window->set_triggers(new_level->triggers());
+        _route_window->set_rooms(new_level->rooms());
+        _statics_windows->set_statics(new_level->static_meshes());
+        _triggers_windows->set_items(new_level->items());
+        _triggers_windows->set_triggers(new_level->triggers());
+        _textures_windows->set_texture_storage(new_level->texture_storage());
     }
 
     void Windows::set_room(const std::weak_ptr<IRoom>& room)

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -1,0 +1,60 @@
+#include "Windows.h"
+#include "Elements/ILevel.h"
+#include "Elements/IRoom.h"
+#include "Settings/UserSettings.h"
+#include "Statics/IStaticsWindowManager.h"
+
+namespace trview
+{
+    IWindows::~IWindows()
+    {
+    }
+
+    Windows::Windows(std::unique_ptr<IStaticsWindowManager> statics_window_manager)
+        : _statics_windows(std::move(statics_window_manager))
+    {
+        _statics_windows->on_static_selected += on_static_selected;
+    }
+
+    void Windows::update(float elapsed)
+    {
+        _statics_windows->update(elapsed);
+    }
+
+    void Windows::render()
+    {
+        _statics_windows->render();
+    }
+
+    void Windows::select(const std::weak_ptr<IStaticMesh>& static_mesh)
+    {
+        _statics_windows->select_static(static_mesh);
+    }
+
+    void Windows::set_level(const std::weak_ptr<ILevel>& level)
+    {
+        if (auto new_level = level.lock())
+        {
+            _statics_windows->set_statics(new_level->static_meshes());
+        }
+        else
+        {
+            // TODO: Clear data?
+        }
+    }
+
+    void Windows::set_room(const std::weak_ptr<IRoom>& room)
+    {
+        _statics_windows->set_room(room);
+    }
+
+    void Windows::setup(const UserSettings& settings)
+    {
+        if (settings.statics_startup)
+        {
+            _statics_windows->create_window();
+        }
+    }
+}
+
+

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -2,6 +2,8 @@
 #include "Elements/ILevel.h"
 #include "Elements/IRoom.h"
 #include "Settings/UserSettings.h"
+
+#include "Plugins/IPluginsWindowManager.h"
 #include "Statics/IStaticsWindowManager.h"
 
 namespace trview
@@ -10,19 +12,23 @@ namespace trview
     {
     }
 
-    Windows::Windows(std::unique_ptr<IStaticsWindowManager> statics_window_manager)
-        : _statics_windows(std::move(statics_window_manager))
+    Windows::Windows(
+        std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
+        std::unique_ptr<IStaticsWindowManager> statics_window_manager)
+        : _plugins_windows(std::move(plugins_window_manager)), _statics_windows(std::move(statics_window_manager))
     {
         _statics_windows->on_static_selected += on_static_selected;
     }
 
     void Windows::update(float elapsed)
     {
+        _plugins_windows->update(elapsed);
         _statics_windows->update(elapsed);
     }
 
     void Windows::render()
     {
+        _plugins_windows->render();
         _statics_windows->render();
     }
 

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -4,12 +4,15 @@
 #include "Settings/UserSettings.h"
 
 #include "CameraSink/ICameraSinkWindowManager.h"
+#include "Console/IConsoleManager.h"
 #include "IItemsWindowManager.h"
 #include "ILightsWindowManager.h"
+#include "Log/ILogWindowManager.h"
 #include "Plugins/IPluginsWindowManager.h"
 #include "IRoomsWindowManager.h"
 #include "IRouteWindowManager.h"
 #include "Statics/IStaticsWindowManager.h"
+#include "Textures/ITexturesWindowManager.h"
 #include "ITriggersWindowManager.h"
 
 using namespace DirectX::SimpleMath;
@@ -22,16 +25,20 @@ namespace trview
 
     Windows::Windows(
         std::unique_ptr<ICameraSinkWindowManager> camera_sink_windows,
+        std::unique_ptr<IConsoleManager> console_manager,
         std::unique_ptr<IItemsWindowManager> items_window_manager,
         std::unique_ptr<ILightsWindowManager> lights_window_manager,
+        std::unique_ptr<ILogWindowManager> log_window_manager,
         std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
         std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
         std::unique_ptr<IRouteWindowManager> route_window_manager,
         std::unique_ptr<IStaticsWindowManager> statics_window_manager,
+        std::unique_ptr<ITexturesWindowManager> textures_window_manager,
         std::unique_ptr<ITriggersWindowManager> triggers_window_manager)
-        : _camera_sink_windows(std::move(camera_sink_windows)), _items_windows(std::move(items_window_manager)), _lights_windows(std::move(lights_window_manager)),
-        _plugins_windows(std::move(plugins_window_manager)), _rooms_windows(std::move(rooms_window_manager)), _route_window(std::move(route_window_manager)),
-        _statics_windows(std::move(statics_window_manager)), _triggers_windows(std::move(triggers_window_manager))
+        : _camera_sink_windows(std::move(camera_sink_windows)), _console_manager(std::move(console_manager)), _items_windows(std::move(items_window_manager)),
+        _lights_windows(std::move(lights_window_manager)), _log_windows(std::move(log_window_manager)), _plugins_windows(std::move(plugins_window_manager)),
+        _rooms_windows(std::move(rooms_window_manager)), _route_window(std::move(route_window_manager)), _statics_windows(std::move(statics_window_manager)),
+        _textures_windows(std::move(textures_window_manager)), _triggers_windows(std::move(triggers_window_manager))
     {
         _camera_sink_windows->on_camera_sink_selected += on_camera_sink_selected;
         _camera_sink_windows->on_trigger_selected += on_trigger_selected;
@@ -88,6 +95,11 @@ namespace trview
         _triggers_windows->on_scene_changed += on_scene_changed;
     }
 
+    bool Windows::is_route_window_open() const
+    {
+        return _route_window->is_window_open();
+    }
+
     void Windows::update(float elapsed)
     {
         _items_windows->update(elapsed);
@@ -102,12 +114,15 @@ namespace trview
     void Windows::render()
     {
         _camera_sink_windows->render();
+        _console_manager->render();
         _items_windows->render();
         _lights_windows->render();
+        _log_windows->render();
         _plugins_windows->render();
         _rooms_windows->render();
         _route_window->render();
         _statics_windows->render();
+        _textures_windows->render();
         _triggers_windows->render();
     }
 
@@ -166,6 +181,7 @@ namespace trview
             _statics_windows->set_statics(new_level->static_meshes());
             _triggers_windows->set_items(new_level->items());
             _triggers_windows->set_triggers(new_level->triggers());
+            _textures_windows->set_texture_storage(new_level->texture_storage());
         }
         else
         {

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -4,8 +4,11 @@
 #include "Settings/UserSettings.h"
 
 #include "CameraSink/ICameraSinkWindowManager.h"
+#include "IItemsWindowManager.h"
+#include "ILightsWindowManager.h"
 #include "Plugins/IPluginsWindowManager.h"
 #include "Statics/IStaticsWindowManager.h"
+#include "ITriggersWindowManager.h"
 
 namespace trview
 {
@@ -15,28 +18,52 @@ namespace trview
 
     Windows::Windows(
         std::unique_ptr<ICameraSinkWindowManager> camera_sink_windows,
+        std::unique_ptr<IItemsWindowManager> items_window_manager,
+        std::unique_ptr<ILightsWindowManager> lights_window_manager,
         std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
-        std::unique_ptr<IStaticsWindowManager> statics_window_manager)
-        : _camera_sink_windows(std::move(camera_sink_windows)), _plugins_windows(std::move(plugins_window_manager)), _statics_windows(std::move(statics_window_manager))
+        std::unique_ptr<IStaticsWindowManager> statics_window_manager,
+        std::unique_ptr<ITriggersWindowManager> triggers_window_manager)
+        : _camera_sink_windows(std::move(camera_sink_windows)), _items_windows(std::move(items_window_manager)), _lights_windows(std::move(lights_window_manager)),
+        _plugins_windows(std::move(plugins_window_manager)), _statics_windows(std::move(statics_window_manager)), _triggers_windows(std::move(triggers_window_manager))
     {
         _camera_sink_windows->on_camera_sink_selected += on_camera_sink_selected;
         _camera_sink_windows->on_trigger_selected += on_trigger_selected;
         _camera_sink_windows->on_scene_changed += on_scene_changed;
 
+        // _items_windows->on_add_to_route
+        _items_windows->on_item_selected += on_item_selected;
+        _items_windows->on_scene_changed += on_scene_changed;
+        _items_windows->on_trigger_selected += on_trigger_selected;
+
+        _lights_windows->on_light_selected += on_light_selected;
+        _lights_windows->on_scene_changed += on_scene_changed;
+
         _statics_windows->on_static_selected += on_static_selected;
+
+        _triggers_windows->on_item_selected += on_item_selected;
+        _triggers_windows->on_trigger_selected += on_trigger_selected;
+        // _triggers_windows->on_add_to_route
+        _triggers_windows->on_camera_sink_selected += on_camera_sink_selected;
+        _triggers_windows->on_scene_changed += on_scene_changed;
     }
 
     void Windows::update(float elapsed)
     {
+        _items_windows->update(elapsed);
+        _lights_windows->update(elapsed);
         _plugins_windows->update(elapsed);
         _statics_windows->update(elapsed);
+        _triggers_windows->update(elapsed);
     }
 
     void Windows::render()
     {
         _camera_sink_windows->render();
+        _items_windows->render();
+        _lights_windows->render();
         _plugins_windows->render();
         _statics_windows->render();
+        _triggers_windows->render();
     }
 
     void Windows::select(const std::weak_ptr<ICameraSink>& camera_sink)
@@ -44,9 +71,24 @@ namespace trview
         _camera_sink_windows->set_selected_camera_sink(camera_sink);
     }
 
+    void Windows::select(const std::weak_ptr<IItem>& item)
+    {
+        _items_windows->set_selected_item(item);
+    }
+
+    void Windows::select(const std::weak_ptr<ILight>& light)
+    {
+        _lights_windows->set_selected_light(light);
+    }
+
     void Windows::select(const std::weak_ptr<IStaticMesh>& static_mesh)
     {
         _statics_windows->select_static(static_mesh);
+    }
+
+    void Windows::select(const std::weak_ptr<ITrigger>& trigger)
+    {
+        _triggers_windows->set_selected_trigger(trigger);
     }
 
     void Windows::set_level(const std::weak_ptr<ILevel>& level)
@@ -54,7 +96,15 @@ namespace trview
         if (auto new_level = level.lock())
         {
             _camera_sink_windows->set_camera_sinks(new_level->camera_sinks());
+            _items_windows->set_items(new_level->items());
+            _items_windows->set_triggers(new_level->triggers());
+            _items_windows->set_level_version(new_level->version());
+            _items_windows->set_model_checker([=](uint32_t id) { return new_level->has_model(id); });
+            _lights_windows->set_level_version(new_level->version());
+            _lights_windows->set_lights(new_level->lights());
             _statics_windows->set_statics(new_level->static_meshes());
+            _triggers_windows->set_items(new_level->items());
+            _triggers_windows->set_triggers(new_level->triggers());
         }
         else
         {
@@ -65,7 +115,9 @@ namespace trview
     void Windows::set_room(const std::weak_ptr<IRoom>& room)
     {
         _camera_sink_windows->set_room(room);
+        _lights_windows->set_room(room);
         _statics_windows->set_room(room);
+        _triggers_windows->set_room(room);
     }
 
     void Windows::setup(const UserSettings& settings)
@@ -75,9 +127,19 @@ namespace trview
             _camera_sink_windows->create_window();
         }
 
+        if (settings.items_startup)
+        {
+            _items_windows->create_window();
+        }
+
         if (settings.statics_startup)
         {
             _statics_windows->create_window();
+        }
+
+        if (settings.triggers_startup)
+        {
+            _triggers_windows->create_window();
         }
     }
 }

--- a/trview.app/Windows/Windows.h
+++ b/trview.app/Windows/Windows.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "IWindows.h"
+
+namespace trview
+{
+    struct IStaticsWindowManager;
+
+    class Windows final : public IWindows
+    {
+    public:
+        explicit Windows(std::unique_ptr<IStaticsWindowManager> statics_window_manager);
+        virtual ~Windows() = default;
+        void update(float elapsed) override;
+        void render() override;
+        void select(const std::weak_ptr<IStaticMesh>& static_mesh) override;
+        void set_level(const std::weak_ptr<ILevel>& level) override;
+        void set_room(const std::weak_ptr<IRoom>& room) override;
+        void setup(const UserSettings& settings) override;
+    private:
+        std::unique_ptr<IStaticsWindowManager> _statics_windows;
+    };
+}

--- a/trview.app/Windows/Windows.h
+++ b/trview.app/Windows/Windows.h
@@ -8,12 +8,15 @@
 namespace trview
 {
     struct ICameraSinkWindowManager;
+    struct IConsoleManager;
     struct IItemsWindowManager;
     struct ILightsWindowManager;
+    struct ILogWindowManager;
     struct IPluginsWindowManager;
     struct IRoomsWindowManager;
     struct IRouteWindowManager;
     struct IStaticsWindowManager;
+    struct ITexturesWindowManager;
     struct ITriggersWindowManager;
 
     class Windows final : public IWindows
@@ -21,14 +24,18 @@ namespace trview
     public:
         explicit Windows(
             std::unique_ptr<ICameraSinkWindowManager> camera_sink_windows,
+            std::unique_ptr<IConsoleManager> console_manager,
             std::unique_ptr<IItemsWindowManager> items_window_manager,
             std::unique_ptr<ILightsWindowManager> lights_window_manager,
+            std::unique_ptr<ILogWindowManager> log_window_manager,
             std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
             std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
             std::unique_ptr<IRouteWindowManager> _route_window_manager,
             std::unique_ptr<IStaticsWindowManager> statics_window_manager,
+            std::unique_ptr<ITexturesWindowManager> textures_window_manager,
             std::unique_ptr<ITriggersWindowManager> triggers_window_manager);
         virtual ~Windows() = default;
+        bool is_route_window_open() const override;
         void update(float elapsed) override;
         void render() override;
         void select(const std::weak_ptr<ICameraSink>& camera_sink) override;
@@ -47,13 +54,16 @@ namespace trview
 
         TokenStore _token_store;
         std::unique_ptr<ICameraSinkWindowManager> _camera_sink_windows;
+        std::unique_ptr<IConsoleManager> _console_manager;
         std::unique_ptr<IItemsWindowManager> _items_windows;
         std::unique_ptr<ILightsWindowManager> _lights_windows;
+        std::unique_ptr<ILogWindowManager> _log_windows;
         std::unique_ptr<IPluginsWindowManager> _plugins_windows;
         std::unique_ptr<IRoomsWindowManager> _rooms_windows;
         std::weak_ptr<IRoute> _route;
         std::unique_ptr<IRouteWindowManager> _route_window;
         std::unique_ptr<IStaticsWindowManager> _statics_windows;
+        std::unique_ptr<ITexturesWindowManager> _textures_windows;
         std::unique_ptr<ITriggersWindowManager> _triggers_windows;
     };
 }

--- a/trview.app/Windows/Windows.h
+++ b/trview.app/Windows/Windows.h
@@ -4,6 +4,7 @@
 
 namespace trview
 {
+    struct ICameraSinkWindowManager;
     struct IPluginsWindowManager;
     struct IStaticsWindowManager;
 
@@ -11,16 +12,19 @@ namespace trview
     {
     public:
         explicit Windows(
+            std::unique_ptr<ICameraSinkWindowManager> camera_sink_windows,
             std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
             std::unique_ptr<IStaticsWindowManager> statics_window_manager);
         virtual ~Windows() = default;
         void update(float elapsed) override;
         void render() override;
+        void select(const std::weak_ptr<ICameraSink>& camera_sink) override;
         void select(const std::weak_ptr<IStaticMesh>& static_mesh) override;
         void set_level(const std::weak_ptr<ILevel>& level) override;
         void set_room(const std::weak_ptr<IRoom>& room) override;
         void setup(const UserSettings& settings) override;
     private:
+        std::unique_ptr<ICameraSinkWindowManager> _camera_sink_windows;
         std::unique_ptr<IPluginsWindowManager> _plugins_windows;
         std::unique_ptr<IStaticsWindowManager> _statics_windows;
     };

--- a/trview.app/Windows/Windows.h
+++ b/trview.app/Windows/Windows.h
@@ -4,12 +4,15 @@
 
 namespace trview
 {
+    struct IPluginsWindowManager;
     struct IStaticsWindowManager;
 
     class Windows final : public IWindows
     {
     public:
-        explicit Windows(std::unique_ptr<IStaticsWindowManager> statics_window_manager);
+        explicit Windows(
+            std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
+            std::unique_ptr<IStaticsWindowManager> statics_window_manager);
         virtual ~Windows() = default;
         void update(float elapsed) override;
         void render() override;
@@ -18,6 +21,7 @@ namespace trview
         void set_room(const std::weak_ptr<IRoom>& room) override;
         void setup(const UserSettings& settings) override;
     private:
+        std::unique_ptr<IPluginsWindowManager> _plugins_windows;
         std::unique_ptr<IStaticsWindowManager> _statics_windows;
     };
 }

--- a/trview.app/Windows/Windows.h
+++ b/trview.app/Windows/Windows.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <trview.common/TokenStore.h>
+#include "../Routing/IWaypoint.h"
+
 #include "IWindows.h"
 
 namespace trview
@@ -9,6 +12,7 @@ namespace trview
     struct ILightsWindowManager;
     struct IPluginsWindowManager;
     struct IRoomsWindowManager;
+    struct IRouteWindowManager;
     struct IStaticsWindowManager;
     struct ITriggersWindowManager;
 
@@ -21,6 +25,7 @@ namespace trview
             std::unique_ptr<ILightsWindowManager> lights_window_manager,
             std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
             std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
+            std::unique_ptr<IRouteWindowManager> _route_window_manager,
             std::unique_ptr<IStaticsWindowManager> statics_window_manager,
             std::unique_ptr<ITriggersWindowManager> triggers_window_manager);
         virtual ~Windows() = default;
@@ -31,16 +36,23 @@ namespace trview
         void select(const std::weak_ptr<ILight>& light) override;
         void select(const std::weak_ptr<IStaticMesh>& static_mesh) override;
         void select(const std::weak_ptr<ITrigger>& trigger) override;
+        void select(const std::weak_ptr<IWaypoint>& waypoint) override;
         void set_level(const std::weak_ptr<ILevel>& level) override;
         void set_room(const std::weak_ptr<IRoom>& room) override;
+        void set_route(const std::weak_ptr<IRoute>& route) override;
         void set_settings(const UserSettings& settings) override;
         void setup(const UserSettings& settings) override;
     private:
+        void add_waypoint(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, IWaypoint::Type type, uint32_t index);
+
+        TokenStore _token_store;
         std::unique_ptr<ICameraSinkWindowManager> _camera_sink_windows;
         std::unique_ptr<IItemsWindowManager> _items_windows;
         std::unique_ptr<ILightsWindowManager> _lights_windows;
         std::unique_ptr<IPluginsWindowManager> _plugins_windows;
         std::unique_ptr<IRoomsWindowManager> _rooms_windows;
+        std::weak_ptr<IRoute> _route;
+        std::unique_ptr<IRouteWindowManager> _route_window;
         std::unique_ptr<IStaticsWindowManager> _statics_windows;
         std::unique_ptr<ITriggersWindowManager> _triggers_windows;
     };

--- a/trview.app/Windows/Windows.h
+++ b/trview.app/Windows/Windows.h
@@ -5,27 +5,39 @@
 namespace trview
 {
     struct ICameraSinkWindowManager;
+    struct IItemsWindowManager;
+    struct ILightsWindowManager;
     struct IPluginsWindowManager;
     struct IStaticsWindowManager;
+    struct ITriggersWindowManager;
 
     class Windows final : public IWindows
     {
     public:
         explicit Windows(
             std::unique_ptr<ICameraSinkWindowManager> camera_sink_windows,
+            std::unique_ptr<IItemsWindowManager> items_window_manager,
+            std::unique_ptr<ILightsWindowManager> lights_window_manager,
             std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
-            std::unique_ptr<IStaticsWindowManager> statics_window_manager);
+            std::unique_ptr<IStaticsWindowManager> statics_window_manager,
+            std::unique_ptr<ITriggersWindowManager> triggers_window_manager);
         virtual ~Windows() = default;
         void update(float elapsed) override;
         void render() override;
         void select(const std::weak_ptr<ICameraSink>& camera_sink) override;
+        void select(const std::weak_ptr<IItem>& item) override;
+        void select(const std::weak_ptr<ILight>& light) override;
         void select(const std::weak_ptr<IStaticMesh>& static_mesh) override;
+        void select(const std::weak_ptr<ITrigger>& trigger) override;
         void set_level(const std::weak_ptr<ILevel>& level) override;
         void set_room(const std::weak_ptr<IRoom>& room) override;
         void setup(const UserSettings& settings) override;
     private:
         std::unique_ptr<ICameraSinkWindowManager> _camera_sink_windows;
+        std::unique_ptr<IItemsWindowManager> _items_windows;
+        std::unique_ptr<ILightsWindowManager> _lights_windows;
         std::unique_ptr<IPluginsWindowManager> _plugins_windows;
         std::unique_ptr<IStaticsWindowManager> _statics_windows;
+        std::unique_ptr<ITriggersWindowManager> _triggers_windows;
     };
 }

--- a/trview.app/Windows/Windows.h
+++ b/trview.app/Windows/Windows.h
@@ -8,6 +8,7 @@ namespace trview
     struct IItemsWindowManager;
     struct ILightsWindowManager;
     struct IPluginsWindowManager;
+    struct IRoomsWindowManager;
     struct IStaticsWindowManager;
     struct ITriggersWindowManager;
 
@@ -19,6 +20,7 @@ namespace trview
             std::unique_ptr<IItemsWindowManager> items_window_manager,
             std::unique_ptr<ILightsWindowManager> lights_window_manager,
             std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
+            std::unique_ptr<IRoomsWindowManager> rooms_window_manager,
             std::unique_ptr<IStaticsWindowManager> statics_window_manager,
             std::unique_ptr<ITriggersWindowManager> triggers_window_manager);
         virtual ~Windows() = default;
@@ -31,12 +33,14 @@ namespace trview
         void select(const std::weak_ptr<ITrigger>& trigger) override;
         void set_level(const std::weak_ptr<ILevel>& level) override;
         void set_room(const std::weak_ptr<IRoom>& room) override;
+        void set_settings(const UserSettings& settings) override;
         void setup(const UserSettings& settings) override;
     private:
         std::unique_ptr<ICameraSinkWindowManager> _camera_sink_windows;
         std::unique_ptr<IItemsWindowManager> _items_windows;
         std::unique_ptr<ILightsWindowManager> _lights_windows;
         std::unique_ptr<IPluginsWindowManager> _plugins_windows;
+        std::unique_ptr<IRoomsWindowManager> _rooms_windows;
         std::unique_ptr<IStaticsWindowManager> _statics_windows;
         std::unique_ptr<ITriggersWindowManager> _triggers_windows;
     };

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -75,9 +75,11 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Plugins\Plugin.cpp" />
     <ClCompile Include="Plugins\Plugins.cpp" />
     <ClCompile Include="Routing\RandomizerRoute.cpp" />
+    <ClCompile Include="Windows\Windows.cpp" />
     <ClInclude Include="Mocks\UI\IFonts.h" />
     <ClInclude Include="Mocks\Windows\IStaticsWindow.h" />
     <ClInclude Include="Mocks\Windows\IStaticsWindowManager.h" />
+    <ClInclude Include="Mocks\Windows\IWindows.h" />
     <ClInclude Include="Settings\FontSetting.h" />
     <ClCompile Include="trview_imgui.cpp" />
     <ClCompile Include="Lua\Lua.cpp" />
@@ -187,6 +189,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Windows\Console\ConsoleManager.h" />
     <ClInclude Include="Windows\Console\IConsole.h" />
     <ClInclude Include="Windows\Console\IConsoleManager.h" />
+    <ClInclude Include="Windows\Windows.h" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Application.h" />
@@ -371,6 +374,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Windows\ITriggersWindow.h" />
     <ClInclude Include="Windows\ITriggersWindowManager.h" />
     <ClInclude Include="Windows\IViewer.h" />
+    <ClInclude Include="Windows\IWindows.h" />
     <ClInclude Include="Windows\LightsWindow.h" />
     <ClInclude Include="Windows\LightsWindowManager.h" />
     <ClInclude Include="Windows\Log\ILogWindow.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -335,6 +335,9 @@
     <ClCompile Include="Windows\Statics\StaticsWindow.cpp">
       <Filter>Windows\Statics</Filter>
     </ClCompile>
+    <ClCompile Include="Windows\Windows.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -1085,6 +1088,15 @@
       <Filter>Mocks\Windows</Filter>
     </ClInclude>
     <ClInclude Include="Mocks\Windows\IStaticsWindowManager.h">
+      <Filter>Mocks\Windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Windows\IWindows.h">
+      <Filter>Windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Windows\Windows.h">
+      <Filter>Windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\Windows\IWindows.h">
       <Filter>Mocks\Windows</Filter>
     </ClInclude>
   </ItemGroup>

--- a/trview.tests.common/Event.h
+++ b/trview.tests.common/Event.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <trview.common/Event.h>
+
+namespace trview
+{
+    namespace tests
+    {
+        template <int index = 0, typename T>
+        inline auto capture(std::shared_ptr<T>& out)
+        {
+            return [&](auto... in) { out = std::get<index>(std::tie(in...)).lock(); };
+        }
+
+        template <int index = 0, typename T>
+        inline auto capture(T& out)
+        {
+            return [&](auto... in) { out = std::get<index>(std::tie(in...)); };
+        }
+
+        inline auto capture_called(bool& out)
+        {
+            return [&](auto&&...) { out = true; };
+        }
+    }
+}

--- a/trview.tests.common/trview.tests.common.vcxproj
+++ b/trview.tests.common/trview.tests.common.vcxproj
@@ -14,6 +14,7 @@
     <ClCompile Include="Window.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Event.h" />
     <ClInclude Include="Mocks.h" />
     <ClInclude Include="Mocks.hpp" />
     <ClInclude Include="Window.h" />

--- a/trview.tests.common/trview.tests.common.vcxproj.filters
+++ b/trview.tests.common/trview.tests.common.vcxproj.filters
@@ -4,6 +4,7 @@
     <ClInclude Include="Window.h" />
     <ClInclude Include="Mocks.h" />
     <ClInclude Include="Mocks.hpp" />
+    <ClInclude Include="Event.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Window.cpp" />


### PR DESCRIPTION
Move windows from `Application` to a separate class that links the common events on the window outputs to single outputs to be consumed (by `Application`). This should make it easier to add new windows without having to change `Application`.
This mostly works although routes have some special cases at the moment.
Removed some events such as events for changing colour of waypoints, type of camera sink etc - the windows now set them directly and just raise an event to say that something has changed.
Closes #1094 