### PR TITLE
Context menu option to filter to items on a tile

### DIFF
--- a/trview.app.tests/ItemsWindowManagerTests.cpp
+++ b/trview.app.tests/ItemsWindowManagerTests.cpp
@@ -240,3 +240,15 @@ TEST(ItemsWindowManager, SetNgPlusPassedToWindows)
     manager->create_window();
     manager->set_ng_plus(false);
 }
+
+TEST(ItemsWindowManager, Windows)
+{
+    auto mock_window = mock_shared<MockItemsWindow>();
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+    manager->create_window();
+    const auto windows = manager->windows();
+    ASSERT_EQ(windows.size(), 2);
+    ASSERT_EQ(windows[0].lock(), mock_window);
+    ASSERT_EQ(windows[1].lock(), mock_window);
+}

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -555,3 +555,11 @@ TEST(ViewerUI, NgPlusDisabled)
     ui->set_level(level);
 }
 
+TEST(ViewerUI, SetTileFilterEnabled)
+{
+    auto [context_menu_ptr, context_menu] = create_mock<MockContextMenu>();
+    EXPECT_CALL(context_menu, set_tile_filter_enabled).Times(1);
+    auto ui = register_test_module().with_context_menu(std::move(context_menu_ptr)).build();
+
+    ui->set_tile_filter_enabled(true);
+}

--- a/trview.app.ui.tests/ContextMenuTests.cpp
+++ b/trview.app.ui.tests/ContextMenuTests.cpp
@@ -319,4 +319,22 @@ void register_context_menu_tests(ImGuiTestEngine* engine)
             ASSERT_FALSE(context.menu->visible());
             ASSERT_EQ(raised.value().lock(), trigger);
         });
+
+    test<ContextMenuContext>(engine, "Context Menu", "Filters Disabled",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
+        [](ImGuiTestContext* ctx)
+        {
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
+            context.menu->set_tile_filter_enabled(true);
+
+            ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
+            IM_CHECK_EQ((ctx->ItemInfo("/**/Filter")->InFlags & ImGuiItemFlags_Disabled) != 0, false);
+
+            context.menu->set_tile_filter_enabled(false);
+            ctx->Yield();
+
+            IM_CHECK_EQ((ctx->ItemInfo("/**/Filter")->InFlags & ImGuiItemFlags_Disabled) != 0, true);
+        });
 }

--- a/trview.app.ui.tests/ContextMenuTests.cpp
+++ b/trview.app.ui.tests/ContextMenuTests.cpp
@@ -9,263 +9,314 @@ using namespace trview;
 using namespace trview::mocks;
 using namespace trview::tests;
 
+namespace
+{
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            std::shared_ptr<IItemsWindowManager> items_window_manager;
+
+            std::unique_ptr<ContextMenu> build()
+            {
+                return std::make_unique<ContextMenu>(items_window_manager);
+            }
+
+            test_module& with_items_window_manager(const std::shared_ptr<IItemsWindowManager>& items_window_manager)
+            {
+                this->items_window_manager = items_window_manager;
+                return *this;
+            }
+        };
+
+        return test_module{};
+    }
+
+    struct ContextMenuContext
+    {
+        std::unique_ptr<ContextMenu> menu;
+    };
+
+    void render(ContextMenuContext& context)
+    {
+        if (context.menu)
+        {
+            context.menu->render();
+        }
+    }
+}
+
 void register_context_menu_tests(ImGuiTestEngine* engine)
 {
-    test<ContextMenu>(engine, "Context Menu", "Add Mid Waypoint Disabled",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Add Mid Waypoint Disabled",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
-            menu.set_mid_waypoint_enabled(true);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
+            context.menu->set_mid_waypoint_enabled(true);
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
             IM_CHECK_EQ((ctx->ItemInfo("/**/Add Mid Waypoint")->InFlags & ImGuiItemFlags_Disabled) != 0, false);
 
-            menu.set_mid_waypoint_enabled(false);
+            context.menu->set_mid_waypoint_enabled(false);
             ctx->Yield();
 
             IM_CHECK_EQ((ctx->ItemInfo("/**/Add Mid Waypoint")->InFlags & ImGuiItemFlags_Disabled) != 0, true);
         });
 
-    test<ContextMenu>(engine, "Context Menu", "Add Mid Waypoint Not Raised When Disabled",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Add Mid Waypoint Not Raised When Disabled",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
-            menu.set_mid_waypoint_enabled(false);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
+            context.menu->set_mid_waypoint_enabled(false);
 
             bool raised = false;
-            auto token = menu.on_add_mid_waypoint += [&raised]() { raised = true; };
+            auto token = context.menu->on_add_mid_waypoint += [&raised]() { raised = true; };
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
             ctx->ItemClick("/**/Add Mid Waypoint");
 
             ASSERT_FALSE(raised);
-            ASSERT_TRUE(menu.visible());
+            ASSERT_TRUE(context.menu->visible());
         });
 
-    test<ContextMenu>(engine, "Context Menu", "Add Mid Waypoint Raised",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Add Mid Waypoint Raised",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
-            menu.set_mid_waypoint_enabled(true);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
+            context.menu->set_mid_waypoint_enabled(true);
 
             bool raised = false;
-            auto token = menu.on_add_mid_waypoint += [&raised]() { raised = true; };
+            auto token = context.menu->on_add_mid_waypoint += [&raised]() { raised = true; };
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
             ctx->ItemClick("/**/Add Mid Waypoint");
 
             IM_CHECK_EQ(raised, true);
-            IM_CHECK_EQ(menu.visible(), false);
+            IM_CHECK_EQ(context.menu->visible(), false);
         });
 
-    test<ContextMenu>(engine, "Context Menu", "Add Waypoint Raised",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Add Waypoint Raised",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
 
             bool raised = false;
-            auto token = menu.on_add_waypoint += [&raised]() { raised = true; };
+            auto token = context.menu->on_add_waypoint += [&raised]() { raised = true; };
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
             ctx->ItemClick("/**/Add Waypoint");
 
             IM_CHECK_EQ(raised, true);
-            IM_CHECK_EQ(menu.visible(), false);
+            IM_CHECK_EQ(context.menu->visible(), false);
         });
 
-    test<ContextMenu>(engine, "Context Menu", "Copy Number",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Copy Number",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
 
             std::optional<trview::IContextMenu::CopyType> raised;
-            auto token = menu.on_copy += [&raised](auto type) { raised = type; };
+            auto token = context.menu->on_copy += [&raised](auto type) { raised = type; };
 
             ctx->ItemOpen("/**/Copy");
             ctx->ItemClick("/##Menu_00/Room\\/Object Number");
 
             IM_CHECK_EQ(raised.has_value(), true);
             IM_CHECK_EQ(raised.value(), trview::IContextMenu::CopyType::Number);
-            IM_CHECK_EQ(menu.visible(), false);
+            IM_CHECK_EQ(context.menu->visible(), false);
         });
 
-    test<ContextMenu>(engine, "Context Menu", "Copy Position",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Copy Position",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
 
             std::optional<trview::IContextMenu::CopyType> raised;
-            auto token = menu.on_copy += [&raised](auto type) { raised = type; };
+            auto token = context.menu->on_copy += [&raised](auto type) { raised = type; };
 
             ctx->ItemOpen("/**/Copy");
             ctx->ItemClick("/**/Position");
 
             IM_CHECK_EQ(raised.has_value(), true);
             IM_CHECK_EQ(raised.value(), trview::IContextMenu::CopyType::Position);
-            IM_CHECK_EQ(menu.visible(), false);
+            IM_CHECK_EQ(context.menu->visible(), false);
         });
 
-    test<ContextMenu>(engine, "Context Menu", "Hide Disabled",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Hide Disabled",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
-            menu.set_hide_enabled(true);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
+            context.menu->set_hide_enabled(true);
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
             IM_CHECK_EQ((ctx->ItemInfo("/**/Hide")->InFlags & ImGuiItemFlags_Disabled) != 0, false);
 
-            menu.set_hide_enabled(false);
+            context.menu->set_hide_enabled(false);
             ctx->Yield();
 
             IM_CHECK_EQ((ctx->ItemInfo("/**/Hide")->InFlags & ImGuiItemFlags_Disabled) != 0, true);
         });
 
-    test<ContextMenu>(engine, "Context Menu", "Hide Not Raised When Disabled",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Hide Not Raised When Disabled",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
-            menu.set_hide_enabled(false);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build(); 
+            context.menu->set_visible(true);
+            context.menu->set_hide_enabled(false);
 
             bool raised = false;
-            auto token = menu.on_hide += [&raised]() { raised = true; };
+            auto token = context.menu->on_hide += [&raised]() { raised = true; };
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
             ctx->ItemClick("/**/Hide");
 
             ASSERT_FALSE(raised);
-            ASSERT_TRUE(menu.visible());
+            ASSERT_TRUE(context.menu->visible());
         });
 
-    test<ContextMenu>(engine, "Context Menu", "Hide Raised",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Hide Raised",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
-            menu.set_hide_enabled(true);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
+            context.menu->set_hide_enabled(true);
 
             bool raised = false;
-            auto token = menu.on_hide += [&raised]() { raised = true; };
+            auto token = context.menu->on_hide += [&raised]() { raised = true; };
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
             ctx->ItemClick("/**/Hide");
 
             ASSERT_TRUE(raised);
-            ASSERT_FALSE(menu.visible());
+            ASSERT_FALSE(context.menu->visible());
         });
 
-    test<ContextMenu>(engine, "Context Menu", "Orbit Here Raised",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Orbit Here Raised",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
 
             bool raised = false;
-            auto token = menu.on_orbit_here += [&raised]() { raised = true; };
+            auto token = context.menu->on_orbit_here += [&raised]() { raised = true; };
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
             ctx->ItemClick("/**/Orbit Here");
 
             ASSERT_TRUE(raised);
-            ASSERT_FALSE(menu.visible());
+            ASSERT_FALSE(context.menu->visible());
         });
 
-    test<ContextMenu>(engine, "Context Menu", "Remove Waypoint Disabled",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Remove Waypoint Disabled",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
-            menu.set_remove_enabled(true);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
+            context.menu->set_remove_enabled(true);
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
             IM_CHECK_EQ((ctx->ItemInfo("/**/Remove Waypoint")->InFlags& ImGuiItemFlags_Disabled) != 0, false);
 
-            menu.set_remove_enabled(false);
+            context.menu->set_remove_enabled(false);
             ctx->Yield();
 
             IM_CHECK_EQ((ctx->ItemInfo("/**/Remove Waypoint")->InFlags& ImGuiItemFlags_Disabled) != 0, true);
         });
 
-    test<ContextMenu>(engine, "Context Menu", "Remove Waypoint Not Raised When Disabled",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Remove Waypoint Not Raised When Disabled",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
-            menu.set_remove_enabled(false);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
+            context.menu->set_remove_enabled(false);
 
             bool raised = false;
-            auto token = menu.on_remove_waypoint += [&raised]() { raised = true; };
+            auto token = context.menu->on_remove_waypoint += [&raised]() { raised = true; };
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
             ctx->ItemClick("/**/Remove Waypoint");
 
             ASSERT_FALSE(raised);
-            ASSERT_TRUE(menu.visible());
+            ASSERT_TRUE(context.menu->visible());
         });
 
-    test<ContextMenu>(engine, "Context Menu", "Remove Waypoint Raised",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Remove Waypoint Raised",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
-            menu.set_remove_enabled(true);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
+            context.menu->set_remove_enabled(true);
 
             bool raised = false;
-            auto token = menu.on_remove_waypoint += [&raised]() { raised = true; };
+            auto token = context.menu->on_remove_waypoint += [&raised]() { raised = true; };
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
             ctx->ItemClick("/**/Remove Waypoint");
 
             ASSERT_TRUE(raised);
-            ASSERT_FALSE(menu.visible());
+            ASSERT_FALSE(context.menu->visible());
         });
 
-    test<ContextMenu>(engine, "Context Menu", "Trigger References",
-        [](ImGuiTestContext* ctx) { ctx->GetVars<ContextMenu>().render(); },
+    test<ContextMenuContext>(engine, "Context Menu", "Trigger References",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ContextMenuContext>()); },
         [](ImGuiTestContext* ctx)
         {
-            auto& menu = ctx->GetVars<ContextMenu>();
-            menu.set_visible(true);
+            auto& context = ctx->GetVars<ContextMenuContext>();
+            context.menu = register_test_module().build();
+            context.menu->set_visible(true);
 
             auto trigger = mock_shared<MockTrigger>();
             ON_CALL(*trigger, number).WillByDefault(testing::Return(100));
             ON_CALL(*trigger, type).WillByDefault(testing::Return(TriggerType::Trigger));
 
-            menu.set_triggered_by({ trigger });
+            context.menu->set_triggered_by({ trigger });
 
             std::optional<std::weak_ptr<ITrigger>> raised;
-            auto token = menu.on_trigger_selected += [&raised](auto type) { raised = type; };
+            auto token = context.menu->on_trigger_selected += [&raised](auto type) { raised = type; };
 
             ctx->MouseClickOnVoid(ImGuiMouseButton_Right);
             ctx->ItemOpen("/**/Trigger References");
             ctx->ItemClick("/##Menu_00/Trigger 100");
 
             ASSERT_TRUE(raised);
-            ASSERT_FALSE(menu.visible());
+            ASSERT_FALSE(context.menu->visible());
             ASSERT_EQ(raised.value().lock(), trigger);
         });
 }

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -319,6 +319,10 @@ namespace trview
         auto imgui_backend = std::make_shared<DX11ImGuiBackend>(window, device, files);
         auto fonts = std::make_shared<Fonts>(files, imgui_backend);
 
+        auto clipboard = std::make_shared<Clipboard>(window);
+        auto items_window_source = [=]() { return std::make_shared<ItemsWindow>(clipboard); };
+        auto items_window_manager = std::make_shared<ItemsWindowManager>(window, shortcuts, items_window_source);
+
         auto viewer_ui = std::make_unique<ViewerUI>(
             window,
             texture_storage,
@@ -326,11 +330,9 @@ namespace trview
             map_renderer_source,
             std::make_unique<SettingsWindow>(dialogs, shell, fonts),
             std::make_unique<ViewOptions>(),
-            std::make_unique<ContextMenu>(),
+            std::make_unique<ContextMenu>(items_window_manager),
             std::make_unique<CameraControls>(),
             std::make_unique<Toolbar>(plugins));
-
-        auto clipboard = std::make_shared<Clipboard>(window);
 
         auto viewer = std::make_unique<Viewer>(
             window,
@@ -349,7 +351,7 @@ namespace trview
             clipboard,
             std::make_shared<Camera>(window.size()));
 
-        auto items_window_source = [=]() { return std::make_shared<ItemsWindow>(clipboard); };
+        
         auto triggers_window_source = [=]() { return std::make_shared<TriggersWindow>(clipboard); };
         auto route_window_source = [=]() { return std::make_shared<RouteWindow>(clipboard, dialogs, files); };
         auto rooms_window_source = [=]() { return std::make_shared<RoomsWindow>(map_renderer_source, clipboard); };
@@ -388,7 +390,7 @@ namespace trview
                 std::make_unique<AboutWindowManager>(window, about_window_source),
                 std::make_unique<CameraSinkWindowManager>(window, shortcuts, camera_sink_window_source),
                 std::make_unique<ConsoleManager>(window, shortcuts, console_source, files),
-                std::make_unique<ItemsWindowManager>(window, shortcuts, items_window_source),
+                items_window_manager,
                 std::make_unique<LightsWindowManager>(window, shortcuts, lights_window_source),
                 std::make_unique<LogWindowManager>(window, log_window_source),
                 std::make_unique<PluginsWindowManager>(window, shortcuts, plugins_window_source),

--- a/trview.app/Filters/Filters.h
+++ b/trview.app/Filters/Filters.h
@@ -59,6 +59,8 @@ namespace trview
             bool initial_state() const noexcept;
         };
 
+        void add_filter(const Filter& filter);
+
         /// <summary>
         /// Add a getter definition to extract a value from an object.
         /// </summary>

--- a/trview.app/Filters/Filters.hpp
+++ b/trview.app/Filters/Filters.hpp
@@ -33,6 +33,13 @@ namespace trview
     }
 
     template <typename T>
+    void Filters<T>::add_filter(const Filter& filter)
+    {
+        _filters.push_back(filter);
+        _changed = true;
+    }
+
+    template <typename T>
     template <typename value_type>
     void Filters<T>::add_getter(const std::string& key, const std::function<value_type(const T&)>& getter)
     {

--- a/trview.app/Mocks/UI/IContextMenu.h
+++ b/trview.app/Mocks/UI/IContextMenu.h
@@ -17,6 +17,7 @@ namespace trview
             MOCK_METHOD(void, set_mid_waypoint_enabled, (bool), (override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_triggered_by, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
+            MOCK_METHOD(void, set_tile_filter_enabled, (bool), (override));
         };
     }
 }

--- a/trview.app/Mocks/UI/IViewerUI.h
+++ b/trview.app/Mocks/UI/IViewerUI.h
@@ -50,6 +50,7 @@ namespace trview
             MOCK_METHOD(void, set_route, (const std::weak_ptr<IRoute>&), (override));
             MOCK_METHOD(void, set_show_camera_position, (bool), (override));
             MOCK_METHOD(void, reset_layout, (), (override));
+            MOCK_METHOD(void, set_tile_filter_enabled, (bool), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IItemsWindow.h
+++ b/trview.app/Mocks/Windows/IItemsWindow.h
@@ -22,7 +22,7 @@ namespace trview
             MOCK_METHOD(void, set_level_version, (trlevel::LevelVersion), (override));
             MOCK_METHOD(void, set_model_checker, (const std::function<bool(uint32_t)>&), (override));
             MOCK_METHOD(void, set_ng_plus, (bool), (override));
-            MOCK_METHOD(void, add_filters, (std::vector<Filters<IItem>::Filter>), (override));
+            MOCK_METHOD(void, set_filters, (std::vector<Filters<IItem>::Filter>), (override));
             MOCK_METHOD(std::string, name, (), (const, override));
         };
     }

--- a/trview.app/Mocks/Windows/IItemsWindow.h
+++ b/trview.app/Mocks/Windows/IItemsWindow.h
@@ -22,6 +22,8 @@ namespace trview
             MOCK_METHOD(void, set_level_version, (trlevel::LevelVersion), (override));
             MOCK_METHOD(void, set_model_checker, (const std::function<bool(uint32_t)>&), (override));
             MOCK_METHOD(void, set_ng_plus, (bool), (override));
+            MOCK_METHOD(void, add_filters, (std::vector<Filters<IItem>::Filter>), (override));
+            MOCK_METHOD(std::string, name, (), (const, override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IItemsWindowManager.h
+++ b/trview.app/Mocks/Windows/IItemsWindowManager.h
@@ -21,6 +21,7 @@ namespace trview
             MOCK_METHOD(void, set_selected_item, (const std::weak_ptr<IItem>&), (override));
             MOCK_METHOD(std::weak_ptr<IItemsWindow>, create_window, (), (override));
             MOCK_METHOD(void, update, (float), (override));
+            MOCK_METHOD(std::vector<std::weak_ptr<IItemsWindow>>, windows, (), (const, override));
         };
     }
 }

--- a/trview.app/UI/ContextMenu.cpp
+++ b/trview.app/UI/ContextMenu.cpp
@@ -66,7 +66,7 @@ namespace trview
                 ImGui::EndMenu();
             }
 
-            if (ImGui::BeginMenu(Names::filter.c_str()))
+            if (ImGui::BeginMenu(Names::filter.c_str(), _tile_filter_enabled))
             {
                 if (ImGui::BeginMenu("By Tile in..."))
                 {
@@ -133,5 +133,10 @@ namespace trview
     void ContextMenu::set_triggered_by(const std::vector<std::weak_ptr<ITrigger>>& triggers)
     {
         _triggered_by = triggers;
+    }
+
+    void ContextMenu::set_tile_filter_enabled(bool value)
+    {
+        _tile_filter_enabled = value;
     }
 }

--- a/trview.app/UI/ContextMenu.cpp
+++ b/trview.app/UI/ContextMenu.cpp
@@ -1,8 +1,14 @@
 #include "ContextMenu.h"
+#include "../Windows/IItemsWindowManager.h"
 
 namespace trview
 {
     IContextMenu::~IContextMenu()
+    {
+    }
+
+    ContextMenu::ContextMenu(const std::weak_ptr<IItemsWindowManager>& items_window_manager)
+        : _items_window_manager(items_window_manager)
     {
     }
 
@@ -56,6 +62,37 @@ namespace trview
                             on_trigger_selected(trigger);
                         }
                     }
+                }
+                ImGui::EndMenu();
+            }
+
+            if (ImGui::BeginMenu(Names::filter.c_str()))
+            {
+                if (ImGui::BeginMenu("By Tile in..."))
+                {
+                    if (ImGui::BeginMenu("Items..."))
+                    {
+                        if (auto items_windows = _items_window_manager.lock())
+                        {
+                            if (ImGui::MenuItem("New Window"))
+                            {
+                                on_filter_items_to_tile(items_windows->create_window());
+                            }
+
+                            for (const auto& window : items_windows->windows())
+                            {
+                                if (auto actual_window = window.lock())
+                                {
+                                    if (ImGui::MenuItem(actual_window->name().c_str()))
+                                    {
+                                        on_filter_items_to_tile(window);
+                                    }
+                                }
+                            }
+                        }
+                        ImGui::EndMenu();
+                    }
+                    ImGui::EndMenu();
                 }
                 ImGui::EndMenu();
             }

--- a/trview.app/UI/ContextMenu.h
+++ b/trview.app/UI/ContextMenu.h
@@ -33,12 +33,14 @@ namespace trview
         virtual void set_mid_waypoint_enabled(bool value) override;
         virtual bool visible() const override;
         virtual void set_triggered_by(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
+        void set_tile_filter_enabled(bool value) override;
     private:
         bool _remove_enabled{ false };
         bool _hide_enabled{ false };
         bool _mid_enabled{ false };
         bool _can_show{ false };
         bool _visible{ false };
+        bool _tile_filter_enabled{ false };
         std::vector<std::weak_ptr<ITrigger>> _triggered_by;
         std::weak_ptr<IItemsWindowManager> _items_window_manager;
     };

--- a/trview.app/UI/ContextMenu.h
+++ b/trview.app/UI/ContextMenu.h
@@ -4,6 +4,8 @@
 
 namespace trview
 {
+    struct IItemsWindowManager;
+
     class ContextMenu final : public IContextMenu
     {
     public:
@@ -19,8 +21,10 @@ namespace trview
             static inline const std::string copy_position = "Position";
             static inline const std::string copy_number = "Room/Object Number";
             static inline const std::string trigger_references = "Trigger References";
+            static inline const std::string filter = "Filter";
         };
 
+        explicit ContextMenu(const std::weak_ptr<IItemsWindowManager>& items_window_manager);
         virtual ~ContextMenu() = default;
         virtual void render() override;
         virtual void set_visible(bool value) override;
@@ -36,5 +40,6 @@ namespace trview
         bool _can_show{ false };
         bool _visible{ false };
         std::vector<std::weak_ptr<ITrigger>> _triggered_by;
+        std::weak_ptr<IItemsWindowManager> _items_window_manager;
     };
 }

--- a/trview.app/UI/IContextMenu.h
+++ b/trview.app/UI/IContextMenu.h
@@ -5,6 +5,8 @@
 
 namespace trview
 {
+    struct IItemsWindow;
+
     struct IContextMenu
     {
         enum class CopyType
@@ -42,6 +44,7 @@ namespace trview
         /// Event raised when a trigger has been selected.
         /// </summary>
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
+        Event<std::weak_ptr<IItemsWindow>> on_filter_items_to_tile;
         virtual void render() = 0;
         /// <summary>
         /// Set the context menu to visible.

--- a/trview.app/UI/IContextMenu.h
+++ b/trview.app/UI/IContextMenu.h
@@ -76,5 +76,6 @@ namespace trview
         /// </summary>
         /// <param name="triggers"></param>
         virtual void set_triggered_by(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;
+        virtual void set_tile_filter_enabled(bool value) = 0;
     };
 }

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -259,5 +259,7 @@ namespace trview
         virtual void set_show_camera_position(bool value) = 0;
 
         virtual void reset_layout() = 0;
+
+        virtual void set_tile_filter_enabled(bool value) = 0;
     };
 }

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -14,6 +14,7 @@ namespace trview
 {
     struct IRoom;
     struct IItem;
+    struct IItemsWindow;
 
     enum class Tool
     {
@@ -106,6 +107,8 @@ namespace trview
         Event<std::weak_ptr<ITrigger>> on_select_trigger;
 
         Event<std::string, FontSetting> on_font;
+
+        Event<std::weak_ptr<IItemsWindow>> on_filter_items_to_tile;
 
         /// Render the UI.
         virtual void render() = 0;

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -116,6 +116,7 @@ namespace trview
         _context_menu->on_hide += on_hide;
         _context_menu->on_copy += on_copy;
         _context_menu->on_trigger_selected += on_select_trigger;
+        _context_menu->on_filter_items_to_tile += on_filter_items_to_tile;
         _context_menu->set_remove_enabled(false);
         _context_menu->set_hide_enabled(false);
 

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -600,4 +600,9 @@ namespace trview
     {
         _camera_position->reset();
     }
+
+    void ViewerUI::set_tile_filter_enabled(bool value)
+    {
+        _context_menu->set_tile_filter_enabled(value);
+    }
 }

--- a/trview.app/UI/ViewerUI.h
+++ b/trview.app/UI/ViewerUI.h
@@ -72,6 +72,7 @@ namespace trview
         void set_route(const std::weak_ptr<IRoute>& route) override;
         void set_show_camera_position(bool value) override;
         void reset_layout() override;
+        void set_tile_filter_enabled(bool value) override;
     private:
         void generate_tool_window();
         void render_route_notes();

--- a/trview.app/Windows/IItemsWindow.h
+++ b/trview.app/Windows/IItemsWindow.h
@@ -5,6 +5,7 @@
 #include <trview.common/Event.h>
 #include "../Elements/IItem.h"
 #include "../Elements/ITrigger.h"
+#include "../Filters/Filters.h"
 
 namespace trview
 {
@@ -27,6 +28,8 @@ namespace trview
 
         /// Event raised when the window is closed.
         Event<> on_window_closed;
+
+        virtual void add_filters(std::vector<Filters<IItem>::Filter> filters) = 0;
 
         /// Set the items to display in the window.
         /// @param items The items to show.
@@ -68,6 +71,8 @@ namespace trview
         virtual void set_model_checker(const std::function<bool(uint32_t)>& checker) = 0;
 
         virtual void set_ng_plus(bool value) = 0;
+
+        virtual std::string name() const = 0;
     };
 }
 

--- a/trview.app/Windows/IItemsWindow.h
+++ b/trview.app/Windows/IItemsWindow.h
@@ -29,7 +29,7 @@ namespace trview
         /// Event raised when the window is closed.
         Event<> on_window_closed;
 
-        virtual void add_filters(std::vector<Filters<IItem>::Filter> filters) = 0;
+        virtual void set_filters(std::vector<Filters<IItem>::Filter> filters) = 0;
 
         /// Set the items to display in the window.
         /// @param items The items to show.

--- a/trview.app/Windows/IItemsWindowManager.h
+++ b/trview.app/Windows/IItemsWindowManager.h
@@ -54,5 +54,7 @@ namespace trview
         /// </summary>
         /// <param name="delta">Elapsed time since previous update.</param>
         virtual void update(float delta) = 0;
+
+        virtual std::vector<std::weak_ptr<IItemsWindow>> windows() const = 0;
     };
 }

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -362,9 +362,9 @@ namespace trview
         return stay_open;
     }
 
-    void ItemsWindow::add_filters(std::vector<Filters<IItem>::Filter> filters)
+    void ItemsWindow::set_filters(std::vector<Filters<IItem>::Filter> filters)
     {
-        std::ranges::for_each(filters, [&](auto&& f) { _filters.add_filter(f); });
+        _filters.set_filters(filters);
     }
 
     void ItemsWindow::render()

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -364,10 +364,7 @@ namespace trview
 
     void ItemsWindow::add_filters(std::vector<Filters<IItem>::Filter> filters)
     {
-        for (auto filter : filters)
-        {
-            _filters.add_filter(filter);
-        }
+        std::ranges::for_each(filters, [&](auto&& f) { _filters.add_filter(f); });
     }
 
     void ItemsWindow::render()

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -362,6 +362,14 @@ namespace trview
         return stay_open;
     }
 
+    void ItemsWindow::add_filters(std::vector<Filters<IItem>::Filter> filters)
+    {
+        for (auto filter : filters)
+        {
+            _filters.add_filter(filter);
+        }
+    }
+
     void ItemsWindow::render()
     {
         if (!render_items_window())
@@ -486,5 +494,10 @@ namespace trview
     void ItemsWindow::set_ng_plus(bool value)
     {
         _ng_plus = value;
+    }
+
+    std::string ItemsWindow::name() const
+    {
+        return _id;
     }
 }

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -32,6 +32,7 @@ namespace trview
 
         explicit ItemsWindow(const std::shared_ptr<IClipboard>& clipboard);
         virtual ~ItemsWindow() = default;
+        virtual void add_filters(std::vector<Filters<IItem>::Filter> filters) override;
         virtual void render() override;
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
@@ -44,6 +45,7 @@ namespace trview
         virtual void set_level_version(trlevel::LevelVersion version) override;
         virtual void set_model_checker(const std::function<bool(uint32_t)>& checker) override;
         void set_ng_plus(bool value) override;
+        std::string name() const override;
     private:
         void set_sync_item(bool value);
         void render_items_list();

--- a/trview.app/Windows/ItemsWindow.h
+++ b/trview.app/Windows/ItemsWindow.h
@@ -32,7 +32,7 @@ namespace trview
 
         explicit ItemsWindow(const std::shared_ptr<IClipboard>& clipboard);
         virtual ~ItemsWindow() = default;
-        virtual void add_filters(std::vector<Filters<IItem>::Filter> filters) override;
+        void set_filters(std::vector<Filters<IItem>::Filter> filters) override;
         virtual void render() override;
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;

--- a/trview.app/Windows/ItemsWindowManager.cpp
+++ b/trview.app/Windows/ItemsWindowManager.cpp
@@ -113,4 +113,11 @@ namespace trview
     {
         WindowManager::update(delta);
     }
+
+    std::vector<std::weak_ptr<IItemsWindow>> ItemsWindowManager::windows() const
+    {
+        return _windows |
+            std::views::transform([](auto&& w) -> std::weak_ptr<IItemsWindow> { return w.second; }) |
+            std::ranges::to<std::vector>();
+    }
 }

--- a/trview.app/Windows/ItemsWindowManager.h
+++ b/trview.app/Windows/ItemsWindowManager.h
@@ -35,6 +35,7 @@ namespace trview
         virtual void set_selected_item(const std::weak_ptr<IItem>& item) override;
         virtual std::weak_ptr<IItemsWindow> create_window() override;
         virtual void update(float delta) override;
+        std::vector<std::weak_ptr<IItemsWindow>> windows() const override;
     private:
         std::vector<std::weak_ptr<IItem>> _items;
         std::vector<std::weak_ptr<ITrigger>> _triggers;

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -605,6 +605,7 @@ namespace trview
                 _ui->set_remove_waypoint_enabled(_current_pick.type == PickResult::Type::Waypoint);
                 _ui->set_hide_enabled(equals_any(_current_pick.type, PickResult::Type::Entity, PickResult::Type::Trigger, PickResult::Type::Light, PickResult::Type::Room, PickResult::Type::CameraSink, PickResult::Type::StaticMesh, PickResult::Type::SoundSource));
                 _ui->set_mid_waypoint_enabled(_current_pick.type == PickResult::Type::Room && _current_pick.triangle.normal.y < 0);
+                _ui->set_tile_filter_enabled(_current_pick.type == PickResult::Type::Room);
 
                 const auto level = _level.lock();
                 if (_current_pick.type == PickResult::Type::Entity && level)

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -283,7 +283,7 @@ namespace trview
                             const auto info = room->info();
                             const auto sector_x = static_cast<int>(_context_pick.position.x - (info.x / trlevel::Scale_X));
                             const auto sector_z = static_cast<int>(_context_pick.position.z - (info.z / trlevel::Scale_Z));
-                            window->add_filters(
+                            window->set_filters(
                                 {
                                     {.key = "Room", .compare = CompareOp::Equal, .value = std::to_string(room->number()), .op = Op::And },
                                     {.key = "X", .compare = CompareOp::Between, .value = std::to_string(info.x + sector_x * 1024), .value2 = std::to_string(info.x + (sector_x + 1) * 1024), .op = Op::And },

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -7,6 +7,8 @@
 #include <trview.graphics/ViewportStore.h>
 #include <trview.common/Strings.h>
 
+#include "../Windows/IItemsWindow.h"
+
 using namespace DirectX::SimpleMath;
 
 namespace trview
@@ -268,6 +270,30 @@ namespace trview
         };
         _ui->on_select_trigger += on_trigger_selected;
         _ui->on_font += on_font;
+        _token_store += _ui->on_filter_items_to_tile += [&](auto&& window_ptr)
+        {
+            if (_context_pick.hit && _context_pick.type == PickResult::Type::Room)
+            {
+                if (auto window = window_ptr.lock())
+                {
+                    if (const auto level = _level.lock())
+                    {
+                        if (const auto room = level->room(_context_pick.index).lock())
+                        {
+                            const auto info = room->info();
+                            const auto sector_x = static_cast<int>(_context_pick.position.x - (info.x / trlevel::Scale_X));
+                            const auto sector_z = static_cast<int>(_context_pick.position.z - (info.z / trlevel::Scale_Z));
+                            window->add_filters(
+                                {
+                                    {.key = "Room", .compare = CompareOp::Equal, .value = std::to_string(room->number()), .op = Op::And },
+                                    {.key = "X", .compare = CompareOp::Between, .value = std::to_string(info.x + sector_x * 1024), .value2 = std::to_string(info.x + (sector_x + 1) * 1024), .op = Op::And },
+                                    {.key = "Z", .compare = CompareOp::Between, .value = std::to_string(info.z + sector_z * 1024), .value2 = std::to_string(info.z + (sector_z + 1) * 1024) }
+                                });
+                        }
+                    }
+                }
+            }
+        };
 
         _ui->set_settings(_settings);
         _ui->set_camera_mode(ICamera::Mode::Orbit);

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -29,7 +29,7 @@ namespace trview
         std::unique_ptr<IAboutWindowManager> about_window_manager,
         std::unique_ptr<ICameraSinkWindowManager> camera_sink_windows,
         std::unique_ptr<IConsoleManager> console_manager,
-        std::unique_ptr<IItemsWindowManager> items_window_manager,
+        std::shared_ptr<IItemsWindowManager> items_window_manager,
         std::unique_ptr<ILightsWindowManager> lights_window_manager,
         std::unique_ptr<ILogWindowManager> log_window_manager,
         std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
@@ -40,7 +40,7 @@ namespace trview
         std::unique_ptr<ITexturesWindowManager> textures_window_manager,
         std::unique_ptr<ITriggersWindowManager> triggers_window_manager)
         : _about_windows(std::move(about_window_manager)), _camera_sink_windows(std::move(camera_sink_windows)), _console_manager(std::move(console_manager)),
-        _items_windows(std::move(items_window_manager)), _lights_windows(std::move(lights_window_manager)), _log_windows(std::move(log_window_manager)),
+        _items_windows(items_window_manager), _lights_windows(std::move(lights_window_manager)), _log_windows(std::move(log_window_manager)),
         _plugins_windows(std::move(plugins_window_manager)), _rooms_windows(std::move(rooms_window_manager)), _route_window(std::move(route_window_manager)),
         _sounds_windows(std::move(sounds_window_manager)), _statics_windows(std::move(statics_window_manager)), _textures_windows(std::move(textures_window_manager)),
         _triggers_windows(std::move(triggers_window_manager))

--- a/trview.app/Windows/Windows.h
+++ b/trview.app/Windows/Windows.h
@@ -28,7 +28,7 @@ namespace trview
             std::unique_ptr<IAboutWindowManager> about_window_manager,
             std::unique_ptr<ICameraSinkWindowManager> camera_sink_windows,
             std::unique_ptr<IConsoleManager> console_manager,
-            std::unique_ptr<IItemsWindowManager> items_window_manager,
+            std::shared_ptr<IItemsWindowManager> items_window_manager,
             std::unique_ptr<ILightsWindowManager> lights_window_manager,
             std::unique_ptr<ILogWindowManager> log_window_manager,
             std::unique_ptr<IPluginsWindowManager> plugins_window_manager,
@@ -62,7 +62,7 @@ namespace trview
         std::unique_ptr<IAboutWindowManager> _about_windows;
         std::unique_ptr<ICameraSinkWindowManager> _camera_sink_windows;
         std::unique_ptr<IConsoleManager> _console_manager;
-        std::unique_ptr<IItemsWindowManager> _items_windows;
+        std::shared_ptr<IItemsWindowManager> _items_windows;
         std::unique_ptr<ILightsWindowManager> _lights_windows;
         std::unique_ptr<ILogWindowManager> _log_windows;
         std::unique_ptr<IPluginsWindowManager> _plugins_windows;


### PR DESCRIPTION
Add an option to the context menu to filter an items window to only show items on the same tile.
Closes #167 