### PR TITLE
Change texture mask to 0x3fff to fix TR5 water surface

### DIFF
--- a/trview.app/Geometry/IMesh.cpp
+++ b/trview.app/Geometry/IMesh.cpp
@@ -7,7 +7,7 @@ namespace trview
 {
     namespace
     {
-        const uint16_t Texture_Mask = 0x7fff;
+        const uint16_t Texture_Mask = 0x3fff;
 
         Vector3 calculate_normal(const Vector3* const vertices)
         {


### PR DESCRIPTION
Fixes issues with TR5 water.
Closes #1201