### PR TITLE
Add support for TR5 October version

### DIFF
--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -207,6 +207,7 @@ namespace trlevel
         void read_sounds_tr4_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const ILevel::LoadCallbacks& callbacks, uint32_t start, const tr4_psx_level_info& info, uint32_t sample_frequency);
         void read_sounds_external_tr1_psx(trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_sound_samples_tr4_5(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void read_sound_map_tr5_psx(std::basic_ispanstream<uint8_t>& file, const tr4_psx_level_info& info, trview::Activity& activity, const LoadCallbacks& callbacks);
         void adjust_room_textures_psx();
 
         void load_tr1_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -384,7 +384,7 @@ namespace trview
         auto sounds_window_source = [=]() { return std::make_shared<SoundsWindow>(); };
         auto about_window_source = [=]() { return std::make_shared<AboutWindow>(); };
         auto diff_window_source = [=]() { return std::make_shared<DiffWindow>(dialogs, level_source, std::make_unique<ImGuiFileMenu>(dialogs, files)); };
-        auto pack_window_source = [=]() { return std::make_shared<PackWindow>(); };
+        auto pack_window_source = [=]() { return std::make_shared<PackWindow>(files, dialogs); };
 
         return std::make_unique<Application>(
             window,

--- a/trview.app/Windows/Pack/PackWindow.cpp
+++ b/trview.app/Windows/Pack/PackWindow.cpp
@@ -7,6 +7,11 @@ namespace trview
     {
     }
 
+    PackWindow::PackWindow(const std::shared_ptr<IFiles>& files, const std::shared_ptr<IDialogs>& dialogs)
+        : _files(files), _dialogs(dialogs)
+    {
+    }
+
     void PackWindow::render()
     {
         if (!render_pack_window())
@@ -52,6 +57,19 @@ namespace trview
                         if (ImGui::Selectable(std::format("{}##{}", part.start, index++).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
                         {
                             on_level_open(std::format("pack://{}\\{}", pack->filename(), part.start));
+                        }
+                        if (ImGui::BeginPopupContextItem())
+                        {
+                            if (ImGui::MenuItem("Save"))
+                            {
+                                if (const auto file = _dialogs->save_file(std::format(L"Saving {}", part.start),
+                                    { { L"TR4 levels", { L"*.tr4" } }, { L"TR5 levels", { L"*.trc" }}, { L"All files", { L"*.*" }} },
+                                    part.version.has_value() ? (part.version.value().version == trlevel::LevelVersion::Tomb4 ? 1 : 2) : 3))
+                                {
+                                    _files->save_file(file->filename, part.data);
+                                }
+                            }
+                            ImGui::EndPopup();
                         }
                         ImGui::TableNextColumn();
                         ImGui::Text(std::to_string(part.size).c_str());

--- a/trview.app/Windows/Pack/PackWindow.h
+++ b/trview.app/Windows/Pack/PackWindow.h
@@ -7,6 +7,7 @@ namespace trview
     class PackWindow final : public IPackWindow
     {
     public:
+        explicit PackWindow(const std::shared_ptr<IFiles>& files, const std::shared_ptr<IDialogs>& dialogs);
         virtual ~PackWindow() = default;
         void render() override;
         void set_number(int32_t number) override;
@@ -17,5 +18,7 @@ namespace trview
         std::weak_ptr<trlevel::IPack> _pack;
         std::string _id{ "Pack 0" };
         int32_t _index{ 0u };
+        std::shared_ptr<IFiles> _files;
+        std::shared_ptr<IDialogs> _dialogs;
     };
 }


### PR DESCRIPTION
TR5 October version has a sound map of 370 but doesn't have any indication of this (that I could find). Attempt to load with retail sound map and then fall back to the 370 size if following data looks wrong.
Also adds right click save to pack files.
Closes #1407 