### PR TITLE
Add 'commands' filter to triggers

### DIFF
--- a/trview.app/Elements/ITrigger.h
+++ b/trview.app/Elements/ITrigger.h
@@ -33,7 +33,7 @@ namespace trview
         virtual int16_t timer() const = 0;
         virtual uint16_t sector_id() const = 0;
         virtual Colour colour() const = 0;
-        virtual const std::vector<Command> commands() const = 0;
+        virtual std::vector<Command> commands() const = 0;
         virtual void set_colour(const std::optional<Colour>& colour) = 0;
         virtual void set_triangles(const std::vector<TransparentTriangle>& transparent_triangles) = 0;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;

--- a/trview.app/Elements/Trigger.cpp
+++ b/trview.app/Elements/Trigger.cpp
@@ -85,7 +85,7 @@ namespace trview
         return _timer;
     }
 
-    const std::vector<Command> Trigger::commands() const
+    std::vector<Command> Trigger::commands() const
     {
         return _commands;
     }

--- a/trview.app/Elements/Trigger.h
+++ b/trview.app/Elements/Trigger.h
@@ -24,7 +24,7 @@ namespace trview
         virtual int16_t timer() const override;
         virtual uint16_t sector_id() const override;
         Colour colour() const override;
-        virtual const std::vector<Command> commands() const override;
+        std::vector<Command> commands() const override;
         void set_colour(const std::optional<Colour>& colour) override;
         virtual void set_triangles(const std::vector<TransparentTriangle>& transparent_triangles) override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;

--- a/trview.app/Mocks/Elements/ITrigger.h
+++ b/trview.app/Mocks/Elements/ITrigger.h
@@ -25,7 +25,7 @@ namespace trview
             MOCK_METHOD(int16_t, timer, (), (const, override));
             MOCK_METHOD(uint16_t, sector_id, (), (const, override));
             MOCK_METHOD(Colour, colour, (), (const, override));
-            MOCK_METHOD(const std::vector<Command>, commands, (), (const, override));
+            MOCK_METHOD(std::vector<Command>, commands, (), (const, override));
             MOCK_METHOD(void, set_colour, (const std::optional<Colour>&), (override));
             MOCK_METHOD(void, set_triangles, (const std::vector<TransparentTriangle>&), (override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -449,6 +449,13 @@ namespace trview
         _filters.add_getter<bool>("Only once", [](auto&& trigger) { return trigger.only_once(); });
         _filters.add_getter<float>("Timer", [](auto&& trigger) { return static_cast<float>(trigger.timer()); });
 
+        _filters.add_multi_getter<std::string>("Command", [=](auto&& trigger)
+            {
+                return trigger.commands()
+                    | std::views::transform([](auto&& t) { return command_type_name(t.type()); })
+                    | std::ranges::to<std::vector>();
+            });
+
         auto all_trigger_indices = [](TriggerCommandType type, const auto& trigger)
         {
             std::vector<float> indices;


### PR DESCRIPTION
Allows for searching based on the commands collection of each trigger (is present, is not present etc)
Closes #1285