### PR TITLE
Add diff window to compare levels

### DIFF
--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -2305,7 +2305,7 @@ namespace trlevel
         {
             return og_main;
         }
-        return _files->load_file(std::format("{}../SFX/MAIN.SFX", path));
+        return _files->load_file(std::format("{}/../SFX/MAIN.SFX", path));
     }
 
     void Level::load_ngle_sound_fx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const LoadCallbacks& callbacks)

--- a/trlevel/tr_lights.cpp
+++ b/trlevel/tr_lights.cpp
@@ -260,7 +260,7 @@ namespace trlevel
         return 0;
     }
 
-    std::string light_type_name(LightType type)
+    std::string to_string(LightType type)
     {
         switch (type)
         {

--- a/trlevel/tr_lights.h
+++ b/trlevel/tr_lights.h
@@ -36,7 +36,7 @@ namespace trlevel
         float density() const;
     };
 
-    std::string light_type_name(LightType type);
+    std::string to_string(LightType type);
 
     std::vector<tr_x_room_light> convert_lights(std::vector<tr_room_light> lights);
     std::vector<tr_x_room_light> convert_lights(std::vector<tr_room_light_psx> lights);

--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -41,7 +41,7 @@ namespace
             std::shared_ptr<Room> build()
             {
                 auto new_room = std::make_shared<Room>(room, mesh_source, level_texture_storage, index, level);
-                new_room->initialise(*tr_level, room, *mesh_storage, static_mesh_source, static_mesh_position_source, sector_source, Activity(log, "Level", "Room 0"));
+                new_room->initialise(*tr_level, room, *mesh_storage, static_mesh_source, static_mesh_position_source, sector_source, 0, Activity(log, "Level", "Room 0"));
                 return new_room;
             }
 

--- a/trview.app.tests/Elements/SectorTests.cpp
+++ b/trview.app.tests/Elements/SectorTests.cpp
@@ -23,7 +23,7 @@ TEST(Sector, HighNumberedPortal)
     tr_room_sector sector { 1, 0xffff, 255, 0, 255, 0 };
     auto room = trview::tests::mock_shared<MockRoom>();
 
-    Sector s(level, tr_room, sector, 0, room);
+    Sector s(level, tr_room, sector, 0, room, 0);
 
     ASSERT_EQ(s.portal(), 378);
 }

--- a/trview.app.tests/Elements/StaticMeshTests.cpp
+++ b/trview.app.tests/Elements/StaticMeshTests.cpp
@@ -16,13 +16,13 @@ TEST(StaticMesh, BoundingBoxRendered)
     auto bounding_mesh = mock_shared<MockMesh>();
     EXPECT_CALL(*bounding_mesh, render(A<const Matrix&>(), A<const ILevelTextureStorage&>(), A<const Color&>(), A<float>(), A<Vector3>(), A<bool>(), A<bool>())).Times(1);
 
-    StaticMesh mesh({}, {}, actual_mesh, {}, bounding_mesh);
+    StaticMesh mesh({}, {}, actual_mesh, {}, {}, bounding_mesh);
     mesh.render_bounding_box(NiceMock<MockCamera>{}, NiceMock<MockLevelTextureStorage>{}, Colour::White);
 }
 
 TEST(StaticMesh, OnChangedRaised)
 {
-    StaticMesh mesh({}, {}, mock_shared<MockMesh>(), {}, mock_shared<MockMesh>());
+    StaticMesh mesh({}, {}, mock_shared<MockMesh>(), {}, {}, mock_shared<MockMesh>());
     bool raised = false;
     auto token = mesh.on_changed += [&] (){ raised = true; };
     mesh.set_visible(false);
@@ -31,14 +31,14 @@ TEST(StaticMesh, OnChangedRaised)
 
 TEST(StaticMesh, HasCollision)
 {
-    StaticMesh collision_mesh({}, { .Flags = 0 }, mock_shared<MockMesh>(), {}, mock_shared<MockMesh>());
+    StaticMesh collision_mesh({}, { .Flags = 0 }, mock_shared<MockMesh>(), {}, {}, mock_shared<MockMesh>());
     ASSERT_EQ(collision_mesh.has_collision(), true);
-    StaticMesh no_collision_mesh({}, { .Flags = 1 }, mock_shared<MockMesh>(), {}, mock_shared<MockMesh>());
+    StaticMesh no_collision_mesh({}, { .Flags = 1 }, mock_shared<MockMesh>(), {}, {}, mock_shared<MockMesh>());
     ASSERT_EQ(no_collision_mesh.has_collision(), false);
 }
 
 TEST(StaticMesh, SpriteNoCollision)
 {
-    StaticMesh collision_mesh({}, {}, {}, mock_shared<MockMesh>(), {});
+    StaticMesh collision_mesh({}, {}, {}, mock_shared<MockMesh>(), {}, {});
     ASSERT_EQ(collision_mesh.has_collision(), false);
 }

--- a/trview.app.tests/Windows/WindowsTests.cpp
+++ b/trview.app.tests/Windows/WindowsTests.cpp
@@ -13,6 +13,7 @@
 #include <trview.app/Mocks/Windows/IAboutWindowManager.h>
 #include <trview.app/Mocks/Windows/ICameraSinkWindowManager.h>
 #include <trview.app/Mocks/Windows/IConsoleManager.h>
+#include <trview.app/Mocks/Windows/IDiffWindowManager.h>
 #include <trview.app/Mocks/Windows/IItemsWindowManager.h>
 #include <trview.app/Mocks/Windows/ILightsWindowManager.h>
 #include <trview.app/Mocks/Windows/ILogWindowManager.h>
@@ -42,7 +43,8 @@ namespace
             std::unique_ptr<IAboutWindowManager> about_window{ mock_unique<MockAboutWindowManager>() };
             std::unique_ptr<ICameraSinkWindowManager> camera_sinks{ mock_unique<MockCameraSinkWindowManager>() };
             std::unique_ptr<IConsoleManager> console_manager{ mock_unique<MockConsoleManager>() };
-            std::unique_ptr<IItemsWindowManager> items{ mock_unique<MockItemsWindowManager>() };
+            std::unique_ptr<IDiffWindowManager> diffs{ mock_unique<MockDiffWindowManager>() };
+            std::shared_ptr<IItemsWindowManager> items{ mock_shared<MockItemsWindowManager>() };
             std::unique_ptr<ILogWindowManager> log{ mock_unique<MockLogWindowManager>() };
             std::unique_ptr<ILightsWindowManager> lights{ mock_unique<MockLightsWindowManager>() };
             std::unique_ptr<IPluginsWindowManager> plugins{ mock_unique<MockPluginsWindowManager>() };
@@ -59,7 +61,8 @@ namespace
                     std::move(about_window),
                     std::move(camera_sinks),
                     std::move(console_manager),
-                    std::move(items),
+                    std::move(diffs),
+                    items,
                     std::move(lights),
                     std::move(log),
                     std::move(plugins),
@@ -80,6 +83,12 @@ namespace
             test_module& with_console(std::unique_ptr<IConsoleManager> manager)
             {
                 console_manager = std::move(manager);
+                return *this;
+            }
+
+            test_module& with_diffs(std::unique_ptr<IDiffWindowManager> manager)
+            {
+                diffs = std::move(manager);
                 return *this;
             }
 

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -91,7 +91,7 @@ namespace trview
         _token_store += _windows->on_new_randomizer_route += [&]() { if (should_discard_changes()) { set_route(_randomizer_route_source(std::nullopt)); } };
         _token_store += _windows->on_static_selected += [this](const auto& stat) { select_static_mesh(stat); };
         _token_store += _windows->on_sound_source_selected += [this](const auto& sound) { select_sound_source(sound); };
-        _token_store += _windows->on_diff_level_selected += [this](auto&& level) { open_diff_level(level); };
+        _token_store += _windows->on_diff_ended += [this](auto&& level) { end_diff(level); };
         _token_store += _windows->on_sector_selected += [this](auto&& sector)
             {
                 if (const auto s = sector.lock())
@@ -992,8 +992,13 @@ namespace trview
         set_current_level(op.level, op.open_mode, false);
     }
 
-    void Application::open_diff_level(const std::weak_ptr<ILevel>& level)
+    void Application::end_diff(const std::weak_ptr<ILevel>& level)
     {
-        _diff_level = level;
+        const auto closed_level = level.lock();
+        const auto open_level = _viewer->level().lock();
+        if (closed_level == open_level)
+        {
+            _viewer->open(_level, ILevel::OpenMode::Reload);
+        }
     }
 }

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -6,8 +6,6 @@
 #include <trview.common/Timer.h>
 #include <trview.common/TokenStore.h>
 
-#include <trlevel/ILevel.h>
-
 #include "Elements/ITypeInfoLookup.h"
 #include <trview.app/Menus/IFileMenu.h>
 #include <trview.app/Menus/IUpdateChecker.h>
@@ -57,7 +55,6 @@ namespace trview
             const Window& application_window,
             std::unique_ptr<IUpdateChecker> update_checker,
             std::shared_ptr<ISettingsLoader> settings_loader,
-            const trlevel::ILevel::Source& trlevel_source,
             std::unique_ptr<IFileMenu> file_menu,
             std::shared_ptr<IViewer> viewer,
             const IRoute::Source& route_source,
@@ -127,13 +124,14 @@ namespace trview
         void select_static_mesh(const std::weak_ptr<IStaticMesh>& static_mesh);
         void select_sound_source(const std::weak_ptr<ISoundSource>& sound_source);
         void check_load();
+        void open_diff_level(const std::weak_ptr<ILevel>& level);
+        
 
         TokenStore _token_store;
 
         // Window message related components.
         std::shared_ptr<ISettingsLoader> _settings_loader;
         UserSettings _settings;
-        trlevel::ILevel::Source _trlevel_source;
         std::unique_ptr<IFileMenu> _file_menu;
         std::unique_ptr<IUpdateChecker> _update_checker;
         ViewMenu _view_menu;
@@ -177,6 +175,7 @@ namespace trview
         std::future<LoadOperation> _load;
         LoadMode _load_mode;
         std::string _progress;
+        std::weak_ptr<ILevel> _diff_level;
     };
 
     std::unique_ptr<IApplication> create_application(HINSTANCE hInstance, int command_show, const std::wstring& command_line);

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -124,8 +124,7 @@ namespace trview
         void select_static_mesh(const std::weak_ptr<IStaticMesh>& static_mesh);
         void select_sound_source(const std::weak_ptr<ISoundSource>& sound_source);
         void check_load();
-        void open_diff_level(const std::weak_ptr<ILevel>& level);
-        
+        void end_diff(const std::weak_ptr<ILevel>& level);
 
         TokenStore _token_store;
 
@@ -175,7 +174,6 @@ namespace trview
         std::future<LoadOperation> _load;
         LoadMode _load_mode;
         std::string _progress;
-        std::weak_ptr<ILevel> _diff_level;
     };
 
     std::unique_ptr<IApplication> create_application(HINSTANCE hInstance, int command_show, const std::wstring& command_line);

--- a/trview.app/Elements/Floordata.cpp
+++ b/trview.app/Elements/Floordata.cpp
@@ -87,7 +87,7 @@ namespace trview
                 std::uint16_t setup = data[++i];
 
                 auto trigger_type = (TriggerType)subfunction;
-                meanings.push_back(trigger_type_name(trigger_type));
+                meanings.push_back(to_string(trigger_type));
                 meanings.push_back("  Timer:" + std::to_string(setup & 0xff) + ", Only Once:" + std::to_string((setup & 0x100) >> 8) + ", Mask:" + format_binary((setup & 0x3e00) >> 9));
 
                 bool continue_processing = true;

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -19,7 +19,7 @@ namespace trview
 
     struct ILevel
     {
-        using Source = std::function<std::shared_ptr<ILevel>(std::shared_ptr<trlevel::ILevel>, trlevel::ILevel::LoadCallbacks)>;
+        using Source = std::function<std::shared_ptr<ILevel>(const std::string&, trlevel::ILevel::LoadCallbacks)>;
 
         enum class OpenMode
         {

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -93,7 +93,7 @@ namespace trview
         /// Create a new implementation of <see cref="IRoom"/>.
         /// </summary>
         using Source = std::function<std::shared_ptr<IRoom>(const trlevel::ILevel&, const trlevel::tr3_room&,
-            const std::shared_ptr<ILevelTextureStorage>&, const IMeshStorage&, uint32_t, const std::weak_ptr<ILevel>&, const Activity& activity)>;
+            const std::shared_ptr<ILevelTextureStorage>&, const IMeshStorage&, uint32_t, const std::weak_ptr<ILevel>&, uint32_t, const Activity& activity)>;
         /// <summary>
         /// Destructor for <see cref="IRoom"/>.
         /// </summary>

--- a/trview.app/Elements/ISector.h
+++ b/trview.app/Elements/ISector.h
@@ -18,7 +18,7 @@ namespace trview
     struct ISector
     {
         using Source = std::function<std::shared_ptr<ISector>(const trlevel::ILevel&, const trlevel::tr3_room&,
-            const trlevel::tr_room_sector&, int, const std::weak_ptr<IRoom>&)>;
+            const trlevel::tr_room_sector&, int, const std::weak_ptr<IRoom>&, uint32_t)>;
 
         enum class Corner
         {
@@ -127,6 +127,7 @@ namespace trview
         virtual std::weak_ptr<ITrigger> trigger() const = 0;
 
         virtual TriangulationDirection ceiling_triangulation() const = 0;
+        virtual uint32_t number() const = 0;
     };
 
     bool is_no_space(SectorFlag flags);

--- a/trview.app/Elements/IStaticMesh.h
+++ b/trview.app/Elements/IStaticMesh.h
@@ -12,6 +12,7 @@ namespace trview
     struct ILevelTextureStorage;
     struct ITransparencyBuffer;
     struct IRoom;
+    struct ILevel;
 
     struct IStaticMesh
     {
@@ -21,8 +22,8 @@ namespace trview
             Sprite
         };
 
-        using PositionSource = std::function<std::shared_ptr<IStaticMesh>(const trlevel::tr_room_sprite&, const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Matrix&, std::shared_ptr<IMesh>, const std::shared_ptr<IRoom>&)>;
-        using MeshSource = std::function<std::shared_ptr<IStaticMesh>(const trlevel::tr3_room_staticmesh&, const trlevel::tr_staticmesh&, const std::shared_ptr<IMesh>&, const std::shared_ptr<IRoom>&)>;
+        using PositionSource = std::function<std::shared_ptr<IStaticMesh>(const trlevel::tr_room_sprite&, const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Matrix&, std::shared_ptr<IMesh>, const std::shared_ptr<IRoom>&, const std::weak_ptr<ILevel>&)>;
+        using MeshSource = std::function<std::shared_ptr<IStaticMesh>(const trlevel::tr3_room_staticmesh&, const trlevel::tr_staticmesh&, const std::shared_ptr<IMesh>&, const std::shared_ptr<IRoom>&, const std::weak_ptr<ILevel>&)>;
 
         virtual ~IStaticMesh() = 0;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) = 0;
@@ -44,6 +45,7 @@ namespace trview
         virtual bool visible() const = 0;
         virtual void set_visible(bool value) = 0;
         virtual bool has_collision() const = 0;
+        virtual std::weak_ptr<ILevel> level() const = 0;
 
         Event<> on_changed;
     };

--- a/trview.app/Elements/ITrigger.cpp
+++ b/trview.app/Elements/ITrigger.cpp
@@ -5,7 +5,7 @@ namespace trview
 {
     namespace
     {
-        const std::unordered_map<TriggerType, std::string> trigger_type_names
+        const std::unordered_map<TriggerType, std::string> to_strings
         {
             { TriggerType::Trigger, "Trigger" },
             { TriggerType::Pad, "Pad" },
@@ -60,10 +60,10 @@ namespace trview
         return std::any_of(types.begin(), types.end(), [&](const auto& type) { return has_command(trigger, type); });
     }
 
-    std::string trigger_type_name(TriggerType type)
+    std::string to_string(TriggerType type)
     {
-        auto name = trigger_type_names.find(type);
-        if (name == trigger_type_names.end())
+        auto name = to_strings.find(type);
+        if (name == to_strings.end())
         {
             return "Unknown";
         }

--- a/trview.app/Elements/ITrigger.h
+++ b/trview.app/Elements/ITrigger.h
@@ -46,7 +46,7 @@ namespace trview
     /// Get the string representation of the trigger type specified.
     /// @param type The type to test.
     /// @returns The string version of the enum.
-    std::string trigger_type_name(TriggerType type);
+    std::string to_string(TriggerType type);
 
     /// Get the string representation of the command type specified.
     /// @param type The type to test.

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -467,16 +467,18 @@ namespace trview
     {
         Activity generate_rooms_activity(_log, "Level", level.name());
         const auto num_rooms = level.num_rooms();
+        uint32_t sector_base_index = 0;
         for (uint32_t i = 0u; i < num_rooms; ++i)
         {
             Activity room_activity(generate_rooms_activity, std::format("Room {}", i));
-            auto room = room_source(level, level.get_room(i), _texture_storage, mesh_storage, i, shared_from_this(), room_activity);
+            auto room = room_source(level, level.get_room(i), _texture_storage, mesh_storage, i, shared_from_this(), sector_base_index, room_activity);
             _token_store += room->on_changed += [&]() 
             {
                 _regenerate_transparency = true; 
                 on_level_changed();
             };
             _rooms.push_back(room);
+            sector_base_index += static_cast<uint32_t>(room->sectors().size());
         }
 
         std::set<uint32_t> alternate_groups;
@@ -1486,7 +1488,7 @@ namespace trview
                     detail = details[index];
                 }
             }
-            auto sound_source = sound_source_source(count++, source, detail, _version);
+            auto sound_source = sound_source_source(count++, source, detail, _version, shared_from_this());
             _token_store += sound_source->on_changed += [this]() { content_changed(); };
             _sound_sources.push_back(sound_source);
         }

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -91,6 +91,7 @@ namespace trview
             const IStaticMesh::MeshSource& static_mesh_mesh_source,
             const IStaticMesh::PositionSource& static_mesh_position_source,
             const ISector::Source& sector_source,
+            uint32_t sector_base_index,
             const Activity& activity);
         std::vector<std::weak_ptr<IStaticMesh>> static_meshes() const override;
     private:
@@ -100,7 +101,7 @@ namespace trview
             const IStaticMesh::MeshSource& static_mesh_mesh_source, const IStaticMesh::PositionSource& static_mesh_position_source, const Activity& activity);
         void render_contained(const ICamera& camera, const DirectX::SimpleMath::Color& colour, RenderFilter render_filter);
         void get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour, RenderFilter render_filter);
-        void generate_sectors(const trlevel::ILevel& level, const trlevel::tr3_room& room, const ISector::Source& sector_source);
+        void generate_sectors(const trlevel::ILevel& level, const trlevel::tr3_room& room, const ISector::Source& sector_source, uint32_t sector_base_index);
         ISector* get_trigger_sector(int32_t x, int32_t z);
         uint32_t get_sector_id(int32_t x, int32_t z) const;
 

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -7,9 +7,9 @@ using namespace DirectX::SimpleMath;
 
 namespace trview
 {
-    Sector::Sector(const trlevel::ILevel& level, const trlevel::tr3_room& room, const trlevel::tr_room_sector& sector, int sector_id, const std::weak_ptr<IRoom>& room_ptr)
+    Sector::Sector(const trlevel::ILevel& level, const trlevel::tr3_room& room, const trlevel::tr_room_sector& sector, int sector_id, const std::weak_ptr<IRoom>& room_ptr, uint32_t sector_number)
         : _sector(sector), _sector_id(static_cast<uint16_t>(sector_id)), _room_above(sector.room_above), _room_below(sector.room_below), _room(room_number(room_ptr)), _info(room.info), _room_ptr(room_ptr),
-        _floordata_index(sector.floordata_index)
+        _floordata_index(sector.floordata_index), _number(sector_number)
     {
         _x = static_cast<int16_t>(sector_id / room.num_z_sectors);
         _z = static_cast<int16_t>(sector_id % room.num_z_sectors);
@@ -732,6 +732,11 @@ namespace trview
     TriangulationDirection Sector::ceiling_triangulation() const
     {
         return _ceiling_triangulation_function;
+    }
+
+    uint32_t Sector::number() const
+    {
+        return _number;
     }
 }
 

--- a/trview.app/Elements/Sector.h
+++ b/trview.app/Elements/Sector.h
@@ -10,7 +10,7 @@ namespace trview
     {
     public:
         // Constructs sector object and parses floor data automatically 
-        Sector(const trlevel::ILevel& level, const trlevel::tr3_room& room, const trlevel::tr_room_sector& sector, int sector_id, const std::weak_ptr<IRoom>& room_ptr);
+        Sector(const trlevel::ILevel& level, const trlevel::tr3_room& room, const trlevel::tr_room_sector& sector, int sector_id, const std::weak_ptr<IRoom>& room_ptr, uint32_t sector_number);
         virtual ~Sector() = default;
         // Returns the id of the room that this floor data points to 
         virtual std::uint16_t portal() const override;
@@ -49,6 +49,7 @@ namespace trview
         void set_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         std::weak_ptr<ITrigger> trigger() const override;
         TriangulationDirection ceiling_triangulation() const override;
+        uint32_t number() const override;
     private:
         bool parse(const trlevel::ILevel& level);
         void parse_slope();
@@ -101,5 +102,6 @@ namespace trview
         uint32_t _floordata_index;
         trlevel::tr_room_info _info;
         std::vector<Triangle> _triangles;
+        uint32_t _number;
     };
 }

--- a/trview.app/Elements/SoundSource/ISoundSource.h
+++ b/trview.app/Elements/SoundSource/ISoundSource.h
@@ -21,7 +21,7 @@ namespace trview
 {
     struct ISoundSource : public IRenderable
     {
-        using Source = std::function<std::shared_ptr<ISoundSource>(uint32_t, const trlevel::tr_sound_source&, const std::optional<trlevel::tr_x_sound_details>&, trlevel::LevelVersion)>;
+        using Source = std::function<std::shared_ptr<ISoundSource>(uint32_t, const trlevel::tr_sound_source&, const std::optional<trlevel::tr_x_sound_details>&, trlevel::LevelVersion, const std::weak_ptr<ILevel>&)>;
         virtual ~ISoundSource() = 0;
 
         virtual uint16_t chance() const = 0;
@@ -35,6 +35,7 @@ namespace trview
         virtual uint8_t range() const = 0;
         virtual std::optional<int16_t> sample() const = 0;
         virtual uint16_t volume() const = 0;
+        virtual std::weak_ptr<ILevel> level() const = 0;
 
         Event<> on_changed;
     };

--- a/trview.app/Elements/SoundSource/SoundSource.cpp
+++ b/trview.app/Elements/SoundSource/SoundSource.cpp
@@ -10,8 +10,8 @@ namespace trview
     {
     }
 
-    SoundSource::SoundSource(const std::shared_ptr<IMesh>& mesh, const std::shared_ptr<ITextureStorage>& texture_storage, uint32_t number, const trlevel::tr_sound_source& source, const std::optional<trlevel::tr_x_sound_details>& details, trlevel::LevelVersion level_version)
-        : _mesh(mesh), _flags(source.Flags), _id(source.SoundID), _number(number), _position(source.x / trlevel::Scale, source.y / trlevel::Scale, source.z / trlevel::Scale)
+    SoundSource::SoundSource(const std::shared_ptr<IMesh>& mesh, const std::shared_ptr<ITextureStorage>& texture_storage, uint32_t number, const trlevel::tr_sound_source& source, const std::optional<trlevel::tr_x_sound_details>& details, trlevel::LevelVersion level_version, const std::weak_ptr<ILevel>& level)
+        : _mesh(mesh), _flags(source.Flags), _id(source.SoundID), _number(number), _position(source.x / trlevel::Scale, source.y / trlevel::Scale, source.z / trlevel::Scale), _level(level)
     {
         _sound_texture = texture_storage->lookup("sound_texture");
 
@@ -134,5 +134,10 @@ namespace trview
     uint16_t SoundSource::volume() const
     {
         return _volume;
+    }
+
+    std::weak_ptr<ILevel> SoundSource::level() const
+    {
+        return _level;
     }
 }

--- a/trview.app/Elements/SoundSource/SoundSource.h
+++ b/trview.app/Elements/SoundSource/SoundSource.h
@@ -15,7 +15,8 @@ namespace trview
             uint32_t number,
             const trlevel::tr_sound_source& source,
             const std::optional<trlevel::tr_x_sound_details>& details,
-            trlevel::LevelVersion level_version);
+            trlevel::LevelVersion level_version,
+            const std::weak_ptr<ILevel>& level);
         virtual ~SoundSource() = default;
         uint16_t chance() const override;
         uint16_t characteristics() const override;
@@ -32,6 +33,7 @@ namespace trview
         void set_visible(bool value) override;
         bool visible() const override;
         uint16_t volume() const override;
+        std::weak_ptr<ILevel> level() const override;
     private:
         uint16_t _chance{ 0u };
         uint16_t _characteristics{ 0u };
@@ -46,6 +48,7 @@ namespace trview
         graphics::Texture _sound_texture;
         bool _visible{ true };
         uint16_t _volume{ 0u };
+        std::weak_ptr<ILevel> _level;
     };
 }
 

--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -24,7 +24,7 @@ namespace trview
     {
     }
 
-    StaticMesh::StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, const std::shared_ptr<IMesh>& mesh, const std::weak_ptr<IRoom>& room, const std::shared_ptr<IMesh>& bounding_mesh)
+    StaticMesh::StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, const std::shared_ptr<IMesh>& mesh, const std::weak_ptr<IRoom>& room, const std::weak_ptr<ILevel>& level, const std::shared_ptr<IMesh>& bounding_mesh)
         : _mesh(mesh),
         _visibility(from_box(level_static_mesh.VisibilityBox)),
         _collision(from_box(level_static_mesh.CollisionBox)),
@@ -33,13 +33,14 @@ namespace trview
         _bounding_mesh(bounding_mesh),
         _room(room),
         _mesh_texture_id(static_mesh.mesh_id),
-        _flags(level_static_mesh.Flags)
+        _flags(level_static_mesh.Flags),
+        _level(level)
     {
         _world = Matrix::CreateRotationY(_rotation) * Matrix::CreateTranslation(_position);
     }
 
-    StaticMesh::StaticMesh(const trlevel::tr_room_sprite& room_sprite, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Matrix& scale, std::shared_ptr<IMesh> mesh, const std::weak_ptr<IRoom>& room)
-        : _position(position), _mesh(mesh), _rotation(0), _scale(scale), _room(room), _mesh_texture_id(room_sprite.texture), _type(Type::Sprite)
+    StaticMesh::StaticMesh(const trlevel::tr_room_sprite& room_sprite, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Matrix& scale, std::shared_ptr<IMesh> mesh, const std::weak_ptr<IRoom>& room, const std::weak_ptr<ILevel>& level)
+        : _position(position), _mesh(mesh), _rotation(0), _scale(scale), _room(room), _mesh_texture_id(room_sprite.texture), _type(Type::Sprite), _level(level)
     {
         using namespace DirectX::SimpleMath;
         _world = Matrix::CreateRotationY(_rotation) * Matrix::CreateTranslation(_position);
@@ -160,6 +161,11 @@ namespace trview
     bool StaticMesh::has_collision() const
     {
         return _type == Type::Mesh && (_flags & 0x1) == 0;
+    }
+
+    std::weak_ptr<ILevel> StaticMesh::level() const
+    {
+        return _level;
     }
 
     uint32_t static_mesh_room(const std::shared_ptr<IStaticMesh>& static_mesh)

--- a/trview.app/Elements/StaticMesh.h
+++ b/trview.app/Elements/StaticMesh.h
@@ -7,8 +7,8 @@ namespace trview
     class StaticMesh final : public IStaticMesh
     {
     public:
-        StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, const std::shared_ptr<IMesh>& mesh, const std::weak_ptr<IRoom>& room, const std::shared_ptr<IMesh>& bounding_mesh);
-        StaticMesh(const trlevel::tr_room_sprite& room_sprite, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Matrix& scale, std::shared_ptr<IMesh> mesh, const std::weak_ptr<IRoom>& room);
+        StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, const std::shared_ptr<IMesh>& mesh, const std::weak_ptr<IRoom>& room, const std::weak_ptr<ILevel>& level, const std::shared_ptr<IMesh>& bounding_mesh);
+        StaticMesh(const trlevel::tr_room_sprite& room_sprite, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Matrix& scale, std::shared_ptr<IMesh> mesh, const std::weak_ptr<IRoom>& room, const std::weak_ptr<ILevel>& level);
         virtual ~StaticMesh() = default;
         virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
         virtual void render_bounding_box(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
@@ -29,6 +29,7 @@ namespace trview
         bool visible() const override;
         void set_visible(bool value) override;
         bool has_collision() const override;
+        std::weak_ptr<ILevel> level() const override;
     private:
         float _rotation;
         DirectX::SimpleMath::Vector3 _position;
@@ -44,5 +45,6 @@ namespace trview
         uint16_t _flags{ 0u };
         bool _visible{ true };
         Type _type{ Type::Mesh };
+        std::weak_ptr<ILevel> _level;
     };
 }

--- a/trview.app/Geometry/PickResult.cpp
+++ b/trview.app/Geometry/PickResult.cpp
@@ -105,7 +105,7 @@ namespace trview
             {
                 if (auto trigger = level.trigger(result.index).lock())
                 {
-                    stream << trigger_type_name(trigger->type()) << " " << result.index;
+                    stream << to_string(trigger->type()) << " " << result.index;
                     for (const auto command : trigger->commands())
                     {
                         stream << "\n  " << command_type_name(command.type());
@@ -126,7 +126,7 @@ namespace trview
             {
                 if (const auto light = level.light(result.index).lock())
                 {
-                    stream << "Light " << result.index << " - " << light_type_name(light->type());
+                    stream << "Light " << result.index << " - " << to_string(light->type());
                 }
                 break;
             }
@@ -152,7 +152,7 @@ namespace trview
                     {
                         if (const auto trigger = level.trigger(waypoint->index()).lock())
                         {
-                            stream << " - " << trigger_type_name(trigger->type()) << " " << waypoint->index();
+                            stream << " - " << to_string(trigger->type()) << " " << waypoint->index();
                         }
                     }
 

--- a/trview.app/Lua/Elements/Light/Lua_Light.cpp
+++ b/trview.app/Lua/Elements/Light/Lua_Light.cpp
@@ -100,7 +100,7 @@ namespace trview
                 }
                 else if (key == "type")
                 {
-                    lua_pushstring(L, trlevel::light_type_name(light->type()).c_str());
+                    lua_pushstring(L, trlevel::to_string(light->type()).c_str());
                     return 1;
                 }
                 else if (key == "visible")

--- a/trview.app/Lua/Elements/Trigger/Lua_Trigger.cpp
+++ b/trview.app/Lua/Elements/Trigger/Lua_Trigger.cpp
@@ -90,7 +90,7 @@ namespace trview
                 }
                 else if (key == "type")
                 {
-                    lua_pushstring(L, trigger_type_name(trigger->type()).c_str());
+                    lua_pushstring(L, to_string(trigger->type()).c_str());
                     return 1;
                 }
                 else if (key == "visible")

--- a/trview.app/Menus/FileMenu.cpp
+++ b/trview.app/Menus/FileMenu.cpp
@@ -216,4 +216,8 @@ namespace trview
             on_file_open(found->path);
         }
     }
+
+    void FileMenu::render()
+    {
+    }
 }

--- a/trview.app/Menus/FileMenu.h
+++ b/trview.app/Menus/FileMenu.h
@@ -19,9 +19,10 @@ namespace trview
             const std::shared_ptr<IFiles>& files);
         virtual ~FileMenu() = default;
         std::vector<std::string> local_levels() const override;
-        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
-        virtual void open_file(const std::string& filename) override;
-        virtual void set_recent_files(const std::list<std::string>& files) override;
+        std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        void open_file(const std::string& filename) override;
+        void render() override;
+        void set_recent_files(const std::list<std::string>& files) override;
         void switch_to(const std::string& filename) override;
     private:
         void choose_file();

--- a/trview.app/Menus/IFileMenu.h
+++ b/trview.app/Menus/IFileMenu.h
@@ -18,6 +18,10 @@ namespace trview
         /// <param name="filename">The file that was opened.</param>
         virtual void open_file(const std::string& filename) = 0;
         /// <summary>
+        /// Render in ImGui mode.
+        /// </summary>
+        virtual void render() = 0;
+        /// <summary>
         /// Set the list of recent files to display in the menu.
         /// </summary>
         /// <param name="files">The files to show.</param>

--- a/trview.app/Menus/ImGuiFileMenu.cpp
+++ b/trview.app/Menus/ImGuiFileMenu.cpp
@@ -1,0 +1,70 @@
+#include "ImGuiFileMenu.h"
+#include <trview.common/Strings.h>
+
+namespace trview
+{
+    ImGuiFileMenu::ImGuiFileMenu(const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files)
+        : _dialogs(dialogs), _files(files)
+    {
+    }
+
+    std::vector<std::string> ImGuiFileMenu::local_levels() const
+    {
+        return {};
+    }
+
+    void ImGuiFileMenu::open_file(const std::string& filename)
+    {
+        _file_switcher = _files->get_files(path_for_filename(filename), default_file_pattern);
+    }
+
+    void ImGuiFileMenu::render()
+    {
+        if (ImGui::BeginMenu("File"))
+        {
+            if (ImGui::MenuItem("Open"))
+            {
+                const auto filename = _dialogs->open_file(L"Open level", { { L"All Tomb Raider Files", { L"*.tr2", L"*.tr4", L"*.trc", L"*.phd", L"*.psx" } } }, OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST);
+                if (filename.has_value())
+                {
+                    on_file_open(filename->filename);
+                }
+            }
+
+            if (ImGui::BeginMenu("Open Recent", !_recent_files.empty()))
+            {
+                for (const auto& file : _recent_files)
+                {
+                    if (ImGui::MenuItem(file.c_str()))
+                    {
+                        on_file_open(file);
+                    }
+                }
+                ImGui::EndMenu();
+            }
+
+            if (ImGui::BeginMenu("Switch Level", !_file_switcher.empty()))
+            {
+                for (const auto& file : _file_switcher)
+                {
+                    if (ImGui::MenuItem(file.path.c_str()))
+                    {
+                        on_file_open(file.path);
+                    }
+                }
+                ImGui::EndMenu();
+            }
+            ImGui::EndMenu();
+        }
+    }
+
+    void ImGuiFileMenu::set_recent_files(const std::list<std::string>& files)
+    {
+        _recent_files = files | std::ranges::to<std::vector>();
+    }
+
+    void ImGuiFileMenu::switch_to(const std::string& filename)
+    {
+        filename;
+    }
+}

--- a/trview.app/Menus/ImGuiFileMenu.h
+++ b/trview.app/Menus/ImGuiFileMenu.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "IFileMenu.h"
+
+#include <trview.common/Windows/IDialogs.h>
+#include <trview.common/IFiles.h>
+
+namespace trview
+{
+    class ImGuiFileMenu final : public IFileMenu
+    {
+    public:
+        explicit ImGuiFileMenu(const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
+        virtual ~ImGuiFileMenu() = default;
+        std::vector<std::string> local_levels() const override;
+        void open_file(const std::string& filename) override;
+        void render() override;
+        void set_recent_files(const std::list<std::string>& files) override;
+        void switch_to(const std::string& filename) override;
+    private:
+        static const inline std::string default_file_pattern{ "\\*.TR2*,\\*.TR4*,\\*.TRC*,\\*.PHD,\\*.PSX" };
+
+        std::shared_ptr<IDialogs> _dialogs;
+        std::shared_ptr<IFiles> _files;
+        std::vector<IFiles::File> _file_switcher;
+        std::vector<std::string> _recent_files;
+    };
+}

--- a/trview.app/Mocks/Elements/IItem.h
+++ b/trview.app/Mocks/Elements/IItem.h
@@ -87,6 +87,12 @@ namespace trview
                 ON_CALL(*this, set_visible).WillByDefault([&](auto v) { _visible_state = v; });
                 return shared_from_this();
             }
+
+            std::shared_ptr<MockItem> with_level(std::weak_ptr<ILevel> level)
+            {
+                ON_CALL(*this, level).WillByDefault(testing::Return(level));
+                return shared_from_this();
+            }
         };
     }
 }

--- a/trview.app/Mocks/Elements/ILight.h
+++ b/trview.app/Mocks/Elements/ILight.h
@@ -70,6 +70,12 @@ namespace trview
                 ON_CALL(*this, set_visible).WillByDefault([&](auto v) { _visible_state = v; });
                 return shared_from_this();
             }
+
+            std::shared_ptr<MockLight> with_level(std::weak_ptr<ILevel> level)
+            {
+                ON_CALL(*this, level).WillByDefault(testing::Return(level));
+                return shared_from_this();
+            }
         };
     }
 }

--- a/trview.app/Mocks/Elements/ISector.h
+++ b/trview.app/Mocks/Elements/ISector.h
@@ -40,6 +40,7 @@ namespace trview
             MOCK_METHOD(int8_t, tilt_z, (), (const, override));
             MOCK_METHOD(std::weak_ptr<ITrigger>, trigger, (), (const, override));
             MOCK_METHOD(TriangulationDirection, ceiling_triangulation, (), (const, override));
+            MOCK_METHOD(uint32_t, number, (), (const, override));
 
             std::shared_ptr<MockSector> with_ceiling_triangulation(TriangulationDirection triangulation)
             {

--- a/trview.app/Mocks/Elements/ISoundSource.h
+++ b/trview.app/Mocks/Elements/ISoundSource.h
@@ -25,6 +25,7 @@ namespace trview
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(bool, visible, (), (const, override));
             MOCK_METHOD(uint16_t, volume, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
         };
     }
 }

--- a/trview.app/Mocks/Elements/IStaticMesh.h
+++ b/trview.app/Mocks/Elements/IStaticMesh.h
@@ -28,6 +28,7 @@ namespace trview
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(bool, breakable, (), (const, override));
             MOCK_METHOD(bool, has_collision, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
 
             std::shared_ptr<MockStaticMesh> with_number(uint32_t number)
             {

--- a/trview.app/Mocks/Menus/IFileMenu.h
+++ b/trview.app/Mocks/Menus/IFileMenu.h
@@ -12,6 +12,7 @@ namespace trview
             virtual ~MockFileMenu();
             MOCK_METHOD(std::vector<std::string>, local_levels, (), (const, override));
             MOCK_METHOD(void, open_file, (const std::string&), (override));
+            MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_recent_files, (const std::list<std::string>&), (override));
             MOCK_METHOD(void, switch_to, (const std::string&), (override));
         };

--- a/trview.app/Mocks/Mocks.cpp
+++ b/trview.app/Mocks/Mocks.cpp
@@ -73,6 +73,8 @@
 #include "Windows/ISoundsWindowManager.h"
 #include "Windows/IAboutWindow.h"
 #include "Windows/IAboutWindowManager.h"
+#include "Windows/IDiffWindowManager.h"
+#include "Windows/IDiffWindow.h"
 
 namespace trview
 {
@@ -293,5 +295,11 @@ namespace trview
 
         MockAboutWindow::MockAboutWindow() {};
         MockAboutWindow::~MockAboutWindow() {};
+
+        MockDiffWindow::MockDiffWindow() {};
+        MockDiffWindow::~MockDiffWindow() {};
+
+        MockDiffWindowManager::MockDiffWindowManager() {};
+        MockDiffWindowManager::~MockDiffWindowManager() {};
     }
 }

--- a/trview.app/Mocks/Windows/IDiffWindow.h
+++ b/trview.app/Mocks/Windows/IDiffWindow.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "../../Windows/Diff/IDiffWindow.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockDiffWindow : public IDiffWindow
+        {
+            MockDiffWindow();
+            virtual ~MockDiffWindow();
+            MOCK_METHOD(void, render, (), (override));
+            MOCK_METHOD(void, set_number, (int32_t), (override));
+        };
+    }
+}

--- a/trview.app/Mocks/Windows/IDiffWindowManager.h
+++ b/trview.app/Mocks/Windows/IDiffWindowManager.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "../../Windows/Diff/IDiffWindowManager.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockDiffWindowManager : public IDiffWindowManager
+        {
+        public:
+            MockDiffWindowManager();
+            virtual ~MockDiffWindowManager();
+            MOCK_METHOD(void, render, (), (override));
+            MOCK_METHOD(std::weak_ptr<IDiffWindow>, create_window, (), (override));
+            MOCK_METHOD(void, set_level, (const std::weak_ptr<ILevel>&), (override));
+            MOCK_METHOD(void, set_settings, (const UserSettings&), (override));
+        };
+    }
+}

--- a/trview.app/Mocks/Windows/IViewer.h
+++ b/trview.app/Mocks/Windows/IViewer.h
@@ -39,6 +39,7 @@ namespace trview
             MOCK_METHOD(void, set_target, (const DirectX::SimpleMath::Vector3&), (override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, target, (), (const, override));
             MOCK_METHOD(void, set_scene_changed, (), (override));
+            MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
         };
     }
 }

--- a/trview.app/Resources/resource.h
+++ b/trview.app/Resources/resource.h
@@ -51,6 +51,7 @@
 #define ID_WINDOWS_SOUNDS               33028
 #define ID_WINDOWS_CAMERA_POSITION      33029
 #define IDR_NGPLUS                      33030
+#define ID_WINDOWS_DIFF                 33031
 
 // Next default values for new objects
 // 

--- a/trview.app/Resources/trview.app.rc
+++ b/trview.app/Resources/trview.app.rc
@@ -77,6 +77,7 @@ BEGIN
         MENUITEM "Plugins\tCtrl+P"              ID_WINDOWS_PLUGINS
         MENUITEM "Statics\tCtrl+S"              ID_WINDOWS_STATICS
         MENUITEM "Sounds"                       ID_WINDOWS_SOUNDS
+        MENUITEM "Diff\tCtrl+D"                 ID_WINDOWS_DIFF
         MENUITEM SEPARATOR
         MENUITEM "Camera Position"              ID_WINDOWS_CAMERA_POSITION
         MENUITEM SEPARATOR

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -107,6 +107,7 @@ namespace trview
             read_attribute(json, settings.fonts, "fonts");
             read_attribute(json, settings.statics_startup, "statics_startup");
             read_attribute(json, settings.camera_position_window, "camera_position_window");
+            read_attribute(json, settings.recent_diff_files, "recent_diff");
 
             settings.recent_files.resize(std::min<std::size_t>(settings.recent_files.size(), settings.max_recent_files));
         }
@@ -176,6 +177,7 @@ namespace trview
             json["fonts"] = settings.fonts;
             json["statics_startup"] = settings.statics_startup;
             json["camera_position_window"] = settings.camera_position_window;
+            json["recent_diff"] = std::list<std::string>(settings.recent_diff_files.begin(), std::next(settings.recent_diff_files.begin(), std::min<std::size_t>(settings.recent_diff_files.size(), settings.max_recent_files)));
             _files->save_file(file_path, json.dump());
         }
         catch (...)

--- a/trview.app/Settings/UserSettings.cpp
+++ b/trview.app/Settings/UserSettings.cpp
@@ -2,21 +2,34 @@
 
 namespace trview
 {
+    namespace
+    {
+        void add_to_files_list(std::list<std::string>& files, const std::string& file, uint32_t max)
+        {
+            // If the file already exists in the recent files list, remove it from where it is
+            // and move it to the to avoid duplicates and to make it ordered by most recent.
+            auto existing = std::find(files.begin(), files.end(), file);
+            if (existing != files.end())
+            {
+                files.erase(existing);
+            }
+
+            files.push_front(file);
+            if (files.size() > max)
+            {
+                files.pop_back();
+            }
+        }
+    }
+
     void UserSettings::add_recent_file(const std::string& file)
     {
-        // If the file already exists in the recent files list, remove it from where it is
-        // and move it to the to avoid duplicates and to make it ordered by most recent.
-        auto existing = std::find(recent_files.begin(), recent_files.end(), file);
-        if (existing != recent_files.end())
-        {
-            recent_files.erase(existing);
-        }
+        add_to_files_list(recent_files, file, max_recent_files);
+    }
 
-        recent_files.push_front(file);
-        if (recent_files.size() > max_recent_files)
-        {
-            recent_files.pop_back();
-        }
+    void UserSettings::add_recent_diff_file(const std::string& file)
+    {
+        add_to_files_list(recent_diff_files, file, max_recent_files);
     }
 
     bool UserSettings::operator==(const UserSettings& other) const
@@ -44,6 +57,7 @@ namespace trview
             camera_sink_startup == other.camera_sink_startup &&
             statics_startup == other.statics_startup &&
             plugin_directories == other.plugin_directories &&
-            camera_position_window == other.camera_position_window;
+            camera_position_window == other.camera_position_window &&
+            recent_diff_files == other.recent_diff_files;
     }
 }

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -11,6 +11,7 @@ namespace trview
     struct UserSettings
     {
         void add_recent_file(const std::string& file);
+        void add_recent_diff_file(const std::string& file);
 
         struct RecentRoute
         {
@@ -65,6 +66,7 @@ namespace trview
         };
         bool statics_startup{ false };
         bool camera_position_window{ true };
+        std::list<std::string> recent_diff_files;
 
         bool operator==(const UserSettings& other) const;
     };

--- a/trview.app/UI/ContextMenu.cpp
+++ b/trview.app/UI/ContextMenu.cpp
@@ -57,7 +57,7 @@ namespace trview
                 {
                     if (const auto trigger_ptr = trigger.lock())
                     {
-                        if (ImGui::MenuItem(std::format("{} {}", trigger_type_name(trigger_ptr->type()), trigger_ptr->number()).c_str()))
+                        if (ImGui::MenuItem(std::format("{} {}", to_string(trigger_ptr->type()), trigger_ptr->number()).c_str()))
                         {
                             on_trigger_selected(trigger);
                         }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -62,7 +62,7 @@ namespace trview
                     const auto triggers = level->triggers()
                         | std::views::transform([](auto&& t) { return t.lock(); })
                         | std::views::filter([](auto&& t) { return t != nullptr; })
-                        | std::views::transform([](auto&& t) -> GoTo::GoToItem { return { .number = t->number(), .name = trigger_type_name(t->type()), .item = t }; })
+                        | std::views::transform([](auto&& t) -> GoTo::GoToItem { return { .number = t->number(), .name = to_string(t->type()), .item = t }; })
                         | std::ranges::to<std::vector>();
 
                     const auto rooms = level->rooms()

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -339,7 +339,7 @@ namespace trview
                         {
                             [](auto&& l, auto&& r) { return l.number() < r.number(); },
                             [](auto&& l, auto&& r) { return std::tuple(trigger_room(l), l.number()) < std::tuple(trigger_room(r), r.number()); },
-                            [](auto&& l, auto&& r) { return std::tuple(trigger_type_name(l.type()), l.number()) < std::tuple(trigger_type_name(r.type()), r.number()); },
+                            [](auto&& l, auto&& r) { return std::tuple(to_string(l.type()), l.number()) < std::tuple(to_string(r.type()), r.number()); },
                         }, _force_sort);
 
                     for (auto& trigger : _triggered_by)
@@ -362,7 +362,7 @@ namespace trview
                         ImGui::TableNextColumn();
                         ImGui::Text(std::to_string(trigger_room(trigger_ptr)).c_str());
                         ImGui::TableNextColumn();
-                        ImGui::Text(trigger_type_name(trigger_ptr->type()).c_str());
+                        ImGui::Text(to_string(trigger_ptr->type()).c_str());
                     }
 
                     ImGui::EndTable();

--- a/trview.app/Windows/Diff/DiffWindow.cpp
+++ b/trview.app/Windows/Diff/DiffWindow.cpp
@@ -428,7 +428,7 @@ namespace trview
         ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(520, 400));
         if (ImGui::Begin(_id.c_str(), &stay_open, ImGuiWindowFlags_MenuBar))
         {
-            if (ImGui::BeginMenuBar())
+            if (!_load.valid() && ImGui::BeginMenuBar())
             {
                 _file_menu->render();
                 ImGui::MenuItem("Only Show Changes", nullptr, &_only_show_changes);
@@ -520,6 +520,7 @@ namespace trview
     DiffWindow::Diff DiffWindow::do_diff(const std::shared_ptr<ILevel>& left, const std::shared_ptr<ILevel>& right)
     {
         // Items:
+        _progress = "Comparing items...";
         const auto item_results = get_results<IItem>(left->items(), right->items(),
             [](auto&& left, auto&& right)
             {
@@ -532,6 +533,7 @@ namespace trview
             [](auto&& i) { return i && i->ng_plus() != true; });
 
         // Triggers:
+        _progress = "Comparing triggers...";
         const auto trigger_results = get_results<ITrigger>(left->triggers(), right->triggers(), 
             [](auto&& left, auto&& right)
             {
@@ -546,6 +548,7 @@ namespace trview
             });;
 
         // Lights:
+        _progress = "Comparing lights...";
         const auto light_results = get_results<ILight>(left->lights(), right->lights(),
             [](auto&& left, auto&& right)
             {
@@ -568,6 +571,7 @@ namespace trview
             });
 
         // Camera/Sinks:
+        _progress = "Comparing camera/sinks...";
         const auto camera_sink_results = get_results<ICameraSink>(left->camera_sinks(), right->camera_sinks(),
             [](auto&& left, auto&& right)
             {
@@ -582,6 +586,7 @@ namespace trview
             });
 
         // Statics:
+        _progress = "Comparing statics...";
         const auto static_results = get_results<IStaticMesh>(left->static_meshes(), right->static_meshes(),
             [](auto&& left, auto&& right)
             {
@@ -599,6 +604,7 @@ namespace trview
             });
 
         // Sounds:
+        _progress = "Comparing sounds...";
         const auto sound_source_results = get_results<ISoundSource>(left->sound_sources(), right->sound_sources(),
             [](auto&& left, auto&& right)
             {
@@ -615,6 +621,7 @@ namespace trview
             });
 
         // Rooms:
+        _progress = "Comparing rooms...";
         const auto rooms_results = get_results<IRoom>(left->rooms(), right->rooms(),
             [](auto&& left, auto&& right)
             {
@@ -634,6 +641,7 @@ namespace trview
             });
 
         // Sectors:
+        _progress = "Comparing sectors...";
         const auto left_sectors = std::ranges::join_view(
                 left->rooms() |
                 std::views::transform([](auto&& r) { return r.lock(); }) |

--- a/trview.app/Windows/Diff/DiffWindow.cpp
+++ b/trview.app/Windows/Diff/DiffWindow.cpp
@@ -1,0 +1,885 @@
+#include "DiffWindow.h"
+#include <format>
+#include <ranges>
+#include <trlevel/LevelEncryptedException.h>
+#include "../../UserCancelledException.h"
+#include "../../trview_imgui.h"
+
+#include "../../Elements/ITrigger.h"
+#include "../../Elements/ILight.h"
+#include "../../Elements/SoundSource/ISoundSource.h"
+#include "../../Elements/IRoom.h"
+#include "../../Elements/ISector.h"
+
+namespace trview
+{
+    namespace
+    {
+        using std::to_string;
+
+        constexpr ImVec4 to_colour(DiffWindow::Diff::Type type) noexcept
+        {
+            switch (type)
+            {
+            case DiffWindow::Diff::Type::Add:
+                return ImVec4(0, 1, 0, 1);
+            case DiffWindow::Diff::Type::Update:
+                return ImVec4(1, 1, 0, 1);
+            case DiffWindow::Diff::Type::Reindex:
+                return ImVec4(1, 0, 1, 1);
+            case DiffWindow::Diff::Type::Delete:
+                return ImVec4(1, 0, 0, 1);
+            }
+            return ImVec4(1, 1, 1, 1);
+        }
+
+        constexpr std::string to_string(DiffWindow::Diff::Type type) noexcept
+        {
+            switch (type)
+            {
+            case DiffWindow::Diff::Type::None:
+                return "None";
+            case DiffWindow::Diff::Type::Add:
+                return "Add";
+            case DiffWindow::Diff::Type::Reindex:
+                return "Reindex";
+            case DiffWindow::Diff::Type::Update:
+                return "Update";
+            case DiffWindow::Diff::Type::Delete:
+                return "Delete";
+            }
+            return "Unknown";
+        }
+
+        std::string to_string(const DirectX::SimpleMath::Vector3& value)
+        {
+            return std::format("{},{},{}", value.x, value.y, value.z);
+        }
+
+        std::string to_string(const Colour& colour)
+        {
+            return std::format("{},{},{},{}", colour.r, colour.g, colour.b, colour.a);
+        }
+
+        template <typename T>
+        std::string to_string(const std::optional<T>& value)
+        {
+            return value.has_value() ? to_string(*value) : "";
+        }
+
+        template <typename T>
+        void find_direct_matches(
+            std::vector<DiffWindow::Diff::Item<T>>& results,
+            const std::vector<std::shared_ptr<T>>& left_entries,
+            const std::vector<std::shared_ptr<T>>& right_entries,
+            std::vector<DiffWindow::Diff::State>& left_resolved,
+            std::vector<DiffWindow::Diff::State>& right_resolved,
+            std::function<bool (const std::shared_ptr<T>&, const std::shared_ptr<T>&)> comparer)
+        {
+            using Diff = DiffWindow::Diff;
+
+            for (auto i = 0; i < results.size(); ++i)
+            {
+                auto& result = results[i];
+                if (result.state == Diff::State::Unresolved && i < left_entries.size())
+                {
+                    const auto left = left_entries[i];
+                    result.left = left;
+
+                    if (i < right_entries.size())
+                    {
+                        const auto right = right_entries[i];
+                        if (comparer(left, right))
+                        {
+                            result.type = Diff::Type::None;
+                            result.state = Diff::State::Resolved;
+                            result.right = right;
+                            left_resolved[i] = Diff::State::Resolved;
+                            right_resolved[i] = Diff::State::Resolved;
+                        }
+                    }
+                }
+            }
+        }
+
+        template <typename T>
+        void find_moves(
+            std::vector<DiffWindow::Diff::Item<T>>& results,
+            const std::vector<std::shared_ptr<T>>& left_entries,
+            const std::vector<std::shared_ptr<T>>& right_entries,
+            std::vector<DiffWindow::Diff::State>& left_resolved,
+            std::vector<DiffWindow::Diff::State>& right_resolved,
+            std::function<bool (const std::shared_ptr<T>&, const std::shared_ptr<T>&)> comparer)
+        {
+            using Diff = DiffWindow::Diff;
+
+            for (auto i = 0; i < results.size(); ++i)
+            {
+                auto& result = results[i];
+                if (result.state == Diff::State::Unresolved && i < left_entries.size())
+                {
+                    const auto left = left_entries[i];
+                    result.left = left;
+
+                    // TODO: Multiple items on the same spot, deal with that.
+                    const auto found =
+                        std::ranges::find_if(right_entries, [left, right_entries, right_resolved, comparer](auto&& right)
+                            {
+                                return
+                                    right_resolved[std::distance(right_entries.begin(), std::ranges::find(right_entries, right))] == Diff::State::Unresolved &&
+                                    comparer(left, right);
+                            });
+
+                    if (found != right_entries.end())
+                    {
+                        result.type = Diff::Type::Reindex;
+                        result.state = Diff::State::Resolved;
+                        result.right = *found;
+                        left_resolved[i] = Diff::State::Resolved;
+                        right_resolved[std::distance(right_entries.begin(), found)] = Diff::State::Resolved;
+                    }
+                }
+            }
+        }
+
+        template <typename T>
+        void mark_updated(
+            std::vector<DiffWindow::Diff::Item<T>>& results,
+            const std::vector<std::shared_ptr<T>>& left_entries,
+            const std::vector<std::shared_ptr<T>>& right_entries,
+            std::vector<DiffWindow::Diff::State>& left_resolved,
+            std::vector<DiffWindow::Diff::State>& right_resolved)
+        {
+            using Diff = DiffWindow::Diff;
+
+            std::vector<Diff::Item<T>> new_results;
+            for (auto i = 0; i < results.size(); ++i)
+            {
+                auto& result = results[i];
+                if (result.state == Diff::State::Unresolved)
+                {
+                    if (result.left.lock())
+                    {
+                        result.type = Diff::Type::Delete;
+                        result.state = Diff::State::Resolved;
+                        result.left = left_entries[i];
+                        left_resolved[i] = Diff::State::Resolved;
+                    }
+                }
+            }
+
+            for (auto i = 0; i < right_entries.size(); ++i)
+            {
+                if (right_resolved[i] == Diff::State::Unresolved)
+                {
+                    // Is the left side also unresolved? Could be an update in this case.
+                    if (i < left_resolved.size() && left_resolved[i] == Diff::State::Resolved && results[i].type == Diff::Type::Delete)
+                    {
+                        results[i].left = left_entries[i];
+                        results[i].right = right_entries[i];
+                        results[i].type = Diff::Type::Update;
+                        results[i].state = Diff::State::Resolved;
+                    }
+                    else
+                    {
+                        results.push_back(
+                            {
+                                .state = Diff::State::Resolved,
+                                .type = Diff::Type::Add,
+                                .right = right_entries[i]
+                            });
+                    }
+                    right_resolved[i] = Diff::State::Resolved;
+                }
+            }
+        }
+
+        struct DiffDetail
+        {
+            std::string type;
+            std::string left;
+            std::string right;
+        };
+
+        void add_if_changed(auto&& results, auto&& name, auto&& left, auto&& right, auto&& left_text, auto&& right_text)
+        {
+            if (left != right)
+            {
+                results.push_back({ .type = name, .left = left_text, .right = right_text });
+            }
+        }
+
+        void add_if_changed(auto&& results, auto&& name, auto&& left, auto&& right)
+        {
+            if constexpr (std::is_same<std::remove_reference_t<decltype(left)>, std::string>::value)
+            {
+                add_if_changed(results, name, left, right, left, right);
+            }
+            else
+            {
+                add_if_changed(results, name, left, right, to_string(left), to_string(right));
+            }
+        }
+
+        std::vector<DiffDetail> get_details(const std::shared_ptr<IItem>& left, const std::shared_ptr<IItem>& right)
+        {
+            std::vector<DiffDetail> results;
+            add_if_changed(results, "Type", left->type_id(), right->type_id(), left->type(), right->type());
+            add_if_changed(results, "Position", left->position() * 1024, right->position() * 1024);
+            add_if_changed(results, "Angle", left->angle(), right->angle());
+            add_if_changed(results, "OCB", left->ocb(), right->ocb());
+            add_if_changed(results, "Flags", format_binary(left->activation_flags()), format_binary(right->activation_flags()));
+            return results;
+        }
+
+        std::vector<DiffDetail> get_details(const std::shared_ptr<ITrigger>& left, const std::shared_ptr<ITrigger>& right)
+        {
+            std::vector<DiffDetail> results;
+            add_if_changed(results, "Type", left->type(), right->type());
+            add_if_changed(results, "Only Once", left->only_once(), right->only_once());
+            add_if_changed(results, "Position", left->position() * 1024, right->position() * 1024);
+            add_if_changed(results, "Flags", format_binary(left->flags()), format_binary(right->flags()));
+            add_if_changed(results, "Timer", left->timer(), right->timer());
+            return results;
+        }
+
+        std::vector<DiffDetail> get_details(const std::shared_ptr<ILight>& left, const std::shared_ptr<ILight>& right)
+        {
+            std::vector<DiffDetail> results;
+            add_if_changed(results, "Type", left->type(), right->type());
+            add_if_changed(results, "Position", left->position() * 1024, right->position() * 1024);
+            add_if_changed(results, "Colour", left->colour(), right->colour());
+            add_if_changed(results, "Intensity", left->intensity(), right->intensity());
+            add_if_changed(results, "Fade", left->fade(), right->fade());
+            add_if_changed(results, "Direction", left->direction() * 1024, right->direction() * 1024);
+            add_if_changed(results, "In", left->in(), right->in());
+            add_if_changed(results, "Out", left->out(), right->out());
+            add_if_changed(results, "Rad In", left->rad_in(), right->rad_in());
+            add_if_changed(results, "Rad Out", left->rad_out(), right->rad_out());
+            add_if_changed(results, "Range", left->range(), right->range());
+            add_if_changed(results, "Length", left->length(), right->length());
+            add_if_changed(results, "Cutoff", left->cutoff(), right->cutoff());
+            add_if_changed(results, "Radius", left->radius(), right->radius());
+            add_if_changed(results, "Density", left->density(), right->density());
+            return results;
+        }
+
+        std::vector<DiffDetail> get_details(const std::shared_ptr<ICameraSink>& left, const std::shared_ptr<ICameraSink>& right)
+        {
+            std::vector<DiffDetail> results;
+            add_if_changed(results, "Type", left->type(), right->type());
+            add_if_changed(results, "Position", left->position() * 1024, right->position() * 1024);
+            add_if_changed(results, "Box Index", left->box_index(), right->box_index());
+            add_if_changed(results, "Flag", left->flag(), right->flag());
+            add_if_changed(results, "Persistent", left->persistent(), right->persistent());
+            add_if_changed(results, "Strength", left->strength(), right->strength());
+            return results;
+        }
+
+        std::vector<DiffDetail> get_details(const std::shared_ptr<IStaticMesh>& left, const std::shared_ptr<IStaticMesh>& right)
+        {
+            std::vector<DiffDetail> results;
+            add_if_changed(results, "Type", left->type(), right->type());
+            add_if_changed(results, "Position", left->position() * 1024, right->position() * 1024);
+            add_if_changed(results, "Rotation", left->rotation(), right->rotation());
+            add_if_changed(results, "ID", left->id(), right->id());
+            add_if_changed(results, "Flags", left->flags(), right->flags(), format_binary(left->flags()), format_binary(right->flags()));
+            add_if_changed(results, "Breakable", left->breakable(), right->breakable());
+            add_if_changed(results, "Has Collision", left->has_collision(), right->has_collision());
+            return results;
+        }
+
+        std::vector<DiffDetail> get_details(const std::shared_ptr<ISoundSource>& left, const std::shared_ptr<ISoundSource>& right)
+        {
+            std::vector<DiffDetail> results;
+            add_if_changed(results, "Position", left->position() * 1024, right->position() * 1024);
+            add_if_changed(results, "ID", left->id(), right->id());
+            add_if_changed(results, "Flags", left->flags(), right->flags(), format_binary(left->flags()), format_binary(right->flags()));
+            add_if_changed(results, "Chance", left->chance(), right->chance());
+            add_if_changed(results, "Characteristics", left->characteristics(), right->characteristics());
+            add_if_changed(results, "Pitch", left->pitch(), right->pitch());
+            add_if_changed(results, "Range", left->range(), right->range());
+            add_if_changed(results, "Volume", left->volume(), right->volume());
+            add_if_changed(results, "Sample", left->sample(), right->sample());
+            return results;
+        }
+
+        std::vector<DiffDetail> get_details(const std::shared_ptr<IRoom>& left, const std::shared_ptr<IRoom>& right)
+        {
+            std::vector<DiffDetail> results;
+            // left->bounding_box() == right->bounding_box() &&
+            // info
+            add_if_changed(results, "Alternate Group", left->alternate_group(), right->alternate_group());
+            add_if_changed(results, "Alternate Mode", left->alternate_mode(), right->alternate_mode());
+            add_if_changed(results, "Ambient", left->ambient(), right->ambient());
+            add_if_changed(results, "Ambient Intensity 1", left->ambient_intensity_1(), right->ambient_intensity_1());
+            add_if_changed(results, "Ambient Intensity 2", left->ambient_intensity_2(), right->ambient_intensity_2());
+            add_if_changed(results, "Centre", left->centre() * 1024, right->centre() * 1024);
+            add_if_changed(results, "Flags", left->flags(), right->flags());
+            add_if_changed(results, "Light Mode", left->light_mode(), right->light_mode());
+            add_if_changed(results, "X Sectors", left->num_x_sectors(), right->num_x_sectors());
+            add_if_changed(results, "Z Sectors", left->num_z_sectors(), right->num_z_sectors());
+            return results;
+        }
+
+        std::vector<DiffDetail> get_details(const std::shared_ptr<ISector>& left, const std::shared_ptr<ISector>& right)
+        {
+            std::vector<DiffDetail> results;
+            add_if_changed(results, "X", left->x(), right->x());
+            add_if_changed(results, "Z", left->z(), right->z());
+            add_if_changed(results, "Flags", static_cast<int>(left->flags()), static_cast<int>(right->flags()));
+            add_if_changed(results, "Corner 0", left->corners()[0], right->corners()[0]);
+            add_if_changed(results, "Corner 1", left->corners()[1], right->corners()[1]);
+            add_if_changed(results, "Corner 2", left->corners()[2], right->corners()[2]);
+            add_if_changed(results, "Corner 3", left->corners()[3], right->corners()[3]);
+            add_if_changed(results, "Ceiling Corner 0", left->ceiling_corners()[0], right->ceiling_corners()[0]);
+            add_if_changed(results, "Ceiling Corner 1", left->ceiling_corners()[1], right->ceiling_corners()[1]);
+            add_if_changed(results, "Ceiling Corner 2", left->ceiling_corners()[2], right->ceiling_corners()[2]);
+            add_if_changed(results, "Ceiling Corner 3", left->ceiling_corners()[3], right->ceiling_corners()[3]);
+            add_if_changed(results, "Tilt X", left->tilt_x(), right->tilt_x());
+            add_if_changed(results, "Tilt Z", left->tilt_z(), right->tilt_z());
+            return results;
+        }
+
+        template <typename T>
+        void show_details(const std::shared_ptr<T>& left, const std::shared_ptr<T>& right)
+        {
+            for (const auto& detail : get_details(left, right))
+            {
+                ImGui::TableNextRow();
+                ImGui::TableNextColumn();
+                ImGui::TableNextColumn();
+                ImGui::Text(detail.type.c_str());
+                ImGui::TableNextColumn();
+                ImGui::Text(detail.left.c_str());
+                ImGui::TableNextColumn();
+                ImGui::TableNextColumn();
+                ImGui::Text(detail.right.c_str());
+            }
+        }
+
+        template <typename T>
+        auto get_results(auto&& left_entries, auto&& right_entries, auto&& comparer, auto&& extra_check)
+        {
+            const auto left_filtered = left_entries
+                | std::views::transform([](auto&& t) { return t.lock(); })
+                | std::views::filter([](auto&& t) { return t != nullptr; })
+                | std::views::filter(extra_check)
+                | std::ranges::to<std::vector>();
+            const auto right_filtered = right_entries
+                | std::views::transform([](auto&& t) { return t.lock(); })
+                | std::views::filter([](auto&& t) { return t != nullptr; })
+                | std::views::filter(extra_check)
+                | std::ranges::to<std::vector>();
+
+            std::vector<DiffWindow::Diff::Item<T>> results{ left_filtered.size() };
+            std::vector<DiffWindow::Diff::State> left_resolved{ left_filtered.size() };
+            std::vector<DiffWindow::Diff::State> right_resolved{ right_filtered.size() };
+
+            find_direct_matches<T>(results, left_filtered, right_filtered, left_resolved, right_resolved, comparer);
+            find_moves<T>(results, left_filtered, right_filtered, left_resolved, right_resolved, comparer);
+            mark_updated<T>(results, left_filtered, right_filtered, left_resolved, right_resolved);
+
+            std::ranges::sort(
+                results, [](const auto& l, const auto& r)
+                {
+                    const auto left_left = l.left.lock();
+                    const auto left_right = l.right.lock();
+                    const auto right_left = r.left.lock();
+                    const auto right_right = r.right.lock();
+                    const auto left_index = (left_right ? left_right->number() : left_left ? left_left->number() : 0);
+                    const auto right_index = (right_right ? right_right->number() : right_left ? right_left->number() : 0);
+                    return left_index < right_index;
+                }
+            );
+
+            return results;
+        };
+
+        template <typename T>
+        auto get_results(auto&& left_entries, auto&& right_entries, auto&& comparer)
+        {
+            return get_results<T>(left_entries, right_entries, comparer, [](auto&&) { return true; });
+        };
+    }
+
+    IDiffWindow::~IDiffWindow()
+    {
+    }
+
+    DiffWindow::DiffWindow(const std::shared_ptr<IDialogs>& dialogs, const ILevel::Source& level_source, std::unique_ptr<IFileMenu> file_menu)
+        : _dialogs(dialogs), _level_source(level_source), _file_menu(std::move(file_menu))
+    {
+        _token_store += _file_menu->on_file_open += [this](auto&& filename) { start_load(filename); };
+    }
+
+    void DiffWindow::render()
+    {
+        if (!render_diff_window())
+        {
+            on_window_closed();
+            return;
+        }
+    }
+
+    bool DiffWindow::render_diff_window()
+    {
+        bool stay_open = true;
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(520, 400));
+        if (ImGui::Begin(_id.c_str(), &stay_open, ImGuiWindowFlags_MenuBar))
+        {
+            if (ImGui::BeginMenuBar())
+            {
+                _file_menu->render();
+                ImGui::MenuItem("Only Show Changes", nullptr, &_only_show_changes);
+                ImGui::EndMenuBar();
+            }
+
+            if (loading())
+            {
+                if (!_progress.empty())
+                {
+                    ImGui::Text(std::format("Loading: {}", _progress).c_str());
+                }
+            }
+            else if (_diff)
+            {
+                render_diff_details();
+            }
+        }
+        ImGui::End();
+        ImGui::PopStyleVar();
+        return stay_open;
+    }
+
+    void DiffWindow::set_level(const std::weak_ptr<ILevel>& level)
+    {
+        _level = level;
+        _diff.reset();
+    }
+
+    void DiffWindow::set_number(int32_t number)
+    {
+        _id = std::format("Diff {}", number);
+    }
+
+    void DiffWindow::set_settings(const UserSettings& settings)
+    {
+        _settings = settings;
+        _file_menu->set_recent_files(_settings.recent_diff_files);
+    }
+
+    void DiffWindow::start_load(const std::string& filename)
+    {
+        const auto level = _level.lock();
+        if (!level)
+        {
+            return;
+        }
+
+        _load = std::async(std::launch::async, [=]() -> LoadOperation
+            {
+                LoadOperation operation
+                {
+                    .filename = filename,
+                };
+
+                try
+                {
+                    operation.level = load_level(filename);
+                    operation.diff = do_diff(level, operation.level);
+                }
+                catch (trlevel::LevelEncryptedException&)
+                {
+                    operation.error = "Level is encrypted and cannot be loaded";
+                }
+                catch (UserCancelledException&)
+                {
+                }
+                catch (std::exception& e)
+                {
+                    operation.error = std::format("Failed to load level : {}", e.what());
+                }
+
+                return operation;
+            });
+    }
+
+    std::shared_ptr<ILevel> DiffWindow::load_level(const std::string& filename)
+    {
+        _progress = std::format("Loading {}", filename);
+        auto level = _level_source(filename,
+            {
+                .on_progress_callback = [&](auto&& p) { _progress = p; }
+            });
+
+        level->set_filename(filename);
+        return level;
+    }
+
+    DiffWindow::Diff DiffWindow::do_diff(const std::shared_ptr<ILevel>& left, const std::shared_ptr<ILevel>& right)
+    {
+        // Items:
+        const auto item_results = get_results<IItem>(left->items(), right->items(),
+            [](auto&& left, auto&& right)
+            {
+                return left->type_id() == right->type_id() &&
+                    left->position() == right->position() &&
+                    left->angle() == right->angle() &&
+                    left->ocb() == right->ocb() &&
+                    left->activation_flags() == right->activation_flags();
+            },
+            [](auto&& i) { return i && i->ng_plus() != true; });
+
+        // Triggers:
+        const auto trigger_results = get_results<ITrigger>(left->triggers(), right->triggers(), 
+            [](auto&& left, auto&& right)
+            {
+                return
+                    // room?
+                    // x/z
+                    left->type() == right->type() &&
+                    left->only_once() == right->only_once() &&
+                    left->flags() == right->flags() &&
+                    left->timer() == right->timer() &&
+                    left->position() == right->position();
+            });;
+
+        // Lights:
+        const auto light_results = get_results<ILight>(left->lights(), right->lights(),
+            [](auto&& left, auto&& right)
+            {
+                return
+                    left->type() == right->type() &&
+                    left->position() == right->position() &&
+                    left->colour() == right->colour() &&
+                    left->intensity() == right->intensity() &&
+                    left->fade() == right->fade() &&
+                    left->direction() == right->direction() &&
+                    left->in() == right->in() &&
+                    left->out() == right->out() &&
+                    left->rad_in() == right->rad_in() &&
+                    left->rad_out() == right->rad_out() &&
+                    left->range() == right->range() &&
+                    left->length() == right->length() &&
+                    left->cutoff() == right->cutoff() &&
+                    left->radius() == right->radius() &&
+                    left->density() == right->density();
+            });
+
+        // Camera/Sinks:
+        const auto camera_sink_results = get_results<ICameraSink>(left->camera_sinks(), right->camera_sinks(),
+            [](auto&& left, auto&& right)
+            {
+                return
+                    left->type() == right->type() &&
+                    left->position() == right->position() &&
+                    left->box_index() == right->box_index() &&
+                    left->flag() == right->flag() &&
+                    left->persistent() == right->persistent() &&
+                    left->strength() == right->strength();
+                // bounding_box
+            });
+
+        // Statics:
+        const auto static_results = get_results<IStaticMesh>(left->static_meshes(), right->static_meshes(),
+            [](auto&& left, auto&& right)
+            {
+                return
+                    // Room?
+                    // visibility
+                    // collision
+                    left->type() == right->type() &&
+                    left->position() == right->position() &&
+                    left->rotation() == right->rotation() &&
+                    left->id() == right->id() &&
+                    left->flags() == right->flags() &&
+                    left->breakable() == right->breakable() &&
+                    left->has_collision() == right->has_collision();
+            });
+
+        // Sounds:
+        const auto sound_source_results = get_results<ISoundSource>(left->sound_sources(), right->sound_sources(),
+            [](auto&& left, auto&& right)
+            {
+                return
+                    left->chance() == right->chance() &&
+                    left->characteristics() == right->characteristics() &&
+                    left->flags() == right->flags() &&
+                    left->id() == right->id() &&
+                    left->position() == right->position() &&
+                    left->pitch() == right->pitch() &&
+                    left->range() == right->range() &&
+                    left->volume() == right->volume() &&
+                    left->sample() == right->sample();
+            });
+
+        // Rooms:
+        const auto rooms_results = get_results<IRoom>(left->rooms(), right->rooms(),
+            [](auto&& left, auto&& right)
+            {
+                return
+                    left->alternate_group() == right->alternate_group() &&
+                    left->ambient() == right->ambient() &&
+                    left->ambient_intensity_1() == right->ambient_intensity_1() &&
+                    left->ambient_intensity_2() == right->ambient_intensity_2() &&
+                    left->alternate_mode() == right->alternate_mode() &&
+                    // left->bounding_box() == right->bounding_box() &&
+                    left->centre() == right->centre() &&
+                    left->flags() == right->flags() &&
+                    // info
+                    left->light_mode() == right->light_mode()&&
+                    left->num_x_sectors() == right->num_x_sectors() &&
+                    left->num_z_sectors() == right->num_z_sectors();
+            });
+
+        // Sectors:
+        const auto left_sectors = std::ranges::join_view(
+                left->rooms() |
+                std::views::transform([](auto&& r) { return r.lock(); }) |
+                std::views::transform([](auto&& r) { return r->sectors(); }) |
+                std::ranges::to<std::vector>()) |
+            std::views::transform([](auto&& s) -> std::weak_ptr<ISector> { return s; }) |
+            std::ranges::to<std::vector>();
+        const auto right_sectors = std::ranges::join_view(
+                right->rooms() |
+                std::views::transform([](auto&& r) { return r.lock(); }) |
+                std::views::transform([](auto&& r) { return r->sectors(); }) |
+                std::ranges::to<std::vector>()) |
+            std::views::transform([](auto&& s) -> std::weak_ptr<ISector> { return s; }) |
+            std::ranges::to<std::vector>();
+
+        const auto sectors_results = get_results<ISector>(left_sectors, right_sectors,
+            [](auto&& left, auto&& right)
+            {
+                return
+                    left->x() == right->x() &&
+                    left->z() == right->z() &&
+                    // left->floordata_index() == right->floordata_index() &&
+                    left->flags() == right->flags() &&
+                    left->corners() == right->corners() &&
+                    left->ceiling_corners() == right->ceiling_corners() &&
+                    left->tilt_x() == right->tilt_x() &&
+                    left->tilt_z() == right->tilt_z();
+            }, [](auto&&) { return true; });
+
+        return Diff
+        {
+            .items = item_results,
+            .triggers = trigger_results,
+            .lights = light_results,
+            .camera_sinks = camera_sink_results,
+            .static_meshes = static_results,
+            .sound_sources = sound_source_results,
+            .rooms = rooms_results,
+            .sectors = sectors_results
+        };
+    }
+
+    bool DiffWindow::loading()
+    {
+        if (_load.valid())
+        {
+            if (_load.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready)
+            {
+                return true;
+            }
+            _diff = _load.get();
+            on_level_selected(_diff->level);
+            if (_diff->level)
+            {
+                _file_menu->open_file(_diff->level->filename());
+                _settings.add_recent_diff_file(_diff->level->filename());
+                _file_menu->set_recent_files(_settings.recent_diff_files);
+                on_settings(_settings);
+            }
+        }
+        return false;
+    }
+
+    void DiffWindow::render_diff_details()
+    {
+        std::string a_filename;
+        if (auto level = _level.lock())
+        {
+            a_filename = level->filename();
+        }
+        ImGui::Text(std::format("A: {}", a_filename).c_str());
+        ImGui::Text(std::format("B: {}", _diff->filename).c_str());
+
+        if (ImGui::BeginTabBar("TabBar"))
+        {
+            const auto any_diff = [](auto&& range) { return std::ranges::any_of(range, [](auto&& e) { return e.type != Diff::Type::None; }); };
+            const bool any_items = any_diff(_diff->diff.items);
+            const bool any_triggers = any_diff(_diff->diff.triggers);
+            const bool any_lights = any_diff(_diff->diff.lights);
+            const bool any_camera_sink = any_diff(_diff->diff.camera_sinks);
+            const bool any_statics = any_diff(_diff->diff.static_meshes);
+            const bool any_sounds = any_diff(_diff->diff.sound_sources);
+            const bool any_rooms = any_diff(_diff->diff.rooms);
+            const bool any_sectors = any_diff(_diff->diff.sectors);
+
+            const auto show_table = [this](
+                const std::string& table_name,
+                const auto& diff_entries,
+                auto& on_selected,
+                const auto& key_get)
+                {
+                    if (ImGui::BeginTable(table_name.c_str(), 5, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY))
+                    {
+                        imgui_header_row(
+                            {
+                                { "#", _column_sizer.size(0) },
+                                { "Type", _column_sizer.size(1) },
+                                { "Change", _column_sizer.size(2) },
+                                { "#", _column_sizer.size(3) },
+                                { "Type", _column_sizer.size(4) },
+                            });
+
+                        for (const auto item_diff : diff_entries)
+                        {
+                            if (_only_show_changes && item_diff.type == Diff::Type::None)
+                            {
+                                continue;
+                            }
+
+                            const auto left_item = item_diff.left.lock();
+                            const auto right_item = item_diff.right.lock();
+
+                            ImGui::TableNextRow();
+                            ImGui::TableNextColumn();
+
+                            const std::string row_text = left_item ? std::to_string(left_item->number()) : "";
+                            bool open = false;
+                            if (item_diff.type == Diff::Type::Update)
+                            {
+                                open = ImGui::TreeNodeEx(row_text.c_str(), ImGuiTreeNodeFlags_OpenOnArrow);
+                            }
+                            else
+                            {
+                                ImGui::Text(row_text.c_str());
+                            }
+
+                            ImGui::TableNextColumn();
+                            if (left_item)
+                            {
+                                if (ImGui::Selectable(std::format("{}##left-{}", key_get(left_item), left_item->number()).c_str()))
+                                {
+                                    on_selected(left_item);
+                                }
+                            }
+
+                            ImGui::TableNextColumn();
+                            ImGui::TextColored(to_colour(item_diff.type), to_string(item_diff.type).c_str());
+
+                            ImGui::TableNextColumn();
+                            if (right_item)
+                            {
+                                ImGui::Text(std::to_string(right_item->number()).c_str());
+                            }
+
+                            ImGui::TableNextColumn();
+                            if (right_item)
+                            {
+                                if (ImGui::Selectable(std::format("{}##right-{}", key_get(right_item), right_item->number()).c_str()))
+                                {
+                                    on_level_selected(_diff->level);
+                                    on_selected(right_item);
+                                }
+                            }
+
+                            if (open && left_item && right_item)
+                            {
+                                show_details(left_item, right_item);
+                                ImGui::TreePop();
+                            }
+                        }
+
+                        ImGui::EndTable();
+                    }
+                };
+            
+            if (ImGui::BeginTabItem(std::format("Items{}", any_items ? "*" : "").c_str()))
+            {
+                show_table("Items List", _diff->diff.items, on_item_selected, [](auto&& i) { return i->type(); });
+                ImGui::EndTabItem();
+            }
+
+            if (ImGui::BeginTabItem(std::format("Triggers{}", any_triggers ? "*" : "").c_str()))
+            {
+                show_table("Triggers List", _diff->diff.triggers, on_trigger_selected, [](auto&& t) { return to_string(t->type()); });
+                ImGui::EndTabItem();
+            }
+
+            if (ImGui::BeginTabItem(std::format("Lights{}", any_lights ? "*" : "").c_str()))
+            {
+                show_table("Lights List", _diff->diff.lights, on_light_selected, [](auto&& l) { return to_string(l->type()); });
+                ImGui::EndTabItem();
+            }
+
+            if (ImGui::BeginTabItem(std::format("Camera/Sink{}", any_camera_sink ? "*" : "").c_str()))
+            {
+                show_table("CameraSink List", _diff->diff.camera_sinks, on_camera_sink_selected, [](auto&& c) { return to_string(c->type()); });
+                ImGui::EndTabItem();
+            }
+
+            if (ImGui::BeginTabItem(std::format("Statics{}", any_statics ? "*" : "").c_str()))
+            {
+                show_table("Statics List", _diff->diff.static_meshes, on_static_mesh_selected, [](auto&& c) { return to_string(c->type()); });
+                ImGui::EndTabItem();
+            }
+
+            if (ImGui::BeginTabItem(std::format("Sound Sources{}", any_sounds ? "*" : "").c_str()))
+            {
+                show_table("Sounds List", _diff->diff.sound_sources, on_sound_source_selected, [](auto&&) { return "Sound"; });
+                ImGui::EndTabItem();
+            }
+
+            if (ImGui::BeginTabItem(std::format("Rooms{}", any_rooms ? "*" : "").c_str()))
+            {
+                show_table("Rooms List", _diff->diff.rooms, on_room_selected, [](auto&&) { return "Room"; });
+                ImGui::EndTabItem();
+            }
+
+            if (ImGui::BeginTabItem(std::format("Sectors{}", any_sectors ? "*" : "").c_str()))
+            {
+                show_table("Sectors List", _diff->diff.sectors, on_sector_selected, [](auto&&) { return "Sector"; });
+                ImGui::EndTabItem();
+            }
+
+            ImGui::EndTabBar();
+        }
+    }
+
+    void DiffWindow::calculate_column_widths()
+    {
+        if (!_diff)
+        {
+            return;
+        }
+
+        _column_sizer.reset();
+        _column_sizer.measure("#__", 0);
+        _column_sizer.measure("Type__", 1);
+        _column_sizer.measure("Change__", 2);
+        _column_sizer.measure("#__", 3);
+        _column_sizer.measure("Type__", 4);
+
+        for (const auto& item : _diff->diff.items)
+        {
+            if (auto item_ptr = item.left.lock())
+            {
+                _column_sizer.measure(std::to_string(item_ptr->number()), 0);
+                _column_sizer.measure(item_ptr->type(), 1);
+            }
+
+            _column_sizer.measure(to_string(item.type), 2);
+
+            if (auto item_ptr = item.right.lock())
+            {
+                _column_sizer.measure(std::to_string(item_ptr->number()), 3);
+                _column_sizer.measure(item_ptr->type(), 4);
+            }
+        }
+    }
+}

--- a/trview.app/Windows/Diff/DiffWindow.cpp
+++ b/trview.app/Windows/Diff/DiffWindow.cpp
@@ -732,15 +732,15 @@ namespace trview
                 auto& on_selected,
                 const auto& key_get)
                 {
-                    if (ImGui::BeginTable(table_name.c_str(), 5, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY))
+                    if (ImGui::BeginTable(table_name.c_str(), 5, ImGuiTableFlags_ScrollY))
                     {
                         imgui_header_row(
                             {
-                                { "#", _column_sizer.size(0) },
-                                { "Type", _column_sizer.size(1) },
+                                { "# ##L", _column_sizer.size(0) },
+                                { "Type##L", _column_sizer.size(1) },
                                 { "Change", _column_sizer.size(2) },
-                                { "#", _column_sizer.size(3) },
-                                { "Type", _column_sizer.size(4) },
+                                { "# ##R", _column_sizer.size(3) },
+                                { "Type##R", _column_sizer.size(4) },
                             });
 
                         for (const auto item_diff : diff_entries)

--- a/trview.app/Windows/Diff/DiffWindow.cpp
+++ b/trview.app/Windows/Diff/DiffWindow.cpp
@@ -416,6 +416,10 @@ namespace trview
     {
         if (!render_diff_window())
         {
+            if (_diff.has_value())
+            {
+                on_diff_ended(_diff->level);
+            }
             on_window_closed();
             return;
         }
@@ -692,7 +696,6 @@ namespace trview
                 return true;
             }
             _diff = _load.get();
-            on_level_selected(_diff->level);
             if (_diff->level)
             {
                 _file_menu->open_file(_diff->level->filename());
@@ -790,7 +793,6 @@ namespace trview
                             {
                                 if (ImGui::Selectable(std::format("{}##right-{}", key_get(right_item), right_item->number()).c_str()))
                                 {
-                                    on_level_selected(_diff->level);
                                     on_selected(right_item);
                                 }
                             }

--- a/trview.app/Windows/Diff/DiffWindow.h
+++ b/trview.app/Windows/Diff/DiffWindow.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <future>
+#include <string>
+#include <trview.common/Windows/IDialogs.h>
+#include <trview.common/TokenStore.h>
+
+#include "../../Menus/IFileMenu.h"
+#include "../../Elements/ILevel.h"
+#include "IDiffWindow.h"
+#include "../ColumnSizer.h"
+#include "../../Settings/UserSettings.h"
+
+namespace trview
+{
+    class DiffWindow final : public IDiffWindow
+    {
+    public:
+        struct Names
+        {
+        };
+
+        explicit DiffWindow(const std::shared_ptr<IDialogs>& dialogs, const ILevel::Source& level_source, std::unique_ptr<IFileMenu> file_menu);
+        virtual ~DiffWindow() = default;
+        void render() override;
+        void set_level(const std::weak_ptr<ILevel>& level) override;
+        void set_number(int32_t number) override;
+        void set_settings(const UserSettings& settings) override;
+
+        struct Diff
+        {
+            enum class State
+            {
+                Unresolved,
+                Resolved
+            };
+
+            enum class Type
+            {
+                None,
+                Add,
+                Update,
+                Reindex,
+                Delete
+            };
+
+            template <typename T>
+            struct Item
+            {
+                State state{ State::Unresolved };
+                Type type{ Type::None };
+                std::weak_ptr<T> left;
+                std::weak_ptr<T> right;
+            };
+
+            std::vector<Item<IItem>> items;
+            std::vector<Item<ITrigger>> triggers;
+            std::vector<Item<ILight>> lights;
+            std::vector<Item<ICameraSink>> camera_sinks;
+            std::vector<Item<IStaticMesh>> static_meshes;
+            std::vector<Item<ISoundSource>> sound_sources;
+            std::vector<Item<IRoom>> rooms;
+            std::vector<Item<ISector>> sectors;
+        };
+    private:
+        struct LoadOperation
+        {
+            std::shared_ptr<ILevel>     level;
+            std::string                 filename;
+            std::optional<std::string>  error;
+            Diff                        diff;
+        };
+
+        void render_diff_details();
+        bool render_diff_window();
+        void start_load(const std::string& filename);
+        std::shared_ptr<ILevel> load_level(const std::string& filename);
+        Diff do_diff(const std::shared_ptr<ILevel>& left, const std::shared_ptr<ILevel>& right);
+        bool loading();
+        void calculate_column_widths();
+
+        std::string _id{ "Diff 0" };
+        std::string _progress;
+        ILevel::Source _level_source;
+        std::future<LoadOperation> _load;
+        std::optional<LoadOperation> _diff;
+        std::shared_ptr<IDialogs> _dialogs;
+        std::weak_ptr<ILevel> _level;
+        ColumnSizer _column_sizer;
+        std::unique_ptr<IFileMenu> _file_menu;
+        TokenStore _token_store;
+        UserSettings _settings;
+        bool _only_show_changes{ false };
+    };
+}

--- a/trview.app/Windows/Diff/DiffWindowManager.cpp
+++ b/trview.app/Windows/Diff/DiffWindowManager.cpp
@@ -1,0 +1,66 @@
+#include "DiffWindowManager.h"
+#include "../../Resources/resource.h"
+
+namespace trview
+{
+    IDiffWindowManager::~IDiffWindowManager()
+    {
+    }
+
+    DiffWindowManager::DiffWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const IDiffWindow::Source& diff_window_source)
+        : _diff_window_source(diff_window_source), MessageHandler(window)
+    {
+        _token_store += shortcuts->add_shortcut(true, 'D') += [&]() { create_window(); };
+    }
+
+    std::weak_ptr<IDiffWindow> DiffWindowManager::create_window()
+    {
+        const auto window = _diff_window_source();
+        window->set_level(_level);
+        window->set_settings(_settings);
+        window->on_item_selected += on_item_selected;
+        window->on_light_selected += on_light_selected;
+        window->on_trigger_selected += on_trigger_selected;
+        window->on_level_selected += on_level_selected;
+        window->on_camera_sink_selected += on_camera_sink_selected;
+        window->on_static_mesh_selected += on_static_mesh_selected;
+        window->on_sound_source_selected += on_sound_source_selected;
+        window->on_room_selected += on_room_selected;
+        window->on_sector_selected += on_sector_selected;
+        window->on_settings += on_settings;
+        return add_window(window);
+    }
+
+    std::optional<int> DiffWindowManager::process_message(UINT message, WPARAM wParam, LPARAM)
+    {
+        if (message == WM_COMMAND && LOWORD(wParam) == ID_WINDOWS_DIFF)
+        {
+            create_window();
+        }
+        return {};
+    }
+
+    void DiffWindowManager::render()
+    {
+        WindowManager::render();
+    }
+
+    void DiffWindowManager::set_level(const std::weak_ptr<ILevel>& level)
+    {
+        _level = level;
+        for (auto& window : _windows)
+        {
+            window.second->set_level(level);
+        }
+    }
+
+    void DiffWindowManager::set_settings(const UserSettings& settings)
+    {
+        _settings = settings;
+        for (auto& window : _windows)
+        {
+            window.second->set_settings(settings);
+        }
+    }
+}
+

--- a/trview.app/Windows/Diff/DiffWindowManager.cpp
+++ b/trview.app/Windows/Diff/DiffWindowManager.cpp
@@ -21,7 +21,7 @@ namespace trview
         window->on_item_selected += on_item_selected;
         window->on_light_selected += on_light_selected;
         window->on_trigger_selected += on_trigger_selected;
-        window->on_level_selected += on_level_selected;
+        window->on_diff_ended += on_diff_ended;
         window->on_camera_sink_selected += on_camera_sink_selected;
         window->on_static_mesh_selected += on_static_mesh_selected;
         window->on_sound_source_selected += on_sound_source_selected;

--- a/trview.app/Windows/Diff/DiffWindowManager.h
+++ b/trview.app/Windows/Diff/DiffWindowManager.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <trview.common/MessageHandler.h>
+#include <trview.common/Windows/Shortcuts.h>
+#include "../WindowManager.h"
+#include "IDiffWindowManager.h"
+#include "IDiffWindow.h"
+#include "../../Settings/UserSettings.h"
+
+namespace trview
+{
+    class DiffWindowManager final : public IDiffWindowManager, public WindowManager<IDiffWindow>, public MessageHandler
+    {
+    public:
+        DiffWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const IDiffWindow::Source& diff_window_source);
+        virtual ~DiffWindowManager() = default;
+        std::weak_ptr<IDiffWindow> create_window() override;
+        std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        void render() override;
+        void set_level(const std::weak_ptr<ILevel>& level) override;
+        void set_settings(const UserSettings& settings) override;
+    private:
+        IDiffWindow::Source _diff_window_source;
+        std::weak_ptr<ILevel> _level;
+        UserSettings _settings;
+    };
+}

--- a/trview.app/Windows/Diff/IDiffWindow.h
+++ b/trview.app/Windows/Diff/IDiffWindow.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <trview.common/Event.h>
+
+namespace trview
+{
+    struct ICameraSink;
+    struct IItem;
+    struct ILevel;
+    struct ILight;
+    struct ISoundSource;
+    struct ITrigger;
+    struct IRoom;
+    struct ISector;
+    struct UserSettings;
+
+    struct IDiffWindow
+    {
+        using Source = std::function<std::shared_ptr<IDiffWindow>()>;
+
+        virtual ~IDiffWindow() = 0;
+        virtual void render() = 0;
+        virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
+        virtual void set_number(int32_t number) = 0;
+        virtual void set_settings(const UserSettings& settings) = 0;
+        /// <summary>
+        /// Event raised when the window is closed.
+        /// </summary>
+        Event<> on_window_closed;
+
+        Event<std::weak_ptr<IItem>> on_item_selected;
+        Event<std::weak_ptr<ILight>> on_light_selected;
+        Event<std::weak_ptr<ITrigger>> on_trigger_selected;
+        Event<std::weak_ptr<ILevel>> on_level_selected;
+        Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
+        Event<std::weak_ptr<IStaticMesh>> on_static_mesh_selected;
+        Event<std::weak_ptr<ISoundSource>> on_sound_source_selected;
+        Event<std::weak_ptr<IRoom>> on_room_selected;
+        Event<std::weak_ptr<ISector>> on_sector_selected;
+        Event<UserSettings> on_settings;
+    };
+}

--- a/trview.app/Windows/Diff/IDiffWindow.h
+++ b/trview.app/Windows/Diff/IDiffWindow.h
@@ -31,7 +31,7 @@ namespace trview
         Event<std::weak_ptr<IItem>> on_item_selected;
         Event<std::weak_ptr<ILight>> on_light_selected;
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
-        Event<std::weak_ptr<ILevel>> on_level_selected;
+        Event<std::weak_ptr<ILevel>> on_diff_ended;
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
         Event<std::weak_ptr<IStaticMesh>> on_static_mesh_selected;
         Event<std::weak_ptr<ISoundSource>> on_sound_source_selected;

--- a/trview.app/Windows/Diff/IDiffWindowManager.h
+++ b/trview.app/Windows/Diff/IDiffWindowManager.h
@@ -28,7 +28,7 @@ namespace trview
         Event<std::weak_ptr<IItem>> on_item_selected;
         Event<std::weak_ptr<ILight>> on_light_selected;
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
-        Event<std::weak_ptr<ILevel>> on_level_selected;
+        Event<std::weak_ptr<ILevel>> on_diff_ended;
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
         Event<std::weak_ptr<IStaticMesh>> on_static_mesh_selected;
         Event<std::weak_ptr<ISoundSource>> on_sound_source_selected;

--- a/trview.app/Windows/Diff/IDiffWindowManager.h
+++ b/trview.app/Windows/Diff/IDiffWindowManager.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <memory>
+#include <trview.common/Event.h>
+
+namespace trview
+{
+    struct ICameraSink;
+    struct IDiffWindow;
+    struct IItem;
+    struct ILevel;
+    struct ILight;
+    struct ISoundSource;
+    struct IStaticMesh;
+    struct ITrigger;
+    struct IRoom;
+    struct ISector;
+    struct UserSettings;
+
+    struct IDiffWindowManager
+    {
+        virtual ~IDiffWindowManager() = 0;
+        virtual std::weak_ptr<IDiffWindow> create_window() = 0;
+        virtual void render() = 0;
+        virtual void set_level(const std::weak_ptr<ILevel>& level) = 0;
+        virtual void set_settings(const UserSettings& settings) = 0;
+
+        Event<std::weak_ptr<IItem>> on_item_selected;
+        Event<std::weak_ptr<ILight>> on_light_selected;
+        Event<std::weak_ptr<ITrigger>> on_trigger_selected;
+        Event<std::weak_ptr<ILevel>> on_level_selected;
+        Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
+        Event<std::weak_ptr<IStaticMesh>> on_static_mesh_selected;
+        Event<std::weak_ptr<ISoundSource>> on_sound_source_selected;
+        Event<std::weak_ptr<IRoom>> on_room_selected;
+        Event<std::weak_ptr<ISector>> on_sector_selected;
+        Event<UserSettings> on_settings;
+    };
+}

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -165,5 +165,6 @@ namespace trview
         virtual void select_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
         virtual void select_static_mesh(const std::weak_ptr<IStaticMesh>& static_mesh) = 0;
         virtual void select_sound_source(const std::weak_ptr<ISoundSource>& sound_source) = 0;
+        virtual std::weak_ptr<ILevel> level() const = 0;
     };
 }

--- a/trview.app/Windows/IWindows.h
+++ b/trview.app/Windows/IWindows.h
@@ -38,6 +38,7 @@ namespace trview
         virtual void setup(const UserSettings& settings) = 0;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
+        Event<std::weak_ptr<ILevel>> on_diff_level_selected;
         Event<std::weak_ptr<IItem>> on_item_selected;
         Event<std::string> on_level_switch;
         Event<std::weak_ptr<ILight>> on_light_selected;
@@ -53,7 +54,9 @@ namespace trview
         Event<std::weak_ptr<IStaticMesh>> on_static_selected;
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
         Event<std::weak_ptr<IWaypoint>> on_waypoint_selected;
+        Event<std::weak_ptr<ISector>> on_sector_selected;
         Event<> on_route_window_created;
         Event<> on_scene_changed;
+        Event<UserSettings> on_settings;
     };
 }

--- a/trview.app/Windows/IWindows.h
+++ b/trview.app/Windows/IWindows.h
@@ -38,7 +38,7 @@ namespace trview
         virtual void setup(const UserSettings& settings) = 0;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
-        Event<std::weak_ptr<ILevel>> on_diff_level_selected;
+        Event<std::weak_ptr<ILevel>> on_diff_ended;
         Event<std::weak_ptr<IItem>> on_item_selected;
         Event<std::string> on_level_switch;
         Event<std::weak_ptr<ILight>> on_light_selected;

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -307,7 +307,7 @@ namespace trview
                     {
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
                         [](auto&& l, auto&& r) { return std::tuple(trigger_room(l), l.number()) < std::tuple(trigger_room(r), r.number()); },
-                        [](auto&& l, auto&& r) { return std::tuple(trigger_type_name(l.type()), l.number()) < std::tuple(trigger_type_name(r.type()), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(to_string(l.type()), l.number()) < std::tuple(to_string(r.type()), r.number()); },
                     }, _force_sort);
 
                 for (auto& trigger : _triggered_by)
@@ -330,7 +330,7 @@ namespace trview
                     ImGui::TableNextColumn();
                     ImGui::Text(std::to_string(trigger_room(trigger_ptr)).c_str());
                     ImGui::TableNextColumn();
-                    ImGui::Text(trigger_type_name(trigger_ptr->type()).c_str());
+                    ImGui::Text(to_string(trigger_ptr->type()).c_str());
                 }
 
                 ImGui::EndTable();

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -133,7 +133,7 @@ namespace trview
                     {
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
                         [](auto&& l, auto&& r) { return std::tuple(light_room(l), l.number()) < std::tuple(light_room(r), r.number()); },
-                        [](auto&& l, auto&& r) { return std::tuple(light_type_name(l.type()), l.number()) < std::tuple(light_type_name(r.type()), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(to_string(l.type()), l.number()) < std::tuple(to_string(r.type()), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.visible(), l.number()) < std::tuple(r.visible(), r.number()); }
                     }, _force_sort);
 
@@ -168,7 +168,7 @@ namespace trview
                     ImGui::TableNextColumn();
                     ImGui::Text(std::to_string(light_room(light)).c_str());
                     ImGui::TableNextColumn();
-                    ImGui::Text(light_type_name(light->type()).c_str());
+                    ImGui::Text(to_string(light->type()).c_str());
                     ImGui::TableNextColumn();
                     bool hidden = !light->visible();
                     ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
@@ -234,7 +234,7 @@ namespace trview
                         return std::format("R: {}, G: {}, B: {}", static_cast<int>(colour.r * 255), static_cast<int>(colour.g * 255), static_cast<int>(colour.b * 255));
                     };
 
-                    add_stat("Type", light_type_name(selected_light->type()));
+                    add_stat("Type", to_string(selected_light->type()));
                     add_stat("#", selected_light->number());
                     add_stat("Room", light_room(selected_light));
 
@@ -320,10 +320,10 @@ namespace trview
         {
             if (auto light_ptr = light.lock())
             {
-                available_types.insert(light_type_name(light_ptr->type()));
+                available_types.insert(to_string(light_ptr->type()));
             }
         }
-        _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& light) { return light_type_name(light.type()); });
+        _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& light) { return to_string(light.type()); });
         _filters.add_getter<float>("#", [](auto&& light) { return static_cast<float>(light.number()); });
         _filters.add_getter<float>("Room", [](auto&& light) { return static_cast<float>(light_room(light)); });
         _filters.add_getter<float>("X", [](auto&& light) { return light.position().x * trlevel::Scale_X; }, has_position);
@@ -379,7 +379,7 @@ namespace trview
             {
                 _column_sizer.measure(std::format("{0}", light_ptr->number()), 0);
                 _column_sizer.measure(std::to_string(light_room(*light_ptr)), 1);
-                _column_sizer.measure(light_type_name(light_ptr->type()), 2);
+                _column_sizer.measure(to_string(light_ptr->type()), 2);
             }
         }
     }

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -614,7 +614,7 @@ namespace trview
                 {
                     if (auto trigger_ptr = trigger.lock())
                     {
-                        available_trigger_types.insert(trigger_type_name(trigger_ptr->type()));
+                        available_trigger_types.insert(to_string(trigger_ptr->type()));
                     }
                 }
             }
@@ -626,7 +626,7 @@ namespace trview
                 {
                     if (const auto trigger_ptr = trigger.lock())
                     {
-                        results.push_back(trigger_type_name(trigger_ptr->type()));
+                        results.push_back(to_string(trigger_ptr->type()));
                     }
                 }
                 return results;
@@ -913,7 +913,7 @@ namespace trview
             imgui_sort_weak(_triggers,
                 {
                     [](auto&& l, auto&& r) { return l.number() < r.number(); },
-                    [&](auto&& l, auto&& r) { return std::tuple(trigger_type_name(l.type()), l.number()) < std::tuple(trigger_type_name(r.type()), r.number()); }
+                    [&](auto&& l, auto&& r) { return std::tuple(to_string(l.type()), l.number()) < std::tuple(to_string(r.type()), r.number()); }
                 }, _force_sort);
 
             for (const auto& trigger : _triggers)
@@ -941,7 +941,7 @@ namespace trview
                     }
 
                     ImGui::TableNextColumn();
-                    ImGui::Text(trigger_type_name(trigger_ptr->type()).c_str());
+                    ImGui::Text(to_string(trigger_ptr->type()).c_str());
                 }
             }
 
@@ -1130,7 +1130,7 @@ namespace trview
             imgui_sort_weak(_lights,
                 {
                     [](auto&& l, auto&& r) { return l.number() < r.number(); },
-                    [&](auto&& l, auto&& r) { return std::tuple(light_type_name(l.type()), l.number()) < std::tuple(light_type_name(r.type()), r.number()); }
+                    [&](auto&& l, auto&& r) { return std::tuple(to_string(l.type()), l.number()) < std::tuple(to_string(r.type()), r.number()); }
                 }, _force_sort);
 
             for (const auto& light : _lights)
@@ -1158,7 +1158,7 @@ namespace trview
                     }
 
                     ImGui::TableNextColumn();
-                    ImGui::Text(light_type_name(light_ptr->type()).c_str());
+                    ImGui::Text(to_string(light_ptr->type()).c_str());
                 }
             }
 

--- a/trview.app/Windows/RouteWindow.cpp
+++ b/trview.app/Windows/RouteWindow.cpp
@@ -557,7 +557,7 @@ namespace trview
             {
                 if (auto trigger = _all_triggers[waypoint.index()].lock())
                 {
-                    return trigger_type_name(trigger->type());
+                    return to_string(trigger->type());
                 }
             }
             else

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -203,7 +203,7 @@ namespace trview
                     {
                         [](auto&& l, auto&& r) { return l.number() < r.number(); },
                         [](auto&& l, auto&& r) { return std::tuple(trigger_room(l), l.number()) < std::tuple(trigger_room(r), r.number()); },
-                        [](auto&& l, auto&& r) { return std::tuple(trigger_type_name(l.type()), l.number()) < std::tuple(trigger_type_name(r.type()), r.number()); },
+                        [](auto&& l, auto&& r) { return std::tuple(to_string(l.type()), l.number()) < std::tuple(to_string(r.type()), r.number()); },
                         [](auto&& l, auto&& r) { return std::tuple(l.visible(), l.number()) < std::tuple(r.visible(), r.number()); }
                     }, _force_sort);
 
@@ -242,7 +242,7 @@ namespace trview
                         ImGui::TableNextColumn();
                         ImGui::Text(std::to_string(trigger_room(trigger_ptr)).c_str());
                         ImGui::TableNextColumn();
-                        ImGui::Text(trigger_type_name(trigger_ptr->type()).c_str());
+                        ImGui::Text(to_string(trigger_ptr->type()).c_str());
                         ImGui::TableNextColumn();
                         bool hidden = !trigger_ptr->visible();
                         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0, 0));
@@ -319,7 +319,7 @@ namespace trview
                             return std::format("{:.0f}, {:.0f}, {:.0f}", p.x, p.y, p.z);
                         };
 
-                    add_stat("Type", trigger_type_name(selected_trigger->type()));
+                    add_stat("Type", to_string(selected_trigger->type()));
                     add_stat("#", selected_trigger->number());
                     add_stat("Position", position_text());
                     add_stat("Room", trigger_room(selected_trigger));
@@ -462,10 +462,10 @@ namespace trview
         {
             if (auto trigger_ptr = trigger.lock())
             {
-                available_types.insert(trigger_type_name(trigger_ptr->type()));
+                available_types.insert(to_string(trigger_ptr->type()));
             }
         }
-        _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& trigger) { return trigger_type_name(trigger.type()); });
+        _filters.add_getter<std::string>("Type", { available_types.begin(), available_types.end() }, [](auto&& trigger) { return to_string(trigger.type()); });
         _filters.add_getter<float>("#", [](auto&& trigger) { return static_cast<float>(trigger.number()); });
         _filters.add_getter<float>("Room", [](auto&& trigger) { return static_cast<float>(trigger_room(trigger)); });
         _filters.add_getter<std::string>("Flags", [](auto&& trigger) { return format_binary(trigger.flags()); });
@@ -580,7 +580,7 @@ namespace trview
                 {
                     _column_sizer.measure(std::to_string(room->number()), 1);
                 }
-                _column_sizer.measure(trigger_type_name(trigger_ptr->type()), 2);
+                _column_sizer.measure(to_string(trigger_ptr->type()), 2);
             }
         }
     }

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1572,4 +1572,9 @@ namespace trview
         }
         set_toggle(Options::ng_plus, show);
     }
+
+    std::weak_ptr<ILevel> Viewer::level() const
+    {
+        return _level;
+    }
 }

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -641,6 +641,12 @@ namespace trview
     {
         auto old_level = _level.lock();
         auto new_level = level.lock();
+
+        if (old_level == new_level)
+        {
+            return;
+        }
+
         _level = level;
 
         _level_token_store.clear();

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -92,6 +92,7 @@ namespace trview
         virtual void select_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
         void select_static_mesh(const std::weak_ptr<IStaticMesh>& static_mesh) override;
         void select_sound_source(const std::weak_ptr<ISoundSource>& sound_source) override;
+        std::weak_ptr<ILevel> level() const override;
     private:
         void initialise_input();
         void toggle_highlight();

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -6,6 +6,7 @@
 #include "About/AboutWindowManager.h"
 #include "CameraSink/ICameraSinkWindowManager.h"
 #include "Console/IConsoleManager.h"
+#include "Diff/IDiffWindowManager.h"
 #include "IItemsWindowManager.h"
 #include "ILightsWindowManager.h"
 #include "Log/ILogWindowManager.h"
@@ -29,6 +30,7 @@ namespace trview
         std::unique_ptr<IAboutWindowManager> about_window_manager,
         std::unique_ptr<ICameraSinkWindowManager> camera_sink_windows,
         std::unique_ptr<IConsoleManager> console_manager,
+        std::unique_ptr<IDiffWindowManager> diff_window_manager,
         std::shared_ptr<IItemsWindowManager> items_window_manager,
         std::unique_ptr<ILightsWindowManager> lights_window_manager,
         std::unique_ptr<ILogWindowManager> log_window_manager,
@@ -40,14 +42,25 @@ namespace trview
         std::unique_ptr<ITexturesWindowManager> textures_window_manager,
         std::unique_ptr<ITriggersWindowManager> triggers_window_manager)
         : _about_windows(std::move(about_window_manager)), _camera_sink_windows(std::move(camera_sink_windows)), _console_manager(std::move(console_manager)),
-        _items_windows(items_window_manager), _lights_windows(std::move(lights_window_manager)), _log_windows(std::move(log_window_manager)),
-        _plugins_windows(std::move(plugins_window_manager)), _rooms_windows(std::move(rooms_window_manager)), _route_window(std::move(route_window_manager)),
-        _sounds_windows(std::move(sounds_window_manager)), _statics_windows(std::move(statics_window_manager)), _textures_windows(std::move(textures_window_manager)),
-        _triggers_windows(std::move(triggers_window_manager))
+        _diff_windows(std::move(diff_window_manager)), _items_windows(items_window_manager), _lights_windows(std::move(lights_window_manager)),
+        _log_windows(std::move(log_window_manager)), _plugins_windows(std::move(plugins_window_manager)), _rooms_windows(std::move(rooms_window_manager)),
+        _route_window(std::move(route_window_manager)), _sounds_windows(std::move(sounds_window_manager)), _statics_windows(std::move(statics_window_manager)),
+        _textures_windows(std::move(textures_window_manager)), _triggers_windows(std::move(triggers_window_manager))
     {
         _camera_sink_windows->on_camera_sink_selected += on_camera_sink_selected;
         _camera_sink_windows->on_trigger_selected += on_trigger_selected;
         _camera_sink_windows->on_scene_changed += on_scene_changed;
+
+        _diff_windows->on_item_selected += on_item_selected;
+        _diff_windows->on_light_selected += on_light_selected;
+        _diff_windows->on_trigger_selected += on_trigger_selected;
+        _diff_windows->on_level_selected += on_diff_level_selected;
+        _diff_windows->on_camera_sink_selected += on_camera_sink_selected;
+        _diff_windows->on_static_mesh_selected += on_static_selected;
+        _diff_windows->on_sound_source_selected += on_sound_source_selected;
+        _diff_windows->on_room_selected += on_room_selected;
+        _diff_windows->on_sector_selected += on_sector_selected;
+        _diff_windows->on_settings += on_settings;
 
         _token_store += _items_windows->on_add_to_route += [this](auto item)
             {
@@ -124,6 +137,7 @@ namespace trview
         _about_windows->render();
         _camera_sink_windows->render();
         _console_manager->render();
+        _diff_windows->render();
         _items_windows->render();
         _lights_windows->render();
         _log_windows->render();
@@ -184,6 +198,7 @@ namespace trview
         }
 
         _camera_sink_windows->set_camera_sinks(new_level->camera_sinks());
+        _diff_windows->set_level(new_level);
         _items_windows->set_items(new_level->items());
         _items_windows->set_triggers(new_level->triggers());
         _items_windows->set_level_version(new_level->version());
@@ -236,6 +251,7 @@ namespace trview
 
     void Windows::set_settings(const UserSettings& settings)
     {
+        _diff_windows->set_settings(settings);
         _rooms_windows->set_map_colours(settings.map_colours);
         _route_window->set_randomizer_enabled(settings.randomizer_tools);
         _route_window->set_randomizer_settings(settings.randomizer);

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -54,7 +54,7 @@ namespace trview
         _diff_windows->on_item_selected += on_item_selected;
         _diff_windows->on_light_selected += on_light_selected;
         _diff_windows->on_trigger_selected += on_trigger_selected;
-        _diff_windows->on_level_selected += on_diff_level_selected;
+        _diff_windows->on_diff_ended += on_diff_ended;
         _diff_windows->on_camera_sink_selected += on_camera_sink_selected;
         _diff_windows->on_static_mesh_selected += on_static_selected;
         _diff_windows->on_sound_source_selected += on_sound_source_selected;

--- a/trview.app/Windows/Windows.h
+++ b/trview.app/Windows/Windows.h
@@ -10,6 +10,7 @@ namespace trview
     struct IAboutWindowManager;
     struct ICameraSinkWindowManager;
     struct IConsoleManager;
+    struct IDiffWindowManager;
     struct IItemsWindowManager;
     struct ILightsWindowManager;
     struct ILogWindowManager;
@@ -28,6 +29,7 @@ namespace trview
             std::unique_ptr<IAboutWindowManager> about_window_manager,
             std::unique_ptr<ICameraSinkWindowManager> camera_sink_windows,
             std::unique_ptr<IConsoleManager> console_manager,
+            std::unique_ptr<IDiffWindowManager> diff_window_manager,
             std::shared_ptr<IItemsWindowManager> items_window_manager,
             std::unique_ptr<ILightsWindowManager> lights_window_manager,
             std::unique_ptr<ILogWindowManager> log_window_manager,
@@ -62,6 +64,7 @@ namespace trview
         std::unique_ptr<IAboutWindowManager> _about_windows;
         std::unique_ptr<ICameraSinkWindowManager> _camera_sink_windows;
         std::unique_ptr<IConsoleManager> _console_manager;
+        std::unique_ptr<IDiffWindowManager> _diff_windows;
         std::shared_ptr<IItemsWindowManager> _items_windows;
         std::unique_ptr<ILightsWindowManager> _lights_windows;
         std::unique_ptr<ILogWindowManager> _log_windows;

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -69,6 +69,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Lua\trview\trview.cpp" />
     <ClCompile Include="Lua\Vector3.cpp" />
     <ClCompile Include="Menus\FileMenu.cpp" />
+    <ClCompile Include="Menus\ImGuiFileMenu.cpp" />
     <ClCompile Include="Mocks\Mocks.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/bigobj %(AdditionalOptions)</AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/bigobj %(AdditionalOptions)</AdditionalOptions>
@@ -81,6 +82,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Windows\AutoHider.cpp" />
     <ClCompile Include="Windows\About\AboutWindow.cpp" />
     <ClCompile Include="Windows\About\AboutWindowManager.cpp" />
+    <ClCompile Include="Windows\Diff\DiffWindow.cpp" />
+    <ClCompile Include="Windows\Diff\DiffWindowManager.cpp" />
     <ClCompile Include="Windows\Sounds\SoundsWindow.cpp" />
     <ClCompile Include="Windows\Sounds\SoundsWindowManager.cpp" />
     <ClCompile Include="Windows\Windows.cpp" />
@@ -91,6 +94,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Lua\Camera\Lua_Camera.h" />
     <ClInclude Include="Lua\Scriptable\IScriptable.h" />
     <ClInclude Include="Lua\Scriptable\Scriptable.h" />
+    <ClInclude Include="Menus\ImGuiFileMenu.h" />
     <ClInclude Include="Mocks\Elements\INgPlusSwitcher.h" />
     <ClInclude Include="Mocks\Elements\ISoundSource.h" />
     <ClInclude Include="Mocks\Lua\IScriptable.h" />
@@ -98,6 +102,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Mocks\Sound\ISoundStorage.h" />
     <ClInclude Include="Mocks\UI\IFonts.h" />
     <ClInclude Include="Mocks\Windows\IAboutWindow.h" />
+    <ClInclude Include="Mocks\Windows\IDiffWindow.h" />
+    <ClInclude Include="Mocks\Windows\IDiffWindowManager.h" />
     <ClInclude Include="Mocks\Windows\ISoundsWindow.h" />
     <ClInclude Include="Mocks\Windows\ISoundsWindowManager.h" />
     <ClInclude Include="Mocks\Windows\IStaticsWindow.h" />
@@ -222,6 +228,10 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Windows\Console\ConsoleManager.h" />
     <ClInclude Include="Windows\Console\IConsole.h" />
     <ClInclude Include="Windows\Console\IConsoleManager.h" />
+    <ClInclude Include="Windows\Diff\DiffWindow.h" />
+    <ClInclude Include="Windows\Diff\DiffWindowManager.h" />
+    <ClInclude Include="Windows\Diff\IDiffWindow.h" />
+    <ClInclude Include="Windows\Diff\IDiffWindowManager.h" />
     <ClInclude Include="Windows\Sounds\ISoundsWindow.h" />
     <ClInclude Include="Windows\Sounds\ISoundsWindowManager.h" />
     <ClInclude Include="Windows\Sounds\SoundsWindow.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -362,6 +362,15 @@
     <ClCompile Include="Windows\About\AboutWindowManager.cpp">
       <Filter>Windows\About</Filter>
     </ClCompile>
+    <ClCompile Include="Windows\Diff\DiffWindow.cpp">
+      <Filter>Windows\Diff</Filter>
+    </ClCompile>
+    <ClCompile Include="Windows\Diff\DiffWindowManager.cpp">
+      <Filter>Windows\Diff</Filter>
+    </ClCompile>
+    <ClCompile Include="Menus\ImGuiFileMenu.cpp">
+      <Filter>Menus</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -1201,6 +1210,27 @@
     <ClInclude Include="Mocks\Windows\IAboutWindowManager.h">
       <Filter>Mocks\Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Windows\Diff\IDiffWindowManager.h">
+      <Filter>Windows\Diff</Filter>
+    </ClInclude>
+    <ClInclude Include="Windows\Diff\DiffWindowManager.h">
+      <Filter>Windows\Diff</Filter>
+    </ClInclude>
+    <ClInclude Include="Windows\Diff\IDiffWindow.h">
+      <Filter>Windows\Diff</Filter>
+    </ClInclude>
+    <ClInclude Include="Windows\Diff\DiffWindow.h">
+      <Filter>Windows\Diff</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\Windows\IDiffWindowManager.h">
+      <Filter>Mocks\Windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\Windows\IDiffWindow.h">
+      <Filter>Mocks\Windows</Filter>
+    </ClInclude>
+    <ClInclude Include="Menus\ImGuiFileMenu.h">
+      <Filter>Menus</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">
@@ -1418,6 +1448,9 @@
     </Filter>
     <Filter Include="Windows\About">
       <UniqueIdentifier>{9a5c8748-0920-46fd-a893-d0e0f1d748d8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Windows\Diff">
+      <UniqueIdentifier>{9903f794-d62d-4218-bd6a-23463418328c}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/trview.common/Colour.h
+++ b/trview.common/Colour.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <external/DirectXTK/Inc/SimpleMath.h>
 
 namespace trview

--- a/trview.common/Strings.cpp
+++ b/trview.common/Strings.cpp
@@ -52,6 +52,6 @@ namespace trview
     std::string path_for_filename(const std::string& filename)
     {
         auto last_index = std::min(filename.find_last_of('\\'), filename.find_last_of('/'));
-        return last_index == filename.npos ? std::string() : filename.substr(0, std::min(last_index + 1, filename.size()));
+        return last_index == filename.npos ? std::string() : filename.substr(0, std::min(last_index, filename.size()));
     }
 }


### PR DESCRIPTION
Add a diff window to allow comparing levels to other levels.
Compare level is owned by the diff window and various aspects are shown to the user.
Clicking on each side of the diff will switch the level in the viewer to that level.
Closes #634 