### PR TITLE
Add map, details indices to sound board

### DIFF
--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -171,11 +171,11 @@ namespace trlevel
         {
             std::function<void(const std::string&)> on_progress_callback;
             std::function<void(const std::vector<uint32_t>&)> on_textile_callback;
-            std::function<void(uint16_t, const std::vector<uint8_t>&)> on_sound_callback;
+            std::function<void(uint16_t, uint16_t, uint16_t, const std::vector<uint8_t>&)> on_sound_callback;
 
             void on_progress(const std::string& message) const;
             void on_textile(const std::vector<uint32_t>& data) const;
-            void on_sound(uint16_t id, const std::vector<uint8_t>&) const;
+            void on_sound(uint16_t sound_map, uint16_t sound_details, uint16_t sample_index, const std::vector<uint8_t>&) const;
         };
 
         virtual void load(const LoadCallbacks& callbacks) = 0;

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -33,11 +33,11 @@ namespace trlevel
         }
     }
 
-    void ILevel::LoadCallbacks::on_sound(uint16_t index, const std::vector<uint8_t>& data) const
+    void ILevel::LoadCallbacks::on_sound(uint16_t sound_map, uint16_t sound_details, uint16_t sample_index, const std::vector<uint8_t>& data) const
     {
         if (on_sound_callback)
         {
-            on_sound_callback(index, data);
+            on_sound_callback(sound_map, sound_details, sample_index, data);
         }
     }
 
@@ -768,7 +768,7 @@ namespace trlevel
                 sfx_file.seekg(-8, std::ios::cur);
                 if (std::ranges::find(_sample_indices, static_cast<uint32_t>(overall_index)) != _sample_indices.end())
                 {
-                    callbacks.on_sound(level_index++, { main->begin() + sfx_file.tellg(), main->begin() + sfx_file.tellg() + size + 8 });
+                    callbacks.on_sound(0, 0, level_index++, { main->begin() + sfx_file.tellg(), main->begin() + sfx_file.tellg() + size + 8 });
                 }
                 overall_index++;
                 sfx_file.seekg(size + 8, std::ios::cur);

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -203,6 +203,7 @@ namespace trlevel
         void read_textiles_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_sprite_textures_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_sounds_external_tr1_psx(trview::Activity& activity, const LoadCallbacks& callbacks);
+        void read_sound_samples_tr4_5(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void adjust_room_textures_psx();
 
         void load_tr1_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -202,6 +202,9 @@ namespace trlevel
         void read_textiles_tr2_psx_demo_70688(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_sprite_textures_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void read_sounds_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks, uint32_t sample_frequency);
+        void read_sounds_tr1_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks, uint32_t sample_frequency);
+        void read_sounds_tr4_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const ILevel::LoadCallbacks& callbacks, uint32_t start, const tr4_psx_level_info& info, uint32_t sample_frequency);
         void read_sounds_external_tr1_psx(trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_sound_samples_tr4_5(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void adjust_room_textures_psx();
@@ -226,7 +229,6 @@ namespace trlevel
         void load_tr5_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_psx_pack(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
 
-        void generate_sounds_tr1(const LoadCallbacks& callbacks);
         void load_sound_fx(trview::Activity& activity, const LoadCallbacks& callbacks);
         std::optional<std::vector<uint8_t>> load_main_sfx() const;
         void load_ngle_sound_fx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const LoadCallbacks& callbacks);
@@ -239,6 +241,8 @@ namespace trlevel
         void generate_mesh_tr3_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
         void generate_mesh_tr4_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
         void generate_object_textures_tr4_psx(std::basic_ispanstream<uint8_t>& file, uint32_t start, const tr4_psx_level_info& info);
+        void generate_sound_samples(const LoadCallbacks& callbacks);
+        void generate_sounds(const LoadCallbacks& callbacks);
 
         PlatformAndVersion _platform_and_version;
 
@@ -281,6 +285,7 @@ namespace trlevel
         std::vector<int16_t> _sound_map;
         std::vector<uint32_t> _sample_indices;
         std::vector<uint8_t> _sound_data;
+        std::vector<std::vector<uint8_t>> _sound_samples;
 
         std::shared_ptr<trview::ILog>   _log;
         std::shared_ptr<IDecrypter>     _decrypter;

--- a/trlevel/Level_common.cpp
+++ b/trlevel/Level_common.cpp
@@ -486,22 +486,6 @@ namespace trlevel
         return sound_map;
     }
 
-    void read_sound_samples_tr4_5(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks)
-    {
-        uint32_t num_samples = read<uint32_t>(file);
-        callbacks.on_progress("Reading sound samples");
-        log_file(activity, file, std::format("Reading {} sound samples", num_samples));
-        std::vector<std::vector<uint8_t>> samples;
-        for (uint32_t i = 0; i < num_samples; ++i)
-        {
-            uint32_t uncompressed = read<uint32_t>(file);
-            uncompressed;
-            uint32_t compressed = read<uint32_t>(file);
-            callbacks.on_sound(static_cast<uint16_t>(i), read_vector<uint8_t>(file, compressed));
-        }
-        log_file(activity, file, std::format("Read {} sound samples", num_samples));
-    }
-
     std::vector<tr_sound_source> read_sound_sources(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks)
     {
         callbacks.on_progress("Reading sound sources");

--- a/trlevel/Level_psx.cpp
+++ b/trlevel/Level_psx.cpp
@@ -127,7 +127,7 @@ namespace trlevel
             log_file(activity, file, std::format("Loading sound {} of {}", s, sample_sizes.size()));
             if (sample_sizes[s] > 0)
             {
-                callbacks.on_sound(static_cast<uint16_t>(s), convert_vag_to_wav(read_vector<uint8_t>(file, sample_sizes[s]), sample_frequency));
+                callbacks.on_sound(0, 0, static_cast<uint16_t>(s), convert_vag_to_wav(read_vector<uint8_t>(file, sample_sizes[s]), sample_frequency));
             }
         }
 
@@ -150,7 +150,7 @@ namespace trlevel
             const std::size_t size = s == sound_offsets.size() - 1 ?
                 sound_data.size() - offset - 1 :
                 sound_offsets[s + 1] - offset;
-            callbacks.on_sound(static_cast<uint16_t>(s), convert_vag_to_wav({ &sound_data[offset], &sound_data[offset + size] }, sample_frequency));
+            callbacks.on_sound(0, 0, static_cast<uint16_t>(s), convert_vag_to_wav({ &sound_data[offset], &sound_data[offset + size] }, sample_frequency));
         }
 
         log_file(activity, file, std::format("Read {} sounds", sound_offsets.size()));

--- a/trlevel/Level_psx.cpp
+++ b/trlevel/Level_psx.cpp
@@ -106,7 +106,7 @@ namespace trlevel
         return models;
     }
 
-    void read_sounds_tr1_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t sample_frequency)
+    void Level::read_sounds_tr1_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const ILevel::LoadCallbacks& callbacks, uint32_t sample_frequency)
     {
         callbacks.on_progress("Reading sounds");
         log_file(activity, file, "Reading sounds");
@@ -127,14 +127,14 @@ namespace trlevel
             log_file(activity, file, std::format("Loading sound {} of {}", s, sample_sizes.size()));
             if (sample_sizes[s] > 0)
             {
-                callbacks.on_sound(0, 0, static_cast<uint16_t>(s), convert_vag_to_wav(read_vector<uint8_t>(file, sample_sizes[s]), sample_frequency));
+                _sound_samples.push_back(convert_vag_to_wav(read_vector<uint8_t>(file, sample_sizes[s]), sample_frequency));
             }
         }
 
         log_file(activity, file, std::format("Read {} sounds", sample_sizes.size()));
     }
 
-    void read_sounds_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t sample_frequency)
+    void Level::read_sounds_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const ILevel::LoadCallbacks& callbacks, uint32_t sample_frequency)
     {
         callbacks.on_progress("Reading sounds");
         log_file(activity, file, "Reading sounds");
@@ -150,7 +150,7 @@ namespace trlevel
             const std::size_t size = s == sound_offsets.size() - 1 ?
                 sound_data.size() - offset - 1 :
                 sound_offsets[s + 1] - offset;
-            callbacks.on_sound(0, 0, static_cast<uint16_t>(s), convert_vag_to_wav({ &sound_data[offset], &sound_data[offset + size] }, sample_frequency));
+            _sound_samples.push_back(convert_vag_to_wav({ &sound_data[offset], &sound_data[offset + size] }, sample_frequency));
         }
 
         log_file(activity, file, std::format("Read {} sounds", sound_offsets.size()));

--- a/trlevel/Level_tr1_pc.cpp
+++ b/trlevel/Level_tr1_pc.cpp
@@ -82,11 +82,23 @@ namespace trlevel
     void Level::generate_sounds_tr1(const LoadCallbacks& callbacks)
     {
         callbacks.on_progress("Generating sounds");
-        for (auto i = 0; i < _sample_indices.size(); ++i)
+        for (auto sound_map_index = 0; sound_map_index < _sound_map.size(); ++sound_map_index)
         {
-            const auto start = _sample_indices[i];
-            const auto end = i + 1 < _sample_indices.size() ? _sample_indices[i + 1] : _sound_data.size();
-            callbacks.on_sound(static_cast<int16_t>(i), { _sound_data.begin() + start, _sound_data.begin() + end });
+            const int16_t sound_details_index = _sound_map[sound_map_index];
+            if (sound_details_index == -1)
+            {
+                continue;
+            }
+
+            const auto sound_detail = _sound_details[sound_details_index];
+            const auto sample_count = (sound_detail.tr_sound_details.Characteristics >> 2) & 0xF;
+            for (int s = 0; s < sample_count; ++s)
+            {
+                const uint16_t sample_index = static_cast<uint16_t>(sound_detail.tr_sound_details.Sample + s);
+                const auto start = _sample_indices[sample_index];
+                const auto end = sample_index + 1 < _sample_indices.size() ? _sample_indices[sample_index + 1] : _sound_data.size();
+                callbacks.on_sound(static_cast<uint16_t>(sound_map_index), sound_details_index, sample_index, { _sound_data.begin() + start, _sound_data.begin() + end });
+            }
         }
     }
 

--- a/trlevel/Level_tr1_pc.cpp
+++ b/trlevel/Level_tr1_pc.cpp
@@ -79,26 +79,14 @@ namespace trlevel
         log_file(activity, file, std::format("Read {} zones", zones.size()));
     }
 
-    void Level::generate_sounds_tr1(const LoadCallbacks& callbacks)
+    void Level::generate_sound_samples(const LoadCallbacks& callbacks)
     {
-        callbacks.on_progress("Generating sounds");
-        for (auto sound_map_index = 0; sound_map_index < _sound_map.size(); ++sound_map_index)
+        callbacks.on_progress("Generating sound samples");
+        for (int s = 0; s < _sample_indices.size(); ++s)
         {
-            const int16_t sound_details_index = _sound_map[sound_map_index];
-            if (sound_details_index == -1)
-            {
-                continue;
-            }
-
-            const auto sound_detail = _sound_details[sound_details_index];
-            const auto sample_count = (sound_detail.tr_sound_details.Characteristics >> 2) & 0xF;
-            for (int s = 0; s < sample_count; ++s)
-            {
-                const uint16_t sample_index = static_cast<uint16_t>(sound_detail.tr_sound_details.Sample + s);
-                const auto start = _sample_indices[sample_index];
-                const auto end = sample_index + 1 < _sample_indices.size() ? _sample_indices[sample_index + 1] : _sound_data.size();
-                callbacks.on_sound(static_cast<uint16_t>(sound_map_index), sound_details_index, sample_index, { _sound_data.begin() + start, _sound_data.begin() + end });
-            }
+            const auto start = _sample_indices[s];
+            const auto end = s + 1 < _sample_indices.size() ? _sample_indices[s + 1] : _sound_data.size();
+            _sound_samples.push_back({ _sound_data.begin() + start, _sound_data.begin() + end });
         }
     }
 
@@ -195,7 +183,8 @@ namespace trlevel
 
         } while (on_demo_attempt);
 
-        generate_sounds_tr1(callbacks);
+        generate_sound_samples(callbacks);
+        generate_sounds(callbacks);
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);
         callbacks.on_progress("Loading complete");

--- a/trlevel/Level_tr1_psx.cpp
+++ b/trlevel/Level_tr1_psx.cpp
@@ -250,7 +250,7 @@ namespace trlevel
             skip(file, 12);
             uint32_t textile_address = read<uint32_t>(file);
             skip(file, 2);
-            read_sounds_tr1_psx(activity, file, callbacks, 11025);
+            read_sounds_tr1_psx(file, activity, callbacks, 11025);
             file.seekg(textile_address + 8, std::ios::beg);
         }
         else
@@ -308,7 +308,8 @@ namespace trlevel
         _entities = read_entities_tr1(activity, file, callbacks);
         _sound_map = read_sound_map(activity, file, callbacks);
         _sound_details = read_sound_details(activity, file, callbacks);
-        generate_sounds_tr1(callbacks);
+
+        generate_sounds(callbacks);
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);
         callbacks.on_progress("Loading complete");
@@ -393,7 +394,7 @@ namespace trlevel
                 sound_file.exceptions(std::ios::failbit);
 
                 skip(sound_file, 18);
-                read_sounds_tr1_psx(activity, sound_file, callbacks, 11025);
+                read_sounds_tr1_psx(sound_file, activity, callbacks, 11025);
             }
         }
         catch(std::exception&)
@@ -436,7 +437,7 @@ namespace trlevel
         _entities = read_entities_tr1(activity, file, callbacks);
         _sound_map = read_sound_map(activity, file, callbacks);
         _sound_details = read_sound_details(activity, file, callbacks);
-        generate_sounds_tr1(callbacks);
+        generate_sounds(callbacks);
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);
         callbacks.on_progress("Loading complete");

--- a/trlevel/Level_tr2_pc.cpp
+++ b/trlevel/Level_tr2_pc.cpp
@@ -136,8 +136,9 @@ namespace trlevel
             skip(file, 4); // RIFF
             uint32_t size = peek<uint32_t>(file);
             file.seekg(-4, std::ios::cur);
-            callbacks.on_sound(0, 0, static_cast<uint16_t>(s), read_vector<uint8_t>(file, size + 4));
+            _sound_samples.push_back(read_vector<uint8_t>(file, size + 4));
         }
+        generate_sounds(callbacks);
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);
         callbacks.on_progress("Loading complete");
@@ -184,6 +185,7 @@ namespace trlevel
         _sound_details = read_sound_details(activity, file, callbacks);
         _sample_indices = read_sample_indices(activity, file, callbacks);
         load_sound_fx(activity, callbacks);
+        generate_sounds(callbacks);
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);
         callbacks.on_progress("Loading complete");

--- a/trlevel/Level_tr2_pc.cpp
+++ b/trlevel/Level_tr2_pc.cpp
@@ -136,7 +136,7 @@ namespace trlevel
             skip(file, 4); // RIFF
             uint32_t size = peek<uint32_t>(file);
             file.seekg(-4, std::ios::cur);
-            callbacks.on_sound(static_cast<uint16_t>(s), read_vector<uint8_t>(file, size + 4));
+            callbacks.on_sound(0, 0, static_cast<uint16_t>(s), read_vector<uint8_t>(file, size + 4));
         }
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);

--- a/trlevel/Level_tr2_psx.cpp
+++ b/trlevel/Level_tr2_psx.cpp
@@ -316,8 +316,6 @@ namespace trlevel
     {
         skip(file, 12);
         uint32_t textile_address = read<uint32_t>(file);
-        skip(file, 2);
-        read_sounds_tr1_psx(activity, file, callbacks, 8000);
         file.seekg(textile_address + 8, std::ios::beg);
         skip(file, 4);
 
@@ -355,6 +353,9 @@ namespace trlevel
         _sound_map = read_sound_map(activity, file, callbacks);
         _sound_details = read_sound_details(activity, file, callbacks);
 
+        file.seekg(22);
+        read_sounds_tr1_psx(file, activity, callbacks, 8000);
+
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);
         callbacks.on_progress("Loading complete");
@@ -364,8 +365,6 @@ namespace trlevel
     {
         skip(file, 12);
         uint32_t textile_address = read<uint32_t>(file);
-        skip(file, 2);
-        read_sounds_tr1_psx(activity, file, callbacks, 8000);
         file.seekg(textile_address + 8, std::ios::beg);
 
         read_textiles_tr2_psx_demo_70688(file, activity, callbacks);
@@ -421,7 +420,7 @@ namespace trlevel
         // TR2 has sound data at the start of the file so must seek back to the start.
         file.seekg(0, std::ios::beg);
 
-        read_sounds_psx(activity, file, callbacks, 8000);
+        read_sounds_psx(file, activity, callbacks, 8000);
         read<uint32_t>(file); // version - already read.
         _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr2_psx_room);
         _floor_data = read_floor_data(activity, file, callbacks);
@@ -456,6 +455,8 @@ namespace trlevel
 
         _sound_map = read_sound_map(activity, file, callbacks);
         _sound_details = read_sound_details(activity, file, callbacks);
+
+        generate_sounds(callbacks);
 
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);

--- a/trlevel/Level_tr3_pc.cpp
+++ b/trlevel/Level_tr3_pc.cpp
@@ -78,6 +78,7 @@ namespace trlevel
         _sound_details = read_sound_details(activity, file, callbacks);
         _sample_indices = read_sample_indices(activity, file, callbacks);
         load_sound_fx(activity, callbacks);
+        generate_sounds(callbacks);
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);
         callbacks.on_progress("Loading complete");

--- a/trlevel/Level_tr3_psx.cpp
+++ b/trlevel/Level_tr3_psx.cpp
@@ -232,7 +232,7 @@ namespace trlevel
 
     void Level::load_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
-        read_sounds_psx(activity, file, callbacks, 11025);
+        read_sounds_psx(file, activity, callbacks, 11025);
         const bool ects = is_tr3_ects(_platform_and_version);
 
         for (int i = 0; i < (ects ? 10 : 13); ++i)
@@ -292,6 +292,7 @@ namespace trlevel
 
         _sound_map = read_sound_map(activity, file, callbacks);
         _sound_details = read_sound_details(activity, file, callbacks);
+        generate_sounds(callbacks);
 
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);

--- a/trlevel/Level_tr4_psx.cpp
+++ b/trlevel/Level_tr4_psx.cpp
@@ -442,7 +442,7 @@ namespace trlevel
             const std::size_t size = s == sound_offsets.size() - 1 ?
                 sound_data.size() - offset - 1 :
                 sound_offsets[s + 1] - offset;
-            callbacks.on_sound(static_cast<uint16_t>(s), convert_vag_to_wav({ &sound_data[offset], &sound_data[offset + size] }, sample_frequency));
+            callbacks.on_sound(0, 0, static_cast<uint16_t>(s), convert_vag_to_wav({ &sound_data[offset], &sound_data[offset + size] }, sample_frequency));
         }
 
         log_file(activity, file, std::format("Read {} sounds", sound_offsets.size()));

--- a/trlevel/Level_tr4_psx.cpp
+++ b/trlevel/Level_tr4_psx.cpp
@@ -424,7 +424,7 @@ namespace trlevel
                 }) | std::ranges::to<std::vector>();
     }
 
-    void read_sounds_tr4_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t start, const tr4_psx_level_info& info, uint32_t sample_frequency)
+    void Level::read_sounds_tr4_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const ILevel::LoadCallbacks& callbacks, uint32_t start, const tr4_psx_level_info& info, uint32_t sample_frequency)
     {
         callbacks.on_progress("Reading sounds");
         log_file(activity, file, "Reading sounds");
@@ -442,7 +442,7 @@ namespace trlevel
             const std::size_t size = s == sound_offsets.size() - 1 ?
                 sound_data.size() - offset - 1 :
                 sound_offsets[s + 1] - offset;
-            callbacks.on_sound(0, 0, static_cast<uint16_t>(s), convert_vag_to_wav({ &sound_data[offset], &sound_data[offset + size] }, sample_frequency));
+            _sound_samples.push_back(convert_vag_to_wav({ &sound_data[offset], &sound_data[offset + size] }, sample_frequency));
         }
 
         log_file(activity, file, std::format("Read {} sounds", sound_offsets.size()));
@@ -691,7 +691,8 @@ namespace trlevel
             callbacks.on_textile(convert_textile(t));
         }
 
-        read_sounds_tr4_psx(activity, file, callbacks, start, info, 11025);
+        read_sounds_tr4_psx(file, activity, callbacks, start, info, 11025);
+        generate_sounds(callbacks);
 
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);

--- a/trlevel/Level_tr5_dc.cpp
+++ b/trlevel/Level_tr5_dc.cpp
@@ -308,6 +308,7 @@ namespace trlevel
             log_file(activity, file, std::format("Failed to load sound samples {}", e.what()));
         }
 
+        generate_sounds(callbacks);
         callbacks.on_progress("Generating meshes");
         log_file(activity, file, "Generating meshes");
         generate_meshes(_mesh_data);

--- a/trlevel/Level_tr5_dc.cpp
+++ b/trlevel/Level_tr5_dc.cpp
@@ -298,7 +298,7 @@ namespace trlevel
         try
         {
             skip(file, 4); // TOSS
-            read_sound_samples_tr4_5(activity, file, callbacks);
+            read_sound_samples_tr4_5(file, activity, callbacks);
         }
         catch (const std::exception& e)
         {

--- a/trlevel/Level_tr5_pc.cpp
+++ b/trlevel/Level_tr5_pc.cpp
@@ -280,6 +280,7 @@ namespace trlevel
             log_file(activity, file, std::format("Failed to load sound samples {}", e.what()));
         }
 
+        generate_sounds(callbacks);
         callbacks.on_progress("Generating meshes");
         log_file(activity, file, "Generating meshes");
         generate_meshes(_mesh_data);
@@ -329,6 +330,7 @@ namespace trlevel
         _entities = read_entities(activity, file, callbacks);
 
         load_sound_fx(activity, callbacks);
+        generate_sounds(callbacks);
 
         callbacks.on_progress("Generating meshes");
         log_file(activity, file, "Generating meshes");

--- a/trlevel/Level_tr5_pc.cpp
+++ b/trlevel/Level_tr5_pc.cpp
@@ -269,7 +269,7 @@ namespace trlevel
             }
             else
             {
-                read_sound_samples_tr4_5(activity, file, callbacks);
+                read_sound_samples_tr4_5(file, activity, callbacks);
             }
         }
         catch (const std::exception& e)

--- a/trlevel/Level_tr5_psx.cpp
+++ b/trlevel/Level_tr5_psx.cpp
@@ -137,7 +137,8 @@ namespace trlevel
             callbacks.on_textile(convert_textile(t));
         }
 
-        read_sounds_tr4_psx(activity, file, callbacks, start, info, 11025);
+        read_sounds_tr4_psx(file, activity, callbacks, start, info, 11025);
+        generate_sounds(callbacks);
 
         callbacks.on_progress("Generating meshes");
         generate_meshes(_mesh_data);

--- a/trview.app.tests/Sound/SoundStorageTests.cpp
+++ b/trview.app.tests/Sound/SoundStorageTests.cpp
@@ -15,7 +15,7 @@ TEST(SoundStorage, AddAndGetSound)
     auto found = storage.get(100).lock();
     ASSERT_EQ(found, nullptr);
 
-    storage.add(100, {});
+    storage.add({ .sound_map = 0, .sound_details = 0, .sample_index = 100 }, {});
 
     found = storage.get(100).lock();
     ASSERT_EQ(found, sound);
@@ -30,10 +30,10 @@ TEST(SoundStorage, AddAndGetSounds)
     auto sounds = storage.sounds();
     ASSERT_EQ(sounds.empty(), true);
 
-    storage.add(100, {});
+    storage.add({ .sound_map = 0, .sound_details = 0, .sample_index = 100 }, {});
 
     sounds = storage.sounds();
     ASSERT_EQ(sounds.size(), 1);
-    ASSERT_NE(sounds.find(100), sounds.end());
-    ASSERT_EQ(sounds[100].lock(), sound);
+    ASSERT_EQ(sounds[0].index.sample_index, 100);
+    ASSERT_EQ(sounds[0].sound.lock(), sound);
 }

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -288,10 +288,10 @@ namespace trview
                     };
 
                 auto sound_storage = std::make_shared<SoundStorage>(sound_source);
-                callbacks.on_sound_callback = [&](auto&& index, auto&& data)
+                callbacks.on_sound_callback = [&](auto&& sound_map, auto&& sound_details, auto&& sample_index, auto&& data)
                     {
-                        callbacks.on_progress(std::format("Loading sound {}", index));
-                        sound_storage->add(index, data);
+                        callbacks.on_progress(std::format("Loading sound {}:{}:{}", sound_map, sound_details, sample_index));
+                        sound_storage->add({ .sound_map = sound_map, .sound_details = sound_details, .sample_index = sample_index }, data);
                     };
 
                 level->load(callbacks);

--- a/trview.app/Mocks/Sound/ISoundStorage.h
+++ b/trview.app/Mocks/Sound/ISoundStorage.h
@@ -10,9 +10,9 @@ namespace trview
         {
             MockSoundStorage();
             virtual ~MockSoundStorage();
-            MOCK_METHOD(void, add, (uint16_t, const std::vector<uint8_t>&), (override));
+            MOCK_METHOD(void, add, (ISoundStorage::Index, const std::vector<uint8_t>&), (override));
             MOCK_METHOD(std::weak_ptr<ISound>, get, (uint16_t), (const, override));
-            MOCK_METHOD((std::unordered_map<uint16_t, std::weak_ptr<ISound>>), sounds, (), (const, override));
+            MOCK_METHOD(std::vector<Entry>, sounds, (), (const, override));
         };
     }
 }

--- a/trview.app/Sound/ISoundStorage.h
+++ b/trview.app/Sound/ISoundStorage.h
@@ -10,9 +10,23 @@ namespace trview
 
     struct ISoundStorage
     {
+        struct Index
+        {
+            uint16_t sound_map;
+            uint16_t sound_details;
+            uint16_t sample_index;
+            auto operator<=>(const Index&) const = default;
+        };
+
+        struct Entry
+        {
+            Index index;
+            std::weak_ptr<ISound> sound;
+        };
+
         virtual ~ISoundStorage() = 0;
-        virtual void add(uint16_t index, const std::vector<uint8_t>& data) = 0;
+        virtual void add(Index index, const std::vector<uint8_t>& data) = 0;
         virtual std::weak_ptr<ISound> get(uint16_t index) const = 0;
-        virtual std::unordered_map<uint16_t, std::weak_ptr<ISound>> sounds() const = 0;
+        virtual std::vector<Entry> sounds() const = 0;
     };
 }

--- a/trview.app/Sound/SoundStorage.cpp
+++ b/trview.app/Sound/SoundStorage.cpp
@@ -1,4 +1,5 @@
 #include "SoundStorage.h"
+#include <ranges>
 
 namespace trview
 {
@@ -11,20 +12,20 @@ namespace trview
     {
     }
 
-    void SoundStorage::add(uint16_t index, const std::vector<uint8_t>& data)
+    void SoundStorage::add(Index index, const std::vector<uint8_t>& data)
     {
         const auto sound = _sound_source(data);
-        _sounds[index] = sound;
+        _sounds.push_back({ .index = index, .sound = sound });
     }
 
     std::weak_ptr<ISound> SoundStorage::get(uint16_t index) const
     {
-        const auto found = _sounds.find(index);
-        return found == _sounds.end() ? nullptr : found->second;
+        const auto found = std::ranges::find_if(_sounds, [=](auto& s) { return s.index.sample_index == index; });
+        return found == _sounds.end() ? nullptr : found->sound;
     }
 
-    std::unordered_map<uint16_t, std::weak_ptr<ISound>> SoundStorage::sounds() const
+    std::vector<ISoundStorage::Entry> SoundStorage::sounds() const
     {
-        return _sounds | std::ranges::to<std::unordered_map<uint16_t, std::weak_ptr<ISound>>>();
+        return _sounds | std::views::transform([](auto&& e) -> Entry { return { .index = e.index, .sound = e.sound }; }) | std::ranges::to<std::vector>();
     }
 }

--- a/trview.app/Sound/SoundStorage.h
+++ b/trview.app/Sound/SoundStorage.h
@@ -14,11 +14,17 @@ namespace trview
     public:
         explicit SoundStorage(const ISound::Source& sound_source);
         virtual ~SoundStorage() = default;
-        void add(uint16_t index, const std::vector<uint8_t>& data) override;
+        void add(Index index, const std::vector<uint8_t>& data) override;
         std::weak_ptr<ISound> get(uint16_t index) const override;
-        std::unordered_map<uint16_t, std::weak_ptr<ISound>> sounds() const override;
+        std::vector<Entry> sounds() const override;
     private:
+        struct OwningEntry
+        {
+            Index index;
+            std::shared_ptr<ISound> sound;
+        };
+
         ISound::Source _sound_source;
-        std::unordered_map<uint16_t, std::shared_ptr<ISound>> _sounds;
+        std::vector<OwningEntry> _sounds;
     };
 }

--- a/trview.app/Windows/Sounds/SoundsWindow.cpp
+++ b/trview.app/Windows/Sounds/SoundsWindow.cpp
@@ -295,13 +295,13 @@ namespace trview
             if (const auto sound_storage = _sound_storage.lock())
             {
                 ImVec2 size = ImGui::GetWindowSize();
-                const int slots = static_cast<int>(size.x / 67);
+                const int slots = static_cast<int>(size.x / 72);
                 int count = 0;
                 for (const auto [index, sound] : sound_storage->sounds())
                 {
                     if (const auto sound_ptr = sound.lock())
                     {
-                        if (ImGui::Button(std::format("Map:{}\nDetails:{}\nSample:{}", index.sound_map, index.sound_details, index.sample_index).c_str(), ImVec2(60, 50)))
+                        if (ImGui::Button(std::format("Map:{}\nDetails:{}\nSample:{}", index.sound_map, index.sound_details, index.sample_index).c_str(), ImVec2(65, 65)))
                         {
                             sound_ptr->play();
                         }

--- a/trview.app/Windows/Sounds/SoundsWindow.cpp
+++ b/trview.app/Windows/Sounds/SoundsWindow.cpp
@@ -295,13 +295,13 @@ namespace trview
             if (const auto sound_storage = _sound_storage.lock())
             {
                 ImVec2 size = ImGui::GetWindowSize();
-                const int slots = static_cast<int>(size.x / 57);
+                const int slots = static_cast<int>(size.x / 67);
                 int count = 0;
-                for (const auto [index, sound] : sound_storage->sounds() | std::ranges::to<std::map<int16_t, std::weak_ptr<ISound>>>())
+                for (const auto [index, sound] : sound_storage->sounds())
                 {
                     if (const auto sound_ptr = sound.lock())
                     {
-                        if (ImGui::Button(std::format("{}", index).c_str(), ImVec2(50, 50)))
+                        if (ImGui::Button(std::format("Map:{}\nDetails:{}\nSample:{}", index.sound_map, index.sound_details, index.sample_index).c_str(), ImVec2(60, 50)))
                         {
                             sound_ptr->play();
                         }


### PR DESCRIPTION
Show the map and details numbers in the sound window sound board as well as the sample index.
Change all loaders to use a common sound generation function.
Closes #1402 