### PR TITLE
Treat rooms with alternate group but no alternate as having alternate

### DIFF
--- a/trview.app.tests/Elements/RoomTests.cpp
+++ b/trview.app.tests/Elements/RoomTests.cpp
@@ -30,7 +30,7 @@ namespace
             std::shared_ptr<IMeshStorage> mesh_storage{ mock_shared<MockMeshStorage>() };
             IMesh::Source mesh_source{ [](auto&&...) { return mock_shared<MockMesh>(); } };
             std::shared_ptr<trlevel::ILevel> tr_level{ mock_shared<trlevel::mocks::MockLevel>() };
-            trlevel::tr3_room room;
+            trlevel::tr3_room room{ .alternate_group = 0 };
             uint32_t index{ 0u };
             std::shared_ptr<ILevel> level{ mock_shared<MockLevel>() };
             IStaticMesh::MeshSource static_mesh_source{ [](auto&&...) { return mock_shared<MockStaticMesh>(); } };
@@ -118,6 +118,20 @@ TEST(Room, AlternateModeDetected)
     auto room = register_test_module().with_room(level_room).build();
     ASSERT_EQ(room->alternate_mode(), IRoom::AlternateMode::HasAlternate);
     ASSERT_EQ(room->alternate_room(), 100);
+}
+
+/// <summary>
+/// Tests that the logic embedded in TR5 alternate group numbers isn't hidden.
+/// </summary>
+TEST(Room, AlternateModeDetectedInvalidAlternate)
+{
+    trlevel::tr3_room level_room;
+    level_room.alternate_group = 15;
+    level_room.alternate_room = -1;
+    auto room = register_test_module().with_room(level_room).build();
+    ASSERT_EQ(room->alternate_mode(), IRoom::AlternateMode::HasAlternate);
+    ASSERT_EQ(room->alternate_room(), -1);
+    ASSERT_EQ(room->alternate_group(), 15);
 }
 
 /// <summary>

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -877,7 +877,7 @@ namespace trview
     {
         if (version() >= trlevel::LevelVersion::Tomb4)
         {
-            return room.alternate_mode() == IRoom::AlternateMode::HasAlternate && is_alternate_group_set(room.alternate_group()) ||
+            return (room.alternate_mode() == IRoom::AlternateMode::HasAlternate && is_alternate_group_set(room.alternate_group()) && room.alternate_room() != -1) ||
                    room.alternate_mode() == IRoom::AlternateMode::IsAlternate && !is_alternate_group_set(room.alternate_group());
         }
 

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -63,7 +63,7 @@ namespace trview
         // Can only determine HasAlternate or normal at this point. After all rooms have been loaded,
         // the level can fix up the rooms so that they know if they are alternates of another room
         // (IsAlternate).
-        _alternate_mode = room.alternate_room != -1 ? AlternateMode::HasAlternate : AlternateMode::None;
+        _alternate_mode = (room.alternate_room != -1 || room.alternate_group != 0) ? AlternateMode::HasAlternate : AlternateMode::None;
 
         _room_offset = Matrix::CreateTranslation(room.info.x / trlevel::Scale_X, 0, room.info.z / trlevel::Scale_Z);
         _inverted_room_offset = _room_offset.Invert();

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -63,7 +63,7 @@ namespace trview
         // Can only determine HasAlternate or normal at this point. After all rooms have been loaded,
         // the level can fix up the rooms so that they know if they are alternates of another room
         // (IsAlternate).
-        _alternate_mode = (room.alternate_room != -1 || room.alternate_group != 0) ? AlternateMode::HasAlternate : AlternateMode::None;
+        _alternate_mode = (room.alternate_room != -1 || !equals_any(room.alternate_group, 0, 0xff)) ? AlternateMode::HasAlternate : AlternateMode::None;
 
         _room_offset = Matrix::CreateTranslation(room.info.x / trlevel::Scale_X, 0, room.info.z / trlevel::Scale_Z);
         _inverted_room_offset = _room_offset.Invert();


### PR DESCRIPTION
TR5 has logic where rooms with an alternate group are used as markers. Previously this was hidden because the alternate was set to -1 but this changes it to show this anyway.
Closes #1337 