### PR TITLE
Add support for TR1 May 1996 PSX level

### DIFF
--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -147,11 +147,6 @@ namespace trlevel
             return;
         }
 
-        // std::ofstream out_file;
-        // out_file.open("c:/dev/trview-temp/aug/meshes.bin", std::ios::out | std::ios::binary);
-        // out_file.write(reinterpret_cast<const char*>(&mesh_data[0]), sizeof(uint16_t) * mesh_data.size());
-        // out_file.close();
-
         // As well as reading the actual mesh data, generate a map of mesh_pointer to 
         // mesh. It seems that a lot of the pointers point to the same mesh.
         std::span span{ reinterpret_cast<const uint8_t*>(&mesh_data[0]), mesh_data.size() * sizeof(uint16_t) };

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -779,4 +779,13 @@ namespace trlevel
     {
         return _platform_and_version;
     }
+
+    uint16_t Level::attribute_for_clut(uint16_t clut_id) const
+    {
+        if (clut_id >= _clut.size())
+        {
+            return 0;
+        }
+        return std::ranges::any_of(_clut[clut_id].Colour, [](auto&& c) { return c.Red == 0 && c.Green == 0 && c.Blue == 0; }) ? 1 : 0;
+    }
 }

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -196,6 +196,7 @@ namespace trlevel
         void load_tr1_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr1_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr1_psx_aug_1996(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void load_tr1_psx_may_1996(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr2_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr2_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr2_psx_beta(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
@@ -214,6 +215,7 @@ namespace trlevel
 
         void generate_mesh(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
         void generate_mesh_tr1_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
+        void generate_mesh_tr1_psx_may_1996(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
         void generate_mesh_tr2_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
         void generate_mesh_tr2_psx_beta(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
         void generate_mesh_tr3_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -174,6 +174,7 @@ namespace trlevel
         void generate_meshes(const std::vector<uint16_t>& mesh_data);
         tr_colour4 colour_from_object_texture(uint32_t texture) const;
         uint16_t convert_textile4(uint16_t tile, uint16_t clut_id);
+        uint16_t attribute_for_clut(uint16_t clut_id) const;
 
         // New level bits:
         void read_header(std::basic_ispanstream<uint8_t>& file, std::vector<uint8_t>& bytes, trview::Activity& activity, const LoadCallbacks& callbacks);

--- a/trlevel/LevelVersion.cpp
+++ b/trlevel/LevelVersion.cpp
@@ -52,6 +52,11 @@ namespace trlevel
         return result;
     }
 
+    bool is_tr1_may_1996(PlatformAndVersion version)
+    {
+        return version.raw_version == 11;
+    }
+
     bool is_tr1_aug_1996(PlatformAndVersion version)
     {
         return version.raw_version == 27;

--- a/trlevel/LevelVersion.h
+++ b/trlevel/LevelVersion.h
@@ -43,6 +43,7 @@ namespace trlevel
     // Returns: The level version.
     PlatformAndVersion convert_level_version(uint32_t version);
 
+    bool is_tr1_may_1996(PlatformAndVersion version);
     bool is_tr1_aug_1996(PlatformAndVersion version);
     bool is_tr2_beta(uint32_t version);
     bool is_tr2_beta(PlatformAndVersion version);

--- a/trlevel/Level_tr1_psx.cpp
+++ b/trlevel/Level_tr1_psx.cpp
@@ -437,6 +437,7 @@ namespace trlevel
         }
 
         read_object_textures_tr1_psx(file, activity, callbacks);
+        std::ranges::for_each(_object_textures, [](auto& t) { t.Attribute = 1; });
         read_sprite_textures_psx(file, activity, callbacks);
 
         for (const auto& t : _textile16)

--- a/trlevel/Level_tr1_psx.cpp
+++ b/trlevel/Level_tr1_psx.cpp
@@ -423,7 +423,6 @@ namespace trlevel
 
         auto static_meshes = read_vector<uint32_t, tr_staticmesh_may_1996>(file);
         log_file(activity, file, std::format("Read {} static meshes", static_meshes.size()));
-        std::unordered_map<uint32_t, tr_staticmesh> mesh_map;
         for (const auto& mesh : static_meshes)
         {
             const tr_staticmesh new_mesh
@@ -434,7 +433,7 @@ namespace trlevel
                 .CollisionBox = mesh.VisibilityBox,
                 .Flags = 0,
             };
-            mesh_map.insert({ mesh.ID, new_mesh });
+            _static_meshes.insert({ mesh.ID, new_mesh });
         }
 
         read_object_textures_tr1_psx(file, activity, callbacks);

--- a/trlevel/Level_tr1_psx.cpp
+++ b/trlevel/Level_tr1_psx.cpp
@@ -10,6 +10,26 @@ namespace trlevel
 {
     namespace
     {
+#pragma pack(push, 1)
+        struct tr_staticmesh_may_1996   // 18 bytes
+        {
+            uint32_t ID;   // Static Mesh Identifier
+            uint16_t Mesh; // Mesh (offset into MeshPointers[])
+            tr_bounding_box VisibilityBox;
+        };
+
+        struct tr_entity_may_1996
+        {
+            int16_t TypeID;
+            int16_t Room;
+            int32_t x;
+            int32_t y;
+            int32_t z;
+            int16_t Angle;
+            uint16_t Flags;
+        };
+#pragma pack(pop)
+
         std::vector<tr_model> read_models_tr1_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks)
         {
             callbacks.on_progress("Reading models");
@@ -61,6 +81,34 @@ namespace trlevel
             read_room_flags(activity, file, room);
         }
 
+        void load_tr1_psx_may_1996_room(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, tr3_room& room)
+        {
+            room.info.x = read<int32_t>(file);
+            room.info.z = read<int32_t>(file);
+
+            uint32_t NumDataWords = read_num_data_words(activity, file);
+            skip(file, 2);
+            if (NumDataWords > 0)
+            {
+                read_room_vertices_tr1(activity, file, room);
+                read_room_rectangles(activity, file, room);
+                read_room_triangles(activity, file, room);
+                read_room_sprites(activity, file, room);
+
+                for (auto& rectangle : room.data.rectangles)
+                {
+                    std::swap(rectangle.vertices[2], rectangle.vertices[3]);
+                }
+            }
+
+            read_room_portals(activity, file, room);
+            read_room_sectors(activity, file, room);
+            read_room_ambient_intensity_1(activity, file, room);
+            read_room_lights_tr1_psx(activity, file, room);
+            read_room_static_meshes_tr1_psx(activity, file, room);
+            read_room_flags(activity, file, room);
+        }
+
         void read_zones_tr1_aug_1996(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t num_boxes)
         {
             callbacks.on_progress("Reading zones");
@@ -68,6 +116,65 @@ namespace trlevel
             std::vector<int16_t> zones = read_vector<int16_t>(file, num_boxes * 4);
             log_file(activity, file, std::format("Read {} zones", zones.size()));
         }
+    }
+
+    void Level::generate_mesh_tr1_psx_may_1996(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream)
+    {
+        mesh.centre = { .x = 0, .y = 0, .z = 0 };
+        mesh.coll_radius = read<uint16_t>(stream);
+        int16_t vertices_count = read<int16_t>(stream);
+        int16_t normals_count = vertices_count;
+        vertices_count = static_cast<int16_t>(std::abs(vertices_count));
+        
+        mesh.vertices = convert_vertices(read_vector<tr_vertex_psx>(stream, vertices_count));
+        
+        for (int i = 0; i < vertices_count; ++i)
+        {
+            if (normals_count > 0)
+            {
+                tr_vertex_psx norm = read<tr_vertex_psx>(stream);
+                norm.w = 1;
+                mesh.normals.push_back({ norm.x, norm.y, norm.z });
+            }
+            else
+            {
+                mesh.lights.push_back(read<int16_t>(stream)); // intensity
+                mesh.normals.push_back({ 0, 0, 0 });
+            }
+        }
+        const auto rectangles = read_vector<int16_t, tr_face4>(stream);
+        const auto triangles = read_vector<int16_t, tr_face3>(stream);
+
+        mesh.textured_rectangles = rectangles
+            | std::views::filter([](const auto& rect) { return rect.texture > 255; })
+            | std::views::transform([](const auto& rect)
+                {
+                    tr4_mesh_face4 new_face4;
+                    memcpy(new_face4.vertices, rect.vertices, sizeof(rect.vertices));
+                    new_face4.texture = rect.texture;
+                    new_face4.effects = 0;
+                    return new_face4;
+                })
+            | std::ranges::to<std::vector>();
+        mesh.textured_triangles = triangles
+            | std::views::filter([](const auto& tri) { return tri.texture > 255; })
+            | std::views::transform([](const auto& tri)
+                {
+                    tr4_mesh_face3 new_face3;
+                    memcpy(new_face3.vertices, tri.vertices, sizeof(tri.vertices));
+                    new_face3.texture = tri.texture;
+                    new_face3.effects = 0;
+                    return new_face3;
+                })
+            | std::ranges::to<std::vector>();
+
+        mesh.coloured_rectangles = rectangles
+            | std::views::filter([](const auto& rect) { return rect.texture < 256; })
+            | std::ranges::to<std::vector>();
+
+        mesh.coloured_triangles = triangles
+            | std::views::filter([](const auto& tri) { return tri.texture < 256; })
+            | std::ranges::to<std::vector>();
     }
 
     void Level::generate_mesh_tr1_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream)
@@ -132,9 +239,14 @@ namespace trlevel
 
     void Level::load_tr1_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
-        if (_platform_and_version.raw_version == 27)
+        if (is_tr1_aug_1996(_platform_and_version))
         {
             return load_tr1_psx_aug_1996(file, activity, callbacks);
+        }
+
+        if (_platform_and_version.raw_version == 11)
+        {
+            return load_tr1_psx_may_1996(file, activity, callbacks);
         }
 
         skip(file, 12);
@@ -277,6 +389,81 @@ namespace trlevel
         _sound_map = read_sound_map(activity, file, callbacks);
         _sound_details = read_sound_details(activity, file, callbacks);
         generate_sounds_tr1(callbacks);
+        callbacks.on_progress("Generating meshes");
+        generate_meshes(_mesh_data);
+        callbacks.on_progress("Loading complete");
+    }
+
+    void Level::load_tr1_psx_may_1996(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    {
+        _num_textiles = 20;
+        _textile4 = read_vector<tr_textile4>(file, _num_textiles);
+        _clut = read_vector<tr_clut>(file, 1024);
+        // skip(file, 772);
+
+        file.seekg(721668, std::ios::beg);
+
+        _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr1_psx_may_1996_room);
+        _floor_data = read_floor_data(activity, file, callbacks);
+        _mesh_data = read_mesh_data(activity, file, callbacks);
+        _mesh_pointers = read_mesh_pointers(activity, file, callbacks);
+
+        uint32_t num_animations = read<uint32_t>(file);
+        skip(file, num_animations * 28);
+
+        read_state_changes(activity, file, callbacks);
+        read_anim_dispatches(activity, file, callbacks);
+        read_anim_commands(activity, file, callbacks);
+        _meshtree = read_meshtree(activity, file, callbacks);
+        _frames = read_frames(activity, file, callbacks);
+        _models = read_models_psx(activity, file, callbacks);
+
+        auto static_meshes = read_vector<uint32_t, tr_staticmesh_may_1996>(file);
+        log_file(activity, file, std::format("Read {} static meshes", static_meshes.size()));
+        std::unordered_map<uint32_t, tr_staticmesh> mesh_map;
+        for (const auto& mesh : static_meshes)
+        {
+            const tr_staticmesh new_mesh
+            {
+                .ID = mesh.ID,
+                .Mesh = mesh.Mesh,
+                .VisibilityBox = mesh.VisibilityBox,
+                .CollisionBox = mesh.VisibilityBox,
+                .Flags = 0,
+            };
+            mesh_map.insert({ mesh.ID, new_mesh });
+        }
+
+        read_object_textures_tr1_psx(file, activity, callbacks);
+        read_sprite_textures_psx(file, activity, callbacks);
+
+        for (const auto& t : _textile16)
+        {
+            callbacks.on_textile(convert_textile(t));
+        }
+
+        _sprite_sequences = read_sprite_sequences(activity, file, callbacks);
+        _cameras = read_cameras(activity, file, callbacks);
+        read_boxes_tr1(activity, file, callbacks);
+        read_overlaps(activity, file, callbacks);
+        read_animated_textures(activity, file, callbacks);
+
+        _entities = read_vector<uint32_t, tr_entity_may_1996>(file) |
+            std::views::transform([](auto&& e) -> tr2_entity {
+                return
+                {
+                    .TypeID = e.TypeID,
+                    .Room = e.Room,
+                    .x = e.x,
+                    .y = e.y,
+                    .z = e.z,
+                    .Angle = e.Angle,
+                    .Intensity1 = 0,
+                    .Intensity2 = 0,
+                    .Flags = e.Flags
+                };
+            }) | std::ranges::to<std::vector>();;
+
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);
         callbacks.on_progress("Loading complete");

--- a/trlevel/Level_tr1_psx.cpp
+++ b/trlevel/Level_tr1_psx.cpp
@@ -248,7 +248,7 @@ namespace trlevel
             return load_tr1_psx_aug_1996(file, activity, callbacks);
         }
 
-        if (_platform_and_version.raw_version == 11)
+        if (is_tr1_may_1996(_platform_and_version))
         {
             return load_tr1_psx_may_1996(file, activity, callbacks);
         }

--- a/trlevel/Level_tr1_psx.cpp
+++ b/trlevel/Level_tr1_psx.cpp
@@ -336,6 +336,7 @@ namespace trlevel
                 {
                     tr_object_texture_psx new_texture = texture;
                     new_texture.Tile = convert_textile4(texture.Tile, texture.Clut);
+                    new_texture.Attribute = attribute_for_clut(texture.Clut);
                     new_texture.Clut = 0U; // Unneeded after conversion
                     return new_texture;
                 })
@@ -437,7 +438,6 @@ namespace trlevel
         }
 
         read_object_textures_tr1_psx(file, activity, callbacks);
-        std::ranges::for_each(_object_textures, [](auto& t) { t.Attribute = 1; });
         read_sprite_textures_psx(file, activity, callbacks);
 
         for (const auto& t : _textile16)

--- a/trlevel/Level_tr1_psx.cpp
+++ b/trlevel/Level_tr1_psx.cpp
@@ -101,6 +101,10 @@ namespace trlevel
                 }
             }
 
+            auto [min, max] = std::ranges::minmax(room.data.vertices | std::views::transform([](auto&& v) { return v.vertex.y; }));
+            room.info.yTop = min;
+            room.info.yBottom = max;
+
             read_room_portals(activity, file, room);
             read_room_sectors(activity, file, room);
             read_room_ambient_intensity_1(activity, file, room);
@@ -399,7 +403,6 @@ namespace trlevel
         _num_textiles = 20;
         _textile4 = read_vector<tr_textile4>(file, _num_textiles);
         _clut = read_vector<tr_clut>(file, 1024);
-        // skip(file, 772);
 
         file.seekg(721668, std::ios::beg);
 

--- a/trview.app/Elements/Floordata.cpp
+++ b/trview.app/Elements/Floordata.cpp
@@ -172,7 +172,7 @@ namespace trview
             return result;
         }
         
-        while (true)
+        while (index < floordata.size())
         {
             // Parse the floordata here.
             const uint16_t floor = floordata[index];

--- a/trview.app/Elements/Floordata.h
+++ b/trview.app/Elements/Floordata.h
@@ -61,9 +61,9 @@ namespace trview
     /// <param name="floordata">The raw floor data.</param>
     /// <param name="index">The index to start at.</param>
     /// <returns>The parsed floor data.</returns>
-    Floordata parse_floordata(const std::vector<uint16_t>& floordata, uint32_t index, FloordataMeanings meanings, bool trng);
+    Floordata parse_floordata(const std::vector<uint16_t>& floordata, uint32_t index, FloordataMeanings meanings, bool trng, std::optional<trlevel::PlatformAndVersion> version = std::nullopt);
 
-    Floordata parse_floordata(const std::vector<uint16_t>& floordata, uint32_t index, FloordataMeanings meanings, const std::vector<std::weak_ptr<IItem>>& items, bool trng);
+    Floordata parse_floordata(const std::vector<uint16_t>& floordata, uint32_t index, FloordataMeanings meanings, const std::vector<std::weak_ptr<IItem>>& items, bool trng, std::optional<trlevel::PlatformAndVersion> version = std::nullopt);
 
     enum class TriangulationDirection
     {

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -134,14 +134,9 @@ namespace trview
         if (model.NumMeshes > 0)
         {
             // Load the frames.
-            auto frame = level.get_frame(model.FrameOffset / 2, model.NumMeshes);
+            auto frame = level.get_frame(trlevel::is_tr1_may_1996(level.platform_and_version()) ? model.FrameOffset : model.FrameOffset / 2, model.NumMeshes);
 
             uint32_t frame_offset = 0;
-            if (frame.values.empty())
-            {
-                _world_transforms.push_back(Matrix::Identity);
-                return;
-            }
 
             auto initial_frame = frame.values[frame_offset++];
 
@@ -180,12 +175,8 @@ namespace trview
 
                 // Get the rotation from the frames.
                 // Rotations are performed in Y, X, Z order.
-                Matrix rotation_matrix = Matrix::Identity;
-                if (frame_offset < frame.values.size())
-                {
-                    auto rotation = frame.values[frame_offset++];
-                    rotation_matrix = get_rotate(rotation);
-                }
+                auto rotation = frame.values[frame_offset++];
+                Matrix rotation_matrix = get_rotate(rotation);
                 Matrix translation_matrix = Matrix::CreateTranslation(node.position());
                 Matrix node_transform = rotation_matrix * translation_matrix * parent_world;
 

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -137,6 +137,11 @@ namespace trview
             auto frame = level.get_frame(model.FrameOffset / 2, model.NumMeshes);
 
             uint32_t frame_offset = 0;
+            if (frame.values.empty())
+            {
+                _world_transforms.push_back(Matrix::Identity);
+                return;
+            }
 
             auto initial_frame = frame.values[frame_offset++];
 
@@ -175,8 +180,12 @@ namespace trview
 
                 // Get the rotation from the frames.
                 // Rotations are performed in Y, X, Z order.
-                auto rotation = frame.values[frame_offset++];
-                Matrix rotation_matrix = get_rotate(rotation);
+                Matrix rotation_matrix = Matrix::Identity;
+                if (frame_offset < frame.values.size())
+                {
+                    auto rotation = frame.values[frame_offset++];
+                    rotation_matrix = get_rotate(rotation);
+                }
                 Matrix translation_matrix = Matrix::CreateTranslation(node.position());
                 Matrix node_transform = rotation_matrix * translation_matrix * parent_world;
 

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -1073,16 +1073,13 @@ namespace trview
         if (has_flag(portal.direct->flags(), SectorFlag::Portal) && portal.direct->portal() != 0xff)
         {
             const auto other_room = level->room(portal.direct->portal()).lock();
-            if (other_room)
+            const auto diff = (position() - other_room->position()) + Vector3(static_cast<float>(x2), 0, static_cast<float>(z2));
+            const int other_id = static_cast<int>(diff.x * other_room->num_z_sectors() + diff.z);
+            const auto sectors = other_room->sectors();
+            if (other_id >= 0 && other_id < std::ssize(sectors))
             {
-                const auto diff = (position() - other_room->position()) + Vector3(static_cast<float>(x2), 0, static_cast<float>(z2));
-                const int other_id = static_cast<int>(diff.x * other_room->num_z_sectors() + diff.z);
-                const auto sectors = other_room->sectors();
-                if (other_id >= 0 && other_id < std::ssize(sectors))
-                {
-                    portal.target = sectors[other_id];
-                    portal.offset = Vector3(static_cast<float>(x2), 0, static_cast<float>(z2)) - diff;
-                }
+                portal.target = sectors[other_id];
+                portal.offset = Vector3(static_cast<float>(x2), 0, static_cast<float>(z2)) - diff;
             }
         }
 

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -1073,13 +1073,16 @@ namespace trview
         if (has_flag(portal.direct->flags(), SectorFlag::Portal) && portal.direct->portal() != 0xff)
         {
             const auto other_room = level->room(portal.direct->portal()).lock();
-            const auto diff = (position() - other_room->position()) + Vector3(static_cast<float>(x2), 0, static_cast<float>(z2));
-            const int other_id = static_cast<int>(diff.x * other_room->num_z_sectors() + diff.z);
-            const auto sectors = other_room->sectors();
-            if (other_id >= 0 && other_id < std::ssize(sectors))
+            if (other_room)
             {
-                portal.target = sectors[other_id];
-                portal.offset = Vector3(static_cast<float>(x2), 0, static_cast<float>(z2)) - diff;
+                const auto diff = (position() - other_room->position()) + Vector3(static_cast<float>(x2), 0, static_cast<float>(z2));
+                const int other_id = static_cast<int>(diff.x * other_room->num_z_sectors() + diff.z);
+                const auto sectors = other_room->sectors();
+                if (other_id >= 0 && other_id < std::ssize(sectors))
+                {
+                    portal.target = sectors[other_id];
+                    portal.offset = Vector3(static_cast<float>(x2), 0, static_cast<float>(z2)) - diff;
+                }
             }
         }
 

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -62,7 +62,7 @@ namespace trview
 
         if (_sector.floordata_index != 0)
         {
-            auto floordata = parse_floordata(level.get_floor_data_all(), _sector.floordata_index, FloordataMeanings::None, level.trng());
+            auto floordata = parse_floordata(level.get_floor_data_all(), _sector.floordata_index, FloordataMeanings::None, level.trng(), level.platform_and_version());
 
             for (const auto& command : floordata.commands)
             {

--- a/trview.app/Elements/TypeInfoLookup.cpp
+++ b/trview.app/Elements/TypeInfoLookup.cpp
@@ -28,7 +28,8 @@ namespace trview
             switch (version.version)
             {
             case trlevel::LevelVersion::Tomb1:
-                return is_tr1_aug_1996(version) ? "tr1_aug_1996" : "tr1";
+                return is_tr1_aug_1996(version) ? "tr1_aug_1996" :
+                       is_tr1_may_1996(version) ? "tr1_may_1996" : "tr1";
                 break;
             case trlevel::LevelVersion::Tomb2:
                 return is_tr2_beta(version) ? "tr2_beta" : "tr2";

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -259,6 +259,21 @@
             { "id": 135, "name": "Scion Piece", "categories": [ "Pickup" ]},
             { "id": 154, "name": "Camera Target", "categories": [ "Effect" ]}
             ],
+        "tr1_may_1996": [
+            { "id": 0, "name": "Lara", "categories": [ "Entity" ]},
+            { "id": 2, "name": "Wolf", "categories": [ "Entity" ]},
+            { "id": 3, "name": "Bear", "categories": [ "Entity" ]},
+            { "id": 9, "name": "Breakable Tile", "categories": [ "Trap" ]},
+            { "id": 10, "name": "Swinging Blade", "categories": [ "Trap" ]},
+            { "id": 14, "name": "Wall Switch", "categories": [ "Switch" ]},
+            { "id": 16, "name": "Door 1", "categories": [ "Door" ]},
+            { "id": 17, "name": "Door 2", "categories": [ "Door" ]},
+            { "id": 18, "name": "Door 3", "categories": [ "Door" ]},
+            { "id": 19, "name": "Trapdoor 1", "categories": [ "Door", "Trapdoor" ]},
+            { "id": 26, "name": "Grenade", "categories": [ "Pickup" ] },
+            { "id": 27, "name": "Small medipack", "categories": [ "Pickup" ]},
+            { "id": 28, "name": "Large medipack", "categories": [ "Pickup" ]}
+            ],
         "tr2": [
             { "id": 0, "name": "Lara", "categories": [ "Entity" ]},
             { "id": 1, "name": "LaraPistolsAnim" },

--- a/trview.app/Resources/Files/type_names.txt
+++ b/trview.app/Resources/Files/type_names.txt
@@ -270,7 +270,7 @@
             { "id": 17, "name": "Door 2", "categories": [ "Door" ]},
             { "id": 18, "name": "Door 3", "categories": [ "Door" ]},
             { "id": 19, "name": "Trapdoor 1", "categories": [ "Door", "Trapdoor" ]},
-            { "id": 26, "name": "Grenade", "categories": [ "Pickup" ] },
+            { "id": 26, "name": "Dynamite", "categories": [ "Pickup" ] },
             { "id": 27, "name": "Small medipack", "categories": [ "Pickup" ]},
             { "id": 28, "name": "Large medipack", "categories": [ "Pickup" ]}
             ],


### PR DESCRIPTION
Add support for CURRENT.PSX from the May 1996 version. There's only one level of this version that I know of so I haven't been able to test against any others, but this one works.
#174 