### PR TITLE
Check SFX folder for MAIN.SFX on remastered levels

### DIFF
--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -2200,7 +2200,7 @@ namespace trlevel
 
     void Level::load_sound_fx(const LoadCallbacks& callbacks)
     {
-        if (auto main = _files->load_file(std::format("{}MAIN.SFX", trview::path_for_filename(_filename))))
+        if (auto main = load_main_sfx())
         {
             std::basic_ispanstream<uint8_t> sfx_file{ { *main } };
 
@@ -2229,5 +2229,16 @@ namespace trlevel
                 sfx_file.seekg(size + 8, std::ios::cur);
             }
         }
+    }
+
+    std::optional<std::vector<uint8_t>> Level::load_main_sfx() const
+    {
+        const auto path = trview::path_for_filename(_filename);
+        const auto og_main = _files->load_file(std::format("{}MAIN.SFX", path));
+        if (og_main.has_value())
+        {
+            return og_main;
+        }
+        return _files->load_file(std::format("{}../SFX/MAIN.SFX", path));
     }
 }

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -189,6 +189,7 @@ namespace trlevel
 
         void generate_sounds_tr1(const LoadCallbacks& callbacks);
         void load_sound_fx(const LoadCallbacks& callbacks);
+        std::optional<std::vector<uint8_t>> load_main_sfx() const;
 
         PlatformAndVersion _platform_and_version;
 


### PR DESCRIPTION
For TR2-3 levels check `../SFX/MAIN.SFX` as well as checking for OG `MAIN.SFX`.
People can then open the levels from the remastered folders without having to copy MAIN.SFX around, or even know about it.
Closes #1309.