### PR TITLE
Show extra values for TRNG flip effects, regular camera/flyby

### DIFF
--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -179,5 +179,6 @@ namespace trlevel
         virtual std::vector<tr_sound_source> sound_sources() const = 0;
         virtual std::vector<tr_x_sound_details> sound_details() const = 0;
         virtual std::vector<int16_t> sound_map() const = 0;
+        virtual bool trng() const = 0;
     };
 }

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -168,6 +168,7 @@ namespace trlevel
         std::vector<tr_sound_source> sound_sources() const override;
         std::vector<tr_x_sound_details> sound_details() const override;
         std::vector<int16_t> sound_map() const override;
+        bool trng() const override;
     private:
         void generate_meshes(const std::vector<uint16_t>& mesh_data);
         tr_colour4 colour_from_object_texture(uint32_t texture) const;
@@ -238,5 +239,6 @@ namespace trlevel
         std::shared_ptr<IDecrypter>     _decrypter;
         std::string                     _filename;
         std::shared_ptr<trview::IFiles> _files;
+        bool                            _trng{ false };
     };
 }

--- a/trlevel/Mocks/ILevel.h
+++ b/trlevel/Mocks/ILevel.h
@@ -48,6 +48,7 @@ namespace trlevel
             MOCK_METHOD(std::vector<tr_sound_source>, sound_sources, (), (const, override));
             MOCK_METHOD(std::vector<tr_x_sound_details>, sound_details, (), (const, override));
             MOCK_METHOD(std::vector<int16_t>, sound_map, (), (const, override));
+            MOCK_METHOD(bool, trng, (), (const, override));
         };
     }
 }

--- a/trview.app.tests/Lua/Elements/Lua_TriggerTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_TriggerTests.cpp
@@ -16,7 +16,7 @@ using namespace DirectX::SimpleMath;
 
 TEST(Lua_Trigger, Commands)
 {
-    Command command{ 123, TriggerCommandType::Camera, 6 };
+    Command command{ 123, TriggerCommandType::Camera, { 6 } };
     auto trigger = mock_shared<MockTrigger>();
     EXPECT_CALL(*trigger, commands).WillRepeatedly(Return(std::vector<Command>{ command }));
 

--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -172,3 +172,13 @@ TEST(RoomsWindowManager, SetNgPlusPassedToWindows)
     manager->create_window();
     manager->set_ng_plus(false);
 }
+
+TEST(RoomsWindowManager, SetTrngPassedToWindows)
+{
+    auto mock_window = mock_shared<MockRoomsWindow>();
+    EXPECT_CALL(*mock_window, set_ng_plus(false)).Times(1);
+    EXPECT_CALL(*mock_window, set_ng_plus(true)).Times(1);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+    manager->set_trng(true);
+}

--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -176,8 +176,8 @@ TEST(RoomsWindowManager, SetNgPlusPassedToWindows)
 TEST(RoomsWindowManager, SetTrngPassedToWindows)
 {
     auto mock_window = mock_shared<MockRoomsWindow>();
-    EXPECT_CALL(*mock_window, set_ng_plus(false)).Times(1);
-    EXPECT_CALL(*mock_window, set_ng_plus(true)).Times(1);
+    EXPECT_CALL(*mock_window, set_trng(false)).Times(1);
+    EXPECT_CALL(*mock_window, set_trng(true)).Times(1);
     auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
     manager->create_window();
     manager->set_trng(true);

--- a/trview.app.tests/Windows/WindowsTests.cpp
+++ b/trview.app.tests/Windows/WindowsTests.cpp
@@ -548,6 +548,8 @@ TEST(Windows, SetLevel)
     EXPECT_CALL(rooms, set_items).Times(1);
     EXPECT_CALL(rooms, set_floordata).Times(1);
     EXPECT_CALL(rooms, set_rooms).Times(1);
+    EXPECT_CALL(rooms, set_ng_plus).Times(1);
+    EXPECT_CALL(rooms, set_trng).Times(1);
     auto [route_ptr, route] = create_mock<MockRouteWindowManager>();
     EXPECT_CALL(route, set_items).Times(1);
     EXPECT_CALL(route, set_triggers).Times(1);

--- a/trview.app.ui.tests/TriggersWindowTests.cpp
+++ b/trview.app.ui.tests/TriggersWindowTests.cpp
@@ -84,7 +84,7 @@ void register_triggers_window_tests(ImGuiTestEngine* engine)
             auto level = mock_shared<MockLevel>();
             ON_CALL(*level, camera_sink(100)).WillByDefault(Return(cam));
 
-            auto trigger = mock_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Camera, 100) })->with_level(level);
+            auto trigger = mock_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Camera, { 100 }) })->with_level(level);
             context.triggers = { trigger };
             context.ptr->set_triggers({ trigger });
             context.ptr->set_selected_trigger(trigger);
@@ -101,7 +101,7 @@ void register_triggers_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<TriggersWindowContext>();
             context.ptr = register_test_module().build();
 
-            auto trigger1 = mock_shared<MockTrigger>()->with_number(0)->with_commands({ Command(0, TriggerCommandType::FlipOff, 0) });
+            auto trigger1 = mock_shared<MockTrigger>()->with_number(0)->with_commands({ Command(0, TriggerCommandType::FlipOff, { 0 }) });
             context.triggers = { trigger1 };
             context.ptr->set_triggers({ trigger1 });
             context.ptr->set_selected_trigger(trigger1);
@@ -118,9 +118,9 @@ void register_triggers_window_tests(ImGuiTestEngine* engine)
         {
             auto& context = ctx->GetVars<TriggersWindowContext>();
             context.ptr = register_test_module().build();
-            auto trigger1 = mock_shared<MockTrigger>()->with_number(0)->with_commands({ Command(0, TriggerCommandType::FlipOff, 0) });
-            auto trigger2 = mock_shared<MockTrigger>()->with_number(1)->with_commands({ Command(0, TriggerCommandType::FlipOn, 0) });
-            auto trigger3 = mock_shared<MockTrigger>()->with_number(2)->with_commands({ Command(0, TriggerCommandType::FlipMap, 0) });
+            auto trigger1 = mock_shared<MockTrigger>()->with_number(0)->with_commands({ Command(0, TriggerCommandType::FlipOff, { 0 }) });
+            auto trigger2 = mock_shared<MockTrigger>()->with_number(1)->with_commands({ Command(0, TriggerCommandType::FlipOn, { 0 }) });
+            auto trigger3 = mock_shared<MockTrigger>()->with_number(2)->with_commands({ Command(0, TriggerCommandType::FlipMap, { 0 }) });
             auto trigger4 = mock_shared<MockTrigger>()->with_number(3);
             context.triggers = { trigger1, trigger2, trigger3, trigger4 };
             context.ptr->set_triggers({ trigger1, trigger2, trigger3, trigger4 });
@@ -157,7 +157,7 @@ void register_triggers_window_tests(ImGuiTestEngine* engine)
                 mock_shared<MockItem>()->with_number(1)
             };
 
-            auto trigger = mock_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Object, 1) });
+            auto trigger = mock_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Object, { 1 }) });
             context.ptr->set_items({ std::from_range, context.items });
             context.ptr->set_triggers({ trigger });
             context.triggers = { trigger };
@@ -196,8 +196,8 @@ void register_triggers_window_tests(ImGuiTestEngine* engine)
             auto& context = ctx->GetVars<TriggersWindowContext>();
             context.ptr = register_test_module().build();
 
-            auto trigger1 = mock_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Object, 1) });
-            auto trigger2 = mock_shared<MockTrigger>()->with_number(1)->with_commands({ Command(0, TriggerCommandType::Camera, 1) });
+            auto trigger1 = mock_shared<MockTrigger>()->with_commands({ Command(0, TriggerCommandType::Object, { 1 }) });
+            auto trigger2 = mock_shared<MockTrigger>()->with_number(1)->with_commands({ Command(0, TriggerCommandType::Camera, { 1 }) });
             std::vector<std::weak_ptr<ITrigger>> triggers{ trigger1, trigger2 };
             context.triggers = { trigger1, trigger2 };
             context.ptr->set_triggers(triggers);

--- a/trview.app/Elements/Floordata.h
+++ b/trview.app/Elements/Floordata.h
@@ -42,13 +42,13 @@ namespace trview
                 Count
             };
 
-            explicit Command(Function type, const std::vector<uint16_t>& data, FloordataMeanings meanings, const std::vector<std::weak_ptr<IItem>>& items);
+            explicit Command(Function type, const std::vector<uint16_t>& data, FloordataMeanings meanings, const std::vector<std::weak_ptr<IItem>>& items, bool trng);
 
             Function type;
             std::vector<uint16_t> data;
             std::vector<std::string> meanings;
         private:
-            void create_meanings(const std::vector<std::weak_ptr<IItem>>& items);
+            void create_meanings(const std::vector<std::weak_ptr<IItem>>& items, bool trng);
         };
 
         std::vector<Command> commands;
@@ -61,9 +61,9 @@ namespace trview
     /// <param name="floordata">The raw floor data.</param>
     /// <param name="index">The index to start at.</param>
     /// <returns>The parsed floor data.</returns>
-    Floordata parse_floordata(const std::vector<uint16_t>& floordata, uint32_t index, FloordataMeanings meanings);
+    Floordata parse_floordata(const std::vector<uint16_t>& floordata, uint32_t index, FloordataMeanings meanings, bool trng);
 
-    Floordata parse_floordata(const std::vector<uint16_t>& floordata, uint32_t index, FloordataMeanings meanings, const std::vector<std::weak_ptr<IItem>>& items);
+    Floordata parse_floordata(const std::vector<uint16_t>& floordata, uint32_t index, FloordataMeanings meanings, const std::vector<std::weak_ptr<IItem>>& items, bool trng);
 
     enum class TriangulationDirection
     {

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -149,6 +149,7 @@ namespace trview
         virtual std::vector<std::weak_ptr<ITrigger>> triggers() const = 0;
         virtual trlevel::LevelVersion version() const = 0;
         virtual std::weak_ptr<ISoundStorage> sound_storage() const = 0;
+        virtual bool trng() const = 0;
 
         Event<std::weak_ptr<IItem>> on_item_selected;
         // Event raised when the level needs to change the selected room.

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1360,6 +1360,7 @@ namespace trview
         _version = level->get_version();
         _floor_data = level->get_floor_data_all();
         _name = level->name();
+        _ng = level->trng();
 
         record_models(*level);
         callbacks.on_progress("Generating rooms");
@@ -1537,7 +1538,11 @@ namespace trview
                 }
             }
         }
-        
+    }
+
+    bool Level::trng() const
+    {
+        return _ng;
     }
 
     bool find_item_by_type_id(const ILevel& level, uint32_t type_id, std::weak_ptr<IItem>& output_item)

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -131,6 +131,7 @@ namespace trview
         bool show_sound_sources() const override;
         void set_ng_plus(bool show) override;
         bool ng_plus() const override;
+        bool trng() const override;
     private:
         void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage);
         void generate_triggers(const ITrigger::Source& trigger_source);
@@ -231,6 +232,7 @@ namespace trview
         std::vector<std::shared_ptr<ISoundSource>> _sound_sources;
 
         std::shared_ptr<INgPlusSwitcher> _ngplus_switcher;
+        bool _ng{ false };
     };
 
     /// Find the first item with the type id specified.

--- a/trview.app/Elements/Trigger.cpp
+++ b/trview.app/Elements/Trigger.cpp
@@ -3,8 +3,8 @@
 
 namespace trview
 {
-    Command::Command(uint32_t number, TriggerCommandType type, uint16_t index)
-        : _number(number), _type(type), _index(index)
+    Command::Command(uint32_t number, TriggerCommandType type, const std::vector<uint16_t>& data)
+        : _number(number), _type(type), _data(data)
     {
     }
 
@@ -20,7 +20,12 @@ namespace trview
 
     uint16_t Command::index() const
     {
-        return _index;
+        return _data.empty() ? 0 : _data[0];
+    }
+
+    std::vector<uint16_t> Command::data() const
+    {
+        return _data;
     }
 
     Trigger::Trigger(uint32_t number, const std::weak_ptr<IRoom>& room, uint16_t x, uint16_t z, const TriggerInfo& trigger_info, trlevel::LevelVersion level_version, const std::weak_ptr<ILevel>& level, const IMesh::TransparentSource& mesh_source)
@@ -29,14 +34,14 @@ namespace trview
         _level_version(level_version), _mesh_source(mesh_source), _level(level)
     {
         uint32_t command_index = 0;
-        for (auto action : trigger_info.commands)
+        for (const auto& action : trigger_info.commands)
         {
-            _commands.push_back({ command_index++, action.first, action.second });
-            // Special case for object still.
-            if (equals_any(action.first, TriggerCommandType::Object, TriggerCommandType::LookAtItem))
+            const Command command{ command_index++, action.type, action.data };
+            if (equals_any(action.type, TriggerCommandType::Object, TriggerCommandType::LookAtItem))
             {
-                _objects.push_back(action.second);
+                _objects.push_back(command.index());
             }
+            _commands.push_back(command);
         }
     }
 

--- a/trview.app/Elements/Types.h
+++ b/trview.app/Elements/Types.h
@@ -49,23 +49,30 @@ namespace trview
 
     struct TriggerInfo
     {
+        struct Command
+        {
+            TriggerCommandType      type;
+            std::vector<uint16_t>   data;
+        };
+
         std::uint8_t timer, oneshot, mask;
         TriggerType type; 
         uint16_t sector_id;
-        std::vector<std::pair<TriggerCommandType, std::uint16_t>> commands;
+        std::vector<Command> commands;
     };
 
     class Command final
     {
     public:
-        Command(uint32_t number, TriggerCommandType type, uint16_t index);
+        Command(uint32_t number, TriggerCommandType type, const std::vector<uint16_t>& data);
         uint32_t number() const;
         TriggerCommandType type() const;
         uint16_t index() const;
+        std::vector<uint16_t> data() const;
     private:
         uint32_t _number;
         TriggerCommandType _type;
-        uint16_t _index;
+        std::vector<uint16_t> _data;
     };
     
 }

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -142,7 +142,7 @@ namespace trview
                             {
                                 lua_newtable(L);
                                 push_list(L, 
-                                    parse_floordata(level->floor_data(), sector->floordata_index(), FloordataMeanings::None).commands
+                                    parse_floordata(level->floor_data(), sector->floordata_index(), FloordataMeanings::None, level->trng()).commands
                                     | std::views::transform([](auto& f) { return f.data; })
                                     | std::views::join,
                                     [](auto L, auto f) { lua_pushinteger(L, f); });

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -87,6 +87,7 @@ namespace trview
             MOCK_METHOD(trlevel::Platform, platform, (), (const, override));
             MOCK_METHOD(void, set_ng_plus, (bool), (override));
             MOCK_METHOD(bool, ng_plus, (), (const, override));
+            MOCK_METHOD(bool, trng, (), (const, override));
 
             std::shared_ptr<MockLevel> with_version(trlevel::LevelVersion version)
             {

--- a/trview.app/Mocks/Windows/IRoomsWindow.h
+++ b/trview.app/Mocks/Windows/IRoomsWindow.h
@@ -27,6 +27,7 @@ namespace trview
             MOCK_METHOD(void, clear_selected_light, (), (override));
             MOCK_METHOD(void, clear_selected_camera_sink, (), (override));
             MOCK_METHOD(void, set_ng_plus, (bool), (override));
+            MOCK_METHOD(void, set_trng, (bool), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IRoomsWindowManager.h
+++ b/trview.app/Mocks/Windows/IRoomsWindowManager.h
@@ -25,6 +25,7 @@ namespace trview
             MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
             MOCK_METHOD(void, set_selected_light, (const std::weak_ptr<ILight>&), (override));
             MOCK_METHOD(void, set_ng_plus, (bool), (override));
+            MOCK_METHOD(void, set_trng, (bool), (override));
         };
     }
 }

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -86,5 +86,6 @@ namespace trview
         virtual void clear_selected_light() = 0;
         virtual void clear_selected_camera_sink() = 0;
         virtual void set_ng_plus(bool value) = 0;
+        virtual void set_trng(bool value) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -63,5 +63,6 @@ namespace trview
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) = 0;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
         virtual void set_ng_plus(bool value) = 0;
+        virtual void set_trng(bool value) = 0;
     };
 }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -719,7 +719,7 @@ namespace trview
             {
                 const auto& sectors = room.sectors();
                 return sectors
-                    | std::views::transform([&](auto&& s) { return parse_floordata(_floordata, s->floordata_index(), FloordataMeanings::None).commands; })
+                    | std::views::transform([&](auto&& s) { return parse_floordata(_floordata, s->floordata_index(), FloordataMeanings::None, _trng).commands; })
                     | std::views::join
                     | std::views::transform([](auto&& c) { return c.type; })
                     | std::ranges::to<std::unordered_set>()
@@ -971,7 +971,7 @@ namespace trview
 
             if (selected_sector)
             {
-                const Floordata floordata = parse_floordata(_floordata, selected_sector->floordata_index(), FloordataMeanings::Generate, _all_items);
+                const Floordata floordata = parse_floordata(_floordata, selected_sector->floordata_index(), FloordataMeanings::Generate, _all_items, _trng);
 
                 uint32_t index = selected_sector->floordata_index();
                 for (const auto& command : floordata.commands)
@@ -1284,5 +1284,10 @@ namespace trview
     void RoomsWindow::set_ng_plus(bool value)
     {
         _ng_plus = value;
+    }
+
+    void RoomsWindow::set_trng(bool value)
+    {
+        _trng = value;
     }
 }

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -50,6 +50,7 @@ namespace trview
         virtual void clear_selected_light() override;
         virtual void clear_selected_camera_sink() override;
         void set_ng_plus(bool value) override;
+        void set_trng(bool value) override;
     private:
         void set_sync_room(bool value);
         void render_rooms_list();
@@ -128,5 +129,6 @@ namespace trview
         ColumnSizer _column_sizer;
         bool _ng_plus{ false };
         AutoHider _auto_hider;
+        bool _trng{ false };
     };
 }

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -118,6 +118,7 @@ namespace trview
         rooms_window->set_selected_camera_sink(_selected_camera_sink);
         rooms_window->set_selected_light(_selected_light);
         rooms_window->set_ng_plus(_ng_plus);
+        rooms_window->set_trng(_trng);
         return add_window(rooms_window);
     }
 
@@ -159,6 +160,15 @@ namespace trview
         for (auto& [_, window] : _windows)
         {
             window->set_ng_plus(value);
+        }
+    }
+
+    void RoomsWindowManager::set_trng(bool value)
+    {
+        _trng = value;
+        for (auto& [_, window] : _windows)
+        {
+            window->set_trng(value);
         }
     }
 }

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -44,6 +44,7 @@ namespace trview
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) override;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
         void set_ng_plus(bool value) override;
+        void set_trng(bool value) override;
     private:
         std::vector<std::weak_ptr<IItem>> _all_items;
         std::vector<std::weak_ptr<IRoom>> _all_rooms;
@@ -58,6 +59,7 @@ namespace trview
         std::weak_ptr<ICameraSink> _selected_camera_sink;
         std::weak_ptr<ILight> _selected_light;
         bool _ng_plus{ false };
+        bool _trng{ false };
     };
 }
 

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -300,7 +300,7 @@ namespace trview
 
                 if (selected_trigger)
                 {
-                    auto add_stat = [&]<typename T>(const std::string& name, const T&& value)
+                    auto add_stat = [&]<typename T>(const std::string & name, const T && value)
                     {
                         const auto string_value = get_string(value);
                         ImGui::TableNextColumn();
@@ -314,10 +314,10 @@ namespace trview
                     };
 
                     auto position_text = [=]()
-                    {
-                        const auto p = selected_trigger->position() * trlevel::Scale;
-                        return std::format("{:.0f}, {:.0f}, {:.0f}", p.x, p.y, p.z);
-                    };
+                        {
+                            const auto p = selected_trigger->position() * trlevel::Scale;
+                            return std::format("{:.0f}, {:.0f}, {:.0f}", p.x, p.y, p.z);
+                        };
 
                     add_stat("Type", trigger_type_name(selected_trigger->type()));
                     add_stat("#", selected_trigger->number());
@@ -349,12 +349,19 @@ namespace trview
             {
                 on_add_to_route(_selected_trigger);
             }
+
+            const bool any_extra = std::ranges::any_of(_local_selected_trigger_commands, [](auto&& c) { return c.data().size() > 1; });
+
             ImGui::Text("Commands");
-            if (ImGui::BeginTable(Names::commands_list.c_str(), 3, ImGuiTableFlags_ScrollY | ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -1)))
+            if (ImGui::BeginTable(Names::commands_list.c_str(), any_extra ? 4 : 3, ImGuiTableFlags_ScrollY | ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -1)))
             {
                 ImGui::TableSetupColumn("Type");
                 ImGui::TableSetupColumn("Index");
                 ImGui::TableSetupColumn("Entity");
+                if (any_extra)
+                {
+                    ImGui::TableSetupColumn("Extra");
+                }
                 ImGui::TableSetupScrollFreeze(1, 1);
                 ImGui::TableHeadersRow();
 
@@ -393,6 +400,14 @@ namespace trview
                     ImGui::Text(std::to_string(command.index()).c_str());
                     ImGui::TableNextColumn();
                     ImGui::Text(get_command_display(command).c_str());;
+                    if (any_extra)
+                    {
+                        ImGui::TableNextColumn();
+                        const auto data = command.data();
+                        ImGui::Text(join(
+                            std::ranges::subrange(data.begin() + 1, data.end()) |
+                            std::views::transform([](auto&& d) { return std::to_string(d); })).c_str());
+                    }
                 }
 
                 ImGui::EndTable();

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -196,6 +196,7 @@ namespace trview
         _rooms_windows->set_floordata(new_level->floor_data());
         _rooms_windows->set_rooms(new_level->rooms());
         _rooms_windows->set_ng_plus(new_level->ng_plus());
+        _rooms_windows->set_trng(new_level->trng());
         _route_window->set_items(new_level->items());
         _route_window->set_triggers(new_level->triggers());
         _route_window->set_rooms(new_level->rooms());


### PR DESCRIPTION
Flipeffect has an extra value in TRNG - show this instead of interpreting it as an item command.
Cameras and Flyby also have an extra value for their command so show that too. 

![image](https://github.com/user-attachments/assets/569bbcea-aaa5-4286-8513-e8bd39bb26a8)
![image](https://github.com/user-attachments/assets/18820360-8510-445e-8e70-c8edbc9a7abb)

Closes #739