### PR TITLE
Re-add 'Trigger References' label to Items Window

### DIFF
--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -491,6 +491,7 @@ namespace trview
 
     void ItemsWindow::render_trigger_references()
     {
+        ImGui::Text("Trigger References");
         if (ImGui::BeginTable(Names::triggers_list.c_str(), 3, ImGuiTableFlags_ScrollY | ImGuiTableFlags_Sortable | ImGuiTableFlags_SizingFixedFit, ImVec2(-1, -1)))
         {
             ImGui::TableSetupColumn("#");


### PR DESCRIPTION
Label was removed when adding trigger triggerer information.
Closes #1368