### PR TITLE
Initial scriptables implementation

### DIFF
--- a/doc/lua/index.md
+++ b/doc/lua/index.md
@@ -11,6 +11,7 @@
 - [Level](level.md)
 - [Room](room.md)
 - [Route](route.md)
+- [Scriptable](scriptable.md)
 - [Sector](sector.md)
 - [Static_mesh](staticmesh.md)
 - [Trigger](trigger.md)

--- a/doc/lua/level.md
+++ b/doc/lua/level.md
@@ -18,3 +18,9 @@ The Level library provides information about the currently loaded Level in trvie
 | static_meshes | [StaticMesh](staticmesh.md)[] | R | All static meshes |
 | triggers | [Trigger](trigger.md)[] | R | All triggers |
 | version | number | R | The game number for which this level was made |
+
+# Functions
+
+| Name | Returns | Parameters | Description |
+| ---- | ------- | ---------- | ----------- |
+| add_scriptable | | [Scriptable](scriptable.md) | Add a scriptable to the level. Level does not own the scriptable. |

--- a/doc/lua/scriptable.md
+++ b/doc/lua/scriptable.md
@@ -9,7 +9,7 @@ The Scriptable library is used to create objects that are integrated into TRView
 | data | Any | RW | User (script) settable custom data storage |
 | notes | string | RW | Notes to appear in the viewer when visible |
 | on_click | `function()` | W | Function to call when user clicks on the scriptable in the viewer |
-| on_click | `function() -> string` | W | Function to call when user hovers over the scriptable |
+| on_tooltip | `function() -> string` | W | Function to call when user hovers over the scriptable |
 | position | [Vector3](vector3.md) | RW | Position in the level |
 
 # Non-Instance Functions

--- a/doc/lua/scriptable.md
+++ b/doc/lua/scriptable.md
@@ -1,0 +1,19 @@
+# Scriptable
+
+The Scriptable library is used to create objects that are integrated into TRView and can be customised by plugins.
+
+# Properties
+
+| Name | Type | Mode | Description |
+| ---- | ---- | ---- | ---- |
+| data | Any | RW | User (script) settable custom data storage |
+| notes | string | RW | Notes to appear in the viewer when visible |
+| on_click | `function()` | W | Function to call when user clicks on the scriptable in the viewer |
+| on_click | `function() -> string` | W | Function to call when user hovers over the scriptable |
+| position | [Vector3](vector3.md) | RW | Position in the level |
+
+# Non-Instance Functions
+
+| Name | Returns | Parameters | Description |
+| ---- | ------- | ---------- | ----------- |
+| new | [Scriptable](scriptable.md) | | Create a new Scriptable |

--- a/trview.app.tests/Lua/Lua_trviewTests.cpp
+++ b/trview.app.tests/Lua/Lua_trviewTests.cpp
@@ -6,6 +6,7 @@
 #include <external/lua/src/lauxlib.h>
 #include <trview.app/Mocks/Routing/IRoute.h>
 #include <trview.app/Mocks/Routing/IRandomizerRoute.h>
+#include <trview.app/Mocks/Lua/IScriptable.h>
 #include "Lua.h"
 
 using namespace trview;
@@ -26,6 +27,7 @@ TEST(Lua_trview, Level)
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
+        [](auto&&...) { return mock_shared<MockScriptable>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());
 
@@ -49,6 +51,7 @@ TEST(Lua_trview, RecentFiles)
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
+        [](auto&&...) { return mock_shared<MockScriptable>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());
 
@@ -72,6 +75,7 @@ TEST(Lua_trview, SetLevel)
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
+        [](auto&&...) { return mock_shared<MockScriptable>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());
 
@@ -93,6 +97,7 @@ TEST(Lua_trview, Route)
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
+        [](auto&&...) { return mock_shared<MockScriptable>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());
 
@@ -110,6 +115,7 @@ TEST(Lua_trview, SetRoute)
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
+        [](auto&&...) { return mock_shared<MockScriptable>(); },
         mock_shared<MockDialogs>(),
         mock_shared<MockFiles>());
 

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -35,6 +35,7 @@
 #include "Graphics/MeshStorage.h"
 #include "Graphics/SelectionRenderer.h"
 #include "Graphics/SectorHighlight.h"
+#include "Lua/Scriptable/Scriptable.h"
 #include "Menus/FileMenu.h"
 #include "Menus/UpdateChecker.h"
 #include "Routing/Waypoint.h"
@@ -281,13 +282,15 @@ namespace trview
                 return new_level;
             };
 
+        auto scriptable_source = [=](auto state) { return std::make_shared<Scriptable>(state, create_cube_mesh(mesh_source), texture_storage->coloured(Colour::White)); };
+
         auto dialogs = std::make_shared<Dialogs>(window);
         auto shell = std::make_shared<Shell>();
 
-        auto plugin_source = [=](auto&&... args) { return std::make_shared<Plugin>(files, std::make_unique<Lua>(route_source, randomizer_route_source, waypoint_source, dialogs, files), args...); };
+        auto plugin_source = [=](auto&&... args) { return std::make_shared<Plugin>(files, std::make_unique<Lua>(route_source, randomizer_route_source, waypoint_source, scriptable_source, dialogs, files), args...); };
         auto plugins = std::make_shared<Plugins>(
             files,
-            std::make_shared<Plugin>(std::make_unique<Lua>(route_source, randomizer_route_source, waypoint_source, dialogs, files), "Default", "trview", "Default Lua plugin for trview"),
+            std::make_shared<Plugin>(std::make_unique<Lua>(route_source, randomizer_route_source, waypoint_source, scriptable_source, dialogs, files), "Default", "trview", "Default Lua plugin for trview"),
             plugin_source,
             settings_loader->load_user_settings());
         auto plugins_window_source = [=]() { return std::make_shared<PluginsWindow>(plugins, shell); };

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -5,6 +5,7 @@
 #include "../Elements/ITrigger.h"
 #include "../Elements/IRoom.h"
 #include "../Elements/IStaticMesh.h"
+#include "../Lua/Scriptable/IScriptable.h"
 #include "IItem.h"
 #include <trview.app/Elements/ILight.h>
 #include "CameraSink/ICameraSink.h"
@@ -31,6 +32,7 @@ namespace trview
         };
 
         virtual ~ILevel() = 0;
+        virtual void add_scriptable(const std::shared_ptr<IScriptable>& scriptable) = 0;
         /// Gets whether the specified alternate group is active.
         /// @param group The group to check.
         /// @returns True if the group is active.
@@ -79,6 +81,7 @@ namespace trview
         // Returns the room with ID provided 
         virtual std::weak_ptr<IRoom> room(uint32_t id) const = 0;
         virtual std::vector<std::weak_ptr<IRoom>> rooms() const = 0;
+        virtual std::vector<std::weak_ptr<IScriptable>> scriptables() const = 0;
         virtual std::optional<uint32_t> selected_item() const = 0;
         virtual std::optional<uint32_t> selected_light() const = 0;
         virtual std::optional<uint32_t> selected_camera_sink() const = 0;

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -32,7 +32,7 @@ namespace trview
         };
 
         virtual ~ILevel() = 0;
-        virtual void add_scriptable(const std::shared_ptr<IScriptable>& scriptable) = 0;
+        virtual void add_scriptable(const std::weak_ptr<IScriptable>& scriptable) = 0;
         /// Gets whether the specified alternate group is active.
         /// @param group The group to check.
         /// @returns True if the group is active.

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -53,6 +53,7 @@ namespace trview
         virtual void render_transparency(const ICamera& camera) override;
         virtual void set_highlight_mode(RoomHighlightMode mode, bool enabled) override;
         virtual bool highlight_mode_enabled(RoomHighlightMode mode) const override;
+        std::vector<std::weak_ptr<IScriptable>> scriptables() const override;
         void set_selected_room(const std::weak_ptr<IRoom>& room) override;
         virtual void set_selected_item(uint32_t index) override;
         virtual void set_neighbour_depth(uint32_t depth) override;
@@ -115,6 +116,7 @@ namespace trview
             const trlevel::ILevel::LoadCallbacks callbacks);
         std::vector<std::weak_ptr<IStaticMesh>> static_meshes() const override;
         std::weak_ptr<IStaticMesh> static_mesh(uint32_t index) const override;
+        void add_scriptable(const std::shared_ptr<IScriptable>& scriptable) override;
     private:
         void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage);
         void generate_triggers(const ITrigger::Source& trigger_source);
@@ -207,6 +209,8 @@ namespace trview
         std::set<uint32_t> _models;
         TokenStore _token_store;
         std::string _name;
+
+        std::vector<std::shared_ptr<IScriptable>> _scriptables;
     };
 
     /// Find the first item with the type id specified.

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -116,7 +116,7 @@ namespace trview
             const trlevel::ILevel::LoadCallbacks callbacks);
         std::vector<std::weak_ptr<IStaticMesh>> static_meshes() const override;
         std::weak_ptr<IStaticMesh> static_mesh(uint32_t index) const override;
-        void add_scriptable(const std::shared_ptr<IScriptable>& scriptable) override;
+        void add_scriptable(const std::weak_ptr<IScriptable>& scriptable) override;
     private:
         void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage);
         void generate_triggers(const ITrigger::Source& trigger_source);
@@ -210,7 +210,7 @@ namespace trview
         TokenStore _token_store;
         std::string _name;
 
-        std::vector<std::shared_ptr<IScriptable>> _scriptables;
+        std::vector<std::weak_ptr<IScriptable>> _scriptables;
     };
 
     /// Find the first item with the type id specified.

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -11,7 +11,6 @@
 #include <trview.app/Geometry/ITransparencyBuffer.h>
 #include <trview.app/Graphics/ISelectionRenderer.h>
 #include <trview.app/Graphics/IMeshStorage.h>
-#include <trview.graphics/IRenderTarget.h>
 #include <trview.graphics/IBuffer.h>
 #include <trview.common/TokenStore.h>
 

--- a/trview.app/Geometry/PickResult.cpp
+++ b/trview.app/Geometry/PickResult.cpp
@@ -184,6 +184,14 @@ namespace trview
                 }
                 break;
             }
+            case PickResult::Type::Scriptable:
+            {
+                if (const auto scriptable = result.scriptable.lock())
+                {
+                    stream << scriptable->tooltip();
+                }
+                break;
+            }
         }
 
         return stream.str();

--- a/trview.app/Geometry/PickResult.h
+++ b/trview.app/Geometry/PickResult.h
@@ -8,6 +8,7 @@ namespace trview
     struct Colour;
     struct ILevel;
     struct IRoute;
+    struct IScriptable;
 
     struct PickResult
     {
@@ -21,7 +22,8 @@ namespace trview
             Compass,
             StaticMesh,
             Light,
-            CameraSink
+            CameraSink,
+            Scriptable
         };
 
         bool                         hit{ false };
@@ -34,6 +36,7 @@ namespace trview
         std::string                  text;
         bool                         override_centre{ false };
         Triangle                     triangle;
+        std::weak_ptr<IScriptable>   scriptable;
     };
 
     /// Convert the pick result to a display string.

--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -7,6 +7,7 @@
 #include "../Trigger/Lua_Trigger.h"
 #include "../Light/Lua_Light.h"
 #include "../StaticMesh/Lua_StaticMesh.h"
+#include "../../Scriptable/IScriptable.h"
 
 namespace trview
 {
@@ -14,19 +15,32 @@ namespace trview
     {
         namespace
         {
+            int level_addscriptable(lua_State* L)
+            {
+                auto level = lua::get_self<ILevel>(L);
+                auto scriptable = lua::get_self<IScriptable>(L, -1);
+                level->add_scriptable(scriptable);
+                return 0;
+            }
+
             int level_index(lua_State* L)
             {
                 auto level = lua::get_self<ILevel>(L);
 
                 const std::string key = lua_tostring(L, 2);
-                if (key == "cameras_and_sinks")
+                if (key == "add_scriptable")
                 {
-                    return push_list_p(L, level->camera_sinks(), create_camera_sink);
+                    lua_pushcfunction(L, level_addscriptable);
+                    return 1;
                 }
                 else if (key == "alternate_mode")
                 {
                     lua_pushboolean(L, level->alternate_mode());
                     return 1;
+                }
+                else if (key == "cameras_and_sinks")
+                {
+                    return push_list_p(L, level->camera_sinks(), create_camera_sink);
                 }
                 else if (key == "filename")
                 {

--- a/trview.app/Lua/Lua.cpp
+++ b/trview.app/Lua/Lua.cpp
@@ -68,8 +68,8 @@ namespace trview
     {
     }
 
-    Lua::Lua(const IRoute::Source& route_source, const IRandomizerRoute::Source& randomizer_route_source, const IWaypoint::Source& waypoint_source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files)
-        : _route_source(route_source), _randomizer_route_source(randomizer_route_source), _waypoint_source(waypoint_source), _dialogs(dialogs), _files(files)
+    Lua::Lua(const IRoute::Source& route_source, const IRandomizerRoute::Source& randomizer_route_source, const IWaypoint::Source& waypoint_source, const IScriptable::Source& scriptable_source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files)
+        : _route_source(route_source), _randomizer_route_source(randomizer_route_source), _waypoint_source(waypoint_source), _scriptable_source(scriptable_source), _dialogs(dialogs), _files(files)
     {
         create_state();
     }
@@ -125,7 +125,7 @@ namespace trview
         *userdata = this;
         lua_pushcclosure(L, dofile, 1);
         lua_setglobal(L, "dofile");
-        lua::trview_register(L, application, _route_source, _randomizer_route_source, _waypoint_source, _dialogs, _files);
+        lua::trview_register(L, application, _route_source, _randomizer_route_source, _waypoint_source, _scriptable_source, _dialogs, _files);
         lua::imgui_register(L);
     }
 

--- a/trview.app/Lua/Lua.h
+++ b/trview.app/Lua/Lua.h
@@ -11,6 +11,7 @@
 #include "../Routing/IRoute.h"
 #include "../Routing/IRandomizerRoute.h"
 #include "../Settings/UserSettings.h"
+#include "Scriptable/IScriptable.h"
 
 #include <trview.common/Windows/IDialogs.h>
 #include <trview.common/IFiles.h>
@@ -22,7 +23,11 @@ namespace trview
     class Lua final : public ILua
     {
     public:
-        explicit Lua(const IRoute::Source& route_source, const IRandomizerRoute::Source& randomizer_route_source, const IWaypoint::Source& waypoint_source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
+        explicit Lua(
+            const IRoute::Source& route_source,
+            const IRandomizerRoute::Source& randomizer_route_source,
+            const IWaypoint::Source& waypoint_source, const IScriptable::Source& scriptable_source,
+            const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
         ~Lua();
         void do_file(const std::string& file) override;
         void execute(const std::string& command) override;
@@ -34,6 +39,7 @@ namespace trview
         lua_State* L{ nullptr };
         IRoute::Source _route_source;
         IRandomizerRoute::Source _randomizer_route_source;
+        IScriptable::Source _scriptable_source;
         IWaypoint::Source _waypoint_source;
         std::shared_ptr<IDialogs> _dialogs;
         std::shared_ptr<IFiles> _files;

--- a/trview.app/Lua/Scriptable/IScriptable.h
+++ b/trview.app/Lua/Scriptable/IScriptable.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+
+#include <trview.common/Event.h>
+
+#include "../../Geometry/IMesh.h"
+
+struct lua_State;
+
+namespace trview
+{
+    struct ICamera;
+
+    struct IScriptable
+    {
+        using Source = std::function<std::shared_ptr<IScriptable>(lua_State*)>;
+        virtual ~IScriptable() = 0;
+        virtual void click() = 0;
+        virtual int data() const = 0;
+        virtual std::shared_ptr<IMesh> mesh() const = 0;
+        virtual std::string notes() const = 0;
+        virtual DirectX::SimpleMath::Vector3 position() const = 0;
+        virtual void render(const ICamera& camera) = 0;
+        virtual DirectX::SimpleMath::Vector3 screen_position() const = 0;
+        virtual void set_data(int ref) = 0;
+        virtual void set_notes(const std::string& notes) = 0;
+        virtual void set_on_click(int ref) = 0;
+        virtual void set_position(const DirectX::SimpleMath::Vector3& position) = 0;
+        virtual void set_on_tooltip(int ref) = 0;
+        virtual void set_screen_position(const DirectX::SimpleMath::Vector3& position) = 0;
+        virtual std::string tooltip() const = 0;
+
+        Event<> on_changed;
+    };
+
+    namespace lua
+    {
+        void scriptable_register(lua_State* L, const IScriptable::Source& source);
+        std::shared_ptr<IScriptable> to_scriptable(lua_State* L, int index);
+    }
+}

--- a/trview.app/Lua/Scriptable/Scriptable.cpp
+++ b/trview.app/Lua/Scriptable/Scriptable.cpp
@@ -105,6 +105,13 @@ namespace trview
     {
     }
 
+    Scriptable::~Scriptable()
+    {
+        luaL_unref(_state, LUA_REGISTRYINDEX, _on_click);
+        luaL_unref(_state, LUA_REGISTRYINDEX, _on_tooltip);
+        luaL_unref(_state, LUA_REGISTRYINDEX, _data);
+    }
+
     void Scriptable::click()
     {
         if (_on_click == LUA_NOREF)

--- a/trview.app/Lua/Scriptable/Scriptable.cpp
+++ b/trview.app/Lua/Scriptable/Scriptable.cpp
@@ -1,0 +1,214 @@
+#include "Scriptable.h"
+#include "../Lua.h"
+#include "../Vector3.h"
+#include "../../Camera/ICamera.h"
+
+using namespace DirectX::SimpleMath;
+
+namespace trview
+{
+    namespace lua
+    {
+        namespace
+        {
+            IScriptable::Source scriptable_source;
+
+            int scriptable_index(lua_State* L)
+            {
+                auto scriptable = get_self<IScriptable>(L);
+                const std::string key = lua_tostring(L, 2);
+
+                if (key == "click")
+                {
+                    scriptable->click();
+                }
+                else if (key == "data")
+                {
+                    int ref = scriptable->data();
+                    lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
+                    return 1;
+                }
+                else if (key == "notes")
+                {
+                    lua_pushstring(L, scriptable->notes().c_str());
+                    return 1;
+                }
+                else if (key == "position")
+                {
+                    return create_vector3(L, scriptable->position() * trlevel::Scale);
+                }
+
+                return 0;
+            }
+
+            int scriptable_newindex(lua_State* L)
+            {
+                auto scriptable = get_self<IScriptable>(L);
+                const std::string key = lua_tostring(L, 2);
+
+                if (key == "data")
+                {
+                    scriptable->set_data(luaL_ref(L, LUA_REGISTRYINDEX));
+                }
+                else if (key == "notes")
+                {
+                    scriptable->set_notes(lua_tostring(L, -1));
+                }
+                else if (key == "on_click")
+                {
+                    scriptable->set_on_click(luaL_ref(L, LUA_REGISTRYINDEX));
+                }
+                else if (key == "on_tooltip")
+                {
+                    scriptable->set_on_tooltip(luaL_ref(L, LUA_REGISTRYINDEX));
+                }
+                else if (key == "position")
+                {
+                    scriptable->set_position(to_vector3(L, -1) / trlevel::Scale);
+                }
+
+                return 0;
+            }
+
+            int create_scriptable(lua_State* L, const std::shared_ptr<IScriptable>& scriptable)
+            {
+                return create(L, scriptable, scriptable_index, scriptable_newindex);
+            }
+
+            int scriptable_new(lua_State* L)
+            {
+                return create_scriptable(L, scriptable_source(L));
+            }
+        }
+
+        void scriptable_register(lua_State* L, const IScriptable::Source& source)
+        {
+            scriptable_source = source;
+            lua_newtable(L);
+            lua_pushcfunction(L, scriptable_new);
+            lua_setfield(L, -2, "new");
+            lua_setglobal(L, "Scriptable");
+        }
+
+        std::shared_ptr<IScriptable> to_scriptable(lua_State* L, int index)
+        {
+            return get_self<IScriptable>(L, index);
+        }
+    }
+
+    IScriptable::~IScriptable()
+    {
+    }
+
+    Scriptable::Scriptable(lua_State* L, const std::shared_ptr<IMesh>& mesh, const graphics::Texture& texture)
+        : _state(L), _mesh(mesh), _texture(texture)
+    {
+    }
+
+    void Scriptable::click()
+    {
+        if (_on_click == LUA_NOREF)
+        {
+            return;
+        }
+
+        if (lua_rawgeti(_state, LUA_REGISTRYINDEX, _on_click) == LUA_TNIL)
+        {
+            lua_pop(_state, 1);
+        }
+        else
+        {
+            lua::create_scriptable(_state, shared_from_this());
+            lua_pcall(_state, 1, 0, 0);
+        }
+    }
+
+    int Scriptable::data() const
+    {
+        return _data;
+    }
+
+    void Scriptable::set_data(int ref)
+    {
+        _data = ref;
+    }
+
+    void Scriptable::set_on_click(int ref)
+    {
+        _on_click = ref;
+    }
+
+    std::shared_ptr<IMesh> Scriptable::mesh() const
+    {
+        return _mesh;
+    }
+
+    std::string Scriptable::notes() const
+    {
+        return _notes;
+    }
+
+    DirectX::SimpleMath::Vector3 Scriptable::position() const
+    {
+        return _position;
+    }
+
+    void Scriptable::render(const ICamera& camera)
+    {
+        auto world = Matrix::CreateScale(0.25f) * Matrix::CreateTranslation(position());
+        auto wvp = world * camera.view_projection();
+        auto light_direction = Vector3::TransformNormal(camera.position() - position(), world.Invert());
+        light_direction.Normalize();
+        mesh()->render(wvp, _texture, Colour::White, 1.0f, light_direction);
+
+        const auto window_size = camera.view_size();
+        set_screen_position(XMVector3Project(position(), 0, 0, window_size.width, window_size.height, 0, 1.0f, camera.projection(), camera.view(), Matrix::Identity));
+    }
+
+    DirectX::SimpleMath::Vector3 Scriptable::screen_position() const
+    {
+        return _screen_position;
+    }
+
+    void Scriptable::set_position(const DirectX::SimpleMath::Vector3& position) 
+    {
+        _position = position;
+        on_changed();
+    }
+
+    void Scriptable::set_notes(const std::string& notes)
+    {
+        _notes = notes;
+        on_changed();
+    }
+
+    void Scriptable::set_on_tooltip(int ref)
+    {
+        _on_tooltip = ref;
+    }
+
+    void Scriptable::set_screen_position(const DirectX::SimpleMath::Vector3& position)
+    {
+        _screen_position = position;
+    }
+
+    std::string Scriptable::tooltip() const
+    {
+        if (_on_tooltip == LUA_NOREF)
+        {
+            return "Scriptable";
+        }
+
+        if (lua_rawgeti(_state, LUA_REGISTRYINDEX, _on_tooltip) == LUA_TNIL)
+        {
+            lua_pop(_state, 1);
+            return "Scriptable";
+        }
+        else
+        {
+            lua::create_scriptable(_state, std::const_pointer_cast<IScriptable>(shared_from_this()));
+            lua_pcall(_state, 1, 1, 0);
+            return lua_tostring(_state, -1);
+        }
+    }
+}

--- a/trview.app/Lua/Scriptable/Scriptable.cpp
+++ b/trview.app/Lua/Scriptable/Scriptable.cpp
@@ -18,11 +18,7 @@ namespace trview
                 auto scriptable = get_self<IScriptable>(L);
                 const std::string key = lua_tostring(L, 2);
 
-                if (key == "click")
-                {
-                    scriptable->click();
-                }
-                else if (key == "data")
+                if (key == "data")
                 {
                     int ref = scriptable->data();
                     lua_rawgeti(L, LUA_REGISTRYINDEX, ref);

--- a/trview.app/Lua/Scriptable/Scriptable.h
+++ b/trview.app/Lua/Scriptable/Scriptable.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "IScriptable.h"
+
+namespace trview
+{
+    class Scriptable : public IScriptable, public std::enable_shared_from_this<IScriptable>
+    {
+    public:
+        explicit Scriptable(lua_State* L, const std::shared_ptr<IMesh>& mesh, const graphics::Texture& texture);
+        virtual ~Scriptable() = default;
+        void click() override;
+        int data() const override;
+        std::shared_ptr<IMesh> mesh() const override;
+        std::string notes() const override;
+        DirectX::SimpleMath::Vector3 position() const override;
+        void render(const ICamera& camera) override;
+        DirectX::SimpleMath::Vector3 screen_position() const override;
+        void set_data(int ref) override;
+        void set_notes(const std::string& notes) override;
+        void set_on_click(int ref) override;
+        void set_on_tooltip(int ref) override;
+        void set_position(const DirectX::SimpleMath::Vector3& position) override;
+        void set_screen_position(const DirectX::SimpleMath::Vector3& position) override;
+        std::string tooltip() const override;
+    private:
+        lua_State* _state;
+        int _on_click{ -2 };
+        int _on_tooltip{ -2 };
+        int _data{ -2 };
+        DirectX::SimpleMath::Vector3 _position;
+        std::shared_ptr<IMesh> _mesh;
+        std::string _notes;
+        DirectX::SimpleMath::Vector3 _screen_position;
+        graphics::Texture _texture;
+    };
+}

--- a/trview.app/Lua/Scriptable/Scriptable.h
+++ b/trview.app/Lua/Scriptable/Scriptable.h
@@ -8,7 +8,7 @@ namespace trview
     {
     public:
         explicit Scriptable(lua_State* L, const std::shared_ptr<IMesh>& mesh, const graphics::Texture& texture);
-        virtual ~Scriptable() = default;
+        virtual ~Scriptable();
         void click() override;
         int data() const override;
         std::shared_ptr<IMesh> mesh() const override;

--- a/trview.app/Lua/trview/trview.cpp
+++ b/trview.app/Lua/trview/trview.cpp
@@ -9,6 +9,7 @@
 #include "../Route/Lua_Waypoint.h"
 #include "../Colour.h"
 #include "../Vector3.h"
+#include "../Scriptable/IScriptable.h"
 #include "Lua/Lua.h"
 
 #include <future>
@@ -134,6 +135,7 @@ namespace trview
             const IRoute::Source& route_source,
             const IRandomizerRoute::Source& randomizer_route_source,
             const IWaypoint::Source& waypoint_source,
+            const IScriptable::Source& scriptable_source,
             const std::shared_ptr<IDialogs>& dialogs,
             const std::shared_ptr<IFiles>& files)
         {
@@ -154,6 +156,7 @@ namespace trview
             waypoint_register(L, waypoint_source);
             colour_register(L);
             vector3_register(L);
+            scriptable_register(L, scriptable_source);
         }
 
         void set_settings(const UserSettings& settings)

--- a/trview.app/Lua/trview/trview.h
+++ b/trview.app/Lua/trview/trview.h
@@ -10,6 +10,7 @@
 #include "../../Routing/IRoute.h"
 #include "../../Routing/IRandomizerRoute.h"
 #include "../../Settings/UserSettings.h"
+#include "../Scriptable/IScriptable.h"
 
 namespace trview
 {
@@ -22,6 +23,7 @@ namespace trview
             const IRoute::Source& route_source,
             const IRandomizerRoute::Source& randomizer_route_source,
             const IWaypoint::Source& waypoint_source,
+            const IScriptable::Source& scriptable_source,
             const std::shared_ptr<IDialogs>& dialogs,
             const std::shared_ptr<IFiles>& files);
         void set_settings(const UserSettings& settings);

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -10,6 +10,7 @@ namespace trview
         {
             MockLevel();
             virtual ~MockLevel();
+            MOCK_METHOD(void, add_scriptable, (const std::shared_ptr<IScriptable>&), (override));
             MOCK_METHOD(bool, alternate_group, (uint32_t), (const, override));
             MOCK_METHOD(std::set<uint32_t>, alternate_groups, (), (const, override));
             MOCK_METHOD(bool, alternate_mode, (), (const, override));
@@ -34,6 +35,7 @@ namespace trview
             MOCK_METHOD(void, render_transparency, (const ICamera&), (override));
             MOCK_METHOD(std::weak_ptr<IRoom>, room, (uint32_t), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<IRoom>>, rooms, (), (const, override));
+            MOCK_METHOD(std::vector<std::weak_ptr<IScriptable>>, scriptables, (), (const, override));
             MOCK_METHOD(std::optional<uint32_t>, selected_item, (), (const, override));
             MOCK_METHOD(std::optional<uint32_t>, selected_light, (), (const, override));
             MOCK_METHOD(std::weak_ptr<IRoom>, selected_room, (), (const, override));

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -10,7 +10,7 @@ namespace trview
         {
             MockLevel();
             virtual ~MockLevel();
-            MOCK_METHOD(void, add_scriptable, (const std::shared_ptr<IScriptable>&), (override));
+            MOCK_METHOD(void, add_scriptable, (const std::weak_ptr<IScriptable>&), (override));
             MOCK_METHOD(bool, alternate_group, (uint32_t), (const, override));
             MOCK_METHOD(std::set<uint32_t>, alternate_groups, (), (const, override));
             MOCK_METHOD(bool, alternate_mode, (), (const, override));

--- a/trview.app/Mocks/Lua/IScriptable.h
+++ b/trview.app/Mocks/Lua/IScriptable.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "../../Lua/Scriptable/IScriptable.h"
+
+namespace trview
+{
+    struct ICamera;
+
+    namespace mocks
+    {
+        struct MockScriptable : public IScriptable
+        {
+            MockScriptable();
+            ~MockScriptable();
+            MOCK_METHOD(void, click, (), (override));
+            MOCK_METHOD(int, data, (), (const, override));
+            MOCK_METHOD(std::shared_ptr<IMesh>, mesh, (), (const, override));
+            MOCK_METHOD(std::string, notes, (), (const, override));
+            MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
+            MOCK_METHOD(void, render, (const ICamera&), (override));
+            MOCK_METHOD(DirectX::SimpleMath::Vector3, screen_position, (), (const, override));
+            MOCK_METHOD(void, set_data, (int), (override));
+            MOCK_METHOD(void, set_notes, (const std::string&), (override));
+            MOCK_METHOD(void, set_on_click, (int), (override));
+            MOCK_METHOD(void, set_position, (const DirectX::SimpleMath::Vector3&), (override));
+            MOCK_METHOD(void, set_on_tooltip, (int), (override));
+            MOCK_METHOD(void, set_screen_position, (const DirectX::SimpleMath::Vector3&), (override));
+            MOCK_METHOD(std::string, tooltip, (), (const, override));
+        };
+    }
+}

--- a/trview.app/Mocks/Mocks.cpp
+++ b/trview.app/Mocks/Mocks.cpp
@@ -18,6 +18,7 @@
 #include "Graphics/ISectorHighlight.h"
 #include "Graphics/ISelectionRenderer.h"
 #include "Graphics/ITextureStorage.h"
+#include "Lua/IScriptable.h"
 #include "Menus/IFileMenu.h"
 #include "Menus/IUpdateChecker.h"
 #include "Routing/IRoute.h"
@@ -257,5 +258,8 @@ namespace trview
 
         MockWindows::MockWindows() {}
         MockWindows::~MockWindows() {}
+
+        MockScriptable::MockScriptable() {}
+        MockScriptable::~MockScriptable() {}
     }
 }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -266,6 +266,7 @@ namespace trview
         }
 
         render_route_notes();
+        render_scriptable_notes();
     }
 
     void ViewerUI::set_alternate_group(uint32_t value, bool enabled)
@@ -532,6 +533,41 @@ namespace trview
                         {
                             ImGui::Text(notes.c_str());
                         }
+                    }
+                    ImGui::End();
+                }
+            }
+        }
+    }
+
+    void ViewerUI::render_scriptable_notes()
+    {
+        const auto level = _level.lock();
+        if (!level)
+        {
+            return;
+        }
+
+        const auto vp = ImGui::GetMainViewport();
+
+        uint32_t i = 0;
+        for (const auto scriptable : level->scriptables())
+        {
+            if (const auto scriptable_ptr = scriptable.lock())
+            {
+                const auto notes = scriptable_ptr->notes();
+                if (notes.empty())
+                {
+                    continue;
+                }
+
+                const auto pos = scriptable_ptr->screen_position();
+                if (is_on_screen(pos, *vp))
+                {
+                    ImGui::SetNextWindowPos(vp->Pos + ImVec2(pos.x, pos.y));
+                    if (ImGui::Begin(std::format("##scriptable{}", i).c_str(), nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoFocusOnAppearing))
+                    {
+                        ImGui::Text(notes.c_str());
                     }
                     ImGui::End();
                 }

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -73,6 +73,7 @@ namespace trview
     private:
         void generate_tool_window();
         void render_route_notes();
+        void render_scriptable_notes();
 
         TokenStore _token_store;
         input::Mouse _mouse;

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1353,6 +1353,12 @@ namespace trview
             }
             break;
         }
+        case PickResult::Type::Scriptable:
+        {
+            auto scriptable = pick.scriptable.lock();
+            scriptable->click();
+            break;
+        }
         }
     }
 

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1355,8 +1355,10 @@ namespace trview
         }
         case PickResult::Type::Scriptable:
         {
-            auto scriptable = pick.scriptable.lock();
-            scriptable->click();
+            if (auto scriptable = pick.scriptable.lock())
+            {
+                scriptable->click();
+            }
             break;
         }
         }

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -65,6 +65,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Lua\Elements\Trigger\Lua_Trigger.cpp" />
     <ClCompile Include="Lua\Route\Lua_Route.cpp" />
     <ClCompile Include="Lua\Route\Lua_Waypoint.cpp" />
+    <ClCompile Include="Lua\Scriptable\Scriptable.cpp" />
     <ClCompile Include="Lua\trview\trview.cpp" />
     <ClCompile Include="Lua\Vector3.cpp" />
     <ClCompile Include="Menus\FileMenu.cpp" />
@@ -76,6 +77,9 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Plugins\Plugins.cpp" />
     <ClCompile Include="Routing\RandomizerRoute.cpp" />
     <ClCompile Include="Windows\Windows.cpp" />
+    <ClInclude Include="Lua\Scriptable\IScriptable.h" />
+    <ClInclude Include="Lua\Scriptable\Scriptable.h" />
+    <ClInclude Include="Mocks\Lua\IScriptable.h" />
     <ClInclude Include="Mocks\UI\IFonts.h" />
     <ClInclude Include="Mocks\Windows\IStaticsWindow.h" />
     <ClInclude Include="Mocks\Windows\IStaticsWindowManager.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -338,6 +338,9 @@
     <ClCompile Include="Windows\Windows.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
+    <ClCompile Include="Lua\Scriptable\Scriptable.cpp">
+      <Filter>Lua\Scriptable</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -1099,6 +1102,15 @@
     <ClInclude Include="Mocks\Windows\IWindows.h">
       <Filter>Mocks\Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Lua\Scriptable\Scriptable.h">
+      <Filter>Lua\Scriptable</Filter>
+    </ClInclude>
+    <ClInclude Include="Lua\Scriptable\IScriptable.h">
+      <Filter>Lua\Scriptable</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\Lua\IScriptable.h">
+      <Filter>Mocks\Lua</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">
@@ -1292,6 +1304,9 @@
     </Filter>
     <Filter Include="Windows\Statics">
       <UniqueIdentifier>{56d85abd-e0f6-45f4-9776-b734b80d4b45}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Lua\Scriptable">
+      <UniqueIdentifier>{7e2d9e42-f62d-4702-9d5e-7b7b13532b5e}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Add the ability to create `Scriptable` objects in Lua and have them rendered and interactable in the level.
First version has options to configure click callback, hover text and notes display.
Closes #1268