### PR TITLE
Pass selected static, room to new static windows

### DIFF
--- a/trview.app.tests/Windows/StaticsWindowManagerTests.cpp
+++ b/trview.app.tests/Windows/StaticsWindowManagerTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Windows/Statics/StaticsWindowManager.h>
 #include <trview.app/Mocks/Windows/IStaticsWindow.h>
+#include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.app/Resources/resource.h>
 
 using namespace trview;
@@ -86,4 +87,28 @@ TEST(StaticsWindowManager, CreateStaticsWindowKeyboardShortcut)
     auto shortcuts = mock_shared<MockShortcuts>();
     EXPECT_CALL(*shortcuts, add_shortcut(true, 'S')).Times(1).WillOnce([&](auto, auto) -> Event<>&{ return shortcut_handler; });
     auto manager = register_test_module().with_shortcuts(shortcuts).build();
+}
+
+TEST(StaticsWindowManager, SelectStaticSetsSelectedStaticOnWindows)
+{
+    auto mock_window = mock_shared<MockStaticsWindow>();
+    EXPECT_CALL(*mock_window, set_selected_static).Times(2);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+
+    auto created_window = manager->create_window().lock();
+    ASSERT_NE(created_window, nullptr);
+    ASSERT_EQ(created_window, mock_window);
+    manager->select_static(mock_shared<MockStaticMesh>());
+}
+
+TEST(StaticsWindowManager, SetRoomSetsCurrentRoomOnWindows)
+{
+    auto mock_window = mock_shared<MockStaticsWindow>();
+    EXPECT_CALL(*mock_window, set_current_room).Times(2);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+
+    auto created_window = manager->create_window().lock();
+    ASSERT_NE(created_window, nullptr);
+    ASSERT_EQ(created_window, mock_window);
+    manager->set_room(mock_shared<MockRoom>());
 }

--- a/trview.app/Windows/Statics/StaticsWindowManager.cpp
+++ b/trview.app/Windows/Statics/StaticsWindowManager.cpp
@@ -31,6 +31,8 @@ namespace trview
     {
         auto window = _source();
         window->set_statics(_statics);
+        window->set_current_room(_current_room);
+        window->set_selected_static(_selected_static);
         window->on_static_selected += on_static_selected;
         return add_window(window);
     }
@@ -60,6 +62,7 @@ namespace trview
 
     void StaticsWindowManager::select_static(const std::weak_ptr<IStaticMesh>& static_mesh)
     {
+        _selected_static = static_mesh;
         for (auto& window : _windows)
         {
             window.second->set_selected_static(static_mesh);

--- a/trview.app/Windows/Statics/StaticsWindowManager.h
+++ b/trview.app/Windows/Statics/StaticsWindowManager.h
@@ -30,5 +30,6 @@ namespace trview
         IStaticsWindow::Source _source;
         std::vector<std::weak_ptr<IStaticMesh>> _statics;
         std::weak_ptr<IRoom> _current_room;
+        std::weak_ptr<IStaticMesh> _selected_static;
     };
 }


### PR DESCRIPTION
New static mesh windows weren't being pass the selected static or room.
Pass these through to these new windows on creation.
Closes #1417