### PR TITLE
Add support for OPSM US 5 TR2 demo, OPSM US 15 TR3 demo

### DIFF
--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -163,6 +163,7 @@ namespace trlevel
         virtual tr_camera get_camera(uint32_t index) const = 0;
 
         virtual Platform platform() const = 0;
+        virtual PlatformAndVersion platform_and_version() const = 0;
 
         struct LoadCallbacks
         {

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -84,6 +84,11 @@ namespace trlevel
                 return false;
             }
         }
+
+        bool is_tr1_frame_format(PlatformAndVersion version)
+        {
+            return version.version == LevelVersion::Tomb1 || is_tr2_demo_70688(version.raw_version);
+        }
     }
 
     Level::Level(const std::string& filename, const std::shared_ptr<trview::IFiles>& files, const std::shared_ptr<IDecrypter>& decrypter, const std::shared_ptr<trview::ILog>& log)
@@ -322,7 +327,7 @@ namespace trlevel
 
         // Tomb Raider I has the mesh count in the frame structure - all other tombs
         // already know based on the number of meshes.
-        if (get_version() == LevelVersion::Tomb1)
+        if (is_tr1_frame_format(_platform_and_version))
         {
             mesh_count = _frames[offset++];
         }
@@ -336,7 +341,7 @@ namespace trlevel
             uint16_t mode = 0;
 
             // Tomb Raider I has reversed words and always uses the two word format.
-            if (get_version() == LevelVersion::Tomb1)
+            if (is_tr1_frame_format(_platform_and_version))
             {
                 next = _frames[offset++];
                 data = _frames[offset++];

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -128,7 +128,7 @@ namespace trlevel
                 }
                 else if (_platform_and_version.version == LevelVersion::Tomb2)
                 {
-                    if (is_tr2_beta(_raw_version))
+                    if (is_tr2_beta(_platform_and_version.raw_version))
                     {
                         generate_mesh_tr2_psx_beta(mesh, stream);
                     }
@@ -546,40 +546,38 @@ namespace trlevel
     void Level::read_header(std::basic_ispanstream<uint8_t>& file, std::vector<uint8_t>& bytes, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
         log_file(activity, file, "Reading version number from file");
-        _raw_version = read<uint32_t>(file);
-        _platform_and_version = convert_level_version(_raw_version);
+        uint32_t raw_version = read<uint32_t>(file);
+        _platform_and_version = convert_level_version(raw_version);
 
-        log_file(activity, file, std::format("Version number is {:X} ({}), Platform is {}", _raw_version, to_string(get_version()), to_string(platform())));
+        log_file(activity, file, std::format("Version number is {:X} ({}), Platform is {}", raw_version, to_string(get_version()), to_string(platform())));
         if (_platform_and_version.version == LevelVersion::Unknown)
         {
             // Test for TR2 PSX
             if (check_for_tr2_psx(file))
             {
-                _raw_version = read<uint32_t>(file);
-                _platform_and_version = { .platform = Platform::PSX, .version = LevelVersion::Tomb2 };
-                log_file(activity, file, std::format("Version number is {:X} ({}), Platform is {}", _raw_version, to_string(get_version()), to_string(platform())));
+                _platform_and_version = { .platform = Platform::PSX, .version = LevelVersion::Tomb2, .raw_version = read<uint32_t>(file) };
+                log_file(activity, file, std::format("Version number is {:X} ({}), Platform is {}", _platform_and_version.raw_version, to_string(get_version()), to_string(platform())));
             }
             else
             {
-                throw LevelLoadException(std::format("Unknown level version ({})", _raw_version));
+                throw LevelLoadException(std::format("Unknown level version ({})", _platform_and_version.raw_version));
             }
         }
 
-        if (_raw_version == 0x63345254)
+        if (_platform_and_version.raw_version == 0x63345254)
         {
             callbacks.on_progress("Decrypting");
             log_file(activity, file, std::format("File is encrypted, decrypting"));
             _decrypter->decrypt(bytes);
             file.seekg(0, std::ios::beg);
-            _raw_version = read<uint32_t>(file);
-            _platform_and_version = convert_level_version(_raw_version);
-            log_file(activity, file, std::format("Version number is {:X} ({})", _raw_version, to_string(get_version())));
+            _platform_and_version = convert_level_version(read<uint32_t>(file));
+            log_file(activity, file, std::format("Version number is {:X} ({})", _platform_and_version.raw_version, to_string(get_version())));
         }
 
         if (is_tr5(activity, get_version(), trview::to_utf16(_filename)))
         {
             _platform_and_version.version = LevelVersion::Tomb5;
-            log_file(activity, file, std::format("Version number is {:X} ({})", _raw_version, to_string(get_version())));
+            log_file(activity, file, std::format("Version number is {:X} ({})", _platform_and_version.raw_version, to_string(get_version())));
         }
     }
 
@@ -713,5 +711,10 @@ namespace trlevel
                 face.texture += static_cast<uint16_t>(_object_textures_psx.size());
             }
         }
+    }
+
+    PlatformAndVersion Level::platform_and_version() const
+    {
+        return _platform_and_version;
     }
 }

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -195,6 +195,7 @@ namespace trlevel
         void load_tr2_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr2_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr2_psx_beta(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void load_tr2_psx_demo_70688(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr3_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr4_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -169,6 +169,7 @@ namespace trlevel
         std::vector<tr_x_sound_details> sound_details() const override;
         std::vector<int16_t> sound_map() const override;
         bool trng() const override;
+        PlatformAndVersion platform_and_version() const override;
     private:
         void generate_meshes(const std::vector<uint16_t>& mesh_data);
         tr_colour4 colour_from_object_texture(uint32_t texture) const;
@@ -213,7 +214,6 @@ namespace trlevel
         void generate_mesh_tr3_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
 
         PlatformAndVersion _platform_and_version;
-        uint32_t _raw_version{ 0u };
 
         std::vector<tr_colour>  _palette;
         std::vector<tr_colour4> _palette16;

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -186,6 +186,7 @@ namespace trlevel
         void read_textiles_tr1_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr2_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr2_psx_beta(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void read_textiles_tr2_psx_demo_70688(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_sprite_textures_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void adjust_room_textures_psx();

--- a/trlevel/LevelVersion.cpp
+++ b/trlevel/LevelVersion.cpp
@@ -56,4 +56,9 @@ namespace trlevel
     {
         return ((version & 0xff) == 0x20) && (version & 0xff0000 || trview::equals_any(version, 0xf820u, 0xd620u, 0x1220u, 0x1a20u));
     }
+
+    bool is_tr2_demo_70688(uint32_t version)
+    {
+        return version == 70688;
+    }
 }

--- a/trlevel/LevelVersion.cpp
+++ b/trlevel/LevelVersion.cpp
@@ -3,6 +3,42 @@
 
 namespace trlevel
 {
+    namespace
+    {
+        PlatformAndVersion platform_and_version(uint32_t version)
+        {
+            if (version == 0x34585254)
+            {
+                return { .platform = Platform::PC, .version = LevelVersion::Tomb4, .remastered = true };
+            }
+            else if (version == 0x35585254)
+            {
+                return { .platform = Platform::PC, .version = LevelVersion::Tomb5, .remastered = true };
+            }
+
+            switch (version & 0xff)
+            {
+            case 0x20:
+                if (is_tr2_beta(version))
+                {
+                    return { .platform = Platform::PSX, .version = LevelVersion::Tomb2 };
+                }
+                return { .platform = (version & 0xff00) ? Platform::PSX : Platform::PC, .version = LevelVersion::Tomb1 };
+            case 0x2D:
+                return { .platform = Platform::PC, .version = LevelVersion::Tomb2 };
+            case 0x34:
+            case 0x38:
+                return { .platform = Platform::PC, .version = LevelVersion::Tomb3 };
+            case 0xc8:
+            case 0xcb:  //TR3 PSX ECTS Demos
+                return { .platform = Platform::PSX, .version = LevelVersion::Tomb3 };
+            case 0x54:
+                return { .platform = Platform::PC, .version = LevelVersion::Tomb4 };
+            }
+            return { .platform = Platform::Unknown, .version = LevelVersion::Unknown };
+        }
+    }
+
     // Converts the level version number into a level version enumeration.
     // This will never return tomb5 as more information is required in order to 
     // make that determination.
@@ -10,35 +46,9 @@ namespace trlevel
     // Returns: The level version.
     PlatformAndVersion convert_level_version(uint32_t version)
     {
-        if (version == 0x34585254)
-        {
-            return { .platform = Platform::PC, .version = LevelVersion::Tomb4, .remastered = true };
-        }
-        else if (version == 0x35585254)
-        {
-            return { .platform = Platform::PC, .version = LevelVersion::Tomb5, .remastered = true };
-        }
-
-        switch (version & 0xff)
-        {
-        case 0x20:
-            if (is_tr2_beta(version))
-            {
-                return { .platform = Platform::PSX, .version = LevelVersion::Tomb2 };
-            }
-            return { .platform = (version & 0xff00) ? Platform::PSX : Platform::PC, .version = LevelVersion::Tomb1 };
-        case 0x2D:
-            return { .platform = Platform::PC, .version = LevelVersion::Tomb2 };
-        case 0x34:
-        case 0x38:
-            return { .platform = Platform::PC, .version = LevelVersion::Tomb3 }; 
-        case 0xc8:
-        case 0xcb:  //TR3 PSX ECTS Demos
-            return { .platform = Platform::PSX, .version = LevelVersion::Tomb3 };
-        case 0x54:
-            return { .platform = Platform::PC, .version = LevelVersion::Tomb4 };
-        }
-        return { .platform = Platform::Unknown, .version = LevelVersion::Unknown };
+        auto result = platform_and_version(version);
+        result.raw_version = version;
+        return result;
     }
 
     constexpr bool is_tr2_beta(uint32_t version)

--- a/trlevel/LevelVersion.cpp
+++ b/trlevel/LevelVersion.cpp
@@ -30,6 +30,7 @@ namespace trlevel
             case 0x38:
                 return { .platform = Platform::PC, .version = LevelVersion::Tomb3 };
             case 0xc8:
+            case 0xc9:
             case 0xcb:  //TR3 PSX ECTS Demos
                 return { .platform = Platform::PSX, .version = LevelVersion::Tomb3 };
             case 0x54:

--- a/trlevel/LevelVersion.h
+++ b/trlevel/LevelVersion.h
@@ -44,6 +44,7 @@ namespace trlevel
     PlatformAndVersion convert_level_version(uint32_t version);
 
     constexpr bool is_tr2_beta(uint32_t version);
+    bool is_tr2_demo_70688(uint32_t version);
 
     constexpr std::string to_string(LevelVersion version) noexcept;
     constexpr std::string to_string(Platform platform) noexcept;

--- a/trlevel/LevelVersion.h
+++ b/trlevel/LevelVersion.h
@@ -28,6 +28,7 @@ namespace trlevel
         Platform platform{ Platform::Unknown };
         LevelVersion version{ LevelVersion::Unknown };
         bool remastered{ false };
+        uint32_t raw_version{ 0 };
     };
 
     inline bool operator==(const PlatformAndVersion & l, const PlatformAndVersion & r)
@@ -56,6 +57,7 @@ struct std::hash<trlevel::PlatformAndVersion>
         std::size_t result = 17;
         result = result * 31 + std::hash<trlevel::Platform>()(p.platform);
         result = result * 31 + std::hash<trlevel::LevelVersion>()(p.version);
+        result = result * 31 + std::hash<bool>()(p.remastered);
         return result;
     }
 };

--- a/trlevel/Level_tr1_psx.cpp
+++ b/trlevel/Level_tr1_psx.cpp
@@ -185,7 +185,7 @@ namespace trlevel
         for (const auto& t : _textile16)
         {
             callbacks.on_textile(convert_textile(t));
-        };
+        }
 
         _sprite_sequences = read_sprite_sequences(activity, file, callbacks);
         _cameras = read_cameras(activity, file, callbacks);

--- a/trlevel/Level_tr2_psx.cpp
+++ b/trlevel/Level_tr2_psx.cpp
@@ -359,7 +359,7 @@ namespace trlevel
 
     void Level::load_tr2_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
-        if (is_tr2_beta(_raw_version))
+        if (is_tr2_beta(_platform_and_version.raw_version))
         {
             return load_tr2_psx_beta(file, activity, callbacks);
         }

--- a/trlevel/Level_tr2_psx.cpp
+++ b/trlevel/Level_tr2_psx.cpp
@@ -364,11 +364,7 @@ namespace trlevel
         uint32_t textile_address = read<uint32_t>(file);
         file.seekg(textile_address + 8, std::ios::beg);
 
-        _num_textiles = 18;
-        _textile4 = read_vector<tr_textile4>(file, _num_textiles);
-        _clut = read_vector<tr_clut>(file, 2048);
-        skip(file, 4);
-
+        read_textiles_tr2_psx_demo_70688(file, activity, callbacks);
         _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr2_psx_beta_room);
         _floor_data = read_floor_data(activity, file, callbacks);
         _mesh_data = read_mesh_data(activity, file, callbacks);
@@ -521,5 +517,13 @@ namespace trlevel
         _textile4 = read_vector<tr_textile4>(file, _num_textiles);
         _clut = read_vector<tr_clut>(file, 2048);
         log_file(activity, file, std::format("Read {} textile4s and {} clut", _textile4.size(), _clut.size()));
+    }
+
+    void Level::read_textiles_tr2_psx_demo_70688(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    {
+        _num_textiles = 18;
+        _textile4 = read_vector<tr_textile4>(file, _num_textiles);
+        _clut = read_vector<tr_clut>(file, 2048);
+        skip(file, 4);
     }
 }

--- a/trlevel/Level_tr2_psx.cpp
+++ b/trlevel/Level_tr2_psx.cpp
@@ -2,6 +2,7 @@
 #include "Level_common.h"
 #include "Level_tr2.h"
 #include "Level_psx.h"
+#include "Level_tr1.h"
 
 #include <ranges>
 
@@ -316,8 +317,7 @@ namespace trlevel
         skip(file, 12);
         uint32_t textile_address = read<uint32_t>(file);
         file.seekg(textile_address + 8, std::ios::beg);
-        uint32_t unknown = read<uint32_t>(file);
-        unknown;
+        skip(file, 4);
 
         _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr2_psx_beta_room);
         _floor_data = read_floor_data(activity, file, callbacks);
@@ -341,6 +341,56 @@ namespace trlevel
         read_overlaps(activity, file, callbacks);
         read_zones(activity, file, callbacks, static_cast<uint32_t>(boxes.size()));
         read_animated_textures(activity, file, callbacks);
+
+        _entities = read_entities(activity, file, callbacks);
+        read<int32_t>(file); // Unknown
+
+        for (const auto& t : _textile16)
+        {
+            callbacks.on_textile(convert_textile(t));
+        };
+
+        _sound_map = read_sound_map(activity, file, callbacks);
+        _sound_details = read_sound_details(activity, file, callbacks);
+
+        callbacks.on_progress("Generating meshes");
+        generate_meshes(_mesh_data);
+        callbacks.on_progress("Loading complete");
+    }
+
+    void Level::load_tr2_psx_demo_70688(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    {
+        skip(file, 12);
+        uint32_t textile_address = read<uint32_t>(file);
+        file.seekg(textile_address + 8, std::ios::beg);
+
+        _num_textiles = 18;
+        _textile4 = read_vector<tr_textile4>(file, _num_textiles);
+        _clut = read_vector<tr_clut>(file, 2048);
+        skip(file, 4);
+
+        _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr2_psx_beta_room);
+        _floor_data = read_floor_data(activity, file, callbacks);
+        _mesh_data = read_mesh_data(activity, file, callbacks);
+        _mesh_pointers = read_mesh_pointers(activity, file, callbacks);
+        read_animations_tr1_3(activity, file, callbacks);
+        read_state_changes(activity, file, callbacks);
+        read_anim_dispatches(activity, file, callbacks);
+        read_anim_commands(activity, file, callbacks);
+        _meshtree = read_meshtree(activity, file, callbacks);
+        _frames = read_frames(activity, file, callbacks);
+        _models = read_models_psx(activity, file, callbacks);
+        _static_meshes = read_static_meshes(activity, file, callbacks);
+        read_object_textures_tr2_psx(file, activity, callbacks);
+        read_sprite_textures_psx(file, activity, callbacks);
+        _sprite_sequences = read_sprite_sequences(activity, file, callbacks);
+        _cameras = read_cameras(activity, file, callbacks);
+        _sound_sources = read_sound_sources(activity, file, callbacks);
+        const auto boxes = read_boxes_tr1(activity, file, callbacks);
+        read_overlaps(activity, file, callbacks);
+        read_zones(activity, file, callbacks, static_cast<uint32_t>(boxes.size()));
+        read_animated_textures(activity, file, callbacks);
+
         _entities = read_entities(activity, file, callbacks);
         read<int32_t>(file); // Unknown
 
@@ -361,6 +411,10 @@ namespace trlevel
     {
         if (is_tr2_beta(_platform_and_version.raw_version))
         {
+            if (is_tr2_demo_70688(_platform_and_version.raw_version))
+            {
+                return load_tr2_psx_demo_70688(file, activity, callbacks);
+            }
             return load_tr2_psx_beta(file, activity, callbacks);
         }
 
@@ -399,7 +453,7 @@ namespace trlevel
         for (const auto& t : _textile16)
         {
             callbacks.on_textile(convert_textile(t));
-        };
+        }
 
         _sound_map = read_sound_map(activity, file, callbacks);
         _sound_details = read_sound_details(activity, file, callbacks);

--- a/trlevel/Level_tr2_psx.cpp
+++ b/trlevel/Level_tr2_psx.cpp
@@ -521,9 +521,12 @@ namespace trlevel
 
     void Level::read_textiles_tr2_psx_demo_70688(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
+        callbacks.on_progress("Reading textiles");
+        log_file(activity, file, "Reading textiles");
         _num_textiles = 18;
         _textile4 = read_vector<tr_textile4>(file, _num_textiles);
         _clut = read_vector<tr_clut>(file, 2048);
         skip(file, 4);
+        log_file(activity, file, std::format("Read {} textile4s and {} clut", _textile4.size(), _clut.size()));
     }
 }

--- a/trlevel/Level_tr3_psx.cpp
+++ b/trlevel/Level_tr3_psx.cpp
@@ -14,6 +14,55 @@ namespace trlevel
             return raw_version == -53;
         }
 
+        constexpr int16_t convert_ects_type_id(uint16_t id)
+        {
+            if (id >= 46 && id <= 61)
+            {
+                return id + 4;
+            }
+            if ((id >= 63 && id <= 67) || (id >= 71 && id <= 79))
+            {
+                return id + 3;
+            }
+            if (id >= 180 && id <= 202)
+            {
+                return id + 1;
+            }
+            if (id >= 203 && id <= 237)
+            {
+                return id + 2;
+            }
+
+            if (id >= 261)
+            {
+                return id + 43;
+            }
+
+            if (id >= 257)
+            {
+                return id + 42;
+            }
+
+            if (id >= 233)
+            {
+                return id + 44;
+            }
+
+            switch (id)
+            {
+            case 15:
+                return 13;
+            case 93:
+                return 96;
+            case 243:
+                return 287;
+            case 244:
+                return 288;
+            }
+
+            return id;
+        }
+
         std::vector<trview_room_vertex> convert_vertices_tr3_psx(std::vector<uint32_t> vertices, int32_t y_top)
         {
             return vertices |
@@ -122,7 +171,7 @@ namespace trlevel
     void Level::generate_mesh_tr3_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream)
     {
         // Avoid skybox mesh for now.
-        const uint32_t skybox_id = is_ects(_raw_version) ? 312 : 355;
+        const uint32_t skybox_id = is_ects(_platform_and_version.raw_version) ? 312 : 355;
         const auto skybox_model = std::ranges::find_if(_models, [skybox_id](auto&& m) { return m.ID == skybox_id; });
         if (skybox_model != _models.end())
         {
@@ -227,7 +276,7 @@ namespace trlevel
     {
         auto sound_offsets = read_vector<uint32_t, uint32_t>(file);
         auto sound_data = read_vector<uint32_t, byte>(file);
-        const bool ects = is_ects(_raw_version);
+        const bool ects = is_ects(_platform_and_version.raw_version);
 
         for (int i = 0; i < (ects ? 10 : 13); ++i)
         {

--- a/trlevel/Level_tr3_psx.cpp
+++ b/trlevel/Level_tr3_psx.cpp
@@ -171,7 +171,10 @@ namespace trlevel
     void Level::generate_mesh_tr3_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream)
     {
         // Avoid skybox mesh for now.
-        const uint32_t skybox_id = is_ects(_platform_and_version.raw_version) ? 312 : 355;
+        const uint32_t skybox_id = 
+            is_ects(_platform_and_version.raw_version) ? 312 : 
+            _platform_and_version.raw_version == -55 ? 315 :
+            355;
         const auto skybox_model = std::ranges::find_if(_models, [skybox_id](auto&& m) { return m.ID == skybox_id; });
         if (skybox_model != _models.end())
         {

--- a/trlevel/Mocks/ILevel.h
+++ b/trlevel/Mocks/ILevel.h
@@ -49,6 +49,7 @@ namespace trlevel
             MOCK_METHOD(std::vector<tr_x_sound_details>, sound_details, (), (const, override));
             MOCK_METHOD(std::vector<int16_t>, sound_map, (), (const, override));
             MOCK_METHOD(bool, trng, (), (const, override));
+            MOCK_METHOD(PlatformAndVersion, platform_and_version, (), (const, override));
         };
     }
 }

--- a/trview.app.tests/Elements/TypeInfoLookupTests.cpp
+++ b/trview.app.tests/Elements/TypeInfoLookupTests.cpp
@@ -10,7 +10,7 @@ TEST(TypeInfoLookup, LookupTR1)
 
     TypeInfoLookup lookup(json);
 
-    ASSERT_EQ("Test Name", lookup.lookup(LevelVersion::Tomb1, 123, 0).name);
+    ASSERT_EQ("Test Name", lookup.lookup({ .version = LevelVersion::Tomb1 }, 123, 0).name);
 }
 
 // Tests that if there are identical entries for different games, the correct result is returned.
@@ -20,8 +20,8 @@ TEST(TypeInfoLookup, LookupMultipleGames)
 
     TypeInfoLookup lookup(json);
 
-    ASSERT_EQ("Test Name TR1", lookup.lookup(LevelVersion::Tomb1, 123, 0).name);
-    ASSERT_EQ("Test Name TR2", lookup.lookup(LevelVersion::Tomb2, 123, 0).name);
+    ASSERT_EQ("Test Name TR1", lookup.lookup({ .version = LevelVersion::Tomb1 }, 123, 0).name);
+    ASSERT_EQ("Test Name TR2", lookup.lookup({ .version = LevelVersion::Tomb2 }, 123, 0).name);
 }
 
 // Tests that if the name is missing, it still returns the number.
@@ -31,7 +31,7 @@ TEST(TypeInfoLookup, LookupMissingItem)
 
     TypeInfoLookup lookup(json);
 
-    ASSERT_EQ("123", lookup.lookup(LevelVersion::Tomb3, 123, 0).name);
+    ASSERT_EQ("123", lookup.lookup({ .version = LevelVersion::Tomb3 }, 123, 0).name);
 }
 
 TEST(TypeInfoLookup, LookupNormalMutantEggs)
@@ -39,12 +39,12 @@ TEST(TypeInfoLookup, LookupNormalMutantEggs)
     std::string json = "{\"games\":{\"tr1\":[{\"id\":163,\"name\":\"Test Name 1\"}]}}";
     TypeInfoLookup lookup(json);
 
-    auto winged = lookup.lookup(trlevel::LevelVersion::Tomb1, 163, 0).name;
-    auto shooter = lookup.lookup(trlevel::LevelVersion::Tomb1, 163, 1 << 9).name;
-    auto centaur = lookup.lookup(trlevel::LevelVersion::Tomb1, 163, 2 << 9).name;
-    auto torso = lookup.lookup(trlevel::LevelVersion::Tomb1, 163, 4 << 9).name;
-    auto grounded = lookup.lookup(trlevel::LevelVersion::Tomb1, 163, 8 << 9).name;
-    auto def = lookup.lookup(trlevel::LevelVersion::Tomb1, 163, 3 << 9).name;
+    auto winged = lookup.lookup({ .version = LevelVersion::Tomb1 }, 163, 0).name;
+    auto shooter = lookup.lookup({ .version = LevelVersion::Tomb1 }, 163, 1 << 9).name;
+    auto centaur = lookup.lookup({ .version = LevelVersion::Tomb1 }, 163, 2 << 9).name;
+    auto torso = lookup.lookup({ .version = LevelVersion::Tomb1 }, 163, 4 << 9).name;
+    auto grounded = lookup.lookup({ .version = LevelVersion::Tomb1 }, 163, 8 << 9).name;
+    auto def = lookup.lookup({ .version = LevelVersion::Tomb1 }, 163, 3 << 9).name;
 
     ASSERT_EQ(winged, "Mutant Egg (Winged)");
     ASSERT_EQ(shooter, "Mutant Egg (Shooter)");
@@ -59,12 +59,12 @@ TEST(TypeInfoLookup, LookupBigMutantEggs)
     std::string json = "{\"games\":{\"tr1\":[{\"id\":181,\"name\":\"Test Name 2\"}]}}";
     TypeInfoLookup lookup(json);
 
-    auto winged = lookup.lookup(trlevel::LevelVersion::Tomb1, 181, 0).name;
-    auto shooter = lookup.lookup(trlevel::LevelVersion::Tomb1, 181, 1 << 9).name;
-    auto centaur = lookup.lookup(trlevel::LevelVersion::Tomb1, 181, 2 << 9).name;
-    auto torso = lookup.lookup(trlevel::LevelVersion::Tomb1, 181, 4 << 9).name;
-    auto grounded = lookup.lookup(trlevel::LevelVersion::Tomb1, 181, 8 << 9).name;
-    auto def = lookup.lookup(trlevel::LevelVersion::Tomb1, 181, 3 << 9).name;
+    auto winged = lookup.lookup({ .version = LevelVersion::Tomb1 }, 181, 0).name;
+    auto shooter = lookup.lookup({ .version = LevelVersion::Tomb1 }, 181, 1 << 9).name;
+    auto centaur = lookup.lookup({ .version = LevelVersion::Tomb1 }, 181, 2 << 9).name;
+    auto torso = lookup.lookup({ .version = LevelVersion::Tomb1 }, 181, 4 << 9).name;
+    auto grounded = lookup.lookup({ .version = LevelVersion::Tomb1 }, 181, 8 << 9).name;
+    auto def = lookup.lookup({ .version = LevelVersion::Tomb1 }, 181, 3 << 9).name;
 
     ASSERT_EQ(winged, "Mutant Egg (Winged)");
     ASSERT_EQ(shooter, "Mutant Egg (Shooter)");
@@ -79,7 +79,7 @@ TEST(TypeInfoLookup, LookupNormalMutantEggsTR2)
     std::string json = "{\"games\":{\"tr1\":[{\"id\":163,\"name\":\"Test Name 1\"}],\"tr2\":[{\"id\":163,\"name\":\"Test Name 2\"}]}}";
     TypeInfoLookup lookup(json);
 
-    auto winged = lookup.lookup(trlevel::LevelVersion::Tomb2, 163, 0).name;
+    auto winged = lookup.lookup({ .version = LevelVersion::Tomb2 }, 163, 0).name;
 
     ASSERT_EQ(winged, "Test Name 2");
 }

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -226,14 +226,14 @@ namespace trview
         auto entity_source = [=](auto&& level, auto&& entity, auto&& index, auto&& triggers, auto&& mesh_storage, auto&& owning_level, auto&& room)
         {
             return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index,
-                type_info_lookup->lookup(level.get_version(), entity.TypeID, entity.Flags),
+                type_info_lookup->lookup(level.platform_and_version(), entity.TypeID, entity.Flags),
                 triggers,
                 room);
         };
 
         auto ai_source = [=](auto&& level, auto&& entity, auto&& index, auto&& mesh_storage, auto&& owning_level, auto&& room)
         {
-            return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index, type_info_lookup->lookup(level.get_version(), entity.type_id, entity.flags), std::vector<std::weak_ptr<ITrigger>>{}, room);
+            return std::make_shared<Item>(mesh_source, level, entity, mesh_storage, owning_level, index, type_info_lookup->lookup(level.platform_and_version(), entity.type_id, entity.flags), std::vector<std::weak_ptr<ITrigger>>{}, room);
         };
 
         auto ngplus = std::make_shared<NgPlusSwitcher>(entity_source);

--- a/trview.app/Elements/ITypeInfoLookup.h
+++ b/trview.app/Elements/ITypeInfoLookup.h
@@ -11,6 +11,6 @@ namespace trview
     {
     public:
         virtual ~ITypeInfoLookup() = 0;
-        virtual TypeInfo lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const = 0;
+        virtual TypeInfo lookup(trlevel::PlatformAndVersion level_version, uint32_t type_id, int16_t flags) const = 0;
     };
 }

--- a/trview.app/Elements/TypeInfoLookup.h
+++ b/trview.app/Elements/TypeInfoLookup.h
@@ -11,8 +11,8 @@ namespace trview
     public:
         explicit TypeInfoLookup(const std::string& type_name_json);
         virtual ~TypeInfoLookup() = default;
-        TypeInfo lookup(trlevel::LevelVersion level_version, uint32_t type_id, int16_t flags) const override;
+        TypeInfo lookup(trlevel::PlatformAndVersion level_version, uint32_t type_id, int16_t flags) const override;
     private:
-        std::unordered_map<trlevel::LevelVersion, std::unordered_map<uint32_t, TypeInfo>> _type_names;
+        std::unordered_map<std::string, std::unordered_map<uint32_t, TypeInfo>> _type_names;
     };
 }

--- a/trview.app/Mocks/Elements/ITypeInfoLookup.h
+++ b/trview.app/Mocks/Elements/ITypeInfoLookup.h
@@ -10,7 +10,7 @@ namespace trview
         {
             MockTypeInfoLookup();
             virtual ~MockTypeInfoLookup();
-            MOCK_METHOD(TypeInfo, lookup, (trlevel::LevelVersion, uint32_t, int16_t), (const, override));
+            MOCK_METHOD(TypeInfo, lookup, (trlevel::PlatformAndVersion, uint32_t, int16_t), (const, override));
         };
     }
 }

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -2724,6 +2724,276 @@
                 "categories": [ "Effect", "Scenery" ]
             }
         ],
+        "tr3_ects": [{
+                "id": 0,
+                "name": "Lara",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 16,
+                "name": "Kayak",
+                "categories": [ "Vehicle" ]
+            }, {
+                "id": 22,
+                "name": "Dog",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 23,
+                "name": "Rat",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 33,
+                "name": "Lizard",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 34,
+                "name": "Puna",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 49,
+                "name": "Punk",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 56,
+                "name": "MP (Baton)",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 58,
+                "name": "Prisoner",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 59,
+                "name": "MP (MP5)",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 60,
+                "name": "Gun Turret",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 63,
+                "name": "Tripwire",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 64,
+                "name": "Electrified Wire",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 71,
+                "name": "AI Guard",
+                "categories": [ "AI" ]
+            }, {
+                "id": 73,
+                "name": "AI Patrol 1",
+                "categories": [ "AI" ]
+            }, {
+                "id": 76,
+                "name": "AI Patrol 2",
+                "categories": [ "AI" ]
+            }, {
+                "id": 80,
+                "name": "Breakable tile",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 83,
+                "name": "Propeller/Diver/Meteor",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 85,
+                "name": "Boulder",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 91,
+                "name": "Skeleton Trap",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 94,
+                "name": "Pushable Block 1",
+                "categories": [ "Movable" ]
+            }, {
+                "id": 98,
+                "name": "Breakable Window",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 103,
+                "name": "Hook",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 113,
+                "name": "Spike Wall (Vertical)",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 117,
+                "name": "Wheel Door",
+                "categories": [ "Door" ]
+            }, {
+                "id": 118,
+                "name": "Small Switch",
+                "categories": [ "Switch" ]
+            }, {
+                "id": 107,
+                "name": "Falling Ceiling",
+                "categories": [ "Trap" ]
+            }, {
+                "id" : 127,
+                "name": "Zipline",
+                "categories": [ "Vehicle" ]
+            }, {
+                "id" : 128,
+                "name": "Button",
+                "categories": [ "Switch" ]
+            }, {
+                "id": 129,
+                "name": "Wall Switch",
+                "categories": [ "Switch" ]
+            }, {
+                "id": 131,
+                "name": "Door 1",
+                "categories": [ "Door" ]
+            }, {
+                "id": 132,
+                "name": "Door 2",
+                "categories": [ "Door" ]
+            }, {
+                "id": 133,
+                "name": "Door 3",
+                "categories": [ "Door" ]
+            }, {
+                "id": 134,
+                "name": "Door 4",
+                "categories": [ "Door" ]
+            }, {
+                "id": 135,
+                "name": "Door 5",
+                "categories": [ "Door" ]
+            }, {
+                "id": 136,
+                "name": "Door 6",
+                "categories": [ "Door" ]
+            }, {
+                "id" : 137,
+                "name": "Door 7",
+                "categories": [ "Door" ]
+            }, {
+                "id" : 138,
+                "name": "Door 8",
+                "categories": [ "Door" ]
+            }, {
+                "id": 139,
+                "name": "Trapdoor 1",
+                "categories": [ "Door", "Trapdoor" ]
+            }, {
+                "id": 140,
+                "name": "Trapdoor 2",
+                "categories": [ "Door", "Trapdoor" ]
+            }, {
+                "id": 142,
+                "name": "Bridge (Flat)",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 143,
+                "name": "Bridge (Tilt 1)",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 161,
+                "name": "Shotgun",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 165,
+                "name": "M16",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 166,
+                "name": "Rocket Launcher",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 167,
+                "name": "Grenade Launcher",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 169,
+                "name": "Shotgun shells",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 171,
+                "name": "Uzi ammo",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 174,
+                "name": "Rocket",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 175,
+                "name": "Grenades",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 176,
+                "name": "Small Medipack",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 177,
+                "name": "Large Medipack",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 178,
+                "name": "Flares",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 201,
+                "name": "Large Medipack",
+                "categories": [ "Pickup" ]
+            }, {
+                "id": 203,
+                "name": "Puzzle 1",
+                "categories": [ "Puzzle", "Pickup" ]
+            }, {
+                "id": 204,
+                "name": "Puzzle 2",
+                "categories": [ "Puzzle", "Pickup" ]
+            }, {
+                "id": 211,
+                "name": "Slot 1",
+                "categories": [ "Slot" ]
+            }, {
+                "id": 212,
+                "name": "Slot 2",
+                "categories": [ "Slot" ]
+            }, {
+                "id": 222,
+                "name": "Key 1",
+                "categories": [ "Key" ]
+            }, {
+                "id": 230,
+                "name": "Keyhole 1",
+                "categories": [ "Keyhole" ]
+            }, {
+                "id": 247,
+                "name": "Moving Lasers",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 271,
+                "name": "Movable Boom",
+                "categories": [ "Trap" ]
+            }, {
+                "id": 275,
+                "name": "Alarm Light",
+                "categories": [ "Effect" ]
+            }, {
+                "id": 306,
+                "name": "Animating 1",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 307,
+                "name": "Animating 2",
+                "categories": [ "Scenery" ]
+            }, {
+                "id": 308,
+                "name": "Monster",
+                "categories": [ "Entity" ]
+            }, {
+                "id": 309,
+                "name": "Wasp",
+                "categories": [ "Entity" ]
+            }
+        ],
         "tr4": [{
                 "id": 0,
                 "name": "Lara",


### PR DESCRIPTION
TR2 is version 70688. Interesting mix of TR1 and TR2 formats
TR3 is the same as regular PSX but needed to exclude the skybox from mesh generation.
Start remapping ECTS entity numbers.
#174