### PR TITLE
Add missing <ranges> references

### DIFF
--- a/trview.app/Lua/Elements/Level/Lua_Level.cpp
+++ b/trview.app/Lua/Elements/Level/Lua_Level.cpp
@@ -9,6 +9,8 @@
 #include "../StaticMesh/Lua_StaticMesh.h"
 #include "../../Scriptable/IScriptable.h"
 
+#include <ranges>
+
 namespace trview
 {
     namespace lua

--- a/trview.app/Lua/Elements/Room/Lua_Room.cpp
+++ b/trview.app/Lua/Elements/Room/Lua_Room.cpp
@@ -10,6 +10,8 @@
 #include "../StaticMesh/Lua_StaticMesh.h"
 #include "../../Vector3.h"
 
+#include <ranges>
+
 namespace trview
 {
     namespace lua

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -7,6 +7,8 @@
 #include <trview.common/Algorithms.h>
 #include "../../../Elements/Floordata.h"
 
+#include <ranges>
+
 namespace trview
 {
     namespace lua

--- a/trview.app/Routing/RandomizerRoute.cpp
+++ b/trview.app/Routing/RandomizerRoute.cpp
@@ -3,6 +3,7 @@
 #include "../Settings/UserSettings.h"
 
 #include <algorithm>
+#include <ranges>
 
 using namespace DirectX;
 using namespace DirectX::SimpleMath;

--- a/trview.app/UI/GoTo.cpp
+++ b/trview.app/UI/GoTo.cpp
@@ -1,5 +1,6 @@
 #include "GoTo.h"
 #include <charconv>
+#include <ranges>
 
 namespace trview
 {

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -7,6 +7,8 @@
 #include "../Routing/IRoute.h"
 #include "../Windows/IViewer.h"
 
+#include <ranges>
+
 using namespace DirectX::SimpleMath;
 
 namespace trview


### PR DESCRIPTION
Something changed with VS update so <ranges> is no longer transitively included, so include it explicitly.
Should have been there anyway.