### PR TITLE
Add Lua bindings for trigger command data

### DIFF
--- a/doc/lua/command.md
+++ b/doc/lua/command.md
@@ -5,6 +5,7 @@ Commands are used in [Triggers](trigger.md)
 # Properties
 | Name | Type | Mode | Description |
 | ---- | ---- | ---- | ---- |
+| data | table | R | Raw data for command |
 | index | number | R | Index argument for command |
 | number | number | R | Command number |
 | type | string | R | Command type name |

--- a/trview.app.tests/Lua/Elements/Lua_TriggerTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_TriggerTests.cpp
@@ -38,6 +38,11 @@ TEST(Lua_Trigger, Commands)
     ASSERT_EQ(0, luaL_dostring(L, "return t.commands[1].index"));
     ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
     ASSERT_EQ(6, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return t.commands[1].data"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return t.commands[1].data[1]"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(6, lua_tointeger(L, -1));
 }
 
 TEST(Lua_Trigger, Flags)

--- a/trview.app.ui.tests/TriggersWindowTests.cpp
+++ b/trview.app.ui.tests/TriggersWindowTests.cpp
@@ -89,7 +89,7 @@ void register_triggers_window_tests(ImGuiTestEngine* engine)
             context.ptr->set_triggers({ trigger });
             context.ptr->set_selected_trigger(trigger);
 
-            ctx->ItemClick("/**/Camera##0");
+            ctx->ItemClick("/**/0##command-0");
 
             IM_CHECK_EQ(raised, cam);
         });
@@ -163,7 +163,7 @@ void register_triggers_window_tests(ImGuiTestEngine* engine)
             context.triggers = { trigger };
             context.ptr->set_selected_trigger(trigger);
 
-            ctx->ItemClick("/**/Item##0");
+            ctx->ItemClick("/**/0##command-0");
 
             auto selected = context.ptr->selected_trigger().lock();
             IM_CHECK_EQ(selected, trigger);

--- a/trview.app/Lua/Elements/Trigger/Lua_Trigger.cpp
+++ b/trview.app/Lua/Elements/Trigger/Lua_Trigger.cpp
@@ -22,6 +22,16 @@ namespace trview
                 lua_setfield(L, -2, "index");
                 lua_pushstring(L, command_type_name(command.type()).c_str());
                 lua_setfield(L, -2, "type");
+                lua_newtable(L);
+                int index = 1;
+                for (const auto& data : command.data())
+                {
+                    lua_pushnumber(L, index);
+                    lua_pushnumber(L, data);
+                    lua_settable(L, -3);
+                    ++index;
+                }
+                lua_setfield(L, -2, "data");
             }
 
             int trigger_index(lua_State* L)

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -353,8 +353,9 @@ namespace trview
             const bool any_extra = std::ranges::any_of(_local_selected_trigger_commands, [](auto&& c) { return c.data().size() > 1; });
 
             ImGui::Text("Commands");
-            if (ImGui::BeginTable(Names::commands_list.c_str(), any_extra ? 4 : 3, ImGuiTableFlags_ScrollY | ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -1)))
+            if (ImGui::BeginTable(Names::commands_list.c_str(), any_extra ? 5 : 4, ImGuiTableFlags_ScrollY | ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -1)))
             {
+                ImGui::TableSetupColumn("#");
                 ImGui::TableSetupColumn("Type");
                 ImGui::TableSetupColumn("Index");
                 ImGui::TableSetupColumn("Entity");
@@ -367,6 +368,7 @@ namespace trview
 
                 imgui_sort(_local_selected_trigger_commands,
                     {
+                        [](auto&& l, auto&& r) { return l.number() < r.number(); },
                         [](auto&& l, auto&& r) { return std::tuple(command_type_name(l.type()), l.index()) < std::tuple(command_type_name(r.type()), r.index()); },
                         [](auto&& l, auto&& r) { return l.index() < r.index(); },
                         [&](auto&& l, auto&& r) { return std::tuple(get_command_display(l), l.index()) < std::tuple(get_command_display(r), r.index()); },
@@ -377,7 +379,7 @@ namespace trview
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
                     bool selected = false;
-                    if (ImGui::Selectable(std::format("{}##{}", command_type_name(command.type()), command.number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
+                    if (ImGui::Selectable(std::format("{}##command-{}", command.number(), command.number()).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                     {
                         if (command.type() == TriggerCommandType::LookAtItem || command.type() == TriggerCommandType::Object && command.index() < _all_items.size())
                         {
@@ -396,6 +398,8 @@ namespace trview
                             }
                         }
                     }
+                    ImGui::TableNextColumn();
+                    ImGui::Text(command_type_name(command.type()).c_str());
                     ImGui::TableNextColumn();
                     ImGui::Text(std::to_string(command.index()).c_str());
                     ImGui::TableNextColumn();


### PR DESCRIPTION
Expose trigger command data to Lua.
Also add '#' column to triggers window commands list for correct ordering.
Closes #1331