### PR TITLE
Move plugins settings to plugins window, add enable/disable

### DIFF
--- a/doc/lua/plugins.md
+++ b/doc/lua/plugins.md
@@ -34,3 +34,4 @@ trview will attempt to call the following functions if they are defined in the p
 |--------|----------|------------|-------|
 |render_ui|None|During trview UI rendering|Used for drawing any plugin windows required|
 |render_toolbar|None|When trview is rendering the toolbar at the bottom of the screen|Used to add a button or other control to the tool`bar - for example if you want a way to open the main plugin window|
+|set_enabled|boolean enabled|At plugin load and when user toggles whether plugin is enabled|Allows plugin to set up when enabled or to clean up when disabled|

--- a/trview.app.tests/Plugins/PluginTests.cpp
+++ b/trview.app.tests/Plugins/PluginTests.cpp
@@ -88,3 +88,12 @@ TEST(Plugin, Reload)
     Plugin plugin(mock_shared<MockFiles>(), std::move(lua_ptr), "test");
     plugin.reload();
 }
+
+TEST(Plugin, SetEnabled)
+{
+    auto [lua_ptr, lua] = create_mock<MockLua>();
+    EXPECT_CALL(lua, execute("if set_enabled ~= nil then set_enabled(true) end")).Times(1);
+
+    Plugin plugin(mock_shared<MockFiles>(), std::move(lua_ptr), "test");
+    plugin.set_enabled(true);
+}

--- a/trview.app.tests/Plugins/PluginsTests.cpp
+++ b/trview.app.tests/Plugins/PluginsTests.cpp
@@ -46,3 +46,18 @@ TEST(Plugins, Initialise)
     EXPECT_CALL(plugin, initialise(application.get())).Times(1);
     plugins.initialise(application.get());
 }
+
+TEST(Plugins, SettingsApplied)
+{
+    auto files = mock_shared<MockFiles>();
+    auto plugin = mock_shared<MockPlugin>();
+    EXPECT_CALL(*plugin, set_enabled(false)).Times(1);
+
+    auto source = [&](auto&&...) { return plugin; };
+    UserSettings settings{ .plugins = { { "plugindir", {.enabled = false } } } };
+    settings.plugin_directories.push_back("dir");
+    EXPECT_CALL(*files, get_directories("dir"))
+        .WillRepeatedly(testing::Return(std::vector<IFiles::Directory>{ { "plugindir", "plugindir_friendly" } }));
+
+    Plugins plugins(files, mock_shared<MockPlugin>(), source, settings);
+}

--- a/trview.app.tests/Settings/SettingsLoaderTests.cpp
+++ b/trview.app.tests/Settings/SettingsLoaderTests.cpp
@@ -782,3 +782,23 @@ TEST(SettingsLoader, CameraPositionWindowSaved)
     loader->save_user_settings(settings);
     EXPECT_THAT(output, HasSubstr("\"camera_position_window\":true"));
 }
+
+TEST(SettingsLoader, PluginsLoaded)
+{
+    auto loader = setup_setting("{\"plugins\":{\"Default\":{\"enabled\":true}}}");
+    auto settings = loader->load_user_settings();
+    auto def = settings.plugins.find("Default");
+    ASSERT_TRUE(def != settings.plugins.end());
+    ASSERT_EQ(def->first, "Default");
+    ASSERT_EQ(def->second.enabled, true);
+}
+
+TEST(SettingsLoader, PluginsSaved)
+{
+    std::string output;
+    auto loader = setup_save_setting(output);
+    UserSettings settings;
+    settings.plugins = { { "Default", {.enabled = true } } };
+    loader->save_user_settings(settings);
+    EXPECT_THAT(output, HasSubstr("\"plugins\":{\"Default\":{\"enabled\":true}}"));
+}

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -447,38 +447,6 @@ TEST(ViewerUI, SetCameraSinkStartupUpdatesSettingsWindow)
     ui->set_settings(settings);
 }
 
-TEST(ViewerUI, OnPluginDirectoriesEventRaised)
-{
-    const std::vector<std::string> expected{ "test " };
-    auto [settings_window_ptr, settings_window] = create_mock<MockSettingsWindow>();
-    auto ui = register_test_module().with_settings_window(std::move(settings_window_ptr)).build();
-
-    std::optional<UserSettings> settings;
-    auto token = ui->on_settings += [&](auto raised)
-    {
-        settings = raised;
-    };
-
-    settings_window.on_plugin_directories(expected);
-
-    ASSERT_TRUE(settings);
-    ASSERT_EQ(settings.value().plugin_directories, expected);
-}
-
-TEST(ViewerUI, SetPluginDirectoriesUpdatesSettingsWindow)
-{
-    const std::vector<std::string> expected{ "test " };
-    auto [settings_window_ptr, settings_window] = create_mock<MockSettingsWindow>();
-    EXPECT_CALL(settings_window, set_plugin_directories(expected)).Times(1);
-
-    auto ui = register_test_module().with_settings_window(std::move(settings_window_ptr)).build();
-
-    UserSettings settings{};
-    settings.plugin_directories = expected;
-    ui->set_settings(settings);
-}
-
-
 TEST(ViewerUI, FontForwarded)
 {
     auto [settings_window_ptr, settings_window] = create_mock<MockSettingsWindow>();

--- a/trview.app.ui.tests/PluginsWindowTests.cpp
+++ b/trview.app.ui.tests/PluginsWindowTests.cpp
@@ -4,6 +4,7 @@
 #include <trview.app/Mocks/Plugins/IPlugin.h>
 #include <trview.app/Mocks/Plugins/IPlugins.h>
 #include <trview.common/Mocks/Windows/IShell.h>
+#include <trview.common/Mocks/Windows/IDialogs.h>
 
 using namespace trview;
 using namespace trview::tests;
@@ -18,10 +19,11 @@ namespace
         {
             std::shared_ptr<IPlugins> plugins{ mock_shared<MockPlugins>() };
             std::shared_ptr<IShell> shell{ mock_shared<MockShell>() };
+            std::shared_ptr<IDialogs> dialogs{ mock_shared<MockDialogs>() };
 
             std::unique_ptr<PluginsWindow> build()
             {
-                return std::make_unique<PluginsWindow>(plugins, shell);
+                return std::make_unique<PluginsWindow>(plugins, shell, dialogs);
             }
 
             test_module& with_plugins(std::shared_ptr<IPlugins> plugins)
@@ -33,6 +35,12 @@ namespace
             test_module& with_shell(std::shared_ptr<IShell> shell)
             {
                 this->shell = shell;
+                return *this;
+            }
+
+            test_module& with_dialogs(std::shared_ptr<IDialogs> dialogs)
+            {
+                this->dialogs = dialogs;
                 return *this;
             }
         };
@@ -99,5 +107,68 @@ void register_plugins_window_tests(ImGuiTestEngine* engine)
             ctx->ItemClick("/**/Reload##Plugin Name");
 
             IM_CHECK_EQ(Mock::VerifyAndClearExpectations(plugin.get()), true);
+        });
+
+    test<PluginsWindowContext>(engine, "Plugins Window", "Add Plugin Directories",
+        [](ImGuiTestContext* ctx) { ctx->GetVars<PluginsWindowContext>().render(); },
+        [](ImGuiTestContext* ctx)
+        {
+            auto& context = ctx->GetVars<PluginsWindowContext>();
+            auto dialogs = mock_shared<MockDialogs>();
+            ON_CALL(*dialogs, open_folder).WillByDefault(Return("test"));
+            context.ptr = register_test_module().with_dialogs(dialogs).build();
+
+            std::optional<UserSettings> raised;
+            auto token = context.ptr->on_settings += [&](const auto& value)
+                {
+                    raised = value;
+                };
+
+            ctx->ItemClick("/**/+");
+
+            const std::vector<std::string> expected{ "test" };
+            IM_CHECK_EQ(raised.has_value(), true);
+            IM_CHECK_EQ(raised.value().plugin_directories, expected);
+        });
+
+    test<PluginsWindowContext>(engine, "Plugins Window", "Open Plugin Directories",
+        [](ImGuiTestContext* ctx) { ctx->GetVars<PluginsWindowContext>().render(); },
+        [](ImGuiTestContext* ctx)
+        {
+            auto shell = mock_shared<MockShell>();
+            EXPECT_CALL(*shell, open(std::wstring(L"path"))).Times(1);
+
+            UserSettings settings{ .plugin_directories = { "path" } };
+
+            auto& context = ctx->GetVars<PluginsWindowContext>();
+            context.ptr = register_test_module().with_shell(shell).build();
+            context.ptr->set_settings(settings);
+
+            ctx->ItemClick("/**/Open##0");
+
+            IM_CHECK_EQ(Mock::VerifyAndClear(shell.get()), true);
+        });
+
+    test<PluginsWindowContext>(engine, "Plugins Window", "Remove Plugin Directories",
+        [](ImGuiTestContext* ctx) { ctx->GetVars<PluginsWindowContext>().render(); },
+        [](ImGuiTestContext* ctx)
+        {
+            auto& context = ctx->GetVars<PluginsWindowContext>();
+            context.ptr = register_test_module().build();
+
+            UserSettings settings{ .plugin_directories = { "path" } };
+            context.ptr->set_settings(settings);
+
+            std::optional<UserSettings> raised;
+            auto token = context.ptr->on_settings += [&](const auto& value)
+                {
+                    raised = value;
+                };
+
+            ctx->ItemClick("/**/Remove##0");
+
+            const std::vector<std::string> expected;
+            IM_CHECK_EQ(raised.has_value(), true);
+            IM_CHECK_EQ(raised.value().plugin_directories, expected);
         });
 }

--- a/trview.app.ui.tests/SettingsWindowTests.cpp
+++ b/trview.app.ui.tests/SettingsWindowTests.cpp
@@ -53,33 +53,6 @@ namespace
 
 void register_settings_window_tests(ImGuiTestEngine* engine)
 {
-    test<MockWrapper<SettingsWindow>>(engine, "Settings Window", "Add Plugin Directories",
-        [](ImGuiTestContext* ctx) { render(ctx->GetVars<MockWrapper<SettingsWindow>>()); },
-        [](ImGuiTestContext* ctx)
-        {
-            auto& controls = ctx->GetVars<MockWrapper<SettingsWindow>>();
-
-            auto dialogs = mock_shared<MockDialogs>();
-            ON_CALL(*dialogs, open_folder).WillByDefault(Return("test"));
-            controls.ptr = register_test_module().with_dialogs(dialogs).build();
-
-            std::optional<std::vector<std::string>> raised;
-            auto token = controls.ptr->on_plugin_directories += [&](const auto& value)
-            {
-                raised = value;
-            };
-
-            controls.ptr->toggle_visibility();
-
-            ctx->SetRef("Settings");
-            ctx->ItemClick("TabBar/Plugins");
-            ctx->ItemClick("TabBar/Plugins/Directories/Add");
-
-            const std::vector<std::string> expected{ "test" };
-            IM_CHECK_EQ(raised.has_value(), true);
-            IM_CHECK_EQ(raised.value(), expected);
-        });
-
     test<MockWrapper<SettingsWindow>>(engine, "Settings Window", "Changing Font Raises Event",
         [](ImGuiTestContext* ctx) { render(ctx->GetVars<MockWrapper<SettingsWindow>>()); },
         [](ImGuiTestContext* ctx)
@@ -623,49 +596,6 @@ void register_settings_window_tests(ImGuiTestEngine* engine)
 
             IM_CHECK_EQ(map_colours.has_value(), true);
             IM_CHECK_EQ(map_colours.value().special_colours().size(), 0.0f);
-        });
-
-    test<MockWrapper<SettingsWindow>>(engine, "Settings Window", "Open Plugin Directories",
-        [](ImGuiTestContext* ctx) { render(ctx->GetVars<MockWrapper<SettingsWindow>>()); },
-        [](ImGuiTestContext* ctx)
-        {
-            auto shell = mock_shared<MockShell>();
-            EXPECT_CALL(*shell, open(std::wstring(L"path"))).Times(1);
-
-            auto& controls = ctx->GetVars<MockWrapper<SettingsWindow>>();
-            controls.ptr = register_test_module().with_shell(shell).build();
-            controls.ptr->toggle_visibility();
-            controls.ptr->set_plugin_directories({ "path" });
-
-            ctx->SetRef("Settings");
-            ctx->ItemClick("TabBar/Plugins");
-            ctx->ItemClick("TabBar/Plugins/Directories/Open##0");
-
-            IM_CHECK_EQ(Mock::VerifyAndClear(shell.get()), true);
-        });
-
-    test<MockWrapper<SettingsWindow>>(engine, "Settings Window", "Remove Plugin Directories",
-        [](ImGuiTestContext* ctx) { render(ctx->GetVars<MockWrapper<SettingsWindow>>()); },
-        [](ImGuiTestContext* ctx)
-        {
-            auto& controls = ctx->GetVars<MockWrapper<SettingsWindow>>();
-            controls.ptr = register_test_module().build();
-            controls.ptr->toggle_visibility();
-            controls.ptr->set_plugin_directories({ "path" });
-
-            std::optional<std::vector<std::string>> raised;
-            auto token = controls.ptr->on_plugin_directories += [&](const auto& value)
-            {
-                raised = value;
-            };
-
-            ctx->SetRef("Settings");
-            ctx->ItemClick("TabBar/Plugins");
-            ctx->ItemClick("TabBar/Plugins/Directories/Remove##0");
-
-            const std::vector<std::string> expected;
-            IM_CHECK_EQ(raised.has_value(), true);
-            IM_CHECK_EQ(raised.value(), expected);
         });
 
     test<MockWrapper<SettingsWindow>>(engine, "Settings Window", "Set Acceleration Rate Updates Slider",

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -106,6 +106,7 @@ namespace trview
         _token_store += _windows->on_settings += [this](auto&& settings)
             {
                 _settings = settings;
+                _plugins->set_settings(_settings);
                 _viewer->set_settings(_settings);
                 _windows->set_settings(settings);
                 lua::set_settings(settings);
@@ -312,6 +313,7 @@ namespace trview
         _token_store += _viewer->on_settings += [this](auto&& settings)
         {
             _settings = settings;
+            _plugins->set_settings(_settings);
             _viewer->set_settings(_settings);
             _windows->set_settings(settings);
             lua::set_settings(settings);

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -323,7 +323,7 @@ namespace trview
             std::make_shared<Plugin>(std::make_unique<Lua>(route_source, randomizer_route_source, waypoint_source, scriptable_source, dialogs, files), "Default", "trview", "Default Lua plugin for trview"),
             plugin_source,
             settings_loader->load_user_settings());
-        auto plugins_window_source = [=]() { return std::make_shared<PluginsWindow>(plugins, shell); };
+        auto plugins_window_source = [=]() { return std::make_shared<PluginsWindow>(plugins, shell, dialogs); };
         auto imgui_backend = std::make_shared<DX11ImGuiBackend>(window, device, files);
         auto fonts = std::make_shared<Fonts>(files, imgui_backend);
 

--- a/trview.app/Mocks/Plugins/IPlugin.h
+++ b/trview.app/Mocks/Plugins/IPlugin.h
@@ -10,9 +10,11 @@ namespace trview
         {
             MockPlugin();
             virtual ~MockPlugin();
+            MOCK_METHOD(bool, built_in, (), (const, override));
             MOCK_METHOD(std::string, name, (), (const, override));
             MOCK_METHOD(std::string, author, (), (const, override));
             MOCK_METHOD(std::string, description, (), (const, override));
+            MOCK_METHOD(bool, enabled, (), (const, override));
             MOCK_METHOD(void, initialise, (IApplication*), (override));
             MOCK_METHOD(std::string, path, (), (const, override));
             MOCK_METHOD(std::string, messages, (), (const, override));
@@ -23,6 +25,7 @@ namespace trview
             MOCK_METHOD(void, reload, (), (override));
             MOCK_METHOD(void, render_toolbar, (), (override));
             MOCK_METHOD(void, render_ui, (), (override));
+            MOCK_METHOD(void, set_enabled, (bool), (override));
         };
     }
 }

--- a/trview.app/Mocks/Plugins/IPlugins.h
+++ b/trview.app/Mocks/Plugins/IPlugins.h
@@ -13,6 +13,8 @@ namespace trview
             MOCK_METHOD(std::vector<std::weak_ptr<IPlugin>>, plugins, (), (const, override));
             MOCK_METHOD(void, initialise, (IApplication*), (override));
             MOCK_METHOD(void, render_ui, (), (override));
+            MOCK_METHOD(void, reload, (), (override));
+            MOCK_METHOD(void, set_settings, (const UserSettings&), (override));
         };
     }
 }

--- a/trview.app/Mocks/UI/ISettingsWindow.h
+++ b/trview.app/Mocks/UI/ISettingsWindow.h
@@ -34,7 +34,6 @@ namespace trview
             MOCK_METHOD(void, set_route_startup, (bool), (override));
             MOCK_METHOD(void, set_fov, (float), (override));
             MOCK_METHOD(void, set_camera_sink_startup, (bool), (override));
-            MOCK_METHOD(void, set_plugin_directories, (const std::vector<std::string>&), (override));
             MOCK_METHOD(void, set_statics_startup, (bool), (override));
         };
     }

--- a/trview.app/Mocks/Windows/IPluginsWindow.h
+++ b/trview.app/Mocks/Windows/IPluginsWindow.h
@@ -13,6 +13,7 @@ namespace trview
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));
+            MOCK_METHOD(void, set_settings, (const UserSettings&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IPluginsWindowManager.h
+++ b/trview.app/Mocks/Windows/IPluginsWindowManager.h
@@ -13,6 +13,7 @@ namespace trview
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(std::weak_ptr<IPluginsWindow>, create_window, (), (override));
             MOCK_METHOD(void, update, (float), (override));
+            MOCK_METHOD(void, set_settings, (const UserSettings&), (override));
         };
     }
 }

--- a/trview.app/Plugins/IPlugin.h
+++ b/trview.app/Plugins/IPlugin.h
@@ -12,9 +12,11 @@ namespace trview
         using Source = std::function<std::shared_ptr<IPlugin>(const std::string& directory)>;
 
         virtual ~IPlugin() = 0;
+        virtual bool built_in() const = 0;
         virtual std::string name() const = 0;
         virtual std::string author() const = 0;
         virtual std::string description() const = 0;
+        virtual bool enabled() const = 0;
         virtual void initialise(IApplication* application) = 0;
         virtual std::string path() const = 0;
         virtual std::string messages() const = 0;
@@ -25,6 +27,7 @@ namespace trview
         virtual void reload() = 0;
         virtual void render_toolbar() = 0;
         virtual void render_ui() = 0;
+        virtual void set_enabled(bool value) = 0;
 
         Event<std::string> on_message;
     };

--- a/trview.app/Plugins/IPlugins.h
+++ b/trview.app/Plugins/IPlugins.h
@@ -5,6 +5,7 @@
 namespace trview
 {
     struct IApplication;
+    struct UserSettings;
 
     struct IPlugins
     {
@@ -12,5 +13,7 @@ namespace trview
         virtual std::vector<std::weak_ptr<IPlugin>> plugins() const = 0;
         virtual void initialise(IApplication* application) = 0;
         virtual void render_ui() = 0;
+        virtual void reload() = 0;
+        virtual void set_settings(const UserSettings& settings) = 0;
     };
 }

--- a/trview.app/Plugins/Plugin.cpp
+++ b/trview.app/Plugins/Plugin.cpp
@@ -176,10 +176,11 @@ namespace trview
         }
 
         _enabled = value;
-
         if (!_script_loaded)
         {
             load_script();
         }
+
+        _lua->execute(std::format("if set_enabled ~= nil then set_enabled({}) end", value));
     }
 }

--- a/trview.app/Plugins/Plugin.cpp
+++ b/trview.app/Plugins/Plugin.cpp
@@ -137,6 +137,7 @@ namespace trview
         if (!_script.empty())
         {
             _lua->do_file(_script);
+            _script_loaded = true;
         }
     }
 
@@ -175,5 +176,10 @@ namespace trview
         }
 
         _enabled = value;
+
+        if (!_script_loaded)
+        {
+            load_script();
+        }
     }
 }

--- a/trview.app/Plugins/Plugin.h
+++ b/trview.app/Plugins/Plugin.h
@@ -49,5 +49,6 @@ namespace trview
         IApplication* _application;
         bool _enabled{ true };
         bool _built_in{ false };
+        bool _script_loaded{ false };
     };
 }

--- a/trview.app/Plugins/Plugin.h
+++ b/trview.app/Plugins/Plugin.h
@@ -15,9 +15,11 @@ namespace trview
             std::unique_ptr<ILua> lua,
             const std::string& path);
         virtual ~Plugin() = default;
+        bool built_in() const override;
         std::string name() const override;
         std::string author() const override;
         std::string description() const override;
+        bool enabled() const override;
         void initialise(IApplication* application) override;
         std::string path() const override;
         std::string messages() const override;
@@ -28,6 +30,7 @@ namespace trview
         void reload() override;
         void render_toolbar() override;
         void render_ui() override;
+        void set_enabled(bool value) override;
     private:
         void load();
         void load_script();
@@ -44,5 +47,7 @@ namespace trview
         std::string _messages;
         TokenStore _token_store;
         IApplication* _application;
+        bool _enabled{ true };
+        bool _built_in{ false };
     };
 }

--- a/trview.app/Plugins/Plugins.cpp
+++ b/trview.app/Plugins/Plugins.cpp
@@ -47,7 +47,14 @@ namespace trview
             const auto plugins = _files->get_directories(directory);
             for (const auto& plugin : plugins)
             {
-                _plugins.push_back(_plugin_source(plugin.path));
+                auto new_plugin = _plugin_source(plugin.path);
+                _plugins.push_back(new_plugin);
+
+                const auto plugin_setting = _settings.plugins.find(plugin.path);
+                if (plugin_setting != _settings.plugins.end())
+                {
+                    new_plugin->set_enabled(plugin_setting->second.enabled);
+                }
             }
         }
 

--- a/trview.app/Plugins/Plugins.cpp
+++ b/trview.app/Plugins/Plugins.cpp
@@ -51,10 +51,7 @@ namespace trview
                 _plugins.push_back(new_plugin);
 
                 const auto plugin_setting = _settings.plugins.find(plugin.path);
-                if (plugin_setting != _settings.plugins.end())
-                {
-                    new_plugin->set_enabled(plugin_setting->second.enabled);
-                }
+                new_plugin->set_enabled(plugin_setting != _settings.plugins.end() ? plugin_setting->second.enabled : true);
             }
         }
 

--- a/trview.app/Plugins/Plugins.cpp
+++ b/trview.app/Plugins/Plugins.cpp
@@ -10,17 +10,10 @@ namespace trview
         const std::shared_ptr<IPlugin>& default_plugin,
         const IPlugin::Source& plugin_source,
         const UserSettings& settings)
+        : _files(files), _settings(settings), _plugin_source(plugin_source)
     {
         _plugins.push_back(default_plugin);
-
-        for (const auto& directory : settings.plugin_directories)
-        {
-            const auto plugins = files->get_directories(directory);
-            for (const auto& plugin : plugins)
-            {
-                _plugins.push_back(plugin_source(plugin.path));
-            }
-        }
+        reload();
     }
 
     std::vector<std::weak_ptr<IPlugin>> Plugins::plugins() const
@@ -32,14 +25,37 @@ namespace trview
 
     void Plugins::initialise(IApplication* application)
     {
+        _application = application;
         for (auto& plugin : _plugins)
         {
-            plugin->initialise(application);
+            plugin->initialise(_application);
         }
     }
 
     void Plugins::render_ui()
     {
         std::ranges::for_each(_plugins, [](auto&& p) { p->render_ui(); });
+    }
+
+    void Plugins::reload()
+    {
+        // Remove all but the default plugin
+        _plugins.resize(1);
+
+        for (const auto& directory : _settings.plugin_directories)
+        {
+            const auto plugins = _files->get_directories(directory);
+            for (const auto& plugin : plugins)
+            {
+                _plugins.push_back(_plugin_source(plugin.path));
+            }
+        }
+
+        initialise(_application);
+    }
+
+    void Plugins::set_settings(const UserSettings& settings)
+    {
+        _settings = settings;
     }
 }

--- a/trview.app/Plugins/Plugins.h
+++ b/trview.app/Plugins/Plugins.h
@@ -18,7 +18,13 @@ namespace trview
         std::vector<std::weak_ptr<IPlugin>> plugins() const override;
         void initialise(IApplication* application) override;
         void render_ui() override;
+        void reload() override;
+        void set_settings(const UserSettings& settings) override;
     private:
         std::vector<std::shared_ptr<IPlugin>> _plugins;
+        std::shared_ptr<IFiles> _files;
+        UserSettings _settings;
+        IPlugin::Source _plugin_source;
+        IApplication* _application;
     };
 }

--- a/trview.app/Settings/PluginSetting.h
+++ b/trview.app/Settings/PluginSetting.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace trview
+{
+    struct PluginSetting final
+    {
+        bool enabled{ true };
+    };
+}

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -190,7 +190,7 @@ namespace trview
             json["camera_position_window"] = settings.camera_position_window;
             json["recent_diff"] = std::list<std::string>(settings.recent_diff_files.begin(), std::next(settings.recent_diff_files.begin(), std::min<std::size_t>(settings.recent_diff_files.size(), settings.max_recent_files)));
             json["plugins"] = settings.plugins;
-            _files->save_file(file_path, json.dump(4));
+            _files->save_file(file_path, json.dump());
         }
         catch (...)
         {

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -34,6 +34,11 @@ namespace trview
         json["size"] = setting.size;
     }
 
+    void to_json(nlohmann::json& json, const PluginSetting& setting)
+    {
+        json["enabled"] = setting.enabled;
+    }
+
     void from_json(const nlohmann::json& json, UserSettings::RecentRoute& item)
     {
         item.route_path = read_attribute<std::string>(json, "route_path");
@@ -57,6 +62,11 @@ namespace trview
         setting.name = read_attribute<std::string>(json, "name");
         setting.filename = read_attribute<std::string>(json, "filename");
         setting.size = read_attribute<int>(json, "size");
+    }
+
+    void from_json(const nlohmann::json& json, PluginSetting& setting)
+    {
+        setting.enabled = read_attribute<bool>(json, "enabled");
     }
 
     SettingsLoader::SettingsLoader(const std::shared_ptr<IFiles>& files)
@@ -108,6 +118,7 @@ namespace trview
             read_attribute(json, settings.statics_startup, "statics_startup");
             read_attribute(json, settings.camera_position_window, "camera_position_window");
             read_attribute(json, settings.recent_diff_files, "recent_diff");
+            read_attribute(json, settings.plugins, "plugins");
 
             settings.recent_files.resize(std::min<std::size_t>(settings.recent_files.size(), settings.max_recent_files));
         }
@@ -178,7 +189,8 @@ namespace trview
             json["statics_startup"] = settings.statics_startup;
             json["camera_position_window"] = settings.camera_position_window;
             json["recent_diff"] = std::list<std::string>(settings.recent_diff_files.begin(), std::next(settings.recent_diff_files.begin(), std::min<std::size_t>(settings.recent_diff_files.size(), settings.max_recent_files)));
-            _files->save_file(file_path, json.dump());
+            json["plugins"] = settings.plugins;
+            _files->save_file(file_path, json.dump(4));
         }
         catch (...)
         {

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -5,6 +5,7 @@
 #include "RandomizerSettings.h"
 #include "../UI/MapColours.h"
 #include "FontSetting.h"
+#include "PluginSetting.h"
 
 namespace trview
 {
@@ -67,6 +68,7 @@ namespace trview
         bool statics_startup{ false };
         bool camera_position_window{ true };
         std::list<std::string> recent_diff_files;
+        std::unordered_map<std::string, PluginSetting> plugins;
 
         bool operator==(const UserSettings& other) const;
     };

--- a/trview.app/UI/ISettingsWindow.h
+++ b/trview.app/UI/ISettingsWindow.h
@@ -79,7 +79,6 @@ namespace trview
         Event<bool> on_route_startup;
         Event<float> on_camera_fov;
         Event<bool> on_camera_sink_startup;
-        Event<std::vector<std::string>> on_plugin_directories;
         Event<std::string, FontSetting> on_font;
         Event<bool> on_statics_startup;
 
@@ -179,7 +178,6 @@ namespace trview
         virtual void set_route_startup(bool value) = 0;
         virtual void set_fov(float value) = 0;
         virtual void set_camera_sink_startup(bool value) = 0;
-        virtual void set_plugin_directories(const std::vector<std::string>& directories) = 0;
         /// <summary>
         /// Toggle the visibility of the settings window.
         /// </summary>

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -200,46 +200,6 @@ namespace trview
                     ImGui::EndTabItem();
                 }
 
-                if (ImGui::BeginTabItem("Plugins"))
-                {
-                    if (ImGui::BeginTable("Directories", 3, 0, ImVec2(-1, -1)))
-                    {
-                        auto directories = _plugin_directories;
-                        for (std::size_t i = 0; i < directories.size(); ++i)
-                        {
-                            ImGui::TableNextRow();
-                            ImGui::TableNextColumn();
-                            if (ImGui::Button(std::format("Remove##{}", i).c_str()))
-                            {
-                                _plugin_directories.erase(_plugin_directories.begin() + i);
-                                on_plugin_directories(_plugin_directories);
-                            }
-                            ImGui::TableNextColumn();
-                            if (ImGui::Button(std::format("Open##{}", i).c_str()))
-                            {
-                                _shell->open(to_utf16(directories[i]));
-                            }
-                            ImGui::TableNextColumn();
-                            ImGui::Text(directories[i].c_str());
-                        }
-
-                        ImGui::TableNextRow();
-                        ImGui::TableNextColumn();
-                        if (ImGui::Button("Add"))
-                        {
-                            if (auto path = _dialogs->open_folder())
-                            {
-                                _plugin_directories.push_back(path.value());
-                                on_plugin_directories(_plugin_directories);
-                            }
-                        }
-
-                        ImGui::EndTable();
-                    }
-
-                    ImGui::EndTabItem();
-                }
-
                 ImGui::EndTabBar();
             }
         }
@@ -365,11 +325,6 @@ namespace trview
     void SettingsWindow::set_camera_sink_startup(bool value)
     {
         _camera_sink_startup = value;
-    }
-
-    void SettingsWindow::set_plugin_directories(const std::vector<std::string>& directories)
-    {
-        _plugin_directories = directories;
     }
 
     void SettingsWindow::set_statics_startup(bool value)

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -68,7 +68,6 @@ namespace trview
         virtual void set_route_startup(bool value) override;
         virtual void set_fov(float value) override;
         virtual void set_camera_sink_startup(bool value) override;
-        void set_plugin_directories(const std::vector<std::string>& directories) override;
         void set_statics_startup(bool value) override;
     private:
         std::shared_ptr<IDialogs> _dialogs;
@@ -96,7 +95,6 @@ namespace trview
         bool _route_startup{ false };
         float _fov{ 45 };
         bool _camera_sink_startup{ false };
-        std::vector<std::string> _plugin_directories;
         std::vector<FontSetting> _all_fonts;
         std::shared_ptr<IFonts> _fonts;
         bool _statics_startup{ false };

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -154,7 +154,6 @@ namespace trview
         forward_setting(_settings_window->on_route_startup, _settings.route_startup);
         forward_setting(_settings_window->on_camera_fov, _settings.fov);
         forward_setting(_settings_window->on_camera_sink_startup, _settings.camera_sink_startup);
-        forward_setting(_settings_window->on_plugin_directories, _settings.plugin_directories);
         forward_setting(_settings_window->on_statics_startup, _settings.statics_startup);
         _settings_window->on_font += on_font;
 
@@ -406,7 +405,6 @@ namespace trview
         _settings_window->set_route_startup(settings.route_startup);
         _settings_window->set_fov(settings.fov);
         _settings_window->set_camera_sink_startup(settings.camera_sink_startup);
-        _settings_window->set_plugin_directories(settings.plugin_directories);
         _settings_window->set_statics_startup(settings.statics_startup);
         _camera_position->set_display_degrees(settings.camera_display_degrees);
         _camera_position->set_visible(settings.camera_position_window);

--- a/trview.app/Windows/Plugins/IPluginsWindow.h
+++ b/trview.app/Windows/Plugins/IPluginsWindow.h
@@ -1,5 +1,12 @@
 #pragma once
 
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+#include <trview.common/Event.h>
+#include "../../Settings/UserSettings.h"
+
 namespace trview
 {
     struct IPluginsWindow
@@ -7,9 +14,11 @@ namespace trview
         using Source = std::function<std::shared_ptr<IPluginsWindow>()>;
         virtual ~IPluginsWindow() = 0;
         virtual void render() = 0;
-        virtual void update(float dt) = 0;
         virtual void set_number(int32_t number) = 0;
+        virtual void set_settings(const UserSettings& settings) = 0;
+        virtual void update(float dt) = 0;
 
+        Event<UserSettings> on_settings;
         Event<> on_window_closed;
     };
 }

--- a/trview.app/Windows/Plugins/IPluginsWindowManager.h
+++ b/trview.app/Windows/Plugins/IPluginsWindowManager.h
@@ -9,6 +9,9 @@ namespace trview
         virtual ~IPluginsWindowManager() = 0;
         virtual void render() = 0;
         virtual std::weak_ptr<IPluginsWindow> create_window() = 0;
+        virtual void set_settings(const UserSettings& settings) = 0;
         virtual void update(float dt) = 0;
+
+        Event<UserSettings> on_settings;
     };
 }

--- a/trview.app/Windows/Plugins/PluginsWindow.cpp
+++ b/trview.app/Windows/Plugins/PluginsWindow.cpp
@@ -26,57 +26,59 @@ namespace trview
         ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(540, 500));
         if (ImGui::Begin(_id.c_str(), &stay_open))
         {
-            ImGui::Text("Plugin Directories");
-            if (ImGui::BeginTable("Directories", 3, ImGuiTableFlags_SizingFixedFit, ImVec2(0, 0)))
+            if (auto plugins = _plugins.lock())
             {
-                const auto directories = _settings.plugin_directories;
-                for (std::size_t i = 0; i < directories.size(); ++i)
+                ImGui::Text("Plugin Directories");
+                if (ImGui::BeginTable("Directories", 3, ImGuiTableFlags_SizingFixedFit, ImVec2(0, 0)))
                 {
+                    const auto directories = _settings.plugin_directories;
+                    for (std::size_t i = 0; i < directories.size(); ++i)
+                    {
+                        ImGui::TableNextRow();
+                        ImGui::TableNextColumn();
+
+                        if (ImGui::Button(std::format("Remove##{}", i).c_str()))
+                        {
+                            _settings.plugin_directories.erase(_settings.plugin_directories.begin() + i);
+                            on_settings(_settings);
+                            plugins->reload();
+                        }
+                        ImGui::TableNextColumn();
+                        if (ImGui::Button(std::format("Open##{}", i).c_str()))
+                        {
+                            _shell->open(to_utf16(directories[i]));
+                        }
+                        ImGui::TableNextColumn();
+                        ImGui::Text(directories[i].c_str());
+                    }
+
                     ImGui::TableNextRow();
                     ImGui::TableNextColumn();
+                    if (ImGui::Button("+"))
+                    {
+                        if (auto path = _dialogs->open_folder())
+                        {
+                            _settings.plugin_directories.push_back(path.value());
+                            on_settings(_settings);
+                            plugins->reload();
+                        }
+                    }
 
-                    if (ImGui::Button(std::format("Remove##{}", i).c_str()))
-                    {
-                        _settings.plugin_directories.erase(_settings.plugin_directories.begin() + i);
-                        on_settings(_settings);
-                    }
-                    ImGui::TableNextColumn();
-                    if (ImGui::Button(std::format("Open##{}", i).c_str()))
-                    {
-                        _shell->open(to_utf16(directories[i]));
-                    }
-                    ImGui::TableNextColumn();
-                    ImGui::Text(directories[i].c_str());
+                    ImGui::EndTable();
                 }
 
-                ImGui::TableNextRow();
-                ImGui::TableNextColumn();
-                if (ImGui::Button("+"))
+                ImGui::Text("Plugins");
+                if (ImGui::BeginTable(Names::plugins_list.c_str(), 6, ImGuiTableFlags_SizingStretchProp))
                 {
-                    if (auto path = _dialogs->open_folder())
-                    {
-                        _settings.plugin_directories.push_back(path.value());
-                        on_settings(_settings);
-                    }
-                }
+                    ImGui::TableSetupColumn("Enabled");
+                    ImGui::TableSetupColumn("Location");
+                    ImGui::TableSetupColumn("Action");
+                    ImGui::TableSetupColumn("Name");
+                    ImGui::TableSetupColumn("Author");
+                    ImGui::TableSetupColumn("Description");
+                    ImGui::TableSetupScrollFreeze(1, 1);
+                    ImGui::TableHeadersRow();
 
-                ImGui::EndTable();
-            }
-
-            ImGui::Text("Plugins");
-            if (ImGui::BeginTable(Names::plugins_list.c_str(), 6, ImGuiTableFlags_SizingStretchProp))
-            {
-                ImGui::TableSetupColumn("Enabled");
-                ImGui::TableSetupColumn("Location");
-                ImGui::TableSetupColumn("Action");
-                ImGui::TableSetupColumn("Name");
-                ImGui::TableSetupColumn("Author");
-                ImGui::TableSetupColumn("Description");
-                ImGui::TableSetupScrollFreeze(1, 1);
-                ImGui::TableHeadersRow();
-
-                if (auto plugins = _plugins.lock())
-                {
                     for (const auto& p : plugins->plugins())
                     {
                         if (auto plugin = p.lock())
@@ -108,9 +110,9 @@ namespace trview
                             ImGui::Text(plugin->description().c_str());
                         }
                     }
-                }
 
-                ImGui::EndTable();
+                    ImGui::EndTable();
+                }
             }
         }
         ImGui::End();

--- a/trview.app/Windows/Plugins/PluginsWindow.cpp
+++ b/trview.app/Windows/Plugins/PluginsWindow.cpp
@@ -23,6 +23,7 @@ namespace trview
     bool PluginsWindow::render_plugins_window()
     {
         bool stay_open = true;
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(540, 500));
         if (ImGui::Begin(_id.c_str(), &stay_open))
         {
             ImGui::Text("Plugin Directories");
@@ -113,6 +114,7 @@ namespace trview
             }
         }
         ImGui::End();
+        ImGui::PopStyleVar();
         return stay_open;
     }
 

--- a/trview.app/Windows/Plugins/PluginsWindow.cpp
+++ b/trview.app/Windows/Plugins/PluginsWindow.cpp
@@ -90,6 +90,8 @@ namespace trview
                             if (ImGui::Checkbox(std::format("##enabled-{}", reinterpret_cast<std::size_t>(plugin.get())).c_str(), &enabled))
                             {
                                 plugin->set_enabled(enabled);
+                                _settings.plugins[plugin->path()].enabled = enabled;
+                                on_settings(_settings);
                             }
                             ImGui::EndDisabled();
                             ImGui::TableNextColumn();

--- a/trview.app/Windows/Plugins/PluginsWindow.h
+++ b/trview.app/Windows/Plugins/PluginsWindow.h
@@ -14,10 +14,11 @@ namespace trview
             static inline const std::string plugins_list = "Plugins";
         };
 
-        explicit PluginsWindow(const std::weak_ptr<IPlugins>& plugins, const std::shared_ptr<IShell>& shell);
+        explicit PluginsWindow(const std::weak_ptr<IPlugins>& plugins, const std::shared_ptr<IShell>& shell, const std::shared_ptr<IDialogs>& dialogs);
         virtual ~PluginsWindow() = default;
         void render() override;
         void set_number(int32_t number) override;
+        void set_settings(const UserSettings& settings) override;
         void update(float dt) override;
     private:
         bool render_plugins_window();
@@ -25,6 +26,8 @@ namespace trview
         std::string _id{ "Plugins 0" };
         std::weak_ptr<IPlugins> _plugins;
         std::shared_ptr<IShell> _shell;
+        std::shared_ptr<IDialogs> _dialogs;
+        UserSettings _settings;
     };
 }
 

--- a/trview.app/Windows/Plugins/PluginsWindow.h
+++ b/trview.app/Windows/Plugins/PluginsWindow.h
@@ -3,6 +3,7 @@
 #include "../../Plugins/IPlugins.h"
 #include "IPluginsWindow.h"
 #include <trview.common/Windows/IShell.h>
+#include <trview.common/Windows/IDialogs.h>
 
 namespace trview
 {

--- a/trview.app/Windows/Plugins/PluginsWindowManager.cpp
+++ b/trview.app/Windows/Plugins/PluginsWindowManager.cpp
@@ -30,12 +30,23 @@ namespace trview
     std::weak_ptr<IPluginsWindow> PluginsWindowManager::create_window()
     {
         auto plugins_window = _source();
+        plugins_window->on_settings += on_settings;
+        plugins_window->set_settings(_settings);
         return add_window(plugins_window);
     }
 
     void PluginsWindowManager::update(float delta)
     {
         WindowManager::update(delta);
+    }
+
+    void PluginsWindowManager::set_settings(const UserSettings& settings)
+    {
+        _settings = settings;
+        for (auto& window : _windows)
+        {
+            window.second->set_settings(settings);
+        }
     }
 }
 

--- a/trview.app/Windows/Plugins/PluginsWindowManager.h
+++ b/trview.app/Windows/Plugins/PluginsWindowManager.h
@@ -11,11 +11,13 @@ namespace trview
     public:
         explicit PluginsWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const IPluginsWindow::Source& plugins_window_source);
         virtual ~PluginsWindowManager() = default;
-        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
-        virtual void render() override;
-        virtual std::weak_ptr<IPluginsWindow> create_window() override;
-        virtual void update(float delta) override;
+        std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        void render() override;
+        std::weak_ptr<IPluginsWindow> create_window() override;
+        void update(float delta) override;
+        void set_settings(const UserSettings& settings) override;
     private:
         IPluginsWindow::Source _source;
+        UserSettings _settings;
     };
 }

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -76,6 +76,8 @@ namespace trview
         _lights_windows->on_light_selected += on_light_selected;
         _lights_windows->on_scene_changed += on_scene_changed;
 
+        _plugins_windows->on_settings += on_settings;
+
         _rooms_windows->on_camera_sink_selected += on_camera_sink_selected;
         _rooms_windows->on_item_selected += on_item_selected;
         _rooms_windows->on_light_selected += on_light_selected;
@@ -252,6 +254,7 @@ namespace trview
     void Windows::set_settings(const UserSettings& settings)
     {
         _diff_windows->set_settings(settings);
+        _plugins_windows->set_settings(settings);
         _rooms_windows->set_map_colours(settings.map_colours);
         _route_window->set_randomizer_enabled(settings.randomizer_tools);
         _route_window->set_randomizer_settings(settings.randomizer);

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -171,6 +171,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Plugins\Plugins.h" />
     <ClInclude Include="Routing\IRandomizerRoute.h" />
     <ClInclude Include="Routing\RandomizerRoute.h" />
+    <ClInclude Include="Settings\PluginSetting.h" />
     <ClInclude Include="Sound\ISound.h" />
     <ClInclude Include="Sound\ISoundStorage.h" />
     <ClInclude Include="Sound\Sound.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -1231,6 +1231,9 @@
     <ClInclude Include="Menus\ImGuiFileMenu.h">
       <Filter>Menus</Filter>
     </ClInclude>
+    <ClInclude Include="Settings\PluginSetting.h">
+      <Filter>Settings</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">


### PR DESCRIPTION
Move the plugins settings from the settings window to the plugins window.
Allow user to disable plugins.
Reload plugins when plugin paths change.
Closes #1358
Closes #1174 