### PR TITLE
Add version detection for TR4 PSX V1.0

### DIFF
--- a/trlevel/LevelVersion.cpp
+++ b/trlevel/LevelVersion.cpp
@@ -19,7 +19,7 @@ namespace trlevel
             {
                 return { .platform = Platform::PSX, .is_pack = true };
             }
-            else if (version == 0x6a20)
+            else if (version == 0x6a20 || version == 0x6ba8)
             {
                 return { .platform = Platform::PSX, .version = LevelVersion::Tomb4 };
             }
@@ -122,5 +122,10 @@ namespace trlevel
     bool is_tr4_opsm_90(PlatformAndVersion version)
     {
         return version.raw_version == 0xffffff88;
+    }
+
+    bool is_tr4_psx_v1(PlatformAndVersion version)
+    {
+        return version.raw_version == 0x6ba8;
     }
 }

--- a/trlevel/LevelVersion.h
+++ b/trlevel/LevelVersion.h
@@ -56,6 +56,7 @@ namespace trlevel
     bool is_tr3_demo_55(PlatformAndVersion version);
     bool is_tr4_oct_1999(PlatformAndVersion version);
     bool is_tr4_opsm_90(PlatformAndVersion version);
+    bool is_tr4_psx_v1(PlatformAndVersion version);
 
     constexpr std::string to_string(LevelVersion version) noexcept;
     constexpr std::string to_string(Platform platform) noexcept;

--- a/trlevel/Level_tr4_psx.cpp
+++ b/trlevel/Level_tr4_psx.cpp
@@ -637,7 +637,7 @@ namespace trlevel
 
     void Level::load_tr4_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
-        if (is_tr4_oct_1999(_platform_and_version))
+        if (is_tr4_oct_1999(_platform_and_version) || is_tr4_psx_v1(_platform_and_version))
         {
             file.seekg(0x7000, std::ios::beg);
         }


### PR DESCRIPTION
'Version' bytes are a bit different as the loader code changed between here and whatever version I tested against before.
Closes #1411