### PR TITLE
Add auto-hiders to all list windows

### DIFF
--- a/trview.app/Windows/AutoHider.cpp
+++ b/trview.app/Windows/AutoHider.cpp
@@ -1,0 +1,25 @@
+#include "AutoHider.h"
+
+namespace trview
+{
+    bool AutoHider::changed() const
+    {
+        return _enabled_changed;
+    }
+
+    void AutoHider::check_focus()
+    {
+        const bool focused = ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows);
+        _enabled_changed = !_was_focused && focused;
+        _was_focused = focused;
+    }
+
+    void AutoHider::render()
+    {
+        ImGui::SameLine();
+        if (ImGui::Checkbox("Auto Hide", &_enabled))
+        {
+            _enabled_changed = true;
+        }
+    }
+}

--- a/trview.app/Windows/AutoHider.h
+++ b/trview.app/Windows/AutoHider.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <ranges>
+#include "../Filters/Filters.h"
+
+namespace trview
+{
+    class AutoHider final
+    {
+    public:
+        bool changed() const;
+        void check_focus();
+        void render();
+
+        template <std::ranges::forward_range T, std::ranges::forward_range R, typename F>
+        bool apply(T&& full_range, R&& partial_range, Filters<F>& filters);
+
+        template <std::ranges::forward_range T, std::ranges::forward_range R>
+        bool apply(T&& full_range, R&& partial_range, bool filter_changed = true);
+    private:
+        bool _was_focused{ false };
+        bool _enabled{ false };
+        bool _enabled_changed{ false };
+    };
+}
+
+#include "AutoHider.inl"

--- a/trview.app/Windows/AutoHider.inl
+++ b/trview.app/Windows/AutoHider.inl
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace trview
+{
+    template <std::ranges::forward_range T, std::ranges::forward_range R, typename F>
+    bool AutoHider::apply(T&& full_range, R&& partial_range, Filters<F>& filters)
+    {
+        return apply(full_range, partial_range, filters.test_and_reset_changed());
+    }
+
+    template <std::ranges::forward_range T, std::ranges::forward_range R>
+    bool AutoHider::apply(T&& full_range, R&& partial_range, bool filter_changed)
+    {
+        if (_enabled_changed || (_enabled && filter_changed))
+        {
+            for (auto& item : full_range)
+            {
+                if (auto item_ptr = item.lock())
+                {
+                    bool new_value = !_enabled || std::ranges::find(partial_range, item_ptr) != partial_range.end();
+                    item_ptr->set_visible(new_value);
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -141,6 +141,7 @@ namespace trview
         calculate_column_widths();
         if (ImGui::BeginChild(Names::list_panel.c_str(), ImVec2(0, 0), ImGuiChildFlags_AlwaysAutoResize | ImGuiChildFlags_AutoResizeX, ImGuiWindowFlags_NoScrollbar))
         {
+            _auto_hider.check_focus();
             _filters.render();
             ImGui::SameLine();
 
@@ -152,6 +153,8 @@ namespace trview
                 set_sync(sync);
             }
 
+            _auto_hider.render();
+
             auto filtered_camera_sinks =
                 _all_camera_sinks |
                 std::views::filter([&](auto&& cs)
@@ -161,6 +164,11 @@ namespace trview
                     }) |
                 std::views::transform([](auto&& cs) { return cs.lock(); }) |
                 std::ranges::to<std::vector>();
+
+            if (_auto_hider.apply(_all_camera_sinks, filtered_camera_sinks, _filters))
+            {
+                on_scene_changed();
+            }
 
             RowCounter counter{ "camera/sinks", _all_camera_sinks.size() };
             if (ImGui::BeginTable(Names::camera_sink_list.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(0, -counter.height())))

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -5,6 +5,7 @@
 #include "../../Track/Track.h"
 #include "ICameraSinkWindow.h"
 #include "../ColumnSizer.h"
+#include "../AutoHider.h"
 
 namespace trview
 {
@@ -53,5 +54,6 @@ namespace trview
         std::vector<std::weak_ptr<ITrigger>> _triggered_by;
         Track<Type::Room> _track;
         ColumnSizer _column_sizer;
+        AutoHider _auto_hider;
     };
 }

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -97,6 +97,8 @@ namespace trview
         calculate_column_widths();
         if (ImGui::BeginChild(Names::item_list_panel.c_str(), ImVec2(0, 0), ImGuiChildFlags_AutoResizeX, ImGuiWindowFlags_NoScrollbar))
         {
+            _auto_hider.check_focus();
+
             _filters.render();
 
             ImGui::SameLine();
@@ -108,6 +110,8 @@ namespace trview
             {
                 set_sync_item(sync_item);
             }
+
+            _auto_hider.render();
 
             auto filtered_items = 
                 _all_items | 
@@ -121,6 +125,11 @@ namespace trview
                         return !(!item || (_track.enabled<Type::Room>() && item->room().lock() != _current_room.lock() || !_filters.match(*item)));
                     }) |
                 std::ranges::to<std::vector>();
+
+            if (_auto_hider.apply(_all_items, filtered_items, _filters))
+            {
+                on_scene_changed();
+            }
 
             RowCounter counter{ "items",
                 static_cast<std::size_t>(std::ranges::count_if(_all_items, [this](auto&& item)

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -10,6 +10,7 @@
 #include "../Elements/IItem.h"
 #include "../Track/Track.h"
 #include "ColumnSizer.h"
+#include "AutoHider.h"
 
 namespace trview
 {
@@ -26,6 +27,7 @@ namespace trview
             static inline const std::string details_panel = "Item Details";
             static inline const std::string triggers_list = "##triggeredby";
             static inline const std::string item_stats = "##itemstats";
+            static inline const std::string auto_hide = "Auto-Hide";
         };
 
         explicit ItemsWindow(const std::shared_ptr<IClipboard>& clipboard);
@@ -73,5 +75,6 @@ namespace trview
 
         ColumnSizer _column_sizer;
         bool _ng_plus{ false };
+        AutoHider _auto_hider;
     };
 }

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -83,6 +83,8 @@ namespace trview
         calculate_column_widths();
         if (ImGui::BeginChild(Names::light_list_panel.c_str(), ImVec2(0, 0), ImGuiChildFlags_AutoResizeX, ImGuiWindowFlags_NoScrollbar))
         {
+            _auto_hider.check_focus();
+
             _filters.render();
             ImGui::SameLine();
 
@@ -94,6 +96,8 @@ namespace trview
                 set_sync_light(sync_light);
             }
 
+            _auto_hider.render();
+
             auto filtered_lights =
                 _all_lights |
                 std::views::filter([&](auto&& light)
@@ -103,6 +107,11 @@ namespace trview
                     }) |
                 std::views::transform([](auto&& light) { return light.lock(); }) |
                 std::ranges::to<std::vector>();
+
+            if (_auto_hider.apply(_all_lights, filtered_lights, _filters))
+            {
+                on_scene_changed();
+            }
 
             RowCounter counter{ "lights", _all_lights.size() };
             if (ImGui::BeginTable(Names::lights_listbox.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(0, -counter.height())))

--- a/trview.app/Windows/LightsWindow.h
+++ b/trview.app/Windows/LightsWindow.h
@@ -6,6 +6,7 @@
 #include "../Filters/Filters.h"
 #include "../Track/Track.h"
 #include "ColumnSizer.h"
+#include "AutoHider.h"
 
 namespace trview
 {
@@ -56,5 +57,6 @@ namespace trview
         bool _force_sort{ false };
         Track<Type::Room> _track;
         ColumnSizer _column_sizer;
+        AutoHider _auto_hider;
     };
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -290,6 +290,8 @@ namespace trview
         calculate_column_widths();
         if (ImGui::BeginChild(Names::rooms_panel.c_str(), ImVec2(0, 0), ImGuiChildFlags_AutoResizeX, ImGuiWindowFlags_NoScrollbar))
         {
+            _auto_hider.check_focus();
+
             _filters.render();
 
             ImGui::SameLine();
@@ -302,6 +304,8 @@ namespace trview
                 set_sync_room(sync_room);
             }
 
+            _auto_hider.render();
+
             auto filtered_rooms =
                 _all_rooms |
                 std::views::filter([&](auto&& room)
@@ -311,6 +315,11 @@ namespace trview
                     }) |
                 std::views::transform([](auto&& room) { return room.lock(); }) |
                 std::ranges::to<std::vector>();
+
+            if (_auto_hider.apply(_all_rooms, filtered_rooms, _filters))
+            {
+                on_scene_changed();
+            }
 
             RowCounter counter{ "rooms", _all_rooms.size() };
             if (ImGui::BeginTable(Names::rooms_list.c_str(), 5, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(0, -counter.height())))

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -11,6 +11,7 @@
 #include "../Filters/Filters.h"
 #include "../Track/Track.h"
 #include "ColumnSizer.h"
+#include "AutoHider.h"
 
 namespace trview
 {
@@ -126,5 +127,6 @@ namespace trview
 
         ColumnSizer _column_sizer;
         bool _ng_plus{ false };
+        AutoHider _auto_hider;
     };
 }

--- a/trview.app/Windows/Sounds/SoundsWindow.cpp
+++ b/trview.app/Windows/Sounds/SoundsWindow.cpp
@@ -89,6 +89,8 @@ namespace trview
         calculate_column_widths();
         if (ImGui::BeginChild(Names::sound_source_list_panel.c_str(), ImVec2(200, 0), ImGuiChildFlags_AutoResizeX, ImGuiWindowFlags_NoScrollbar))
         {
+            _auto_hider.check_focus();
+
             _filters.render();
             ImGui::SameLine();
             bool sync_sound_source = _sync_sound_source;
@@ -96,6 +98,8 @@ namespace trview
             {
                 set_sync_sound_source(sync_sound_source);
             }
+
+            _auto_hider.render();
 
             auto filtered_sound_sources =
                 _all_sound_sources |
@@ -106,6 +110,11 @@ namespace trview
                     }) |
                 std::views::transform([](auto&& sound) { return sound.lock(); }) |
                 std::ranges::to<std::vector>();
+
+            if (_auto_hider.apply(_all_sound_sources, filtered_sound_sources, _filters))
+            {
+                on_scene_changed();
+            }
 
             RowCounter counter{ "sound sources", _all_sound_sources.size() };
             if (ImGui::BeginTable(Names::sound_sources_list.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(200, -counter.height())))

--- a/trview.app/Windows/Sounds/SoundsWindow.h
+++ b/trview.app/Windows/Sounds/SoundsWindow.h
@@ -3,6 +3,7 @@
 #include "ISoundsWindow.h"
 #include "../ColumnSizer.h"
 #include "../../Filters/Filters.h"
+#include "../AutoHider.h"
 
 namespace trview
 {
@@ -53,5 +54,6 @@ namespace trview
         trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Unknown };
         Filters<ISoundSource> _filters;
         trlevel::Platform _level_platform{ trlevel::Platform::Unknown };
+        AutoHider _auto_hider;
     };
 }

--- a/trview.app/Windows/Statics/StaticsWindow.cpp
+++ b/trview.app/Windows/Statics/StaticsWindow.cpp
@@ -44,6 +44,7 @@ namespace trview
         calculate_column_widths();
         if (ImGui::BeginChild(Names::statics_list_panel.c_str(), ImVec2(0, 0), ImGuiChildFlags_AutoResizeX, ImGuiWindowFlags_NoScrollbar))
         {
+            _auto_hider.check_focus();
             _filters.render();
 
             ImGui::SameLine();
@@ -56,6 +57,8 @@ namespace trview
                 set_sync_static(sync_static);
             }
 
+            _auto_hider.render();
+
             auto filtered_statics =
                 _all_statics |
                 std::views::filter([&](auto&& stat)
@@ -65,6 +68,8 @@ namespace trview
                     }) |
                 std::views::transform([](auto&& stat) { return stat.lock(); }) |
                 std::ranges::to<std::vector>();
+
+            _auto_hider.apply(_all_statics, filtered_statics, _filters);
 
             RowCounter counter{ "statics", _all_statics.size() };
             if (ImGui::BeginTable(Names::statics_list.c_str(), 5, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(0, -counter.height())))

--- a/trview.app/Windows/Statics/StaticsWindow.h
+++ b/trview.app/Windows/Statics/StaticsWindow.h
@@ -10,6 +10,7 @@
 #include "../../Elements/IStaticMesh.h"
 #include "../../Filters/Filters.h"
 #include "../../Track/Track.h"
+#include "../AutoHider.h"
 
 namespace trview
 {
@@ -55,6 +56,7 @@ namespace trview
         std::weak_ptr<IRoom> _current_room;
         std::weak_ptr<IStaticMesh> _global_selected_static;
         std::shared_ptr<IClipboard> _clipboard;
+        AutoHider _auto_hider;
     };
 }
 

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -130,6 +130,8 @@ namespace trview
         calculate_column_widths();
         if (ImGui::BeginChild(Names::trigger_list_panel.c_str(), ImVec2(0, 0), ImGuiChildFlags_AutoResizeX, ImGuiWindowFlags_NoScrollbar))
         {
+            _auto_hider.check_focus();
+
             _filters.render();
             ImGui::SameLine();
 
@@ -140,6 +142,8 @@ namespace trview
             {
                 set_sync_trigger(sync_trigger);
             }
+
+            _auto_hider.render();
 
             ImGui::PushItemWidth(-1);
             const auto current_command = _selected_command.value_or(VirtualCommand{ .name = "All" });
@@ -513,7 +517,7 @@ namespace trview
 
     void TriggersWindow::filter_triggers()
     {
-        if (!_need_filtering && !_filters.test_and_reset_changed())
+        if (!_need_filtering && !_filters.test_and_reset_changed() && !_auto_hider.changed())
         {
             return;
         }
@@ -528,6 +532,11 @@ namespace trview
             });
         _need_filtering = false;
         _force_sort = true;
+
+        if (_auto_hider.apply(_all_triggers, _filtered_triggers | std::views::transform([](auto&& t) { return t.lock(); })))
+        {
+            on_scene_changed();
+        }
     }
 
     void TriggersWindow::calculate_column_widths()

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -12,6 +12,7 @@
 #include "../Elements/IItem.h"
 #include "../Elements/ITrigger.h"
 #include "ColumnSizer.h"
+#include "AutoHider.h"
 
 namespace trview
 {
@@ -85,5 +86,6 @@ namespace trview
         ColumnSizer _column_sizer;
         bool _force_sort{ false };
         Track<Type::Room> _track;
+        AutoHider _auto_hider;
     };
 }

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -78,6 +78,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Routing\RandomizerRoute.cpp" />
     <ClCompile Include="Sound\Sound.cpp" />
     <ClCompile Include="Sound\SoundStorage.cpp" />
+    <ClCompile Include="Windows\AutoHider.cpp" />
     <ClCompile Include="Windows\Sounds\SoundsWindow.cpp" />
     <ClCompile Include="Windows\Sounds\SoundsWindowManager.cpp" />
     <ClCompile Include="Windows\Windows.cpp" />
@@ -207,6 +208,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="UI\Fonts\Fonts.h" />
     <ClInclude Include="UI\Fonts\IFonts.h" />
     <ClInclude Include="UserCancelledException.h" />
+    <ClInclude Include="Windows\AutoHider.h" />
     <ClInclude Include="Windows\ColumnSizer.h" />
     <ClInclude Include="Windows\Console\Console.h" />
     <ClInclude Include="Windows\Console\ConsoleManager.h" />
@@ -451,6 +453,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <None Include="Elements\IStaticMesh.inl" />
     <None Include="Lua\Lua.inl" />
     <None Include="Track\Track.inl" />
+    <None Include="Windows\AutoHider.inl" />
     <Text Include="Resources\Files\actions.json">
       <FileType>Document</FileType>
     </Text>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -353,6 +353,9 @@
     <ClCompile Include="Elements\Remastered\NgPlusSwitcher.cpp">
       <Filter>Elements\Remastered</Filter>
     </ClCompile>
+    <ClCompile Include="Windows\AutoHider.cpp">
+      <Filter>Windows</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -1171,6 +1174,9 @@
     <ClInclude Include="Mocks\Elements\INgPlusSwitcher.h">
       <Filter>Mocks\Elements</Filter>
     </ClInclude>
+    <ClInclude Include="Windows\AutoHider.h">
+      <Filter>Windows</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">
@@ -1451,6 +1457,9 @@
     </None>
     <None Include="Elements\IStaticMesh.inl">
       <Filter>Elements\StaticMesh</Filter>
+    </None>
+    <None Include="Windows\AutoHider.inl">
+      <Filter>Windows</Filter>
     </None>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Add `Auto Hide` checkbox to all list windows. This will make the visibility of the elements in the level match the filters of the window.
Closes #1053 