### PR TITLE
Correctly offset room sprites based on their size

### DIFF
--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -55,7 +55,7 @@ namespace trview
 
         if (_type == Type::Sprite)
         {
-            _world = create_billboard(_position, Vector3(0, -0.5f, 0), _scale, camera);
+            _world = create_billboard(_position, Vector3(), _scale, camera);
         }
         _mesh->render(_world * camera.view_projection(), texture_storage, colour);
     }
@@ -80,7 +80,7 @@ namespace trview
 
         if (_type == Type::Sprite)
         {
-            _world = create_billboard(_position, Vector3(0, -0.5f, 0), _scale, camera);
+            _world = create_billboard(_position, Vector3(), _scale, camera);
         }
 
         for (const auto& triangle : _mesh->transparent_triangles())

--- a/trview.app/Geometry/IMesh.cpp
+++ b/trview.app/Geometry/IMesh.cpp
@@ -66,7 +66,8 @@ namespace trview
 
             if (offset_mode == SpriteOffsetMode::RoomSprite)
             {
-                offset = Vector3(0, (1 - object_height) * 0.5f, 0);
+                const float y_factor = (-0.5f + ((fabs(static_cast<float>(top)) / (bottom - top))));
+                offset = Vector3(0, -object_height * y_factor, 0);
             }
             else
             {

--- a/trview.app/Geometry/IMesh.cpp
+++ b/trview.app/Geometry/IMesh.cpp
@@ -66,8 +66,11 @@ namespace trview
 
             if (offset_mode == SpriteOffsetMode::RoomSprite)
             {
-                const float y_factor = (-0.5f + ((fabs(static_cast<float>(top)) / (bottom - top))));
-                offset = Vector3(0, -object_height * y_factor, 0);
+                if (bottom != top)
+                {
+                    const float y_factor = (-0.5f + ((fabs(static_cast<float>(top)) / (bottom - top))));
+                    offset = Vector3(0, -object_height * y_factor, 0);
+                }
             }
             else
             {


### PR DESCRIPTION
Room sprite offset was assuming that sprites were had equal size on either side of the centre y.
Take into account sprite like the dangling vines that need to be moved up, not down and not just by half the object height.
Closes #1414