### PR TITLE
Add extra words to explain filtering on windows

### DIFF
--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -170,7 +170,7 @@ namespace trview
                 on_scene_changed();
             }
 
-            RowCounter counter{ "camera/sinks", _all_camera_sinks.size() };
+            RowCounter counter{ "camera/sink", _all_camera_sinks.size() };
             if (ImGui::BeginTable(Names::camera_sink_list.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(0, -counter.height())))
             {
                 imgui_header_row(

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -131,7 +131,7 @@ namespace trview
                 on_scene_changed();
             }
 
-            RowCounter counter{ "items",
+            RowCounter counter{ "item",
                 static_cast<std::size_t>(std::ranges::count_if(_all_items, [this](auto&& item)
                     {
                         const auto item_ptr = item.lock();

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -113,7 +113,7 @@ namespace trview
                 on_scene_changed();
             }
 
-            RowCounter counter{ "lights", _all_lights.size() };
+            RowCounter counter{ "light", _all_lights.size() };
             if (ImGui::BeginTable(Names::lights_listbox.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(0, -counter.height())))
             {
                 imgui_header_row(

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -321,7 +321,7 @@ namespace trview
                 on_scene_changed();
             }
 
-            RowCounter counter{ "rooms", _all_rooms.size() };
+            RowCounter counter{ "room", _all_rooms.size() };
             if (ImGui::BeginTable(Names::rooms_list.c_str(), 5, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(0, -counter.height())))
             {
                 imgui_header_row(

--- a/trview.app/Windows/RowCounter.cpp
+++ b/trview.app/Windows/RowCounter.cpp
@@ -3,6 +3,14 @@
 
 namespace trview
 {
+    namespace
+    {
+        constexpr std::string plural(std::size_t count)
+        {
+            return (count == 0 || count > 1) ? "s" : "";
+        }
+    }
+
     RowCounter::RowCounter(const std::string& entry_name, std::size_t maximum_size)
         : _entry_name(entry_name), _maximum_size(maximum_size), _count(0)
     {
@@ -25,12 +33,16 @@ namespace trview
 
     void RowCounter::render()
     {
+        const bool is_filtered = _count != _maximum_size;
         const std::string text =
-            _count == _maximum_size ?
-            std::format("{} {}", _maximum_size, _entry_name) :
-            std::format("{} of {} {}", _count, _maximum_size, _entry_name);
+            is_filtered ?
+            std::format("Results are filtered. {} {}{} out of {}.", _count, _entry_name, plural(_count), _maximum_size) :
+            std::format("{} {}{}", _maximum_size, _entry_name, plural(_count));
         const ImVec2 size = ImGui::CalcTextSize(text.c_str());
-        ImGui::SetCursorPosX(ImGui::GetWindowWidth() - size.x - 5);
+        ImGui::SetCursorPosX(
+            is_filtered ? 
+                ImGui::GetWindowWidth() * 0.5f - size.x * 0.5f :
+                ImGui::GetWindowWidth() - size.x - 5);
         ImGui::Text(text.c_str());
     }
 }

--- a/trview.app/Windows/Sounds/SoundsWindow.cpp
+++ b/trview.app/Windows/Sounds/SoundsWindow.cpp
@@ -116,7 +116,7 @@ namespace trview
                 on_scene_changed();
             }
 
-            RowCounter counter{ "sound sources", _all_sound_sources.size() };
+            RowCounter counter{ "sound source", _all_sound_sources.size() };
             if (ImGui::BeginTable(Names::sound_sources_list.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(200, -counter.height())))
             {
                 imgui_header_row(

--- a/trview.app/Windows/Statics/StaticsWindow.cpp
+++ b/trview.app/Windows/Statics/StaticsWindow.cpp
@@ -71,7 +71,7 @@ namespace trview
 
             _auto_hider.apply(_all_statics, filtered_statics, _filters);
 
-            RowCounter counter{ "statics", _all_statics.size() };
+            RowCounter counter{ "static", _all_statics.size() };
             if (ImGui::BeginTable(Names::statics_list.c_str(), 5, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(0, -counter.height())))
             {
                 imgui_header_row(

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -177,7 +177,7 @@ namespace trview
                 ImGui::EndCombo();
             }
 
-            RowCounter counter{ "triggers", _all_triggers.size() };
+            RowCounter counter{ "trigger", _all_triggers.size() };
             if (ImGui::BeginTable(Names::triggers_list.c_str(), 4, ImGuiTableFlags_Sortable | ImGuiTableFlags_ScrollY, ImVec2(0, -counter.height())))
             {
                 imgui_header_row(


### PR DESCRIPTION
When a window has filtered results, change the counter message to explain that the list is now filtered.
Now shows `Results are filtered. 1 item out of 60` or similar.
Should make it more clear that filtering is taking place.
Closes #1361 