### PR TITLE
Add version number to log

### DIFF
--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -9,6 +9,7 @@
 #include "Level_common.h"
 #include "Level_psx.h"
 #include "Level_tr3.h"
+#include <trview.common/Version.h>
 
 namespace trlevel
 {
@@ -577,6 +578,7 @@ namespace trlevel
 
         try
         {
+            activity.log(std::format("trview version {}", trview::version()));
             activity.log(std::format("Opening file \"{}\"", _filename));
 
             const bool is_packed = _filename.starts_with("pack") && _pack;

--- a/trview.app/Windows/About/AboutWindow.cpp
+++ b/trview.app/Windows/About/AboutWindow.cpp
@@ -1,4 +1,5 @@
 #include "AboutWindow.h"
+#include <trview.common/Version.h>
 
 namespace trview
 {
@@ -23,7 +24,7 @@ namespace trview
         ImGui::PushStyleVar(ImGuiStyleVar_WindowMinSize, ImVec2(400, 0));
         if (ImGui::Begin("About", &stay_open, ImGuiWindowFlags_None))
         {
-            ImGui::TextWrapped("trview, Version 2.7.4");
+            ImGui::TextWrapped(std::format("trview, Version {}", trview::version()).c_str());
             ImGui::TextWrapped("Copyright (c) 2025 trview team");
             ImGui::TextWrapped("Licensed under the MIT license");
             ImGui::TextWrapped("Uses DirectXTK (MIT)");

--- a/trview.common/Version.h
+++ b/trview.common/Version.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+namespace trview
+{
+    constexpr std::string version();
+}
+
+#include "Version.hpp"

--- a/trview.common/Version.hpp
+++ b/trview.common/Version.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace trview
+{
+    constexpr std::string version()
+    {
+        return "2.7.4";
+    }
+}

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -39,6 +39,8 @@
     <ClInclude Include="Strings.h" />
     <ClInclude Include="Timer.h" />
     <ClInclude Include="TokenStore.h" />
+    <ClInclude Include="Version.h" />
+    <ClInclude Include="Version.hpp" />
     <ClInclude Include="Window.h" />
     <ClInclude Include="Windows\Clipboard.h" />
     <ClInclude Include="Windows\Dialogs.h" />

--- a/trview.common/trview.common.vcxproj.filters
+++ b/trview.common/trview.common.vcxproj.filters
@@ -80,6 +80,8 @@
     <ClInclude Include="Logs\Message.h">
       <Filter>Logs</Filter>
     </ClInclude>
+    <ClInclude Include="Version.h" />
+    <ClInclude Include="Version.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Size.cpp" />


### PR DESCRIPTION
Add the version number to the start of the file loading log.
Reuse the same version number in the about window.
Closes #1384