### PR TITLE
 Allow user to close Camera Position window, anchor to bottom left

### DIFF
--- a/trview.app.tests/Settings/SettingsLoaderTests.cpp
+++ b/trview.app.tests/Settings/SettingsLoaderTests.cpp
@@ -757,3 +757,28 @@ TEST(SettingsLoader, FontsSaved)
     loader->save_user_settings(settings);
     EXPECT_THAT(output, HasSubstr("\"fonts\":{\"Default\":{\"filename\":\"tahoma.ttf\",\"name\":\"Tahoma\",\"size\":10}}"));
 }
+
+TEST(SettingsLoader, CameraPositionWindowLoaded)
+{
+    auto loader = setup_setting("{\"camera_position_window\":false}");
+    auto settings = loader->load_user_settings();
+    ASSERT_EQ(settings.camera_position_window, false);
+
+    auto loader_true = setup_setting("{\"camera_position_window\":true}");
+    auto settings_true = loader_true->load_user_settings();
+    ASSERT_EQ(settings_true.camera_position_window, true);
+}
+
+TEST(SettingsLoader, CameraPositionWindowSaved)
+{
+    std::string output;
+    auto loader = setup_save_setting(output);
+    UserSettings settings;
+    settings.camera_position_window = false;
+    loader->save_user_settings(settings);
+    EXPECT_THAT(output, HasSubstr("\"camera_position_window\":false"));
+
+    settings.camera_position_window = true;
+    loader->save_user_settings(settings);
+    EXPECT_THAT(output, HasSubstr("\"camera_position_window\":true"));
+}

--- a/trview.app.ui.tests/CameraPositionTests.cpp
+++ b/trview.app.ui.tests/CameraPositionTests.cpp
@@ -8,6 +8,24 @@ using namespace DirectX::SimpleMath;
 
 void register_camera_position_tests(ImGuiTestEngine* engine)
 {
+    test<CameraPosition>(engine, "Camera Position", "Close Raises Event",
+        [](ImGuiTestContext* ctx) { ctx->GetVars<CameraPosition>().render(); },
+        [](ImGuiTestContext* ctx)
+        {
+            auto& camera_position = ctx->GetVars<CameraPosition>();
+            camera_position.set_rotation(-1.5707963267f, 1);
+
+            bool raised = false;
+            auto token = camera_position.on_hidden += [&]()
+                {
+                    raised = true;
+                };
+
+            ctx->ItemClick("Camera Position/#CLOSE");
+
+            IM_CHECK_EQ(raised, true);
+        });
+
     test<CameraPosition>(engine, "Camera Position", "Coordinates Updated",
         [](ImGuiTestContext* ctx) { ctx->GetVars<CameraPosition>().render(); },
         [](ImGuiTestContext* ctx)

--- a/trview.app/Mocks/UI/IViewerUI.h
+++ b/trview.app/Mocks/UI/IViewerUI.h
@@ -48,6 +48,8 @@ namespace trview
             MOCK_METHOD(void, set_scalar, (const std::string&, int32_t), (override));
             MOCK_METHOD(void, set_triggered_by, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(void, set_route, (const std::weak_ptr<IRoute>&), (override));
+            MOCK_METHOD(void, set_show_camera_position, (bool), (override));
+            MOCK_METHOD(void, reset_layout, (), (override));
         };
     }
 }

--- a/trview.app/Resources/resource.h
+++ b/trview.app/Resources/resource.h
@@ -50,6 +50,7 @@
 #define ID_WINDOWS_RESET_FONTS          33026
 #define ID_WINDOWS_STATICS              33027
 #define ID_WINDOWS_SOUNDS               33028
+#define ID_WINDOWS_CAMERA_POSITION      33029
 
 // Next default values for new objects
 // 

--- a/trview.app/Resources/trview.app.rc
+++ b/trview.app/Resources/trview.app.rc
@@ -78,6 +78,8 @@ BEGIN
         MENUITEM "Statics\tCtrl+S"              ID_WINDOWS_STATICS
         MENUITEM "Sounds"                       ID_WINDOWS_SOUNDS
         MENUITEM SEPARATOR
+        MENUITEM "Camera Position"              ID_WINDOWS_CAMERA_POSITION
+        MENUITEM SEPARATOR
         MENUITEM "Reset Layout"                 ID_WINDOWS_RESET_LAYOUT
         MENUITEM "Reset Fonts"                  ID_WINDOWS_RESET_FONTS
     END

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -106,6 +106,7 @@ namespace trview
             read_attribute(json, settings.toggles, "toggles");
             read_attribute(json, settings.fonts, "fonts");
             read_attribute(json, settings.statics_startup, "statics_startup");
+            read_attribute(json, settings.camera_position, "camera_position");
 
             settings.recent_files.resize(std::min<std::size_t>(settings.recent_files.size(), settings.max_recent_files));
         }
@@ -174,6 +175,7 @@ namespace trview
             json["toggles"] = settings.toggles;
             json["fonts"] = settings.fonts;
             json["statics_startup"] = settings.statics_startup;
+            json["camera_position"] = settings.camera_position;
             _files->save_file(file_path, json.dump());
         }
         catch (...)

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -106,7 +106,7 @@ namespace trview
             read_attribute(json, settings.toggles, "toggles");
             read_attribute(json, settings.fonts, "fonts");
             read_attribute(json, settings.statics_startup, "statics_startup");
-            read_attribute(json, settings.camera_position, "camera_position");
+            read_attribute(json, settings.camera_position_window, "camera_position_window");
 
             settings.recent_files.resize(std::min<std::size_t>(settings.recent_files.size(), settings.max_recent_files));
         }
@@ -175,7 +175,7 @@ namespace trview
             json["toggles"] = settings.toggles;
             json["fonts"] = settings.fonts;
             json["statics_startup"] = settings.statics_startup;
-            json["camera_position"] = settings.camera_position;
+            json["camera_position_window"] = settings.camera_position_window;
             _files->save_file(file_path, json.dump());
         }
         catch (...)

--- a/trview.app/Settings/UserSettings.cpp
+++ b/trview.app/Settings/UserSettings.cpp
@@ -43,6 +43,7 @@ namespace trview
             fov == other.fov &&
             camera_sink_startup == other.camera_sink_startup &&
             statics_startup == other.statics_startup &&
-            plugin_directories == other.plugin_directories;
+            plugin_directories == other.plugin_directories &&
+            camera_position == other.camera_position;
     }
 }

--- a/trview.app/Settings/UserSettings.cpp
+++ b/trview.app/Settings/UserSettings.cpp
@@ -44,6 +44,6 @@ namespace trview
             camera_sink_startup == other.camera_sink_startup &&
             statics_startup == other.statics_startup &&
             plugin_directories == other.plugin_directories &&
-            camera_position == other.camera_position;
+            camera_position_window == other.camera_position_window;
     }
 }

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -64,7 +64,7 @@ namespace trview
             { "Console", {.name = "Consolas", .filename = "consola.ttf", .size = 12 } }
         };
         bool statics_startup{ false };
-        bool camera_position{ true };
+        bool camera_position_window{ true };
 
         bool operator==(const UserSettings& other) const;
     };

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -64,6 +64,7 @@ namespace trview
             { "Console", {.name = "Consolas", .filename = "consola.ttf", .size = 12 } }
         };
         bool statics_startup{ false };
+        bool camera_position{ true };
 
         bool operator==(const UserSettings& other) const;
     };

--- a/trview.app/UI/CameraPosition.h
+++ b/trview.app/UI/CameraPosition.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <optional>
 #include <SimpleMath.h>
 #include <trview.common/Event.h>
 
@@ -43,11 +44,23 @@ namespace trview
         /// <param name="value">True to use degrees - radians if false.</param>
         void set_display_degrees(bool value);
 
+        void set_visible(bool value);
+
         Event<float, float> on_rotation_changed;
+
+        Event<> on_hidden;
+
+        void reposition();
+        void reset();
     private:
+        void check_reposition();
+        void capture_position();
         DirectX::SimpleMath::Vector3 _position;
         float _rotation_yaw{ 0 };
         float _rotation_pitch{ 0 };
         bool _display_degrees{ true };
+        bool _visible{ true };
+        bool _reposition{ true };
+        std::optional<ImVec2> _in_window_offset{ {  4, -148 } };
     };
 }

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -252,5 +252,9 @@ namespace trview
         virtual void set_triggered_by(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
 
         virtual void set_route(const std::weak_ptr<IRoute>& route) = 0;
+
+        virtual void set_show_camera_position(bool value) = 0;
+
+        virtual void reset_layout() = 0;
     };
 }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -160,7 +160,7 @@ namespace trview
         _camera_position->on_rotation_changed += on_camera_rotation;
         _token_store += _camera_position->on_hidden += [this]()
             {
-                _settings.camera_position = false;
+                _settings.camera_position_window = false;
                 on_settings(_settings);
             };
 
@@ -400,7 +400,7 @@ namespace trview
         _settings_window->set_plugin_directories(settings.plugin_directories);
         _settings_window->set_statics_startup(settings.statics_startup);
         _camera_position->set_display_degrees(settings.camera_display_degrees);
-        _camera_position->set_visible(settings.camera_position);
+        _camera_position->set_visible(settings.camera_position_window);
         _map_renderer->set_colours(settings.map_colours);
         for (const auto& toggle : settings.toggles)
         {

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -158,6 +158,11 @@ namespace trview
         _camera_position = std::make_unique<CameraPosition>();
         _camera_position->on_position_changed += on_camera_position;
         _camera_position->on_rotation_changed += on_camera_rotation;
+        _token_store += _camera_position->on_hidden += [this]()
+            {
+                _settings.camera_position = false;
+                on_settings(_settings);
+            };
 
         _map_renderer = map_renderer_source(window.size());
         _token_store += _map_renderer->on_sector_hover += [this](const std::shared_ptr<ISector>& sector)
@@ -312,6 +317,7 @@ namespace trview
     void ViewerUI::set_host_size(const Size& size)
     {
         _map_renderer->set_window_size(size);
+        _camera_position->reposition();
     }
 
     void ViewerUI::set_level(const std::weak_ptr<ILevel>& level)
@@ -394,6 +400,7 @@ namespace trview
         _settings_window->set_plugin_directories(settings.plugin_directories);
         _settings_window->set_statics_startup(settings.statics_startup);
         _camera_position->set_display_degrees(settings.camera_display_degrees);
+        _camera_position->set_visible(settings.camera_position);
         _map_renderer->set_colours(settings.map_colours);
         for (const auto& toggle : settings.toggles)
         {
@@ -573,5 +580,15 @@ namespace trview
                 }
             }
         }
+    }
+
+    void ViewerUI::set_show_camera_position(bool value)
+    {
+        _camera_position->set_visible(value);
+    }
+
+    void ViewerUI::reset_layout()
+    {
+        _camera_position->reset();
     }
 }

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -70,6 +70,8 @@ namespace trview
         virtual bool toggle(const std::string& name) const override;
         virtual void set_triggered_by(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         void set_route(const std::weak_ptr<IRoute>& route) override;
+        void set_show_camera_position(bool value) override;
+        void reset_layout() override;
     private:
         void generate_tool_window();
         void render_route_notes();

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1,4 +1,5 @@
 #include "Viewer.h"
+#include "Resources/resource.h"
 
 #include <trlevel/ILevel.h>
 #include <trview.graphics/RenderTargetStore.h>
@@ -1360,11 +1361,37 @@ namespace trview
         _scene_changed = true;
     }
 
-    std::optional<int> Viewer::process_message(UINT message, WPARAM, LPARAM)
+    std::optional<int> Viewer::process_message(UINT message, WPARAM wParam, LPARAM)
     {
-        if (message == WM_ACTIVATE)
+        switch (message)
         {
-            _camera_input.reset_input();
+            case WM_ACTIVATE:
+            {
+                _camera_input.reset_input();
+                break;
+            }
+            case WM_COMMAND:
+            {
+                switch (LOWORD(wParam))
+                {
+                    case ID_WINDOWS_CAMERA_POSITION:
+                    {
+                        _settings.camera_position = true;
+                        on_settings(_settings);
+                        _ui->set_show_camera_position(true);
+                        break;
+                    }
+                    case ID_WINDOWS_RESET_LAYOUT:
+                    {
+                        _settings.camera_position = true;
+                        on_settings(_settings);
+                        _ui->reset_layout();
+                        _ui->set_show_camera_position(true);
+                        break;
+                    }
+                }
+            }
+            
         }
         return {};
     }

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1376,14 +1376,14 @@ namespace trview
                 {
                     case ID_WINDOWS_CAMERA_POSITION:
                     {
-                        _settings.camera_position = true;
+                        _settings.camera_position_window = true;
                         on_settings(_settings);
                         _ui->set_show_camera_position(true);
                         break;
                     }
                     case ID_WINDOWS_RESET_LAYOUT:
                     {
-                        _settings.camera_position = true;
+                        _settings.camera_position_window = true;
                         on_settings(_settings);
                         _ui->reset_layout();
                         _ui->set_show_camera_position(true);


### PR DESCRIPTION
Allow the user to close the camera position window if they want to. It can be reopened from the `Windows` menu by selecting the `Camera Position` option or `Reset Layout`.
The window now anchors to the bottom left of the main viewport if it is contained inside it.
Closes #1292 