### PR TITLE
Map music IDs to music filename numbers

### DIFF
--- a/trview.app.tests/TriggersWindowManagerTests.cpp
+++ b/trview.app.tests/TriggersWindowManagerTests.cpp
@@ -166,6 +166,19 @@ TEST(TriggersWindowManager, SetItemsSetsItemsOnWindows)
     manager->set_items({});
 }
 
+TEST(TriggersWindowManager, SetPlatformAndVersionSetsPlatformAndVersionOnWindows)
+{
+    auto mock_window = mock_shared<MockTriggersWindow>();
+    EXPECT_CALL(*mock_window, set_platform_and_version).Times(2);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+
+    auto created_window = manager->create_window().lock();
+    ASSERT_NE(created_window, nullptr);
+    ASSERT_EQ(created_window, mock_window);
+
+    manager->set_platform_and_version({});
+}
+
 TEST(TriggersWindowManager, SetTriggersSetsTriggersOnWindows)
 {
     auto mock_window = mock_shared<MockTriggersWindow>();

--- a/trview.app.tests/Windows/WindowsTests.cpp
+++ b/trview.app.tests/Windows/WindowsTests.cpp
@@ -598,6 +598,7 @@ TEST(Windows, SetLevel)
     auto [triggers_ptr, triggers] = create_mock<MockTriggersWindowManager>();
     EXPECT_CALL(triggers, set_items).Times(1);
     EXPECT_CALL(triggers, set_triggers).Times(1);
+    EXPECT_CALL(triggers, set_platform_and_version).Times(1);
     auto [textures_ptr, textures] = create_mock<MockTexturesWindowManager>();
     EXPECT_CALL(textures, set_texture_storage).Times(1);
     auto windows = register_test_module()

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -147,6 +147,7 @@ namespace trview
         virtual std::weak_ptr<ISoundStorage> sound_storage() const = 0;
         virtual bool trng() const = 0;
         virtual std::weak_ptr<trlevel::IPack> pack() const = 0;
+        virtual trlevel::PlatformAndVersion platform_and_version() const = 0;
 
         Event<std::weak_ptr<IItem>> on_item_selected;
         // Event raised when the level needs to change the selected room.

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -262,7 +262,7 @@ namespace trview
 
     trlevel::Platform Level::platform() const
     {
-        return _platform;
+        return _platform_and_version.platform;
     }
 
     void Level::render(const ICamera& camera, bool render_selection)
@@ -535,7 +535,7 @@ namespace trview
             {
                 if (has_flag(sector->flags(), SectorFlag::Trigger))
                 {
-                    auto trigger = trigger_source(static_cast<uint32_t>(_triggers.size()), room, sector->x(), sector->z(), sector->trigger_info(), _version, shared_from_this(), sector);
+                    auto trigger = trigger_source(static_cast<uint32_t>(_triggers.size()), room, sector->x(), sector->z(), sector->trigger_info(), _platform_and_version.version, shared_from_this(), sector);
                     _triggers.push_back(trigger);
                     sector->set_trigger(trigger);
                     room->add_trigger(trigger);
@@ -1050,7 +1050,7 @@ namespace trview
 
     trlevel::LevelVersion Level::version() const
     {
-        return _version;
+        return _platform_and_version.version;
     }
 
     std::string Level::filename() const
@@ -1350,8 +1350,7 @@ namespace trview
         const ISoundSource::Source& sound_source_source,
         const trlevel::ILevel::LoadCallbacks callbacks)
     {
-        _platform = level->platform();
-        _version = level->get_version();
+        _platform_and_version = level->platform_and_version();
         _floor_data = level->get_floor_data_all();
         _name = level->name();
         _ng = level->trng();
@@ -1482,7 +1481,7 @@ namespace trview
                     detail = details[index];
                 }
             }
-            auto sound_source = sound_source_source(count++, source, detail, _version, shared_from_this());
+            auto sound_source = sound_source_source(count++, source, detail, _platform_and_version.version, shared_from_this());
             _token_store += sound_source->on_changed += [this]() { content_changed(); };
             _sound_sources.push_back(sound_source);
         }
@@ -1544,6 +1543,11 @@ namespace trview
     std::weak_ptr<trlevel::IPack> Level::pack() const
     {
         return _pack;
+    }
+
+    trlevel::PlatformAndVersion Level::platform_and_version() const
+    {
+        return _platform_and_version;
     }
 
     bool find_item_by_type_id(const ILevel& level, uint32_t type_id, std::weak_ptr<IItem>& output_item)

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -128,6 +128,7 @@ namespace trview
         bool ng_plus() const override;
         bool trng() const override;
         std::weak_ptr<trlevel::IPack> pack() const override;
+        trlevel::PlatformAndVersion platform_and_version() const override;
     private:
         void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage);
         void generate_triggers(const ITrigger::Source& trigger_source);
@@ -214,8 +215,6 @@ namespace trview
 
         std::unique_ptr<ISelectionRenderer> _selection_renderer;
         std::set<uint32_t> _alternate_groups;
-        trlevel::LevelVersion _version;
-        trlevel::Platform _platform;
         std::string _filename;
         std::shared_ptr<ILog> _log;
         std::vector<uint16_t> _floor_data;
@@ -230,6 +229,7 @@ namespace trview
         std::shared_ptr<INgPlusSwitcher> _ngplus_switcher;
         bool _ng{ false };
         std::shared_ptr<trlevel::IPack> _pack;
+        trlevel::PlatformAndVersion _platform_and_version;
     };
 
     /// Find the first item with the type id specified.

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -84,6 +84,7 @@ namespace trview
             MOCK_METHOD(bool, ng_plus, (), (const, override));
             MOCK_METHOD(bool, trng, (), (const, override));
             MOCK_METHOD(std::weak_ptr<trlevel::IPack>, pack, (), (const, override));
+            MOCK_METHOD(trlevel::PlatformAndVersion, platform_and_version, (), (const, override));
 
             std::shared_ptr<MockLevel> with_version(trlevel::LevelVersion version)
             {

--- a/trview.app/Mocks/Windows/ITriggersWindow.h
+++ b/trview.app/Mocks/Windows/ITriggersWindow.h
@@ -17,6 +17,7 @@ namespace trview
             MOCK_METHOD(void, set_items, (const std::vector<std::weak_ptr<IItem>>&), (override));
             MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));
+            MOCK_METHOD(void, set_platform_and_version, (const trlevel::PlatformAndVersion&), (override));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(void, update, (float), (override));
         };

--- a/trview.app/Mocks/Windows/ITriggersWindowManager.h
+++ b/trview.app/Mocks/Windows/ITriggersWindowManager.h
@@ -12,6 +12,7 @@ namespace trview
             virtual ~MockTriggersWindowManager();
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_items, (const std::vector<std::weak_ptr<IItem>>&), (override));
+            MOCK_METHOD(void, set_platform_and_version, (const trlevel::PlatformAndVersion&), (override));
             MOCK_METHOD(void, set_triggers, (const std::vector<std::weak_ptr<ITrigger>>&), (override));
             MOCK_METHOD(void, set_room, (const std::weak_ptr<IRoom>&), (override));
             MOCK_METHOD(void, set_selected_trigger, (const std::weak_ptr<ITrigger>&), (override));

--- a/trview.app/Windows/ITriggersWindow.h
+++ b/trview.app/Windows/ITriggersWindow.h
@@ -51,6 +51,8 @@ namespace trview
 
         virtual void set_number(int32_t number) = 0;
 
+        virtual void set_platform_and_version(const trlevel::PlatformAndVersion& platform_and_version) = 0;
+
         /// Set the selected trigger.
         /// @param item The selected trigger.
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) = 0;

--- a/trview.app/Windows/ITriggersWindowManager.h
+++ b/trview.app/Windows/ITriggersWindowManager.h
@@ -28,6 +28,8 @@ namespace trview
         /// @param items The items in the level.
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) = 0;
 
+        virtual void set_platform_and_version(const trlevel::PlatformAndVersion& platform_and_version) = 0;
+
         /// Set the triggers to use in the windows.
         /// @param triggers The triggers in the level.
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) = 0;

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -18,7 +18,86 @@ namespace trview
                 return room->sector(static_cast<int32_t>(pos.x), static_cast<int32_t>(pos.z)).lock();
             }
             return {};
-        };
+        }
+
+        uint16_t soundtrack_id_to_file(uint16_t index)
+        {
+            switch (index)
+            {
+            case 1:
+            case 2:
+            case 3:
+            case 4:
+            case 5:
+                break;
+            case 6:
+                return 5;
+            case 7:
+            case 8:
+            case 9:
+            case 10:
+            case 11:
+            case 12:
+            case 13:
+            case 14:
+            case 15:
+            case 16:
+            case 17:
+            case 18:
+            case 19:
+            case 20:
+            case 21:
+            case 22:
+            case 23:
+            case 24:
+            case 25:
+            case 26:
+            case 27:
+                break;
+            case 28:
+                return 24;
+            case 29:
+                return 25;
+            case 30:
+            case 31:
+            case 32:
+            case 33:
+            case 34:
+            case 35:
+            case 36:
+            case 37:
+            case 38:
+            case 39:
+            case 40:
+            case 41:
+            case 42:
+            case 43:
+            case 44:
+            case 45:
+            case 46:
+            case 47:
+            case 48:
+            case 49:
+            case 50:
+            case 51:
+            case 52:
+            case 53:
+            case 54:
+            case 55:
+            case 56:
+            case 57:
+            case 58:
+            case 59:
+            case 60:
+            case 61:
+            case 62:
+            case 63:
+            case 64:
+            case 65:
+                break;
+            }
+            return index;
+        }
     }
 
     ITriggersWindow::~ITriggersWindow()
@@ -431,7 +510,15 @@ namespace trview
                     ImGui::TableNextColumn();
                     ImGui::Text(command_type_name(command.type()).c_str());
                     ImGui::TableNextColumn();
-                    ImGui::Text(std::to_string(command.index()).c_str());
+                    // TODO: Check for TR2?
+                    if (command.type() == TriggerCommandType::PlaySoundtrack)
+                    {
+                        ImGui::Text(std::format("{} ({})", command.index(), soundtrack_id_to_file(command.index())).c_str());
+                    }
+                    else
+                    {
+                        ImGui::Text(std::to_string(command.index()).c_str());
+                    }
                     ImGui::TableNextColumn();
                     ImGui::Text(get_command_display(command).c_str());;
                     if (any_extra)

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -20,83 +20,18 @@ namespace trview
             return {};
         }
 
-        uint16_t soundtrack_id_to_file(uint16_t index)
+        std::string soundtrack_id_to_file(uint16_t index)
         {
-            switch (index)
+            std::optional<uint16_t> new_index;
+            if (index >= 3 && index <= 23)
             {
-            case 1:
-            case 2:
-            case 3:
-            case 4:
-            case 5:
-                break;
-            case 6:
-                return 5;
-            case 7:
-            case 8:
-            case 9:
-            case 10:
-            case 11:
-            case 12:
-            case 13:
-            case 14:
-            case 15:
-            case 16:
-            case 17:
-            case 18:
-            case 19:
-            case 20:
-            case 21:
-            case 22:
-            case 23:
-            case 24:
-            case 25:
-            case 26:
-            case 27:
-                break;
-            case 28:
-                return 24;
-            case 29:
-                return 25;
-            case 30:
-            case 31:
-            case 32:
-            case 33:
-            case 34:
-            case 35:
-            case 36:
-            case 37:
-            case 38:
-            case 39:
-            case 40:
-            case 41:
-            case 42:
-            case 43:
-            case 44:
-            case 45:
-            case 46:
-            case 47:
-            case 48:
-            case 49:
-            case 50:
-            case 51:
-            case 52:
-            case 53:
-            case 54:
-            case 55:
-            case 56:
-            case 57:
-            case 58:
-            case 59:
-            case 60:
-            case 61:
-            case 62:
-            case 63:
-            case 64:
-            case 65:
-                break;
+                new_index = static_cast<uint16_t>(index - 1);
             }
-            return index;
+            else if (index >= 27)
+            {
+                new_index = static_cast<uint16_t>(index - 4);
+            }
+            return new_index.has_value() ? std::to_string(new_index.value()) : "?";
         }
     }
 
@@ -189,6 +124,11 @@ namespace trview
     void TriggersWindow::set_items(const std::vector<std::weak_ptr<IItem>>& items)
     {
         _all_items = items;
+    }
+
+    void TriggersWindow::set_platform_and_version(const trlevel::PlatformAndVersion& platform_and_version)
+    {
+        _platform_and_version = platform_and_version;
     }
 
     std::weak_ptr<ITrigger> TriggersWindow::selected_trigger() const
@@ -510,10 +450,16 @@ namespace trview
                     ImGui::TableNextColumn();
                     ImGui::Text(command_type_name(command.type()).c_str());
                     ImGui::TableNextColumn();
-                    // TODO: Check for TR2?
-                    if (command.type() == TriggerCommandType::PlaySoundtrack)
+                    if (command.type() == TriggerCommandType::PlaySoundtrack &&
+                        _platform_and_version.version == trlevel::LevelVersion::Tomb2)
                     {
                         ImGui::Text(std::format("{} ({})", command.index(), soundtrack_id_to_file(command.index())).c_str());
+                        if (ImGui::IsItemHovered())
+                        {
+                            ImGui::BeginTooltip();
+                            ImGui::Text("Actual track file number is in parenthesis");
+                            ImGui::EndTooltip();
+                        }
                     }
                     else
                     {

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -42,6 +42,7 @@ namespace trview
         virtual void set_number(int32_t number) override;
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) override;
+        void set_platform_and_version(const trlevel::PlatformAndVersion& platform_and_version) override;
         virtual std::weak_ptr<ITrigger> selected_trigger() const override;
         virtual void update(float delta) override;
     private:
@@ -89,5 +90,6 @@ namespace trview
         bool _force_sort{ false };
         Track<Type::Room> _track;
         AutoHider _auto_hider;
+        trlevel::PlatformAndVersion _platform_and_version;
     };
 }

--- a/trview.app/Windows/TriggersWindowManager.cpp
+++ b/trview.app/Windows/TriggersWindowManager.cpp
@@ -36,6 +36,7 @@ namespace trview
         triggers_window->on_add_to_route += on_add_to_route;
         triggers_window->on_camera_sink_selected += on_camera_sink_selected;
         triggers_window->set_items(_items);
+        triggers_window->set_platform_and_version(_platform_and_version);
         triggers_window->set_triggers(_triggers);
         triggers_window->set_current_room(_current_room);
         triggers_window->set_selected_trigger(_selected_trigger);
@@ -53,6 +54,15 @@ namespace trview
         for (auto& window : _windows)
         {
             window.second->set_items(items);
+        }
+    }
+
+    void TriggersWindowManager::set_platform_and_version(const trlevel::PlatformAndVersion& platform_and_version)
+    {
+        _platform_and_version = platform_and_version;
+        for (auto& window : _windows)
+        {
+            window.second->set_platform_and_version(platform_and_version);
         }
     }
 

--- a/trview.app/Windows/TriggersWindowManager.h
+++ b/trview.app/Windows/TriggersWindowManager.h
@@ -25,6 +25,7 @@ namespace trview
         virtual void render() override;
         const std::weak_ptr<ITrigger> selected_trigger() const;
         virtual void set_items(const std::vector<std::weak_ptr<IItem>>& items) override;
+        virtual void set_platform_and_version(const trlevel::PlatformAndVersion& platform_and_version) override;
         virtual void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers) override;
         void set_room(const std::weak_ptr<IRoom>& room) override;
         virtual void set_selected_trigger(const std::weak_ptr<ITrigger>& trigger) override;
@@ -36,5 +37,6 @@ namespace trview
         std::weak_ptr<IRoom> _current_room;
         std::weak_ptr<ITrigger> _selected_trigger;
         ITriggersWindow::Source _triggers_window_source;
+        trlevel::PlatformAndVersion _platform_and_version;
     };
 }

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -231,6 +231,7 @@ namespace trview
         _statics_windows->set_statics(new_level->static_meshes());
         _triggers_windows->set_items(new_level->items());
         _triggers_windows->set_triggers(new_level->triggers());
+        _triggers_windows->set_platform_and_version(new_level->platform_and_version());
         _textures_windows->set_texture_storage(new_level->texture_storage());
 
         _level_token_store.clear();


### PR DESCRIPTION
For TR2 show the music filename number in `()` alongside the soundtrack ID.
Had to hardcode the mapping. Unsure about other games.
Closes #541 

![image](https://github.com/user-attachments/assets/c8ddd0df-0ecc-4d49-947a-92ab5e7e6cab)
