### PR TITLE
Add TR3 PSX support

### DIFF
--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -670,6 +670,7 @@ namespace trlevel
             const size_type num_rooms = read<size_type>(file);
 
             callbacks.on_progress(std::format("Reading {} rooms", num_rooms));
+            log_file(activity, file, std::format("Reading {} rooms", num_rooms));
             for (auto i = 0u; i < num_rooms; ++i)
             {
                 trview::Activity room_activity(activity, std::format("Room {}", i));
@@ -1069,6 +1070,87 @@ namespace trlevel
             skip(file, 1); // filler in TR3
         }
 
+        void load_tr3_psx_room(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, tr3_room& room)
+        {
+            room.info = read_room_info(activity, file);
+            uint32_t NumDataWords = read_num_data_words(activity, file);
+
+            const auto data_start = file.tellg();
+
+            const uint32_t number_of_roomlets = read<uint32_t>(file);
+            number_of_roomlets;
+
+            const std::vector<uint32_t> roomlet_offsets = read_vector<uint32_t>(file, 16);
+
+            uint16_t total_vertices = 0;
+            uint32_t previous_offset = 0;
+            for (std::size_t i = 0; i < number_of_roomlets; ++i)
+            {
+                previous_offset = roomlet_offsets[i];
+
+                file.seekg(static_cast<std::size_t>(data_start) + roomlet_offsets[i]);
+
+                const auto bounding_box = read_vector<uint8_t>(file, 6);
+                bounding_box;
+
+                uint8_t num_vertices = read<uint8_t>(file);
+                uint8_t num_triangles = read<uint8_t>(file);
+
+                room.data.vertices.append_range(convert_vertices_tr3_psx(read_vector<uint32_t>(file, num_vertices), room.info.yTop));
+                room.data.triangles.append_range(convert_tr3_psx_room_triangles(read_vector<uint32_t>(file, num_triangles), total_vertices));
+
+                bool more_quads = true;
+                while (more_quads)
+                {
+                    const uint32_t tex_info = read<uint32_t>(file);
+
+                    uint32_t face_index = 0;
+                    for (uint32_t face : read_vector<uint32_t>(file, 3))
+                    {
+                        if (((tex_info >> (10 * face_index)) & 0x3ff) == 0x3ff)
+                        {
+                            more_quads = false;
+                            break;
+                        }
+
+                        room.data.rectangles.push_back
+                        (
+                            tr4_mesh_face4
+                            {
+                                .vertices =
+                                {
+                                    static_cast<uint16_t>(total_vertices + (face & 0x7f)),
+                                    static_cast<uint16_t>(total_vertices + ((face >> 7) & 0x7f)),
+                                    static_cast<uint16_t>(total_vertices + ((face >> 21) & 0x7f)),    // swapped with last
+                                    static_cast<uint16_t>(total_vertices + ((face >> 14) & 0x7f))
+                                },
+                                .texture = static_cast<uint16_t>((tex_info >> (face_index * 10)) & 0x3ff),
+                                .effects = 0
+                            }
+                        );
+                        face_index++;
+                    }
+                }
+
+                total_vertices += num_vertices;
+            }
+
+            file.seekg(data_start, std::ios::beg);
+            skip(file, NumDataWords * 2);
+
+            read_room_portals(activity, file, room);
+            read_room_sectors(activity, file, room);
+            read_room_ambient_intensity_1(activity, file, room);
+            read_room_light_mode(activity, file, room);
+            read_room_lights_tr3_pc(activity, file, room);
+            read_room_static_meshes(activity, file, room);
+            read_room_alternate_room(activity, file, room);
+            read_room_flags(activity, file, room);
+            read_room_water_scheme(activity, file, room);
+            read_room_reverb_info(activity, file, room);
+            skip(file, 1); // filler in TR3
+        }
+
         void load_tr4_pc_room(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, tr3_room& room)
         {
             room.info = read_room_info(activity, file);
@@ -1280,92 +1362,21 @@ namespace trlevel
             stream.seekg(pointer, std::ios::beg);
 
             tr_mesh mesh;
-            mesh.centre = read<tr_vertex>(stream);
-            mesh.coll_radius = read<int32_t>(stream);
 
             if (_platform_and_version.platform == Platform::PSX)
             {
-                int16_t vertices_count = read<int16_t>(stream);
-                int16_t normals_count = vertices_count;
-                vertices_count = static_cast<int16_t>(std::abs(vertices_count));
-
-                mesh.vertices = convert_vertices(read_vector<tr_vertex_psx>(stream, vertices_count));
-
-                for (int i = 0; i < vertices_count; ++i)
+                if (_platform_and_version.version == LevelVersion::Tomb1)
                 {
-                    if (normals_count > 0)
-                    {
-                        tr_vertex_psx norm = read<tr_vertex_psx>(stream);
-                        norm.w = 1;
-                        mesh.normals.push_back({ norm.x, norm.y, norm.z });
-                    }
-                    else
-                    {
-                        mesh.lights.push_back(read<int16_t>(stream)); // intensity
-                        mesh.normals.push_back({ 0, 0, 0 });
-                    }
+                    generate_mesh_tr1_psx(mesh, stream);
                 }
-
-                const auto rectangles = read_vector<int16_t, tr_face4>(stream);
-                const auto triangles = read_vector<int16_t, tr_face3>(stream);
-
-                mesh.textured_rectangles = rectangles
-                    | std::views::filter([](const auto& rect) { return rect.texture > 255; })
-                    | std::views::transform([](const auto& rect) 
-                        {
-                            tr4_mesh_face4 new_face4;
-                            memcpy(new_face4.vertices, rect.vertices, sizeof(rect.vertices));
-                            new_face4.texture = rect.texture;
-                            new_face4.effects = 0;
-                            return new_face4;
-                        })
-                    | std::ranges::to<std::vector>();
-                mesh.textured_triangles = triangles
-                    | std::views::filter([](const auto& tri) { return tri.texture > 255; })
-                    | std::views::transform([](const auto& tri)
-                        {
-                            tr4_mesh_face3 new_face3;
-                            memcpy(new_face3.vertices, tri.vertices, sizeof(tri.vertices));
-                            new_face3.texture = tri.texture;
-                            new_face3.effects = 0;
-                            return new_face3;
-                        })
-                    | std::ranges::to<std::vector>();
-
-                mesh.coloured_rectangles = rectangles
-                    | std::views::filter([](const auto& rect) { return rect.texture < 256; })
-                    | std::ranges::to<std::vector>();
-
-                mesh.coloured_triangles = triangles
-                    | std::views::filter([](const auto& tri) { return tri.texture < 256; })
-                    | std::ranges::to<std::vector>();
+                else if (_platform_and_version.version == LevelVersion::Tomb3)
+                {
+                    generate_mesh_tr3_psx(mesh, stream);
+                }
             }
             else
             {
-                mesh.vertices = read_vector<int16_t, tr_vertex>(stream);
-
-                int16_t normals = read<int16_t>(stream);
-                if (normals > 0)
-                {
-                    mesh.normals = read_vector<tr_vertex>(stream, normals);
-                }
-                else
-                {
-                    mesh.lights = read_vector<int16_t>(stream, abs(normals));
-                }
-
-                if (get_version() < LevelVersion::Tomb4)
-                {
-                    mesh.textured_rectangles = convert_rectangles(read_vector<int16_t, tr_face4>(stream));
-                    mesh.textured_triangles = convert_triangles(read_vector<int16_t, tr_face3>(stream));
-                    mesh.coloured_rectangles = read_vector<int16_t, tr_face4>(stream);
-                    mesh.coloured_triangles = read_vector<int16_t, tr_face3>(stream);
-                }
-                else
-                {
-                    mesh.textured_rectangles = read_vector<int16_t, tr4_mesh_face4>(stream);
-                    mesh.textured_triangles = read_vector<int16_t, tr4_mesh_face3>(stream);
-                }
+                generate_mesh(mesh, stream);
             }
 
             _meshes.insert({ pointer, mesh });
@@ -1374,7 +1385,7 @@ namespace trlevel
 
     tr_colour Level::get_palette_entry8(uint32_t index) const
     {
-        return _palette[index];
+        return index < _palette.size() ? _palette[index] : tr_colour { .Red = 0, .Green = 0, .Blue = 0 };
     }
 
     tr_colour4 Level::get_palette_entry_16(uint32_t index) const
@@ -1784,6 +1795,7 @@ namespace trlevel
             const std::unordered_map<PlatformAndVersion, std::function<void ()>> loaders
             {
                 {{.platform = Platform::PSX, .version = LevelVersion::Tomb1 }, [&]() { load_tr1_psx(file, activity, callbacks); }},
+                {{.platform = Platform::PSX, .version = LevelVersion::Tomb3 }, [&]() { load_tr3_psx(file, activity, callbacks); }},
                 {{.platform = Platform::PC, .version = LevelVersion::Tomb1 }, [&]() { load_tr1_pc(file, activity, callbacks); }},
                 {{.platform = Platform::PC, .version = LevelVersion::Tomb2 }, [&]() { load_tr2_pc(file, activity, callbacks); }},
                 {{.platform = Platform::PC, .version = LevelVersion::Tomb3 }, [&]() { load_tr3_pc(file, activity, callbacks); }},
@@ -2017,11 +2029,6 @@ namespace trlevel
                     tr_object_texture_psx new_texture = texture;
                     new_texture.Tile = convert_textile4(texture.Tile, texture.Clut);
                     new_texture.Clut = 0U; // Unneeded after conversion
-                    if (new_texture.x3 || new_texture.y3)
-                    {
-                        std::swap(new_texture.x2, new_texture.x3);
-                        std::swap(new_texture.y2, new_texture.y3);
-                    }
                     return new_texture;
                 })
             | std::views::transform([&](const auto texture) -> tr_object_texture
@@ -2042,20 +2049,8 @@ namespace trlevel
             | std::ranges::to<std::vector>();
         log_file(activity, file, std::format("Read {} object textures", _object_textures.size()));
 
-        callbacks.on_progress("Reading sprite textures");
-        log_file(activity, file, "Reading sprite textures");
-        auto textures = read_vector<uint32_t, tr_sprite_texture_psx>(file);
-        _sprite_textures = textures
-            | std::views::transform([&](const auto texture) -> tr_sprite_texture
-                {
-                    const uint16_t tile = convert_textile4(texture.Tile, texture.Clut);
-                    const uint16_t width = (texture.u1 - texture.u0) * 256 + 255;
-                    const uint16_t height = (texture.v1 - texture.v0) * 256 + 255;
-                    return { tile, texture.u0, texture.v0, width, height, texture.LeftSide, texture.TopSide, texture.RightSide, texture.BottomSide };
-                })
-            | std::ranges::to<std::vector>();
-        log_file(activity, file, std::format("Read {} sprite textures", _sprite_textures.size()));
-
+        read_sprite_textures_psx(file, activity, callbacks);
+        
         for (const auto& t : _textile16)
         {
             callbacks.on_textile(convert_textile(t));
@@ -2161,6 +2156,70 @@ namespace trlevel
         _sound_details = read_sound_details(activity, file, callbacks);
         _sample_indices = read_sample_indices(activity, file, callbacks);
         load_sound_fx(activity, callbacks);
+        callbacks.on_progress("Generating meshes");
+        generate_meshes(_mesh_data);
+        callbacks.on_progress("Loading complete");
+    }
+
+    void Level::load_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    {
+        auto sound_offsets = read_vector<uint32_t, uint32_t>(file);
+        auto sound_data = read_vector<uint32_t, byte>(file);
+
+        for (int i = 0; i < 13; ++i)
+        {
+            int size = read<int>(file);
+            if (size != 0)
+            {
+                skip(file, size);
+                int size2 = read<int>(file);
+                skip(file, size2);
+            }
+        }
+
+        _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr3_psx_room);
+        _floor_data = read_floor_data(activity, file, callbacks);
+
+        // 'Room outside map':
+        read_vector<uint16_t>(file, 729);
+        // Outside room table:
+        read_vector<uint32_t, uint8_t>(file);
+        // Bounding boxes
+        int bb_count = read<int>(file);
+        skip(file, bb_count * 8);
+
+        _mesh_data = read_mesh_data(activity, file, callbacks);
+        _mesh_pointers = read_mesh_pointers(activity, file, callbacks);
+        read_animations_tr1_3(activity, file, callbacks);
+        read_state_changes(activity, file, callbacks);
+        read_anim_dispatches(activity, file, callbacks);
+        read_anim_commands(activity, file, callbacks);
+        _meshtree = read_meshtree(activity, file, callbacks);
+        _frames = read_frames(activity, file, callbacks);
+        _models = read_models_tr1_psx(activity, file, callbacks);
+        _static_meshes = read_static_meshes(activity, file, callbacks);
+        read_textiles_tr3_psx(file, activity, callbacks);
+        read_object_textures_tr3_psx(file, activity, callbacks);
+        read_sprite_textures_psx(file, activity, callbacks);
+        _sprite_sequences = read_sprite_sequences(activity, file, callbacks);
+        _cameras = read_cameras(activity, file, callbacks);
+        _sound_sources = read_sound_sources(activity, file, callbacks);
+        const auto boxes = read_boxes(activity, file, callbacks);
+        read_overlaps(activity, file, callbacks);
+        read_zones(activity, file, callbacks, static_cast<uint32_t>(boxes.size()));
+        read_animated_textures(activity, file, callbacks);
+        _entities = read_entities(activity, file, callbacks);
+        read<int32_t>(file); // horizon colour
+        read_room_textures_tr3_psx(file, activity, callbacks);
+
+        for (const auto& t : _textile16)
+        {
+            callbacks.on_textile(convert_textile(t));
+        };
+
+        _sound_map = read_sound_map(activity, file, callbacks);
+        _sound_details = read_sound_details(activity, file, callbacks);
+
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);
         callbacks.on_progress("Loading complete");
@@ -2486,6 +2545,23 @@ namespace trlevel
         log_file(activity, file, std::format("Read {} textile4s and {} clut", _textile4.size(), _clut.size()));
     }
 
+    void Level::read_textiles_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    {
+        callbacks.on_progress("Reading textiles");
+        log_file(activity, file, "Reading textiles");
+        _num_textiles = read<uint32_t>(file);
+        _textile4 = read_vector<tr_textile4>(file, _num_textiles);
+
+        uint32_t num_cluts = read<uint32_t>(file);
+        if (num_cluts & 0xffff0000)
+        {
+            file.seekg(-2, std::ios::cur);
+            num_cluts = read<uint32_t>(file);
+        }
+        _clut = read_vector<tr_clut>(file, num_cluts * 2);
+        log_file(activity, file, std::format("Read {} textile4s and {} clut", _textile4.size(), _clut.size()));
+    }
+
     void Level::generate_sounds_tr1(const LoadCallbacks& callbacks)
     {
         callbacks.on_progress("Generating sounds");
@@ -2572,5 +2648,311 @@ namespace trlevel
     bool Level::trng() const
     {
         return _trng;
+    }
+
+    void Level::generate_mesh(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream)
+    {
+        mesh.centre = read<tr_vertex>(stream);
+        mesh.coll_radius = read<int32_t>(stream);
+        mesh.vertices = read_vector<int16_t, tr_vertex>(stream);
+
+        int16_t normals = read<int16_t>(stream);
+        if (normals > 0)
+        {
+            mesh.normals = read_vector<tr_vertex>(stream, normals);
+        }
+        else
+        {
+            mesh.lights = read_vector<int16_t>(stream, abs(normals));
+        }
+
+        if (get_version() < LevelVersion::Tomb4)
+        {
+            mesh.textured_rectangles = convert_rectangles(read_vector<int16_t, tr_face4>(stream));
+            mesh.textured_triangles = convert_triangles(read_vector<int16_t, tr_face3>(stream));
+            mesh.coloured_rectangles = read_vector<int16_t, tr_face4>(stream);
+            mesh.coloured_triangles = read_vector<int16_t, tr_face3>(stream);
+        }
+        else
+        {
+            mesh.textured_rectangles = read_vector<int16_t, tr4_mesh_face4>(stream);
+            mesh.textured_triangles = read_vector<int16_t, tr4_mesh_face3>(stream);
+        }
+    }
+
+    void Level::generate_mesh_tr1_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream)
+    {
+        mesh.centre = read<tr_vertex>(stream);
+        mesh.coll_radius = read<int32_t>(stream);
+        int16_t vertices_count = read<int16_t>(stream);
+        int16_t normals_count = vertices_count;
+        vertices_count = static_cast<int16_t>(std::abs(vertices_count));
+
+        mesh.vertices = convert_vertices(read_vector<tr_vertex_psx>(stream, vertices_count));
+
+        for (int i = 0; i < vertices_count; ++i)
+        {
+            if (normals_count > 0)
+            {
+                tr_vertex_psx norm = read<tr_vertex_psx>(stream);
+                norm.w = 1;
+                mesh.normals.push_back({ norm.x, norm.y, norm.z });
+            }
+            else
+            {
+                mesh.lights.push_back(read<int16_t>(stream)); // intensity
+                mesh.normals.push_back({ 0, 0, 0 });
+            }
+        }
+
+        const auto rectangles = read_vector<int16_t, tr_face4>(stream);
+        const auto triangles = read_vector<int16_t, tr_face3>(stream);
+
+        mesh.textured_rectangles = rectangles
+            | std::views::filter([](const auto& rect) { return rect.texture > 255; })
+            | std::views::transform([](const auto& rect)
+                {
+                    tr4_mesh_face4 new_face4;
+                    memcpy(new_face4.vertices, rect.vertices, sizeof(rect.vertices));
+                    new_face4.texture = rect.texture;
+                    new_face4.effects = 0;
+                    return new_face4;
+                })
+            | std::ranges::to<std::vector>();
+        mesh.textured_triangles = triangles
+            | std::views::filter([](const auto& tri) { return tri.texture > 255; })
+            | std::views::transform([](const auto& tri)
+                {
+                    tr4_mesh_face3 new_face3;
+                    memcpy(new_face3.vertices, tri.vertices, sizeof(tri.vertices));
+                    new_face3.texture = tri.texture;
+                    new_face3.effects = 0;
+                    return new_face3;
+                })
+            | std::ranges::to<std::vector>();
+
+        mesh.coloured_rectangles = rectangles
+            | std::views::filter([](const auto& rect) { return rect.texture < 256; })
+            | std::ranges::to<std::vector>();
+
+        mesh.coloured_triangles = triangles
+            | std::views::filter([](const auto& tri) { return tri.texture < 256; })
+            | std::ranges::to<std::vector>();
+    }
+
+    void Level::generate_mesh_tr3_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream)
+    {
+        // Avoid skybox mesh for now.
+        const auto skybox_model = std::ranges::find_if(_models, [](auto&& m) { return m.ID == 355; });
+        if (skybox_model != _models.end())
+        {
+            if (stream.tellg() == _mesh_pointers[skybox_model->StartingMesh])
+            {
+                return;
+            }
+        }
+
+        mesh.centre = read<tr_vertex>(stream);
+        mesh.coll_radius = read<int16_t>(stream);
+        uint8_t vertices_count = read<uint8_t>(stream);
+        uint8_t flags = read<uint8_t>(stream);
+        uint16_t face_data_offset = read<uint16_t>(stream);
+        const auto at = stream.tellg();
+
+        mesh.vertices = convert_vertices(read_vector<tr_vertex_psx>(stream, vertices_count));
+        if ((flags & 0x80) == 0)
+        {
+            mesh.normals = convert_vertices(read_vector<tr_vertex_psx>(stream, vertices_count));
+        }
+        else
+        {
+            mesh.lights = read_vector<int16_t>(stream, vertices_count);
+            mesh.normals.push_back({ 0,0,0 });
+        }
+
+        stream.seekg(static_cast<std::size_t>(at) + face_data_offset, std::ios::beg);
+
+        uint16_t num_triangles = read<uint16_t>(stream);
+        uint16_t num_rectangles = read<uint16_t>(stream);
+
+        if (num_triangles)
+        {
+            const auto triangle_start = stream.tellg();
+            const uint16_t* data = reinterpret_cast<const uint16_t*>(stream.span().data() + stream.tellg());
+            const uint16_t* ptr = data;
+            const auto start = ptr;
+
+            uint32_t face_a = 0;
+            uint32_t face_b = 0;
+            for (int t = 0; t < num_triangles; ++t)
+            {
+                if (!(t % 4))
+                {
+                    face_a = *ptr++;
+                    face_a |= (*ptr++) << 16;
+                }
+
+                face_b = *ptr++;
+                face_b |= (*ptr++) << 16;
+
+                tr4_mesh_face3 tri
+                {
+                    .vertices = { face_b & 0xff, (face_b >> 8) & 0xff, (face_b >> 16) & 0xff },
+                    .texture = (face_a & 0xff) | (((face_b >> 24) & 0xff) << 8)
+                };
+                mesh.textured_triangles.push_back(tri);
+
+                face_a >>= 8;
+            }
+
+            const auto skip_amount = ptr - start;
+            skip(stream, static_cast<uint32_t>(skip_amount * 2));
+        }
+
+        if (num_rectangles)
+        {
+            const uint16_t* data = reinterpret_cast<const uint16_t*>(stream.span().data() + stream.tellg());
+            const uint16_t* ptr = data;
+            const auto start = ptr;
+
+            uint32_t face_a = 0;
+            uint32_t face_b = 0;
+            for (int r = 0; r < num_rectangles; ++r)
+            {
+                if (!(r % 2))
+                {
+                    face_a = *ptr++;
+                    face_a |= (*ptr++) << 16;
+                }
+
+                face_b = *ptr++;
+                face_b |= (*ptr++) << 16;
+
+                tr4_mesh_face4 rect
+                {
+                    .vertices = { face_b & 0xff, (face_b >> 8) & 0xff, (face_b >> 24) & 0xff, (face_b >> 16) & 0xff },
+                    .texture = (face_a & 0xffff)
+                };
+                mesh.textured_rectangles.push_back(rect);
+
+                face_a >>= 16;
+            }
+
+            const auto skip_amount = ptr - start;
+            skip(stream, static_cast<uint32_t>(skip_amount * 2));
+        }
+    }
+
+    void Level::read_sprite_textures_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    {
+        callbacks.on_progress("Reading sprite textures");
+        log_file(activity, file, "Reading sprite textures");
+        auto textures = read_vector<uint32_t, tr_sprite_texture_psx>(file);
+        _sprite_textures = textures
+            | std::views::transform([&](const auto texture) -> tr_sprite_texture
+                {
+                    const uint16_t tile = convert_textile4(texture.Tile, texture.Clut);
+                    const uint16_t width = (texture.u1 - texture.u0) * 256 + 255;
+                    const uint16_t height = (texture.v1 - texture.v0) * 256 + 255;
+                    return { tile, texture.u0, texture.v0, width, height, texture.LeftSide, texture.TopSide, texture.RightSide, texture.BottomSide };
+                })
+            | std::ranges::to<std::vector>();
+        log_file(activity, file, std::format("Read {} sprite textures", _sprite_textures.size()));
+    }
+
+    void Level::read_object_textures_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    {
+        callbacks.on_progress("Reading object textures");
+        log_file(activity, file, "Reading object textures");
+        _object_textures_psx = read_vector<uint32_t, tr_object_texture_psx>(file);
+        _object_textures = _object_textures_psx
+            | std::views::transform([&](const auto texture)
+                {
+                    tr_object_texture_psx new_texture = texture;
+                    new_texture.Tile = convert_textile4(texture.Tile, texture.Clut);
+                    new_texture.Clut = 0U; // Unneeded after conversion
+                    new_texture.Attribute = texture.tri_draw & 0x2 ? 2 : texture.tri_draw & 0x4 ? 1 : 0;
+                    return new_texture;
+                })
+            | std::views::transform([&](const auto texture) -> tr_object_texture
+                {
+                    return
+                    {
+                        .Attribute = texture.Attribute,
+                        .TileAndFlag = texture.Tile,
+                        .Vertices =
+                        {
+                            { 0, texture.x0, 0, texture.y0 },
+                            { 0, texture.x1, 0, texture.y1 },
+                            { 0, texture.x2, 0, texture.y2 },
+                            { 0, texture.x3, 0, texture.y3 },
+                        }
+                    };
+                })
+            | std::ranges::to<std::vector>();
+        log_file(activity, file, std::format("Read {} object textures", _object_textures.size()));
+    }
+
+    void Level::read_room_textures_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    {
+        callbacks.on_progress("Reading room textures");
+        log_file(activity, file, "Reading room textures");
+
+        std::vector<tr_object_texture_psx> room_textures_psx;
+        uint32_t num_room_textures = read<uint32_t>(file);
+        for (auto i = 0u; i < num_room_textures; ++i)
+        {
+            room_textures_psx.push_back(read<tr_object_texture_psx>(file));
+            skip(file, sizeof(tr_object_texture_psx) * 2);
+        }
+
+        auto room_textures_object_psx = room_textures_psx
+            | std::views::transform([&](const auto texture)
+                {
+                    tr_object_texture_psx new_texture = texture;
+                    new_texture.Tile = convert_textile4(texture.Tile, texture.Clut);
+                    new_texture.Clut = 0U; // Unneeded after conversion
+                    new_texture.Attribute = texture.tri_draw & 0x2 ? 2 : texture.tri_draw & 0x4 ? 1 : 0;
+                    return new_texture;
+                })
+            | std::ranges::to<std::vector>();
+        auto room_textures = room_textures_object_psx
+            | std::views::transform([&](const auto texture) -> tr_object_texture
+                {
+                    return
+                    {
+                        .Attribute = texture.Attribute,
+                        .TileAndFlag = texture.Tile,
+                        .Vertices =
+                        {
+                            { 0, texture.x0, 0, texture.y0 },
+                            { 0, texture.x1, 0, texture.y1 },
+                            { 0, texture.x2, 0, texture.y2 },
+                            { 0, texture.x3, 0, texture.y3 },
+                        }
+                    };
+                })
+            | std::ranges::to<std::vector>();
+        log_file(activity, file, std::format("Read {} room textures", room_textures.size()));
+
+        adjust_room_textures_psx();
+        _object_textures_psx.append_range(room_textures_object_psx);
+        _object_textures.append_range(room_textures);
+    }
+
+    void Level::adjust_room_textures_psx()
+    {
+        for (auto& room : _rooms)
+        {
+            for (auto& face : room.data.rectangles)
+            {
+                face.texture += static_cast<uint16_t>(_object_textures_psx.size());
+            }
+
+            for (auto& face : room.data.triangles)
+            {
+                face.texture += static_cast<uint16_t>(_object_textures_psx.size());
+            }
+        }
     }
 }

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -176,15 +176,21 @@ namespace trlevel
 
         // New level bits:
         void read_header(std::basic_ispanstream<uint8_t>& file, std::vector<uint8_t>& bytes, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void read_object_textures_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_palette_tr1(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_palette_tr2_3(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void read_room_textures_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr1_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr1_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void read_textiles_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void read_sprite_textures_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void adjust_room_textures_psx();
 
         void load_tr1_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr1_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr2_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr3_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void load_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr4_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr4_pc_remastered(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr5_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
@@ -194,6 +200,10 @@ namespace trlevel
         void load_sound_fx(trview::Activity& activity, const LoadCallbacks& callbacks);
         std::optional<std::vector<uint8_t>> load_main_sfx() const;
         void load_ngle_sound_fx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const LoadCallbacks& callbacks);
+
+        void generate_mesh(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
+        void generate_mesh_tr1_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
+        void generate_mesh_tr3_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
 
         PlatformAndVersion _platform_and_version;
 

--- a/trlevel/tr_rooms.cpp
+++ b/trlevel/tr_rooms.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "tr_rooms.h"
+#include <ranges>
 
 using namespace DirectX::SimpleMath;
 
@@ -89,5 +90,28 @@ namespace trlevel
                 return trview_room_vertex{ vertex, 0, 0, to_colour(vert.colour) };
             });
         return new_vertices;
+    }
+
+    std::vector<trview_room_vertex> convert_vertices_tr3_psx(std::vector<uint32_t> vertices, int32_t y_top)
+    {
+        return vertices |
+            std::views::transform([=](auto&& v)
+                {
+                    const uint16_t colour = (v >> 15) & 0x7fff;
+                    return trview_room_vertex
+                    {
+                        .vertex =
+                        {
+                            .x = static_cast<int16_t>(((v >> 10) & 0x1f) << 10),
+                            .y = static_cast<int16_t>((((v >> 5) & 0x1f) << 8) + y_top),
+                            .z = static_cast<int16_t>((v & 0x1f) << 10)
+                         },
+                        .attributes = 0,
+                        .colour = trview::Colour(
+                            static_cast<float>((colour & 0x1F)) / 0x1F,
+                            static_cast<float>(((colour >> 5) & 0x1F)) / 0x1F,
+                            static_cast<float>(((colour >> 10) & 0x1F)) / 0x1F)
+                    };
+                }) | std::ranges::to<std::vector>();
     }
 }

--- a/trlevel/tr_rooms.h
+++ b/trlevel/tr_rooms.h
@@ -53,4 +53,5 @@ namespace trlevel
     std::vector<trview_room_vertex> convert_vertices(std::vector<tr2_room_vertex> vertices);
     std::vector<trview_room_vertex> convert_vertices(std::vector<tr3_room_vertex> vertices);
     std::vector<trview_room_vertex> convert_vertices(std::vector<tr5_room_vertex> vertices);
+    std::vector<trview_room_vertex> convert_vertices_tr3_psx(std::vector<uint32_t> vertices, int32_t y_top);
 }

--- a/trlevel/trtypes.cpp
+++ b/trlevel/trtypes.cpp
@@ -186,4 +186,23 @@ namespace trlevel
             | std::views::transform([](const auto& vert) { return tr_vertex{ vert.x, vert.y, vert.z }; })
             | std::ranges::to<std::vector>();
     }
+
+    std::vector<tr4_mesh_face3> convert_tr3_psx_room_triangles(std::vector<uint32_t> triangles, uint16_t total_vertices)
+    {
+        return triangles |
+            std::views::transform([=](const auto& t)
+                {
+                    return tr4_mesh_face3
+                    {
+                        .vertices =
+                        {
+                            static_cast<uint16_t>(total_vertices + (t & 0x7f)),
+                            static_cast<uint16_t>(total_vertices + ((t >> 7) & 0x7f)),
+                            static_cast<uint16_t>(total_vertices + ((t >> 14) & 0x7f))
+                        },
+                        .texture = static_cast<uint16_t>(t >> 21),
+                        .effects = 0
+                    };
+                }) | std::ranges::to<std::vector>();
+    }
 }

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -478,10 +478,11 @@ namespace trlevel
         uint16_t Clut;
         uint8_t x1;
         uint8_t y1;
-        uint16_t Tile : 14, : 2;
+        uint16_t Tile;
         uint8_t x2;
         uint8_t y2;
-        uint16_t Unknown;
+        uint8_t tri_draw;
+        uint8_t quad_draw;
         uint8_t x3;
         uint8_t y3;
         uint16_t Attribute;
@@ -864,6 +865,8 @@ namespace trlevel
     std::vector<tr_model> convert_models(std::vector<tr5_model> models);
 
     std::vector<tr_vertex> convert_vertices(std::vector<tr_vertex_psx> vertices);
+
+    std::vector<tr4_mesh_face3> convert_tr3_psx_room_triangles(std::vector<uint32_t> triangles, uint16_t total_vertices);
 
     constexpr LightType convert(LightTypeTR3 type);
 }

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -112,7 +112,11 @@ namespace trview
             const uint32_t end_pointer = static_cast<uint32_t>(model.StartingMesh + model.NumMeshes);
             for (uint32_t mesh_pointer = model.StartingMesh; mesh_pointer < end_pointer; ++mesh_pointer)
             {
-                _meshes.push_back(mesh_storage.mesh(mesh_pointer));
+                auto mesh = mesh_storage.mesh(mesh_pointer);
+                if (mesh)
+                {
+                    _meshes.push_back(mesh);
+                }
             }
         }
     }
@@ -225,7 +229,7 @@ namespace trview
         {
             for (const auto& triangle : _meshes[i]->transparent_triangles())
             {
-                transparency.add(triangle.transform(_world_transforms[i] * _world, colour));
+                transparency.add(triangle.transform(_world_transforms[i] * _world, colour, true));
             }
         }
 
@@ -234,7 +238,7 @@ namespace trview
             auto world = create_billboard(_position, _offset, _scale, camera);
             for (const auto& triangle : _sprite_mesh->transparent_triangles())
             {
-                transparency.add(triangle.transform(world, colour));
+                transparency.add(triangle.transform(world, colour, true));
             }
         }
     }

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -481,7 +481,7 @@ namespace trview
             {
                 for (const auto& triangle : _mesh->transparent_triangles())
                 {
-                    transparency.add(triangle.transform(_room_offset, colour));
+                    transparency.add(triangle.transform(_room_offset, colour, !has_flag(render_filter, RenderFilter::Lighting)));
                 }
 
                 for (const auto& static_mesh : _static_meshes)
@@ -656,7 +656,7 @@ namespace trview
 
             const auto add_tri = [&triangles](const Vector3& v0, const Vector3& v1, const Vector3& v2)
             {
-                triangles.push_back(TransparentTriangle(v0, v1, v2, ITrigger::Trigger_Colour));
+                triangles.push_back(TransparentTriangle(v0, v1, v2, ITrigger::Trigger_Colour, ITrigger::Trigger_Colour, ITrigger::Trigger_Colour));
             };
 
             // + Y

--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -48,6 +48,11 @@ namespace trview
 
     void StaticMesh::render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour)
     {
+        if (!_mesh)
+        {
+            return;
+        }
+
         if (_type == Type::Sprite)
         {
             _world = create_billboard(_position, Vector3(0, -0.5f, 0), _scale, camera);
@@ -68,6 +73,11 @@ namespace trview
 
     void StaticMesh::get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour)
     {
+        if (!_mesh)
+        {
+            return;
+        }
+
         if (_type == Type::Sprite)
         {
             _world = create_billboard(_position, Vector3(0, -0.5f, 0), _scale, camera);
@@ -75,12 +85,17 @@ namespace trview
 
         for (const auto& triangle : _mesh->transparent_triangles())
         {
-            transparency.add(triangle.transform(_world, colour));
+            transparency.add(triangle.transform(_world, colour, true));
         }
     }
 
     PickResult StaticMesh::pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const
     {
+        if (!_mesh)
+        {
+            return {};
+        }
+
         const auto transform = _world.Invert();
         auto normal_direction = Vector3::TransformNormal(direction, transform);
         normal_direction.Normalize();

--- a/trview.app/Elements/Trigger.cpp
+++ b/trview.app/Elements/Trigger.cpp
@@ -149,7 +149,7 @@ namespace trview
         using namespace DirectX::SimpleMath;
         for (auto& triangle : _mesh->transparent_triangles())
         {
-            transparency.add(triangle.transform(Matrix::Identity, colour));
+            transparency.add(triangle.transform(Matrix::Identity, colour, true));
         }
     }
 

--- a/trview.app/Geometry/IMesh.cpp
+++ b/trview.app/Geometry/IMesh.cpp
@@ -50,8 +50,8 @@ namespace trview
 
             std::vector<TransparentTriangle> transparent_triangles
             {
-                { vertices[0].pos, vertices[1].pos, vertices[2].pos, vertices[0].uv, vertices[1].uv, vertices[2].uv, tile, TransparentTriangle::Mode::Normal },
-                { vertices[2].pos, vertices[1].pos, vertices[3].pos, vertices[2].uv, vertices[1].uv, vertices[3].uv, tile, TransparentTriangle::Mode::Normal },
+                { vertices[0].pos, vertices[1].pos, vertices[2].pos, vertices[0].uv, vertices[1].uv, vertices[2].uv, tile, TransparentTriangle::Mode::Normal, Colour::White, Colour::White, Colour::White },
+                { vertices[2].pos, vertices[1].pos, vertices[3].pos, vertices[2].uv, vertices[1].uv, vertices[3].uv, tile, TransparentTriangle::Mode::Normal, Colour::White, Colour::White, Colour::White },
             };
 
             std::vector<Triangle> collision_triangles
@@ -264,13 +264,18 @@ namespace trview
                 uvs[i] = texture_storage.uv(texture, i);
             }
 
+            if (texture_storage.platform_and_version().platform == Platform::PSX)
+            {
+                std::swap(uvs[2], uvs[3]);
+            }
+
             const bool double_sided = rect.texture & 0x8000;
 
             TransparentTriangle::Mode transparency_mode;
             if (determine_transparency(texture_storage.attribute(texture), rect.effects, transparency_mode))
             {
-                transparent_triangles.emplace_back(verts[0], verts[1], verts[2], uvs[0], uvs[1], uvs[2], texture_storage.tile(texture), transparency_mode);
-                transparent_triangles.emplace_back(verts[2], verts[3], verts[0], uvs[2], uvs[3], uvs[0], texture_storage.tile(texture), transparency_mode);
+                transparent_triangles.emplace_back(verts[0], verts[1], verts[2], uvs[0], uvs[1], uvs[2], texture_storage.tile(texture), transparency_mode, colors[0], colors[1], colors[2]);
+                transparent_triangles.emplace_back(verts[2], verts[3], verts[0], uvs[2], uvs[3], uvs[0], texture_storage.tile(texture), transparency_mode, colors[2], colors[3], colors[0]);
                 if (transparent_collision)
                 {
                     collision_triangles.emplace_back(verts[0], verts[1], verts[2]);
@@ -280,8 +285,8 @@ namespace trview
                 if (double_sided)
                 {
 
-                    transparent_triangles.emplace_back(verts[2], verts[1], verts[0], uvs[2], uvs[1], uvs[0], texture_storage.tile(texture), transparency_mode);
-                    transparent_triangles.emplace_back(verts[0], verts[3], verts[2], uvs[0], uvs[3], uvs[2], texture_storage.tile(texture), transparency_mode);
+                    transparent_triangles.emplace_back(verts[2], verts[1], verts[0], uvs[2], uvs[1], uvs[0], texture_storage.tile(texture), transparency_mode, colors[2], colors[1], colors[0]);
+                    transparent_triangles.emplace_back(verts[0], verts[3], verts[2], uvs[0], uvs[3], uvs[2], texture_storage.tile(texture), transparency_mode, colors[0], colors[3], colors[2]);
                     if (transparent_collision)
                     {
                         collision_triangles.emplace_back(verts[2], verts[1], verts[0]);
@@ -365,14 +370,14 @@ namespace trview
             TransparentTriangle::Mode transparency_mode;
             if (determine_transparency(texture_storage.attribute(texture), tri.effects, transparency_mode))
             {
-                transparent_triangles.emplace_back(verts[0], verts[1], verts[2], uvs[0], uvs[1], uvs[2], texture_storage.tile(texture), transparency_mode);
+                transparent_triangles.emplace_back(verts[0], verts[1], verts[2], uvs[0], uvs[1], uvs[2], texture_storage.tile(texture), transparency_mode, colors[0], colors[1], colors[2]);
                 if (transparent_collision)
                 {
                     collision_triangles.emplace_back(verts[0], verts[1], verts[2]);
                 }
                 if (double_sided)
                 {
-                    transparent_triangles.emplace_back(verts[2], verts[1], verts[0], uvs[2], uvs[1], uvs[0], texture_storage.tile(texture), transparency_mode);
+                    transparent_triangles.emplace_back(verts[2], verts[1], verts[0], uvs[2], uvs[1], uvs[0], texture_storage.tile(texture), transparency_mode, colors[2], colors[1], colors[0]);
                     if (transparent_collision)
                     {
                         collision_triangles.emplace_back(verts[2], verts[1], verts[0]);

--- a/trview.app/Geometry/TransparencyBuffer.cpp
+++ b/trview.app/Geometry/TransparencyBuffer.cpp
@@ -197,7 +197,7 @@ namespace trview
             auto normal = triangle.normal();
             for (uint32_t i = 0; i < 3; ++i)
             {
-                _vertices[index++] = { triangle.vertices[i], normal, triangle.uvs[i], triangle.colour };
+                _vertices[index++] = { triangle.vertices[i], normal, triangle.uvs[i], triangle.colours[i] };
             }
         }
 

--- a/trview.app/Geometry/TransparentTriangle.cpp
+++ b/trview.app/Geometry/TransparentTriangle.cpp
@@ -4,16 +4,16 @@ using namespace DirectX::SimpleMath;
 
 namespace trview
 {
-    TransparentTriangle::TransparentTriangle(const Vector3& v0, const Vector3& v1, const Vector3& v2, const Vector2& uv0, const Vector2& uv1, const Vector2& uv2, uint32_t texture, Mode mode, Color colour)
-        : vertices{ v0, v1, v2 }, uvs{ uv0, uv1, uv2 }, texture(texture), mode(mode), colour(colour)
+    TransparentTriangle::TransparentTriangle(const Vector3& v0, const Vector3& v1, const Vector3& v2, const Vector2& uv0, const Vector2& uv1, const Vector2& uv2, uint32_t texture, Mode mode, const DirectX::SimpleMath::Color& c0, const DirectX::SimpleMath::Color& c1, const DirectX::SimpleMath::Color& c2)
+        : vertices{ v0, v1, v2 }, uvs{ uv0, uv1, uv2 }, texture(texture), mode(mode), colours{ c0, c1, c2 }
     {
         Vector3 minimum = Vector3::Min(Vector3::Min(v0, v1), v2);
         Vector3 maximum = Vector3::Max(Vector3::Max(v0, v1), v2);
         position = Vector3::Lerp(minimum, maximum, 0.5f);
     }
 
-    TransparentTriangle::TransparentTriangle(const Vector3& v0, const Vector3& v1, const Vector3& v2, const Color& colour)
-        : TransparentTriangle(v0, v1, v2, Vector2::Zero, Vector2::Zero, Vector2::Zero, Untextured, Mode::Normal, colour)
+    TransparentTriangle::TransparentTriangle(const Vector3& v0, const Vector3& v1, const Vector3& v2, const DirectX::SimpleMath::Color& c0, const DirectX::SimpleMath::Color& c1, const DirectX::SimpleMath::Color& c2)
+        : TransparentTriangle(v0, v1, v2, Vector2::Zero, Vector2::Zero, Vector2::Zero, Untextured, Mode::Normal, c0, c1, c2)
     {
     }
 
@@ -26,14 +26,17 @@ namespace trview
         return first.Cross(second);
     }
 
-    TransparentTriangle TransparentTriangle::transform(const DirectX::SimpleMath::Matrix& matrix, const DirectX::SimpleMath::Color& colour_override) const
+    TransparentTriangle TransparentTriangle::transform(const DirectX::SimpleMath::Matrix& matrix, const DirectX::SimpleMath::Color& colour_override, bool use_colour_override) const
     {
         using namespace DirectX::SimpleMath;
         return TransparentTriangle(
             Vector3::Transform(vertices[0], matrix),
             Vector3::Transform(vertices[1], matrix),
             Vector3::Transform(vertices[2], matrix),
-            uvs[0], uvs[1], uvs[2], texture, mode, colour_override);
+            uvs[0], uvs[1], uvs[2], texture, mode, 
+            use_colour_override ? colour_override : colours[0],
+            use_colour_override ? colour_override : colours[1],
+            use_colour_override ? colour_override : colours[2]);
     }
 
     // Determine whether the face should be transparent give the attribute and effects values. The 

--- a/trview.app/Geometry/TransparentTriangle.h
+++ b/trview.app/Geometry/TransparentTriangle.h
@@ -17,18 +17,18 @@ namespace trview
 
         TransparentTriangle(const DirectX::SimpleMath::Vector3& v0, const DirectX::SimpleMath::Vector3& v1, const DirectX::SimpleMath::Vector3& v2,
             const DirectX::SimpleMath::Vector2& uv0, const DirectX::SimpleMath::Vector2& uv1, const DirectX::SimpleMath::Vector2& uv2,
-            uint32_t texture, Mode mode, DirectX::SimpleMath::Color = { 1,1,1,1 });
+            uint32_t texture, Mode mode, const DirectX::SimpleMath::Color& c0, const DirectX::SimpleMath::Color& c1, const DirectX::SimpleMath::Color& c2);
 
         /// Create an untextured transparent triangle with the specified colour.
         /// @param v0 The first vertex.
         /// @param v1 The second vertex.
         /// @param v2 The third vertex.
         /// @param colour The colour for the triangle.
-        TransparentTriangle(const DirectX::SimpleMath::Vector3& v0, const DirectX::SimpleMath::Vector3& v1, const DirectX::SimpleMath::Vector3& v2, const DirectX::SimpleMath::Color& colour);
+        TransparentTriangle(const DirectX::SimpleMath::Vector3& v0, const DirectX::SimpleMath::Vector3& v1, const DirectX::SimpleMath::Vector3& v2, const DirectX::SimpleMath::Color& c0, const DirectX::SimpleMath::Color& c1, const DirectX::SimpleMath::Color& c2);
 
         DirectX::SimpleMath::Vector3 normal() const;
 
-        TransparentTriangle transform(const DirectX::SimpleMath::Matrix& matrix, const DirectX::SimpleMath::Color& colour_override) const;
+        TransparentTriangle transform(const DirectX::SimpleMath::Matrix& matrix, const DirectX::SimpleMath::Color& colour_override, bool use_colour_override) const;
 
         // The world space positions that make up the triangle.
         DirectX::SimpleMath::Vector3 vertices[3];
@@ -41,7 +41,7 @@ namespace trview
         
         Mode                         mode;
 
-        DirectX::SimpleMath::Color   colour{ 1, 1, 1, 1 };
+        DirectX::SimpleMath::Color   colours[3];
     };
 
     // Determine whether the face should be transparent give the attribute and effects values. The 

--- a/trview.app/Graphics/ILevelTextureStorage.h
+++ b/trview.app/Graphics/ILevelTextureStorage.h
@@ -33,6 +33,8 @@ namespace trview
         virtual graphics::Texture geometry_texture() const = 0;
 
         virtual uint32_t num_object_textures() const = 0;
+
+        virtual trlevel::PlatformAndVersion platform_and_version() const = 0;
     };
 }
 

--- a/trview.app/Graphics/LevelTextureStorage.cpp
+++ b/trview.app/Graphics/LevelTextureStorage.cpp
@@ -139,6 +139,11 @@ namespace trview
         return static_cast<uint32_t>(_object_textures.size());
     }
 
+    trlevel::PlatformAndVersion LevelTextureStorage::platform_and_version() const
+    {
+        return { .platform = _platform, .version = _version };
+    }
+
     void LevelTextureStorage::load(const std::shared_ptr<trlevel::ILevel>& level)
     {
         _version = level->get_version();

--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -29,6 +29,7 @@ namespace trview
         virtual DirectX::SimpleMath::Color palette_from_texture(uint32_t texture) const override;
         virtual graphics::Texture geometry_texture() const override;
         virtual uint32_t num_object_textures() const override;
+        trlevel::PlatformAndVersion platform_and_version() const override;
         void load(const std::shared_ptr<trlevel::ILevel>& level);
         void add_textile(const std::vector<uint32_t>& textile);
     private:

--- a/trview.app/Mocks/Graphics/ILevelTextureStorage.h
+++ b/trview.app/Mocks/Graphics/ILevelTextureStorage.h
@@ -23,6 +23,7 @@ namespace trview
             MOCK_METHOD(DirectX::SimpleMath::Color, palette_from_texture, (uint32_t), (const, override));
             MOCK_METHOD(graphics::Texture, geometry_texture, (), (const, override));
             MOCK_METHOD(uint32_t, num_object_textures, (), (const, override));
+            MOCK_METHOD(trlevel::PlatformAndVersion, platform_and_version, (), (const, override));
         };
     }
 }

--- a/trview.app/Windows/Diff/DiffWindow.cpp
+++ b/trview.app/Windows/Diff/DiffWindow.cpp
@@ -772,7 +772,7 @@ namespace trview
                             bool open = false;
                             if (item_diff.type == Diff::Type::Update)
                             {
-                                open = ImGui::TreeNodeEx(row_text.c_str(), ImGuiTreeNodeFlags_OpenOnArrow);
+                                open = ImGui::TreeNodeEx(row_text.c_str(), ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_DefaultOpen);
                             }
                             else
                             {


### PR DESCRIPTION
Load TR3 PSX levels.
As part of this also add lighting for transparent geometry as the level is being rendered as potentially transparent for now.
Diff window now auto expands changes.
#174