### PR TITLE
Add filter for 'Extra' value to Triggers window

### DIFF
--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -526,6 +526,19 @@ namespace trview
                     | std::ranges::to<std::vector>();
             });
 
+        _filters.add_multi_getter<float>("Extra", [&](auto&& trigger)
+            {
+                return trigger.commands()
+                    | std::views::transform([](auto&& t)
+                        {
+                            const auto data = t.data();
+                            return std::ranges::subrange(data.begin() + 1, data.end())
+                                 | std::views::transform([](auto&& d) { return static_cast<float>(d); });
+                        })
+                    | std::views::join
+                    | std::ranges::to<std::vector>();
+            });
+
         auto all_trigger_indices = [](TriggerCommandType type, const auto& trigger)
         {
             std::vector<float> indices;

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -529,11 +529,13 @@ namespace trview
         _filters.add_multi_getter<float>("Extra", [&](auto&& trigger)
             {
                 return trigger.commands()
-                    | std::views::transform([](auto&& t)
+                    | std::views::transform([](auto&& t) -> std::vector<float>
                         {
                             const auto data = t.data();
-                            return std::ranges::subrange(data.begin() + 1, data.end())
-                                 | std::views::transform([](auto&& d) { return static_cast<float>(d); });
+                            return data.size() < 2 ? std::vector<float>{} : (
+                                      std::ranges::subrange(data.begin() + 1, data.end())
+                                    | std::views::transform([](auto&& d) { return static_cast<float>(d); })
+                                    | std::ranges::to<std::vector>());
                         })
                     | std::views::join
                     | std::ranges::to<std::vector>();


### PR DESCRIPTION
Add a multi-getter trigger to the triggers window that filters on the 'Extra' data that cameras and a couple of other commands have.
Since the triggers window is filtering on triggers and not on commands all of the extras are joined and that is what is queried - for example if a trigger has two commands, one with 255 and one with 256 the trigger will have extra value of [255, 256] and will match both.
Closes #1409