### PR TITLE
Re-enable package library

### DIFF
--- a/trview.app/Lua/Lua.cpp
+++ b/trview.app/Lua/Lua.cpp
@@ -64,6 +64,7 @@ namespace trview
 
         static const luaL_Reg loadedlibs[] = {
           {LUA_GNAME, luaopen_base},
+          {LUA_LOADLIBNAME, luaopen_package},
           {LUA_COLIBNAME, luaopen_coroutine},
           {LUA_TABLIBNAME, luaopen_table},
           {LUA_IOLIBNAME, luaopen_io},


### PR DESCRIPTION
Re-enable package library for Lua so plugins start working again.
Closes #1329