### PR TITLE
Prevent selection highlighting wrapping

### DIFF
--- a/trview.app/Graphics/SelectionRenderer.cpp
+++ b/trview.app/Graphics/SelectionRenderer.cpp
@@ -45,6 +45,18 @@ namespace trview
     {
         _pixel_shader = shader_storage->get("selection_pixel_shader");
         _vertex_shader = shader_storage->get("ui_vertex_shader");
+
+        D3D11_SAMPLER_DESC sampler_desc;
+        memset(&sampler_desc, 0, sizeof(sampler_desc));
+        sampler_desc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+        sampler_desc.AddressU = D3D11_TEXTURE_ADDRESS_CLAMP;
+        sampler_desc.AddressV = D3D11_TEXTURE_ADDRESS_CLAMP;
+        sampler_desc.AddressW = D3D11_TEXTURE_ADDRESS_CLAMP;
+        sampler_desc.MaxAnisotropy = 1;
+        sampler_desc.ComparisonFunc = D3D11_COMPARISON_ALWAYS;
+        sampler_desc.MaxLOD = D3D11_FLOAT32_MAX;
+        _sampler_state = device->create_sampler_state(sampler_desc);
+
         create_buffers(*device);
     }
 
@@ -176,6 +188,7 @@ namespace trview
         _vertex_shader->apply(context);
         _pixel_shader->apply(context);
         
+        context->PSSetSamplers(0, 1, _sampler_state.GetAddressOf());
         context->PSSetShaderResources(0, 1, _texture->texture().view().GetAddressOf());
         UINT stride = sizeof(SelectionVertex);
         UINT offset = 0;

--- a/trview.app/Graphics/SelectionRenderer.h
+++ b/trview.app/Graphics/SelectionRenderer.h
@@ -59,6 +59,7 @@ namespace trview
         Microsoft::WRL::ComPtr<ID3D11Buffer> _index_buffer;
         Microsoft::WRL::ComPtr<ID3D11Buffer> _matrix_buffer;
         Microsoft::WRL::ComPtr<ID3D11Buffer> _scale_buffer;
+        Microsoft::WRL::ComPtr<ID3D11SamplerState> _sampler_state;
         graphics::IShader* _pixel_shader;
         graphics::IShader* _vertex_shader;
     };


### PR DESCRIPTION
Change address mode on selection sampler state to clamp instead of wrap.
Closes #1357