### PR TITLE
Add "Has Collision" attribute for static meshes

### DIFF
--- a/doc/lua/staticmesh.md
+++ b/doc/lua/staticmesh.md
@@ -6,6 +6,7 @@
 | ---- | ---- | ---- | ---- |
 | breakable | boolean | R | Whether this is a breakable static |
 | collision | [BoundingBox](boundingbox.md) | R | Collision bounding box |
+| has_collision | boolean | R | Whether this is a collidable mesh |
 | id | number | R | Mesh ID or sprite texture ID |
 | position | [Vector3](vector3.md) | R | Static mesh position in the world. |
 | room | [Room](room.md) | R | Room that contains the static mesh |

--- a/trview.app.tests/Elements/StaticMeshTests.cpp
+++ b/trview.app.tests/Elements/StaticMeshTests.cpp
@@ -28,3 +28,17 @@ TEST(StaticMesh, OnChangedRaised)
     mesh.set_visible(false);
     ASSERT_EQ(raised, true);
 }
+
+TEST(StaticMesh, HasCollision)
+{
+    StaticMesh collision_mesh({}, { .Flags = 0 }, mock_shared<MockMesh>(), {}, mock_shared<MockMesh>());
+    ASSERT_EQ(collision_mesh.has_collision(), true);
+    StaticMesh no_collision_mesh({}, { .Flags = 1 }, mock_shared<MockMesh>(), {}, mock_shared<MockMesh>());
+    ASSERT_EQ(no_collision_mesh.has_collision(), false);
+}
+
+TEST(StaticMesh, SpriteNoCollision)
+{
+    StaticMesh collision_mesh({}, {}, {}, mock_shared<MockMesh>(), {});
+    ASSERT_EQ(collision_mesh.has_collision(), false);
+}

--- a/trview.app.tests/Lua/Elements/Lua_StaticMeshTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_StaticMeshTests.cpp
@@ -62,6 +62,20 @@ TEST(Lua_StaticMesh, Collision)
     ASSERT_DOUBLE_EQ(3072.0, lua_tonumber(L, -1));
 }
 
+TEST(Lua_StaticMesh, HasCollision)
+{
+    auto static_mesh = mock_shared<MockStaticMesh>();
+    EXPECT_CALL(*static_mesh, has_collision).WillRepeatedly(Return(true));
+
+    LuaState L;
+    lua::create_static_mesh(L, static_mesh);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.has_collision"));
+    ASSERT_EQ(LUA_TBOOLEAN, lua_type(L, -1));
+    ASSERT_EQ(true, lua_toboolean(L, -1));
+}
+
 TEST(Lua_StaticMesh, Id)
 {
     auto static_mesh = mock_shared<MockStaticMesh>();

--- a/trview.app/Elements/IStaticMesh.h
+++ b/trview.app/Elements/IStaticMesh.h
@@ -43,6 +43,7 @@ namespace trview
         virtual bool breakable() const = 0;
         virtual bool visible() const = 0;
         virtual void set_visible(bool value) = 0;
+        virtual bool has_collision() const = 0;
 
         Event<> on_changed;
     };

--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -157,6 +157,11 @@ namespace trview
         }
     }
 
+    bool StaticMesh::has_collision() const
+    {
+        return _type == Type::Mesh && (_flags & 0x1) == 0;
+    }
+
     uint32_t static_mesh_room(const std::shared_ptr<IStaticMesh>& static_mesh)
     {
         if (!static_mesh)

--- a/trview.app/Elements/StaticMesh.h
+++ b/trview.app/Elements/StaticMesh.h
@@ -28,6 +28,7 @@ namespace trview
         bool breakable() const override;
         bool visible() const override;
         void set_visible(bool value) override;
+        bool has_collision() const override;
     private:
         float _rotation;
         DirectX::SimpleMath::Vector3 _position;

--- a/trview.app/Lua/Elements/StaticMesh/Lua_StaticMesh.cpp
+++ b/trview.app/Lua/Elements/StaticMesh/Lua_StaticMesh.cpp
@@ -23,6 +23,11 @@ namespace trview
                 {
                     return create_bounding_box(L, static_mesh->collision());
                 }
+                else if (key == "has_collision")
+                {
+                    lua_pushboolean(L, static_mesh->has_collision());
+                    return 1;
+                }
                 else if (key == "id")
                 {
                     lua_pushinteger(L, static_mesh->id());

--- a/trview.app/Mocks/Elements/IStaticMesh.h
+++ b/trview.app/Mocks/Elements/IStaticMesh.h
@@ -27,6 +27,7 @@ namespace trview
             MOCK_METHOD(bool, visible, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(bool, breakable, (), (const, override));
+            MOCK_METHOD(bool, has_collision, (), (const, override));
 
             std::shared_ptr<MockStaticMesh> with_number(uint32_t number)
             {

--- a/trview.app/Windows/Statics/StaticsWindow.cpp
+++ b/trview.app/Windows/Statics/StaticsWindow.cpp
@@ -185,6 +185,7 @@ namespace trview
                     add_stat("Rotation", DirectX::XMConvertToDegrees(stat->rotation()));
                     add_stat("Flags", format_binary(stat->flags()));
                     add_stat("Breakable", stat->breakable());
+                    add_stat("Has Collision", stat->has_collision());
                 }
 
                 ImGui::EndTable();
@@ -259,6 +260,7 @@ namespace trview
         _filters.add_getter<float>("Room", [](auto&& stat) { return static_cast<float>(static_mesh_room(stat)); });
         _filters.add_getter<bool>("Breakable", [](auto&& item) { return item.breakable(); });
         _filters.add_getter<std::string>("Flags", [](auto&& stat) { return format_binary(stat.flags()); });
+        _filters.add_getter<bool>("Has Collision", [](auto&& stat) { return stat.has_collision(); });
     }
 
     void StaticsWindow::set_local_selected_static_mesh(std::weak_ptr<IStaticMesh> static_mesh)


### PR DESCRIPTION
Add a "has collision" property to the static mesh window, filters and Lua.
Closes #1290