### PR TITLE
Add header level hide checkbox for lists

### DIFF
--- a/trview.app.tests/Windows/WindowsTests.cpp
+++ b/trview.app.tests/Windows/WindowsTests.cpp
@@ -560,12 +560,14 @@ TEST(Windows, SetLevel)
 TEST(Windows, SetRoom)
 {
     auto [cameras_ptr, cameras] = create_mock<MockCameraSinkWindowManager>();
+    auto [items_ptr, items] = create_mock<MockItemsWindowManager>();
     auto [lights_ptr, lights] = create_mock<MockLightsWindowManager>();
     auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
     auto [statics_ptr, statics] = create_mock<MockStaticsWindowManager>();
     auto [triggers_ptr, triggers] = create_mock<MockTriggersWindowManager>();
     auto windows = register_test_module()
         .with_camera_sinks(std::move(cameras_ptr))
+        .with_items(std::move(items_ptr))
         .with_lights(std::move(lights_ptr))
         .with_rooms(std::move(rooms_ptr))
         .with_statics(std::move(statics_ptr))
@@ -574,6 +576,8 @@ TEST(Windows, SetRoom)
 
     std::shared_ptr<IRoom> cameras_room;
     EXPECT_CALL(cameras, set_room).Times(1).WillRepeatedly([&](auto r) { cameras_room = r.lock(); });
+    std::shared_ptr<IRoom> items_room;
+    EXPECT_CALL(items, set_room).Times(1).WillRepeatedly([&](auto r) { items_room = r.lock(); });
     std::shared_ptr<IRoom> lights_room;
     EXPECT_CALL(lights, set_room).Times(1).WillRepeatedly([&](auto r) { lights_room = r.lock(); });
     std::shared_ptr<IRoom> rooms_room;
@@ -587,6 +591,7 @@ TEST(Windows, SetRoom)
     windows->set_room(room);
 
     ASSERT_EQ(cameras_room, room);
+    ASSERT_EQ(items_room, room);
     ASSERT_EQ(lights_room, room);
     ASSERT_EQ(rooms_room, room);
     ASSERT_EQ(statics_room, room);

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -176,12 +176,21 @@ namespace trview
             RowCounter counter{ "triggers", _all_triggers.size() };
             if (ImGui::BeginTable(Names::triggers_list.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(0, -counter.height())))
             {
-                ImGui::TableSetupColumn("#", ImGuiTableColumnFlags_WidthFixed, _column_sizer.size(0));
-                ImGui::TableSetupColumn("Room", ImGuiTableColumnFlags_WidthFixed, _column_sizer.size(1));
-                ImGui::TableSetupColumn("Type", ImGuiTableColumnFlags_WidthFixed, _column_sizer.size(2));
-                ImGui::TableSetupColumn("Hide", ImGuiTableColumnFlags_WidthFixed, _column_sizer.size(3));
-                ImGui::TableSetupScrollFreeze(1, 1);
-                ImGui::TableHeadersRow();
+                imgui_header_row(
+                    {
+                        { "#", _column_sizer.size(0) },
+                        { "Room", _column_sizer.size(1) },
+                        { "Type", _column_sizer.size(2) },
+                        { .name = "Hide", .width = _column_sizer.size(3), .set_checked = [&](bool v)
+                            {
+                                std::ranges::for_each(_filtered_triggers, [=](auto&& trigger) 
+                                    {
+                                        auto trigger_ptr = trigger.lock(); trigger_ptr->set_visible(!v); 
+                                    });
+                                on_scene_changed();
+                            }, .checked = std::ranges::all_of(_filtered_triggers, [](auto&& trigger) { auto trigger_ptr = trigger.lock(); return trigger_ptr ? !trigger_ptr->visible() : false; })
+                        }
+                    });
 
                 filter_triggers();
                 counter.set_count(_filtered_triggers.size());

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -206,6 +206,7 @@ namespace trview
     void Windows::set_room(const std::weak_ptr<IRoom>& room)
     {
         _camera_sink_windows->set_room(room);
+        _items_windows->set_room(room);
         _lights_windows->set_room(room);
         _rooms_windows->set_room(room);
         _statics_windows->set_room(room);

--- a/trview.app/trview_imgui.cpp
+++ b/trview.app/trview_imgui.cpp
@@ -2,6 +2,40 @@
 
 namespace trview
 {
+    void imgui_header_row(std::vector<ImGuiHeader> headers)
+    {
+        for (const auto& header : headers)
+        {
+            ImGui::TableSetupColumn(header.name.c_str(), ImGuiTableColumnFlags_WidthFixed, header.width);
+        }
+        ImGui::TableSetupScrollFreeze(1, 1);
+        ImGui::TableNextRow(ImGuiTableRowFlags_Headers, ImGui::TableGetHeaderRowHeight());
+
+        int column_n = 0;
+        for (const auto& header : headers)
+        {
+            if (!ImGui::TableSetColumnIndex(column_n++))
+            {
+                continue;
+            }
+
+            if (header.set_checked)
+            {
+                ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
+
+                bool value = header.checked;
+                if (ImGui::Checkbox("##checkall", &value))
+                {
+                    header.set_checked(value);
+                }
+
+                ImGui::PopStyleVar();
+                ImGui::SameLine(0.0f, ImGui::GetStyle().ItemInnerSpacing.x);
+            }
+            ImGui::TableHeader(header.name.c_str());
+        }
+    }
+
     ImGuiScroller::ImGuiScroller()
     {
         const auto window = ImGui::GetCurrentWindow();

--- a/trview.app/trview_imgui.h
+++ b/trview.app/trview_imgui.h
@@ -8,6 +8,16 @@ namespace trview
     template < typename T >
     void imgui_sort_weak(std::vector<std::weak_ptr<T>>& container, std::vector<std::function<bool(const T&, const T&)>> callbacks, bool force_sort = false);
 
+    struct ImGuiHeader
+    {
+        std::string name;
+        float width;
+        std::function<void(bool)> set_checked = nullptr;
+        bool checked;
+    };
+
+    void imgui_header_row(std::vector<ImGuiHeader> headers);
+
     struct ImGuiScroller
     {
     public:


### PR DESCRIPTION
When there is a list add a checkbox to the 'hide' column header. This will set all of the filtered entries to either hidden or not hidden. 
Fixes an issue where the items window wasn't having the current room set so it was failing to track rooms.
Closes #1282