### PR TITLE
Add support for TR5 PlayStation levels

### DIFF
--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -239,7 +239,8 @@ namespace trlevel
                 {
                     generate_mesh_tr3_psx(mesh, stream);
                 }
-                else if (_platform_and_version.version == LevelVersion::Tomb4)
+                else if (_platform_and_version.version == LevelVersion::Tomb4 ||
+                         _platform_and_version.version == LevelVersion::Tomb5)
                 {
                     generate_mesh_tr4_psx(mesh, stream);
                 }

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -219,6 +219,7 @@ namespace trlevel
         void load_tr4_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr4_pc_remastered(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr4_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void load_tr4_5_psx(std::basic_ispanstream<uint8_t>& file, uint32_t start, const tr4_psx_level_info& info, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr5_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr5_pc_remastered(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr5_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -221,6 +221,7 @@ namespace trlevel
         void load_tr4_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr5_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr5_pc_remastered(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void load_tr5_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_psx_pack(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
 
         void generate_sounds_tr1(const LoadCallbacks& callbacks);

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -219,7 +219,6 @@ namespace trlevel
         void load_tr4_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr4_pc_remastered(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr4_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
-        void load_tr4_5_psx(std::basic_ispanstream<uint8_t>& file, uint32_t start, const tr4_psx_level_info& info, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr5_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr5_pc_remastered(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr5_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
@@ -237,6 +236,7 @@ namespace trlevel
         void generate_mesh_tr2_psx_beta(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
         void generate_mesh_tr3_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
         void generate_mesh_tr4_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
+        void generate_object_textures_tr4_psx(std::basic_ispanstream<uint8_t>& file, uint32_t start, const tr4_psx_level_info& info);
 
         PlatformAndVersion _platform_and_version;
 

--- a/trlevel/Level_psx.h
+++ b/trlevel/Level_psx.h
@@ -16,4 +16,6 @@ namespace trlevel
     void read_sounds_tr1_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t sample_frequency);
     void read_sounds_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t sample_frequency);
     uint16_t attribute_for_object_texture(const tr_object_texture_psx& texture, const tr_clut& clut);
+    std::vector<tr3_room> read_rooms_tr4_psx(uint16_t num_rooms, std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const ILevel::LoadCallbacks& callbacks);
+    void read_sounds_tr4_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t sounds_offset, uint32_t data_offset, uint32_t num_sounds, uint32_t data_length, uint32_t sample_frequency);
 }

--- a/trlevel/Level_psx.h
+++ b/trlevel/Level_psx.h
@@ -11,11 +11,23 @@
 
 namespace trlevel
 {
+    uint16_t attribute_for_object_texture(const tr_object_texture_psx& texture, const tr_clut& clut);
     std::vector<uint8_t> convert_vag_to_wav(const std::vector<uint8_t>& bytes, uint32_t sample_frequency);
+    std::vector<tr4_ai_object> read_ai_objects(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const tr4_psx_level_info& info, const ILevel::LoadCallbacks& callbacks);
+    std::vector<tr2_entity> read_entities(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const tr4_psx_level_info& info, const ILevel::LoadCallbacks& callbacks);
+    std::vector<uint16_t> read_frames(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, uint32_t start, const tr4_psx_level_info& info, const ILevel::LoadCallbacks& callbacks);
+    std::vector<uint16_t> read_mesh_data(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const tr4_psx_level_info& info, const ILevel::LoadCallbacks& callbacks);
+    std::vector<uint32_t> read_mesh_pointers(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const tr4_psx_level_info& info, const ILevel::LoadCallbacks& callbacks);
+    std::vector<uint32_t> read_meshtree(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const tr4_psx_level_info& info, const ILevel::LoadCallbacks& callbacks);
+    std::vector<tr_model> read_models(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, uint32_t start, const tr4_psx_level_info& info, const ILevel::LoadCallbacks& callbacks);
     std::vector<tr_model> read_models_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks);
+    std::vector<tr_object_texture_psx> read_object_textures(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const tr4_psx_level_info& info, const ILevel::LoadCallbacks& callbacks);
+    void read_room_geometry_tr4_psx(std::basic_ispanstream<uint8_t>& file, tr3_room& room, const tr4_psx_room_info& info);
+    std::vector<tr_object_texture_psx> read_room_textures(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const tr4_psx_level_info& info, const ILevel::LoadCallbacks& callbacks);
+    std::vector<tr3_room> read_rooms_tr4_psx(uint16_t num_rooms, std::basic_ispanstream<uint8_t>& file, LevelVersion version, trview::Activity& activity, const ILevel::LoadCallbacks& callbacks);
+    std::vector<tr_sound_source> read_sound_sources(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const tr4_psx_level_info& info, const ILevel::LoadCallbacks& callbacks);
     void read_sounds_tr1_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t sample_frequency);
     void read_sounds_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t sample_frequency);
-    uint16_t attribute_for_object_texture(const tr_object_texture_psx& texture, const tr_clut& clut);
-    std::vector<tr3_room> read_rooms_tr4_psx(uint16_t num_rooms, std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const ILevel::LoadCallbacks& callbacks);
-    void read_sounds_tr4_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t sounds_offset, uint32_t data_offset, uint32_t num_sounds, uint32_t data_length, uint32_t sample_frequency);
+    void read_sounds_tr4_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t start, const tr4_psx_level_info& info, uint32_t sample_frequency);
+    std::unordered_map<uint32_t, tr_staticmesh> read_static_meshes_tr4_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks);
 }

--- a/trlevel/Level_tr4_psx.cpp
+++ b/trlevel/Level_tr4_psx.cpp
@@ -385,11 +385,8 @@ namespace trlevel
         return frames;
     }
 
-    std::vector<tr3_room> read_rooms_tr4_psx(uint16_t num_rooms, std::basic_ispanstream<uint8_t>& file, LevelVersion version, trview::Activity& activity, const ILevel::LoadCallbacks& callbacks)
+    std::vector<tr3_room> read_rooms_tr4_psx(uint16_t num_rooms, std::basic_ispanstream<uint8_t>& file)
     {
-        activity;
-        callbacks;
-
         return read_vector<tr4_psx_room_info>(file, num_rooms)
             | std::views::transform([&](auto&& room_info)
                 {
@@ -644,7 +641,7 @@ namespace trlevel
         const uint32_t start = static_cast<uint32_t>(file.tellg());
         auto info = read<tr4_psx_level_info>(file);
         file.seekg(start + info.room_data_offset, std::ios::beg);
-        _rooms = read_rooms_tr4_psx(info.num_rooms, file, _platform_and_version.version);
+        _rooms = read_rooms_tr4_psx(info.num_rooms, file);
         _floor_data = read_vector<uint16_t>(file, info.floor_data_size / 2);
 
         // 'Room outside map':

--- a/trlevel/Level_tr5_psx.cpp
+++ b/trlevel/Level_tr5_psx.cpp
@@ -8,60 +8,291 @@ namespace trlevel
 {
     namespace
     {
-        struct tr4_psx_level_info
+        struct tr4_psx_entity
         {
-            int32_t  version;
-            uint32_t sound_offsets;
-            uint32_t sound_data_offset;
-            uint32_t textiles_offset;
-            uint32_t frames_offset;
-            uint32_t room_data_offset;
-            uint32_t models_offset;
-            uint32_t unknown[2];
-            uint32_t num_sounds;
-            uint32_t sound_data_length;
-            uint16_t clut_start;
-            uint16_t num_rooms;
-            char     unknown_2[2];
-            uint16_t num_items;
-            char     unknown_3[4];
-            uint32_t room_data_size;
-            uint32_t floor_data_size;
-            uint32_t outside_room_size;
-            uint32_t bounding_boxes_size;
-            char     unknown_4[0x4];
-            uint32_t mesh_data_size;
-            uint32_t mesh_pointer_size;
-            uint32_t animations_size;
-            uint32_t state_changes_size;
-            uint32_t dispatches_size;
-            uint32_t commands_size;
-            uint32_t meshtree_size;
-            uint32_t frames_size;
-            uint32_t texture_info_length;
-            uint32_t sprite_info_length;
-            uint32_t texture_info_length2;
-            uint32_t animated_texture_length;
-            uint32_t sfx_info_length;
-            uint32_t sample_info_length;
-            char     unknown_5[12];
-            uint32_t unknown_offsets[7];
-            uint32_t num_cameras;
-            char     unknown_5a[4];
-            int      camera_length;
-            char     unknown_6[4];
-            uint16_t num_ai_objects;
-            char     unknown_7[38];
+            char      unknown_0[12];
+            int16_t   TypeID;
+            char      unknown_1[10];
+            int16_t   Room;
+            char      unknown_2[14];
+            uint16_t  Flags;
+            char      unknown_3[2];
+            int16_t   ocb;
+            char      unknown_4[18];
+            int32_t   x;
+            int32_t   y;
+            int32_t   z;
+            char      unknown_5[2];
+            int16_t   Angle;
+            char      unknown_6[64];
         };
-        static_assert(sizeof(tr4_psx_level_info) == 228);
+        static_assert(sizeof(tr4_psx_entity) == 144);
+
+        struct tr4_psx_ai_object
+        {
+            uint16_t type_id;
+            uint16_t room;
+            int32_t  x;
+            int32_t  y;
+            int32_t  z;
+            int16_t  ocb;
+            uint16_t flags;
+            int16_t  angle;
+            uint16_t box;
+        };
+        static_assert(sizeof(tr4_psx_ai_object) == 24);
+
+        struct tr4_psx_model
+        {
+            uint16_t NumMeshes;    // Number of meshes in this object
+            uint16_t StartingMesh; // Starting mesh (offset into MeshPointers[])
+            uint32_t MeshTree;     // Offset into MeshTree[]
+            uint32_t FrameOffset;  // Byte offset into Frames[] (divide by 2 for Frames[i])
+            char     unknown[52];
+        };
+        static_assert(sizeof(tr4_psx_model) == 64);
+
+        struct tr4_psx_staticmesh
+        {
+            uint16_t Mesh; // Mesh (offset into MeshPointers[])
+            uint16_t Flags;
+            tr_bounding_box VisibilityBox;
+            tr_bounding_box CollisionBox;
+        };
+        static_assert(sizeof(tr4_psx_staticmesh) == 28);
+
+        constexpr std::tuple<int, int> tile_to_x_y(uint16_t tile)
+        {
+            int x = ((tile & 0xf) * 64);
+            int y = ((tile >> 4) & 0x1) * 256;
+            x = (x - 512) * 2;
+            return  { x, y };
+        }
+
+        constexpr std::tuple<uint16_t, uint16_t> clut_to_clut(uint16_t clut)
+        {
+            uint16_t x = (clut & 0x3f) * 16;
+            uint16_t y = (clut >> 6) & 0x1ff;
+            x = (x - 512) * 2;
+            return { x, y };
+        }
     }
 
     void Level::load_tr5_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
         file.seekg(313344);
-        tr4_psx_level_info convert_room_info = read<tr4_psx_level_info>(file);
+        const uint32_t start = static_cast<uint32_t>(file.tellg());
+        auto info = read<tr4_psx_level_info>(file);
 
-        activity;
-        callbacks;
+        
+
+        file.seekg(start + info.room_data_offset, std::ios::beg);
+        _rooms = read_rooms_tr4_psx(info.num_rooms, file, activity, callbacks);
+
+        _floor_data = read_vector<uint16_t>(file, info.floor_data_size / 2);
+
+        // 'Room outside map':
+        read_vector<uint16_t>(file, 729);
+        skip(file, 2);
+        // Outside room table:
+        read_vector<uint8_t>(file, info.outside_room_size);
+        // Bounding boxes
+        skip(file, info.bounding_boxes_size);
+
+        const uint32_t mesh_data_start = static_cast<uint32_t>(file.tellg());
+        _mesh_data = read_vector<uint16_t>(file, info.mesh_data_size / sizeof(uint16_t));
+        file.seekg(mesh_data_start + info.mesh_data_size, std::ios::beg);
+
+        const uint32_t mesh_pointers_start = static_cast<uint32_t>(file.tellg());
+        _mesh_pointers = read_vector<uint32_t>(file, info.mesh_pointer_size / sizeof(uint32_t));
+        file.seekg(mesh_pointers_start + info.mesh_pointer_size, std::ios::beg);
+
+        skip(file, info.animations_size);
+        skip(file, info.state_changes_size);
+        skip(file, info.dispatches_size);
+        skip(file, info.commands_size);
+
+        const uint32_t meshtree_pointers_start = static_cast<uint32_t>(file.tellg());
+        _meshtree = read_vector<uint32_t>(file, info.meshtree_size / sizeof(uint32_t));
+        file.seekg(meshtree_pointers_start + info.meshtree_size, std::ios::beg);
+
+        skip(file, info.animated_texture_length);
+
+        const uint32_t object_textures_start = static_cast<uint32_t>(file.tellg());
+        _object_textures_psx = read_vector<tr_object_texture_psx>(file, info.texture_info_length / sizeof(tr_object_texture_psx));
+        file.seekg(object_textures_start + info.texture_info_length, std::ios::beg);
+
+        skip(file, info.sprite_info_length);
+        const uint32_t room_textures_start = static_cast<uint32_t>(file.tellg());
+
+        adjust_room_textures_psx();
+
+        std::vector<tr_object_texture_psx> room_textures_psx;
+        uint32_t num_room_textures = info.texture_info_length2 / sizeof(tr_object_texture_psx) / 3;
+        for (auto i = 0u; i < num_room_textures; ++i)
+        {
+            room_textures_psx.push_back(read<tr_object_texture_psx>(file));
+            skip(file, sizeof(tr_object_texture_psx) * 2);
+        }
+
+        _object_textures_psx.append_range(room_textures_psx);
+        file.seekg(room_textures_start + info.texture_info_length2, std::ios::beg);
+        skip(file, info.sfx_info_length);
+        _sound_map = read_vector<int16_t>(file, 450);
+        _sound_details = read_vector<tr_x_sound_details>(file, info.sample_info_length / sizeof(tr_x_sound_details));
+
+        _entities = read_vector<tr4_psx_entity>(file, 256)
+            | std::views::take(info.num_items)
+            | std::views::transform([](auto&& e) -> tr2_entity
+                {
+                    return
+                    {
+                        .TypeID = e.TypeID,
+                        .Room = e.Room,
+                        .x = e.x,
+                        .y = e.y,
+                        .z = e.z,
+                        .Angle = e.Angle,
+                        .Intensity2 = e.ocb,
+                        .Flags = e.Flags
+                    };
+                }) | std::ranges::to<std::vector>();
+
+        _ai_objects = read_vector<tr4_psx_ai_object>(file, info.num_ai_objects)
+            | std::views::transform([](auto&& a) -> tr4_ai_object
+                {
+                    return
+                    {
+                        .type_id = a.type_id,
+                        .room = a.room,
+                        .x = a.x,
+                        .y = a.y,
+                        .z = a.z,
+                        .ocb = a.ocb,
+                        .flags = a.flags,
+                        .angle = a.angle
+                    };
+                }) | std::ranges::to<std::vector>();
+
+        skip(file, info.unknown_offsets[0] + info.unknown_offsets[1]);
+        skip(file, 2 * (info.unknown_offsets[2] + info.unknown_offsets[3] + info.unknown_offsets[4] + info.unknown_offsets[5] + info.unknown_offsets[6]));
+        _cameras = read_vector<tr_camera>(file, info.num_cameras);
+
+        file.seekg(start + info.frames_offset);
+        _frames = read_vector<uint16_t>(file, info.frames_size / sizeof(uint16_t));
+
+        file.seekg(start + info.models_offset);
+
+        callbacks.on_progress("Reading models");
+        log_file(activity, file, "Reading models");
+        auto models = read_vector<tr4_psx_model>(file, 460);
+        for (uint32_t m = 0; m < models.size(); ++m)
+        {
+            const auto& model = models[m];
+            _models.push_back(tr_model
+                {
+                    .ID = m,
+                    .NumMeshes = model.NumMeshes,
+                    .StartingMesh = model.StartingMesh,
+                    .MeshTree = model.MeshTree,
+                    .FrameOffset = model.FrameOffset
+                });
+        }
+
+        log_file(activity, file, std::format("Read {} models", _models.size()));
+
+        auto static_meshes = read_vector<tr4_psx_staticmesh>(file, 70);
+        for (uint32_t s = 0; s < static_meshes.size(); ++s)
+        {
+            const auto& staticmesh = static_meshes[s];
+            _static_meshes.insert({ s, tr_staticmesh
+                {
+                    .ID = s,
+                    .Mesh = staticmesh.Mesh,
+                    .VisibilityBox = staticmesh.VisibilityBox,
+                    .CollisionBox = staticmesh.CollisionBox,
+                    .Flags = staticmesh.Flags
+                } });
+        }
+
+        file.seekg(start + info.textiles_offset);
+
+        // Create giant texture for whole memory:
+        const auto textile_bytes = read_vector<uint8_t>(file, 0x80000);
+        file.seekg(start + info.textiles_offset);
+
+        auto convert_textile4_tr4_psx = [&](tr_object_texture_psx& t)
+            {
+                const auto [tx, ty] = tile_to_x_y(t.Tile);
+                const auto [cx, cy] = clut_to_clut(t.Clut);
+                tr_clut clut = *reinterpret_cast<const tr_clut*>(&textile_bytes[cy * 1024 + cx]);
+
+                // Check if we've already converted this tile + clut
+                for (auto i = _converted_t16.begin(); i < _converted_t16.end(); ++i)
+                {
+                    if (i->first == t.Tile && i->second == t.Clut)
+                    {
+                        t.Attribute = attribute_for_object_texture(t, clut),
+                            t.Tile = static_cast<uint16_t>(std::distance(_converted_t16.begin(), i));
+                        t.Clut = 0;
+                        return;
+                    }
+                }
+                // If not, create new conversion
+                _converted_t16.push_back(std::make_pair(t.Tile, t.Clut));
+
+                tr_textile16& tile16 = _textile16.emplace_back();
+                for (int y = 0; y < 256; ++y)
+                {
+                    for (int x = 0; x < 256; ++x)
+                    {
+                        const std::size_t src_pixel = ((ty + y) * 1024) + (tx + (x / 2));
+                        const std::size_t dest_pixel = y * 256 + x;
+                        const tr_colorindex4 index = *reinterpret_cast<const tr_colorindex4*>(&textile_bytes[src_pixel]);
+                        const tr_rgba5551& colour = clut.Colour[(x % 2) ? index.b : index.a];
+                        tile16.Tile[dest_pixel] = (colour.Alpha << 15) | (colour.Red << 10) | (colour.Green << 5) | colour.Blue;
+                    }
+                }
+
+                _num_textiles = static_cast<uint32_t>(_textile16.size());
+                t.Attribute = attribute_for_object_texture(t, clut);
+                t.Tile = static_cast<uint16_t>(_textile16.size() - 1);
+                t.Clut = 0;
+            };
+
+        _object_textures = _object_textures_psx
+            | std::views::transform([&](auto texture)
+                {
+                    convert_textile4_tr4_psx(texture);
+                    return texture;
+                })
+            | std::views::transform([&](const auto texture) -> tr_object_texture
+                {
+                    return
+                    {
+                        .Attribute = texture.Attribute,
+                        .TileAndFlag = texture.Tile,
+                        .Vertices =
+                        {
+                            { 0, static_cast<uint8_t>(texture.x0), 0, texture.y0 },
+                            { 0, static_cast<uint8_t>(texture.x1), 0, texture.y1 },
+                            { 0, static_cast<uint8_t>(texture.x2), 0, texture.y2 },
+                            { 0, static_cast<uint8_t>(texture.x3), 0, texture.y3 },
+                        }
+                    };
+                })
+            | std::ranges::to<std::vector>();
+
+        for (const auto& t : _textile16)
+        {
+            callbacks.on_textile(convert_textile(t));
+        }
+
+        file.seekg(start + info.sound_offsets);
+        read_sounds_tr4_psx(activity, file, callbacks, start + info.sound_offsets, start + info.sound_data_offset, info.num_sounds, info.sound_data_length, 11025);
+
+        callbacks.on_progress("Generating meshes");
+        generate_meshes(_mesh_data);
+        callbacks.on_progress("Loading complete");
     }
 }

--- a/trlevel/Level_tr5_psx.cpp
+++ b/trlevel/Level_tr5_psx.cpp
@@ -1,0 +1,67 @@
+#include "Level.h"
+#include "Level_common.h"
+#include "Level_psx.h"
+
+#include <ranges>
+
+namespace trlevel
+{
+    namespace
+    {
+        struct tr4_psx_level_info
+        {
+            int32_t  version;
+            uint32_t sound_offsets;
+            uint32_t sound_data_offset;
+            uint32_t textiles_offset;
+            uint32_t frames_offset;
+            uint32_t room_data_offset;
+            uint32_t models_offset;
+            uint32_t unknown[2];
+            uint32_t num_sounds;
+            uint32_t sound_data_length;
+            uint16_t clut_start;
+            uint16_t num_rooms;
+            char     unknown_2[2];
+            uint16_t num_items;
+            char     unknown_3[4];
+            uint32_t room_data_size;
+            uint32_t floor_data_size;
+            uint32_t outside_room_size;
+            uint32_t bounding_boxes_size;
+            char     unknown_4[0x4];
+            uint32_t mesh_data_size;
+            uint32_t mesh_pointer_size;
+            uint32_t animations_size;
+            uint32_t state_changes_size;
+            uint32_t dispatches_size;
+            uint32_t commands_size;
+            uint32_t meshtree_size;
+            uint32_t frames_size;
+            uint32_t texture_info_length;
+            uint32_t sprite_info_length;
+            uint32_t texture_info_length2;
+            uint32_t animated_texture_length;
+            uint32_t sfx_info_length;
+            uint32_t sample_info_length;
+            char     unknown_5[12];
+            uint32_t unknown_offsets[7];
+            uint32_t num_cameras;
+            char     unknown_5a[4];
+            int      camera_length;
+            char     unknown_6[4];
+            uint16_t num_ai_objects;
+            char     unknown_7[38];
+        };
+        static_assert(sizeof(tr4_psx_level_info) == 228);
+    }
+
+    void Level::load_tr5_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    {
+        file.seekg(313344);
+        tr4_psx_level_info convert_room_info = read<tr4_psx_level_info>(file);
+
+        activity;
+        callbacks;
+    }
+}

--- a/trlevel/Level_tr5_psx.cpp
+++ b/trlevel/Level_tr5_psx.cpp
@@ -8,73 +8,86 @@ namespace trlevel
 {
     namespace
     {
-        struct tr4_psx_entity
+        tr_x_room_light to_tr5_light(const tr4_psx_room_light& l)
         {
-            char      unknown_0[12];
-            int16_t   TypeID;
-            char      unknown_1[10];
-            int16_t   Room;
-            char      unknown_2[14];
-            uint16_t  Flags;
-            char      unknown_3[2];
-            int16_t   ocb;
-            char      unknown_4[18];
-            int32_t   x;
-            int32_t   y;
-            int32_t   z;
-            char      unknown_5[2];
-            int16_t   Angle;
-            char      unknown_6[64];
-        };
-        static_assert(sizeof(tr4_psx_entity) == 144);
+            tr_x_room_light new_light
+            {
+                .level_version = LevelVersion::Tomb5,
+                .tr5 =
+                {
+                    .position = {.x = static_cast<float>(l.x), .y = static_cast<float>(l.y), .z = static_cast<float>(l.z) },
+                    .colour = {.r = static_cast<float>(l.r) / 255.0f, .g = static_cast<float>(l.g) / 255.0f, .b = static_cast<float>(l.b) / 255.0f },
+                    .direction = {.x = static_cast<float>(l.dx) / 4096.0f, .y = static_cast<float>(l.dy) / 4096.0f, .z = static_cast<float>(l.dz) / 4096.0f },
+                    .light_type = l.type
+                    // .intensity = l.intensity,
+                }
+            };
 
-        struct tr4_psx_ai_object
-        {
-            uint16_t type_id;
-            uint16_t room;
-            int32_t  x;
-            int32_t  y;
-            int32_t  z;
-            int16_t  ocb;
-            uint16_t flags;
-            int16_t  angle;
-            uint16_t box;
-        };
-        static_assert(sizeof(tr4_psx_ai_object) == 24);
+            switch (l.type)
+            {
+            case LightType::Spot:
+            {
+                new_light.tr5.in = static_cast<float>(l.spot.in << 2) / 16384.0f;
+                new_light.tr5.out = static_cast<float>(l.spot.out << 2) / 16384.0f;
+                new_light.tr5.rad_in = static_cast<float>(l.spot.length << 7);
+                new_light.tr5.rad_out = static_cast<float>(l.spot.length << 7);
+                new_light.tr5.range = static_cast<float>(l.spot.cutoff << 7);
+                break;
+            }
+            case LightType::Shadow:
+            {
+                new_light.tr5.in = static_cast<float>(l.shadow.hotspot << 7);
+                new_light.tr5.out = static_cast<float>(l.shadow.falloff << 7);
+                break;
+            }
+            case LightType::Point:
+            {
+                new_light.tr5.in = static_cast<float>(l.point.hotspot << 7);
+                new_light.tr5.out = static_cast<float>(l.point.falloff << 7);
+                break;
+            }
+            }
 
-        struct tr4_psx_model
-        {
-            uint16_t NumMeshes;    // Number of meshes in this object
-            uint16_t StartingMesh; // Starting mesh (offset into MeshPointers[])
-            uint32_t MeshTree;     // Offset into MeshTree[]
-            uint32_t FrameOffset;  // Byte offset into Frames[] (divide by 2 for Frames[i])
-            char     unknown[52];
-        };
-        static_assert(sizeof(tr4_psx_model) == 64);
-
-        struct tr4_psx_staticmesh
-        {
-            uint16_t Mesh; // Mesh (offset into MeshPointers[])
-            uint16_t Flags;
-            tr_bounding_box VisibilityBox;
-            tr_bounding_box CollisionBox;
-        };
-        static_assert(sizeof(tr4_psx_staticmesh) == 28);
-
-        constexpr std::tuple<int, int> tile_to_x_y(uint16_t tile)
-        {
-            int x = ((tile & 0xf) * 64);
-            int y = ((tile >> 4) & 0x1) * 256;
-            x = (x - 512) * 2;
-            return  { x, y };
+            return new_light;
         }
 
-        constexpr std::tuple<uint16_t, uint16_t> clut_to_clut(uint16_t clut)
+        std::vector<tr3_room> read_rooms_tr5_psx(uint16_t num_rooms, std::basic_ispanstream<uint8_t>& file, LevelVersion version)
         {
-            uint16_t x = (clut & 0x3f) * 16;
-            uint16_t y = (clut >> 6) & 0x1ff;
-            x = (x - 512) * 2;
-            return { x, y };
+            return read_vector<tr4_psx_room_info>(file, num_rooms)
+                | std::views::transform([&](auto&& room_info)
+                    {
+                        tr3_room room
+                        {
+                            .info = room_info.info,
+                            .num_z_sectors = room_info.num_z_sectors,
+                            .num_x_sectors = room_info.num_x_sectors,
+                            .alternate_room = room_info.alternate_room,
+                            .flags = room_info.flags,
+                            .alternate_group = room_info.alternate_group,
+                        };
+
+                        read_room_geometry_tr4_psx(file, room, room_info);
+
+                        const uint32_t portals_start = static_cast<uint32_t>(file.tellg());
+                        room.portals = read_vector<tr_room_portal>(file, room_info.portal_size / sizeof(tr_room_portal));
+                        file.seekg(portals_start + room_info.portal_size, std::ios::beg);
+
+                        const uint32_t sectors_start = static_cast<uint32_t>(file.tellg());
+                        room.sector_list = read_vector<tr_room_sector>(file, room.num_z_sectors * room.num_x_sectors);
+                        file.seekg(sectors_start + room_info.sectors_size, std::ios::beg);
+
+                        const uint32_t lights_start = static_cast<uint32_t>(file.tellg());
+                        room.lights = read_vector<tr4_psx_room_light>(file, room_info.num_lights)
+                            | std::views::transform(to_tr5_light)
+                            | std::ranges::to<std::vector>();
+                        file.seekg(lights_start + room_info.light_size, std::ios::beg);
+
+                        const uint32_t statics_start = static_cast<uint32_t>(file.tellg());
+                        room.static_meshes = read_vector<tr3_room_staticmesh>(file, room_info.num_meshes);
+                        file.seekg(statics_start + room_info.static_mesh_size, std::ios::beg);
+
+                        return room;
+                    }) | std::ranges::to<std::vector>();
         }
     }
 
@@ -83,12 +96,8 @@ namespace trlevel
         file.seekg(313344);
         const uint32_t start = static_cast<uint32_t>(file.tellg());
         auto info = read<tr4_psx_level_info>(file);
-
-        
-
         file.seekg(start + info.room_data_offset, std::ios::beg);
-        _rooms = read_rooms_tr4_psx(info.num_rooms, file, activity, callbacks);
-
+        _rooms = read_rooms_tr5_psx(info.num_rooms, file, _platform_and_version.version);
         _floor_data = read_vector<uint16_t>(file, info.floor_data_size / 2);
 
         // 'Room outside map':
@@ -99,197 +108,37 @@ namespace trlevel
         // Bounding boxes
         skip(file, info.bounding_boxes_size);
 
-        const uint32_t mesh_data_start = static_cast<uint32_t>(file.tellg());
-        _mesh_data = read_vector<uint16_t>(file, info.mesh_data_size / sizeof(uint16_t));
-        file.seekg(mesh_data_start + info.mesh_data_size, std::ios::beg);
-
-        const uint32_t mesh_pointers_start = static_cast<uint32_t>(file.tellg());
-        _mesh_pointers = read_vector<uint32_t>(file, info.mesh_pointer_size / sizeof(uint32_t));
-        file.seekg(mesh_pointers_start + info.mesh_pointer_size, std::ios::beg);
-
+        _mesh_data = read_mesh_data(activity, file, info, callbacks);
+        _mesh_pointers = read_mesh_pointers(activity, file, info, callbacks);
         skip(file, info.animations_size);
         skip(file, info.state_changes_size);
         skip(file, info.dispatches_size);
         skip(file, info.commands_size);
-
-        const uint32_t meshtree_pointers_start = static_cast<uint32_t>(file.tellg());
-        _meshtree = read_vector<uint32_t>(file, info.meshtree_size / sizeof(uint32_t));
-        file.seekg(meshtree_pointers_start + info.meshtree_size, std::ios::beg);
-
+        _meshtree = read_meshtree(activity, file, info, callbacks);
         skip(file, info.animated_texture_length);
-
-        const uint32_t object_textures_start = static_cast<uint32_t>(file.tellg());
-        _object_textures_psx = read_vector<tr_object_texture_psx>(file, info.texture_info_length / sizeof(tr_object_texture_psx));
-        file.seekg(object_textures_start + info.texture_info_length, std::ios::beg);
-
+        _object_textures_psx = read_object_textures(activity, file, info, callbacks);
         skip(file, info.sprite_info_length);
-        const uint32_t room_textures_start = static_cast<uint32_t>(file.tellg());
-
         adjust_room_textures_psx();
-
-        std::vector<tr_object_texture_psx> room_textures_psx;
-        uint32_t num_room_textures = info.texture_info_length2 / sizeof(tr_object_texture_psx) / 3;
-        for (auto i = 0u; i < num_room_textures; ++i)
-        {
-            room_textures_psx.push_back(read<tr_object_texture_psx>(file));
-            skip(file, sizeof(tr_object_texture_psx) * 2);
-        }
-
-        _object_textures_psx.append_range(room_textures_psx);
-        file.seekg(room_textures_start + info.texture_info_length2, std::ios::beg);
-        skip(file, info.sfx_info_length);
+        _object_textures_psx.append_range(read_room_textures(activity, file, info, callbacks));
+        _sound_sources = read_sound_sources(activity, file, info, callbacks);
         _sound_map = read_vector<int16_t>(file, 450);
         _sound_details = read_vector<tr_x_sound_details>(file, info.sample_info_length / sizeof(tr_x_sound_details));
-
-        _entities = read_vector<tr4_psx_entity>(file, 256)
-            | std::views::take(info.num_items)
-            | std::views::transform([](auto&& e) -> tr2_entity
-                {
-                    return
-                    {
-                        .TypeID = e.TypeID,
-                        .Room = e.Room,
-                        .x = e.x,
-                        .y = e.y,
-                        .z = e.z,
-                        .Angle = e.Angle,
-                        .Intensity2 = e.ocb,
-                        .Flags = e.Flags
-                    };
-                }) | std::ranges::to<std::vector>();
-
-        _ai_objects = read_vector<tr4_psx_ai_object>(file, info.num_ai_objects)
-            | std::views::transform([](auto&& a) -> tr4_ai_object
-                {
-                    return
-                    {
-                        .type_id = a.type_id,
-                        .room = a.room,
-                        .x = a.x,
-                        .y = a.y,
-                        .z = a.z,
-                        .ocb = a.ocb,
-                        .flags = a.flags,
-                        .angle = a.angle
-                    };
-                }) | std::ranges::to<std::vector>();
-
+        _entities = read_entities(activity, file, info, callbacks);
+        _ai_objects = read_ai_objects(activity, file, info, callbacks);
         skip(file, info.unknown_offsets[0] + info.unknown_offsets[1]);
         skip(file, 2 * (info.unknown_offsets[2] + info.unknown_offsets[3] + info.unknown_offsets[4] + info.unknown_offsets[5] + info.unknown_offsets[6]));
         _cameras = read_vector<tr_camera>(file, info.num_cameras);
-
-        file.seekg(start + info.frames_offset);
-        _frames = read_vector<uint16_t>(file, info.frames_size / sizeof(uint16_t));
-
-        file.seekg(start + info.models_offset);
-
-        callbacks.on_progress("Reading models");
-        log_file(activity, file, "Reading models");
-        auto models = read_vector<tr4_psx_model>(file, 460);
-        for (uint32_t m = 0; m < models.size(); ++m)
-        {
-            const auto& model = models[m];
-            _models.push_back(tr_model
-                {
-                    .ID = m,
-                    .NumMeshes = model.NumMeshes,
-                    .StartingMesh = model.StartingMesh,
-                    .MeshTree = model.MeshTree,
-                    .FrameOffset = model.FrameOffset
-                });
-        }
-
-        log_file(activity, file, std::format("Read {} models", _models.size()));
-
-        auto static_meshes = read_vector<tr4_psx_staticmesh>(file, 70);
-        for (uint32_t s = 0; s < static_meshes.size(); ++s)
-        {
-            const auto& staticmesh = static_meshes[s];
-            _static_meshes.insert({ s, tr_staticmesh
-                {
-                    .ID = s,
-                    .Mesh = staticmesh.Mesh,
-                    .VisibilityBox = staticmesh.VisibilityBox,
-                    .CollisionBox = staticmesh.CollisionBox,
-                    .Flags = staticmesh.Flags
-                } });
-        }
-
-        file.seekg(start + info.textiles_offset);
-
-        // Create giant texture for whole memory:
-        const auto textile_bytes = read_vector<uint8_t>(file, 0x80000);
-        file.seekg(start + info.textiles_offset);
-
-        auto convert_textile4_tr4_psx = [&](tr_object_texture_psx& t)
-            {
-                const auto [tx, ty] = tile_to_x_y(t.Tile);
-                const auto [cx, cy] = clut_to_clut(t.Clut);
-                tr_clut clut = *reinterpret_cast<const tr_clut*>(&textile_bytes[cy * 1024 + cx]);
-
-                // Check if we've already converted this tile + clut
-                for (auto i = _converted_t16.begin(); i < _converted_t16.end(); ++i)
-                {
-                    if (i->first == t.Tile && i->second == t.Clut)
-                    {
-                        t.Attribute = attribute_for_object_texture(t, clut),
-                            t.Tile = static_cast<uint16_t>(std::distance(_converted_t16.begin(), i));
-                        t.Clut = 0;
-                        return;
-                    }
-                }
-                // If not, create new conversion
-                _converted_t16.push_back(std::make_pair(t.Tile, t.Clut));
-
-                tr_textile16& tile16 = _textile16.emplace_back();
-                for (int y = 0; y < 256; ++y)
-                {
-                    for (int x = 0; x < 256; ++x)
-                    {
-                        const std::size_t src_pixel = ((ty + y) * 1024) + (tx + (x / 2));
-                        const std::size_t dest_pixel = y * 256 + x;
-                        const tr_colorindex4 index = *reinterpret_cast<const tr_colorindex4*>(&textile_bytes[src_pixel]);
-                        const tr_rgba5551& colour = clut.Colour[(x % 2) ? index.b : index.a];
-                        tile16.Tile[dest_pixel] = (colour.Alpha << 15) | (colour.Red << 10) | (colour.Green << 5) | colour.Blue;
-                    }
-                }
-
-                _num_textiles = static_cast<uint32_t>(_textile16.size());
-                t.Attribute = attribute_for_object_texture(t, clut);
-                t.Tile = static_cast<uint16_t>(_textile16.size() - 1);
-                t.Clut = 0;
-            };
-
-        _object_textures = _object_textures_psx
-            | std::views::transform([&](auto texture)
-                {
-                    convert_textile4_tr4_psx(texture);
-                    return texture;
-                })
-            | std::views::transform([&](const auto texture) -> tr_object_texture
-                {
-                    return
-                    {
-                        .Attribute = texture.Attribute,
-                        .TileAndFlag = texture.Tile,
-                        .Vertices =
-                        {
-                            { 0, static_cast<uint8_t>(texture.x0), 0, texture.y0 },
-                            { 0, static_cast<uint8_t>(texture.x1), 0, texture.y1 },
-                            { 0, static_cast<uint8_t>(texture.x2), 0, texture.y2 },
-                            { 0, static_cast<uint8_t>(texture.x3), 0, texture.y3 },
-                        }
-                    };
-                })
-            | std::ranges::to<std::vector>();
+        _frames = read_frames(activity, file, start, info, callbacks);
+        _models = read_models(activity, file, start, info, callbacks);
+        _static_meshes = read_static_meshes_tr4_psx(activity, file, callbacks);
+        generate_object_textures_tr4_psx(file, start, info);
 
         for (const auto& t : _textile16)
         {
             callbacks.on_textile(convert_textile(t));
         }
 
-        file.seekg(start + info.sound_offsets);
-        read_sounds_tr4_psx(activity, file, callbacks, start + info.sound_offsets, start + info.sound_data_offset, info.num_sounds, info.sound_data_length, 11025);
+        read_sounds_tr4_psx(activity, file, callbacks, start, info, 11025);
 
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);

--- a/trlevel/Level_tr5_psx.cpp
+++ b/trlevel/Level_tr5_psx.cpp
@@ -19,7 +19,6 @@ namespace trlevel
                     .colour = {.r = static_cast<float>(l.r) / 255.0f, .g = static_cast<float>(l.g) / 255.0f, .b = static_cast<float>(l.b) / 255.0f },
                     .direction = {.x = static_cast<float>(l.dx) / 4096.0f, .y = static_cast<float>(l.dy) / 4096.0f, .z = static_cast<float>(l.dz) / 4096.0f },
                     .light_type = l.type
-                    // .intensity = l.intensity,
                 }
             };
 
@@ -29,8 +28,8 @@ namespace trlevel
             {
                 new_light.tr5.in = static_cast<float>(l.spot.in << 2) / 16384.0f;
                 new_light.tr5.out = static_cast<float>(l.spot.out << 2) / 16384.0f;
-                new_light.tr5.rad_in = static_cast<float>(l.spot.length << 7);
-                new_light.tr5.rad_out = static_cast<float>(l.spot.length << 7);
+                new_light.tr5.rad_in = std::acosf(new_light.tr5.in) * 2.0f;
+                new_light.tr5.rad_out = std::acosf(new_light.tr5.out) * 2.0f;
                 new_light.tr5.range = static_cast<float>(l.spot.cutoff << 7);
                 break;
             }
@@ -51,7 +50,7 @@ namespace trlevel
             return new_light;
         }
 
-        std::vector<tr3_room> read_rooms_tr5_psx(uint16_t num_rooms, std::basic_ispanstream<uint8_t>& file, LevelVersion version)
+        std::vector<tr3_room> read_rooms_tr5_psx(uint16_t num_rooms, std::basic_ispanstream<uint8_t>& file)
         {
             return read_vector<tr4_psx_room_info>(file, num_rooms)
                 | std::views::transform([&](auto&& room_info)
@@ -97,7 +96,7 @@ namespace trlevel
         const uint32_t start = static_cast<uint32_t>(file.tellg());
         auto info = read<tr4_psx_level_info>(file);
         file.seekg(start + info.room_data_offset, std::ios::beg);
-        _rooms = read_rooms_tr5_psx(info.num_rooms, file, _platform_and_version.version);
+        _rooms = read_rooms_tr5_psx(info.num_rooms, file);
         _floor_data = read_vector<uint16_t>(file, info.floor_data_size / 2);
 
         // 'Room outside map':

--- a/trlevel/trlevel.vcxproj
+++ b/trlevel/trlevel.vcxproj
@@ -133,6 +133,7 @@
     <ClCompile Include="Level_tr4_pc.cpp" />
     <ClCompile Include="Level_tr4_psx.cpp" />
     <ClCompile Include="Level_tr5_pc.cpp" />
+    <ClCompile Include="Level_tr5_psx.cpp" />
     <ClCompile Include="Mocks\MockLevel.cpp" />
     <ClCompile Include="Pack.cpp" />
     <ClCompile Include="stdafx.cpp">

--- a/trlevel/trlevel.vcxproj.filters
+++ b/trlevel/trlevel.vcxproj.filters
@@ -85,6 +85,9 @@
       <Filter>Level\PSX</Filter>
     </ClCompile>
     <ClCompile Include="Pack.cpp" />
+    <ClCompile Include="Level_tr5_psx.cpp">
+      <Filter>Level\PSX</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Mocks">

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -784,6 +784,71 @@ namespace trlevel
     };
     static_assert(sizeof(tr4_psx_level_info) == 228);
 
+    struct tr4_psx_room_info
+    {
+        uint32_t        data_size;
+        uint32_t        portal_size;
+        uint32_t        sectors_size;
+        uint32_t        light_size;
+        uint32_t        static_mesh_size;
+        tr_room_info    info;
+        uint16_t        num_z_sectors;
+        uint16_t        num_x_sectors;
+        char            unknown_1[4];
+        uint16_t        num_lights;
+        uint16_t        num_meshes;
+        char            unknown_2[1];
+        uint8_t         alternate_group;
+        char            unknown_3[22];
+        int16_t         alternate_room;
+        int16_t         flags;
+    };
+    static_assert(sizeof(tr4_psx_room_info) == 80);
+
+    struct tr4_psx_room_light
+    {
+        int32_t x;
+        int32_t y;
+        int32_t z;
+        LightType type;
+        uint8_t r;
+        uint8_t g;
+        uint8_t b;
+        int16_t dx;
+        int16_t dy;
+        int16_t dz;
+        uint16_t intensity;
+
+        struct spot_light
+        {
+            uint8_t length;
+            uint8_t cutoff;
+            int16_t unused;
+            int16_t in;
+            int16_t out;
+        };
+
+        struct shadow_light
+        {
+            uint8_t hotspot;
+            uint8_t falloff;
+        };
+
+        struct point_light
+        {
+            uint8_t hotspot;
+            uint8_t falloff;
+        };
+
+        union
+        {
+            spot_light spot;
+            shadow_light shadow;
+            point_light point;
+        };
+    };
+    static_assert(sizeof(tr4_psx_room_light) == 32);
+
 #pragma pack(pop)
 
     struct tr2_frame

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -737,6 +737,53 @@ namespace trlevel
         }
     };
 
+    struct tr4_psx_level_info
+    {
+        int32_t  version;
+        uint32_t sound_offsets;
+        uint32_t sound_data_offset;
+        uint32_t textiles_offset;
+        uint32_t frames_offset;
+        uint32_t room_data_offset;
+        uint32_t models_offset;
+        uint32_t unknown[2];
+        uint32_t num_sounds;
+        uint32_t sound_data_length;
+        uint16_t clut_start;
+        uint16_t num_rooms;
+        char     unknown_2[2];
+        uint16_t num_items;
+        char     unknown_3[4];
+        uint32_t room_data_size;
+        uint32_t floor_data_size;
+        uint32_t outside_room_size;
+        uint32_t bounding_boxes_size;
+        char     unknown_4[0x4];
+        uint32_t mesh_data_size;
+        uint32_t mesh_pointer_size;
+        uint32_t animations_size;
+        uint32_t state_changes_size;
+        uint32_t dispatches_size;
+        uint32_t commands_size;
+        uint32_t meshtree_size;
+        uint32_t frames_size;
+        uint32_t texture_info_length;
+        uint32_t sprite_info_length;
+        uint32_t texture_info_length2;
+        uint32_t animated_texture_length;
+        uint32_t sfx_info_length;
+        uint32_t sample_info_length;
+        char     unknown_5[12];
+        uint32_t unknown_offsets[7];
+        uint32_t num_cameras;
+        char     unknown_5a[4];
+        int      camera_length;
+        char     unknown_6[4];
+        uint16_t num_ai_objects;
+        char     unknown_7[38];
+    };
+    static_assert(sizeof(tr4_psx_level_info) == 228);
+
 #pragma pack(pop)
 
     struct tr2_frame

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -110,7 +110,7 @@ namespace trview
         if (level.get_model_by_id(level.get_mesh_from_type_id(type_id), model))
         {
             if (level.platform_and_version().platform == trlevel::Platform::PSX && 
-                level.platform_and_version().version == trlevel::LevelVersion::Tomb4)
+                equals_any(level.platform_and_version().version, trlevel::LevelVersion::Tomb4, trlevel::LevelVersion::Tomb5))
             {
                 const uint32_t end_pointer = static_cast<uint32_t>(model.StartingMesh + model.NumMeshes * 2);
                 for (uint32_t mesh_pointer = model.StartingMesh; mesh_pointer < end_pointer; mesh_pointer += 2)


### PR DESCRIPTION
Add support for loading TR5 levels, from GAMEWAD.OBJ as with TR4.
Rearrange TR4 loading and make it reusable by TR5.
Closes #174 