### PR TITLE
Allow level switching in pack files

### DIFF
--- a/trlevel/IPack.h
+++ b/trlevel/IPack.h
@@ -7,6 +7,8 @@
 #include <optional>
 #include <vector>
 
+#include <trview.common/IFiles.h>
+
 namespace trlevel
 {
     struct IPack
@@ -29,5 +31,6 @@ namespace trlevel
 
     std::string pack_filename(const std::string& filename);
     std::optional<std::vector<uint8_t>> pack_entry(const IPack& pack, uint32_t offset);
+    std::vector<trview::IFiles::File> valid_pack_levels(const IPack& pack);
 }
 

--- a/trlevel/Pack.cpp
+++ b/trlevel/Pack.cpp
@@ -102,4 +102,19 @@ namespace trlevel
         }
         return std::nullopt;
     }
+
+    std::vector<trview::IFiles::File> valid_pack_levels(const IPack& pack)
+    {
+        return pack.parts() |
+            std::views::filter([](auto&& p) { return p.version.has_value() && p.version->version != trlevel::LevelVersion::Unknown; }) |
+            std::views::transform([&](auto&& p) -> trview::IFiles::File
+                {
+                    return
+                    {
+                        .path = std::format("pack://{}\\{}", pack.filename(), p.start),
+                        .friendly_name = std::to_string(p.start)
+                    };
+                }) |
+            std::ranges::to<std::vector>();
+    }
 }

--- a/trview.app.tests/FileMenuTests.cpp
+++ b/trview.app.tests/FileMenuTests.cpp
@@ -189,7 +189,7 @@ TEST(FileMenu, PreviousFile)
         raised = f;
     };
 
-    menu->open_file("file2");
+    menu->open_file("file2", {});
 
     f6_shortcut();
     ASSERT_TRUE(raised);
@@ -210,7 +210,7 @@ TEST(FileMenu, NextFile)
         raised = f;
     };
 
-    menu->open_file("file1");
+    menu->open_file("file1", {});
 
     f7_shortcut();
     ASSERT_TRUE(raised);
@@ -231,7 +231,7 @@ TEST(FileMenu, SwitchTo)
         raised = f;
     };
 
-    menu->open_file("file1");
+    menu->open_file("file1", {});
     menu->switch_to("c:\\dir\\file2");
     ASSERT_TRUE(raised);
     ASSERT_EQ(raised.value(), "file2");

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -774,7 +774,7 @@ namespace trview
         auto old_level = _level;
         _level = level;
 
-        _file_menu->open_file(level->filename());
+        _file_menu->open_file(level->filename(), level->pack());
         _level->set_map_colours(_settings.map_colours);
         _windows->set_level(_level);
         if (open_mode == ILevel::OpenMode::Full)

--- a/trview.app/Menus/FileMenu.cpp
+++ b/trview.app/Menus/FileMenu.cpp
@@ -129,14 +129,18 @@ namespace trview
         return std::nullopt;
     }
 
-    void FileMenu::open_file(const std::string& filename)
+    void FileMenu::open_file(const std::string& filename, const std::weak_ptr<trlevel::IPack>& pack)
     {
         _opened_file = filename;
 
-        const std::size_t pos = filename.find_last_of("\\/");
-        const std::string folder = filename.substr(0, pos);
-
-        _file_switcher_list = _files->get_files(folder, default_file_pattern);
+        if (const auto pack_ptr = pack.lock())
+        {
+            _file_switcher_list = valid_pack_levels(*pack_ptr);
+        }
+        else
+        {
+            _file_switcher_list = _files->get_files(path_for_filename(filename), default_file_pattern);
+        }
 
         // Enable menu when populating in case it's not enabled
         EnableMenuItem(GetMenu(window()), ID_FILE_SWITCHLEVEL, MF_ENABLED);

--- a/trview.app/Menus/FileMenu.h
+++ b/trview.app/Menus/FileMenu.h
@@ -20,7 +20,7 @@ namespace trview
         virtual ~FileMenu() = default;
         std::vector<std::string> local_levels() const override;
         std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
-        void open_file(const std::string& filename) override;
+        void open_file(const std::string& filename, const std::weak_ptr<trlevel::IPack>& pack) override;
         void render() override;
         void set_recent_files(const std::list<std::string>& files) override;
         void switch_to(const std::string& filename) override;

--- a/trview.app/Menus/IFileMenu.h
+++ b/trview.app/Menus/IFileMenu.h
@@ -3,6 +3,7 @@
 #include <list>
 #include <string>
 #include <trview.common/Event.h>
+#include <trlevel/IPack.h>
 
 namespace trview
 {
@@ -16,7 +17,7 @@ namespace trview
         /// Open the specified file. This will populate the switcher menu.
         /// </summary>
         /// <param name="filename">The file that was opened.</param>
-        virtual void open_file(const std::string& filename) = 0;
+        virtual void open_file(const std::string& filename, const std::weak_ptr<trlevel::IPack>& pack) = 0;
         /// <summary>
         /// Render in ImGui mode.
         /// </summary>

--- a/trview.app/Menus/ImGuiFileMenu.cpp
+++ b/trview.app/Menus/ImGuiFileMenu.cpp
@@ -13,9 +13,16 @@ namespace trview
         return {};
     }
 
-    void ImGuiFileMenu::open_file(const std::string& filename)
+    void ImGuiFileMenu::open_file(const std::string& filename, const std::weak_ptr<trlevel::IPack>& pack)
     {
-        _file_switcher = _files->get_files(path_for_filename(filename), default_file_pattern);
+        if (const auto pack_ptr = pack.lock())
+        {
+            _file_switcher = valid_pack_levels(*pack_ptr);
+        }
+        else
+        {
+            _file_switcher = _files->get_files(path_for_filename(filename), default_file_pattern);
+        }
     }
 
     void ImGuiFileMenu::render()

--- a/trview.app/Menus/ImGuiFileMenu.h
+++ b/trview.app/Menus/ImGuiFileMenu.h
@@ -15,7 +15,7 @@ namespace trview
         explicit ImGuiFileMenu(const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
         virtual ~ImGuiFileMenu() = default;
         std::vector<std::string> local_levels() const override;
-        void open_file(const std::string& filename) override;
+        void open_file(const std::string& filename, const std::weak_ptr<trlevel::IPack>& pack) override;
         void render() override;
         void set_recent_files(const std::list<std::string>& files) override;
         void switch_to(const std::string& filename) override;

--- a/trview.app/Mocks/Menus/IFileMenu.h
+++ b/trview.app/Mocks/Menus/IFileMenu.h
@@ -11,7 +11,7 @@ namespace trview
             MockFileMenu();
             virtual ~MockFileMenu();
             MOCK_METHOD(std::vector<std::string>, local_levels, (), (const, override));
-            MOCK_METHOD(void, open_file, (const std::string&), (override));
+            MOCK_METHOD(void, open_file, (const std::string&, const std::weak_ptr<trlevel::IPack>&), (override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_recent_files, (const std::list<std::string>&), (override));
             MOCK_METHOD(void, switch_to, (const std::string&), (override));

--- a/trview.app/Windows/Diff/DiffWindow.cpp
+++ b/trview.app/Windows/Diff/DiffWindow.cpp
@@ -708,7 +708,7 @@ namespace trview
             _diff = _load.get();
             if (_diff->level)
             {
-                _file_menu->open_file(_diff->level->filename());
+                _file_menu->open_file(_diff->level->filename(), _diff->level->pack());
                 _settings.add_recent_diff_file(_diff->level->filename());
                 _file_menu->set_recent_files(_settings.recent_diff_files);
                 on_settings(_settings);

--- a/trview.app/Windows/Diff/DiffWindow.cpp
+++ b/trview.app/Windows/Diff/DiffWindow.cpp
@@ -520,8 +520,30 @@ namespace trview
     std::shared_ptr<ILevel> DiffWindow::load_level(const std::string& filename)
     {
         _progress = std::format("Loading {}", filename);
+
+        std::shared_ptr<trlevel::IPack> current_pack;
+        if (filename.starts_with("pack://"))
+        {
+            const auto pack_filename = trlevel::pack_filename(filename);
+
+            if (_diff.has_value())
+            {
+                // Attempt to reuse the current level pack.
+                auto level = _diff->level;
+                current_pack = level ? level->pack().lock() : nullptr;
+                if (!current_pack || current_pack->filename() != pack_filename)
+                {
+                    auto pack_level = _level_source(pack_filename, {}, { .on_progress_callback = [&](auto&& p) { _progress = p; } });
+                    if (auto pack = pack_level->pack().lock())
+                    {
+                        current_pack = pack;
+                    }
+                }
+            }
+        }
+
         auto level = _level_source(filename,
-            {},
+            current_pack,
             {
                 .on_progress_callback = [&](auto&& p) { _progress = p; }
             });

--- a/trview.app/Windows/Diff/DiffWindow.cpp
+++ b/trview.app/Windows/Diff/DiffWindow.cpp
@@ -526,18 +526,14 @@ namespace trview
         {
             const auto pack_filename = trlevel::pack_filename(filename);
 
-            if (_diff.has_value())
+            std::shared_ptr<ILevel> level = _diff.has_value() ? _diff->level : nullptr;
+            current_pack = level ? level->pack().lock() : nullptr;
+            if (!current_pack || current_pack->filename() != pack_filename)
             {
-                // Attempt to reuse the current level pack.
-                auto level = _diff->level;
-                current_pack = level ? level->pack().lock() : nullptr;
-                if (!current_pack || current_pack->filename() != pack_filename)
+                auto pack_level = _level_source(pack_filename, {}, { .on_progress_callback = [&](auto&& p) { _progress = p; } });
+                if (auto pack = pack_level->pack().lock())
                 {
-                    auto pack_level = _level_source(pack_filename, {}, { .on_progress_callback = [&](auto&& p) { _progress = p; } });
-                    if (auto pack = pack_level->pack().lock())
-                    {
-                        current_pack = pack;
-                    }
+                    current_pack = pack;
                 }
             }
         }


### PR DESCRIPTION
Allow the level switcher to work when using a GAMEWAD (pack file). This also lets you open files in a GAMEWAD from the diff window.
Closes #1389 