### PR TITLE
Improve version detection, transparency in OPSM1

### DIFF
--- a/doc/formats/index.md
+++ b/doc/formats/index.md
@@ -1,0 +1,59 @@
+# Versions
+
+TRView has support for several older formats including some demos and other versions.
+
+# Timeline
+
+## Version 9
+
+Earliest version that TRView supports. The only example of this is the early version of The Lost Valley in LEVEL3.TOM.
+
+## Version 11
+
+The 'May 1996' version of TR1.
+
+## Version 26
+
+July Saturn demo of TR1.
+
+## Version 27
+
+The 'August 1996' version of TR1.
+
+## Version 32
+
+TR1 retail version. Last version on Saturn.
+
+## Version 38
+
+TR2 OPSM 1 demo on PSX or E3 demo on PC.
+
+## Version 42
+
+TR2 OPSM 5 demo on PSX.
+
+## Version 44
+
+TR2 'beta' version.
+
+## Version 45
+
+TR2 retail version.
+
+## Version 53
+
+TR3 ECTS demo on PlayStation.
+
+## Version 55
+
+TR3 OPSM 15 demo on PlayStation.
+
+## Version 56
+
+TR3 retail version.
+
+## Some time passes - TR4 is in here somewhere
+
+## Version 225
+
+TR5 retail version.

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -72,8 +72,7 @@ namespace trlevel
 
                 file.seekg(sizeof(tr_textile4) * 13 + sizeof(tr_clut) * 1024);
                 const uint32_t potential_version = read<uint32_t>(file);
-
-                const bool is_tr1_psx = convert_level_version(potential_version).version == LevelVersion::Tomb1;
+                const bool is_tr1_psx = potential_version == 32;
                 file.seekg(0);
 
                 return is_tr1_psx;
@@ -97,7 +96,7 @@ namespace trlevel
                 skip(file, sizeof(tr_textile4) * 13 + sizeof(tr_clut) * 1024);
                 const uint32_t potential_version = read<uint32_t>(file);
 
-                const bool is_tr1_psx = convert_level_version(potential_version).version == LevelVersion::Tomb1;
+                const bool is_tr1_psx = potential_version == 32;
                 file.seekg(0);
                 return is_tr1_psx;
             }
@@ -120,7 +119,7 @@ namespace trlevel
                 skip(file, read<uint32_t>(file) * sizeof(uint32_t));
                 skip(file, read<uint32_t>(file));
                 const uint32_t potential_version = read<uint32_t>(file);
-                const bool is_tr2_psx = convert_level_version(potential_version).version == LevelVersion::Tomb2;
+                const bool is_tr2_psx = potential_version == 45;
                 file.seekg(0);
                 return is_tr2_psx;
             }

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -260,6 +260,10 @@ namespace trlevel
             {
                 return { .platform = Platform::PSX, .version = LevelVersion::Tomb1, .raw_version = 11 };
             }
+            else if (check_for_tr1_psx_without_sound(file))
+            {
+                return { .platform = Platform::PSX, .version = LevelVersion::Tomb1, .raw_version = 32 };
+            }
             else if (check_for_tr5_psx(file))
             {
                 return { .platform = Platform::PSX, .version = LevelVersion::Tomb5, .raw_version = static_cast<uint32_t>(-225) };

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -708,13 +708,13 @@ namespace trlevel
             {
                 _platform_and_version = { .platform = Platform::PSX, .version = LevelVersion::Tomb5, .raw_version = 0xFFFFFF1F };
             }
-            else if (check_for_tr1_psx_without_sound(file))
-            {
-                _platform_and_version = { .platform = Platform::PSX, .version = LevelVersion::Tomb1, .raw_version = read<uint32_t>(file) };
-            }
             else if (check_for_tr2_psx(file))
             {
                 _platform_and_version = { .platform = Platform::PSX, .version = LevelVersion::Tomb2, .raw_version = read<uint32_t>(file) };
+            }
+            else if (check_for_tr1_psx_without_sound(file))
+            {
+                _platform_and_version = { .platform = Platform::PSX, .version = LevelVersion::Tomb1, .raw_version = read<uint32_t>(file) };
             }
             else if (check_for_tr1_aug_1996(file))
             {

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -199,8 +199,8 @@ namespace trlevel
         void read_textiles_tr1_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr1_psx_aug_1996(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr2_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
-        void read_textiles_tr2_psx_beta(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
-        void read_textiles_tr2_psx_demo_70688(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void read_textiles_tr2_psx_version_44(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void read_textiles_tr2_psx_version_42(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_sprite_textures_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_sounds_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks, uint32_t sample_frequency);
@@ -226,9 +226,9 @@ namespace trlevel
         void load_tr2_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr2_pc_e3(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr2_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
-        void load_tr2_psx_beta(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
-        void load_tr2_psx_demo_70688(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
-        void load_tr2_psx_opsm_1(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void load_tr2_psx_version_38(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void load_tr2_psx_version_42(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void load_tr2_psx_version_44(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr3_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr4_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
@@ -251,8 +251,8 @@ namespace trlevel
         void generate_mesh_tr1_psx_may_1996(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
         void generate_mesh_tr1_saturn(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
         void generate_mesh_tr2_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
-        void generate_mesh_tr2_psx_beta(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
-        void generate_mesh_tr2_psx_opsm1(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
+        void generate_mesh_tr2_psx_version_44(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
+        void generate_mesh_tr2_psx_version_38(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
         void generate_mesh_tr3_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
         void generate_mesh_tr4_psx(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream);
         void generate_object_textures_tr4_psx(std::basic_ispanstream<uint8_t>& file, uint32_t start, const tr4_psx_level_info& info);

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -197,7 +197,7 @@ namespace trlevel
         void read_textiles_tr1_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr2_pc_e3(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr1_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
-        void read_textiles_tr1_psx_aug_1996(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void read_textiles_tr1_psx_version_27(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr2_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr2_psx_version_44(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void read_textiles_tr2_psx_version_42(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
@@ -216,7 +216,7 @@ namespace trlevel
         void load_tr1_pc_may_1996_wad(std::vector<uint8_t>& textile_buffer, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr1_pc_may_1996_swd(std::vector<uint8_t>& textile_buffer, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr1_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
-        void load_tr1_psx_aug_1996(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
+        void load_tr1_psx_version_27(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr1_psx_may_1996(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr1_saturn(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks);
         void load_tr1_saturn_sat(std::basic_ispanstream<uint8_t>& level_file, trview::Activity& activity, const LoadCallbacks& callbacks);

--- a/trlevel/LevelVersion.cpp
+++ b/trlevel/LevelVersion.cpp
@@ -33,10 +33,6 @@ namespace trlevel
             case 0x09:
             case 0x0B:
             case 0x20:
-                if (is_tr2_beta(version))
-                {
-                    return { .platform = Platform::PSX, .version = LevelVersion::Tomb2 };
-                }
                 return { .platform = (version & 0xff00) ? Platform::PSX : Platform::PC, .version = LevelVersion::Tomb1 };
             case 0x26:
             case 0x2D:
@@ -88,24 +84,19 @@ namespace trlevel
         return version.raw_version == 27;
     }
 
-    bool is_tr2_beta(uint32_t version)
-    {
-        return ((version & 0xff) == 0x20) && (version & 0xff0000 || trview::equals_any(version, 0xf820u, 0xd620u, 0x1220u, 0x1a20u, 0xe220u));
-    }
-
-    bool is_tr2_beta(PlatformAndVersion version)
-    {
-        return is_tr2_beta(version.raw_version);
-    }
-
-    bool is_tr2_demo_70688(PlatformAndVersion version)
-    {
-        return version.raw_version == 70688;
-    }
-
-    bool is_tr2_demo_opsm1(PlatformAndVersion version)
+    bool is_tr2_version_38(PlatformAndVersion version)
     {
         return version.raw_version == 38;
+    }
+
+    bool is_tr2_version_42(PlatformAndVersion version)
+    {
+        return version.raw_version == 42;
+    }
+
+    bool is_tr2_version_44(PlatformAndVersion version)
+    {
+        return version.raw_version == 44;
     }
 
     bool is_tr2_e3(PlatformAndVersion version)

--- a/trlevel/LevelVersion.cpp
+++ b/trlevel/LevelVersion.cpp
@@ -101,7 +101,7 @@ namespace trlevel
 
     bool is_tr2_e3(PlatformAndVersion version)
     {
-        return version.raw_version == 0x26;
+        return version.raw_version == 38;
     }
 
     bool is_tr3_ects(PlatformAndVersion version)

--- a/trlevel/LevelVersion.cpp
+++ b/trlevel/LevelVersion.cpp
@@ -79,7 +79,7 @@ namespace trlevel
         return is_tr1_may_1996(version) && version.platform == Platform::PC;
     }
 
-    bool is_tr1_aug_1996(PlatformAndVersion version)
+    bool is_tr1_version_27(PlatformAndVersion version)
     {
         return version.raw_version == 27;
     }

--- a/trlevel/LevelVersion.cpp
+++ b/trlevel/LevelVersion.cpp
@@ -90,7 +90,7 @@ namespace trlevel
 
     bool is_tr2_beta(uint32_t version)
     {
-        return ((version & 0xff) == 0x20) && (version & 0xff0000 || trview::equals_any(version, 0xf820u, 0xd620u, 0x1220u, 0x1a20u));
+        return ((version & 0xff) == 0x20) && (version & 0xff0000 || trview::equals_any(version, 0xf820u, 0xd620u, 0x1220u, 0x1a20u, 0xe220u));
     }
 
     bool is_tr2_beta(PlatformAndVersion version)

--- a/trlevel/LevelVersion.h
+++ b/trlevel/LevelVersion.h
@@ -49,7 +49,7 @@ namespace trlevel
 
     bool is_tr1_may_1996(PlatformAndVersion version);
     bool is_tr1_pc_may_1996(PlatformAndVersion version);
-    bool is_tr1_aug_1996(PlatformAndVersion version);
+    bool is_tr1_version_27(PlatformAndVersion version);
     bool is_tr2_version_38(PlatformAndVersion version);
     bool is_tr2_version_42(PlatformAndVersion version);
     bool is_tr2_version_44(PlatformAndVersion version);

--- a/trlevel/LevelVersion.h
+++ b/trlevel/LevelVersion.h
@@ -50,10 +50,9 @@ namespace trlevel
     bool is_tr1_may_1996(PlatformAndVersion version);
     bool is_tr1_pc_may_1996(PlatformAndVersion version);
     bool is_tr1_aug_1996(PlatformAndVersion version);
-    bool is_tr2_beta(uint32_t version);
-    bool is_tr2_beta(PlatformAndVersion version);
-    bool is_tr2_demo_70688(PlatformAndVersion version);
-    bool is_tr2_demo_opsm1(PlatformAndVersion version);
+    bool is_tr2_version_38(PlatformAndVersion version);
+    bool is_tr2_version_42(PlatformAndVersion version);
+    bool is_tr2_version_44(PlatformAndVersion version);
     bool is_tr2_e3(PlatformAndVersion version);
     bool is_tr3_ects(PlatformAndVersion version);
     bool is_tr3_demo_55(PlatformAndVersion version);

--- a/trlevel/Level_psx.cpp
+++ b/trlevel/Level_psx.cpp
@@ -26,6 +26,14 @@ namespace trlevel
         }
     }
 
+    std::vector<tr_room_vertex> convert_psx_vertex_lighting(std::vector<tr_room_vertex> vertices)
+    {
+        return vertices | std::views::transform([](auto&& v) -> tr_room_vertex
+            {
+                return  { .vertex = v.vertex, .lighting = static_cast<int16_t>(8192 - (v.lighting << 5)) };
+            }) | std::ranges::to<std::vector>();
+    }
+
     /// <summary>
     /// Based on vag2wav from http://unhaut.epizy.com/psxsdk/
     /// </summary>

--- a/trlevel/Level_psx.h
+++ b/trlevel/Level_psx.h
@@ -12,6 +12,7 @@
 namespace trlevel
 {
     uint16_t attribute_for_object_texture(const tr_object_texture_psx& texture, const tr_clut& clut);
+    std::vector<tr_room_vertex> convert_psx_vertex_lighting(std::vector<tr_room_vertex> vertices);
     std::vector<uint8_t> convert_vag_to_wav(const std::vector<uint8_t>& bytes, uint32_t sample_frequency);
     std::vector<tr4_ai_object> read_ai_objects(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const tr4_psx_level_info& info, const ILevel::LoadCallbacks& callbacks);
     std::vector<tr2_entity> read_entities(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const tr4_psx_level_info& info, const ILevel::LoadCallbacks& callbacks);
@@ -30,4 +31,5 @@ namespace trlevel
     void read_sounds_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t sample_frequency);
     void read_sounds_tr4_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t start, const tr4_psx_level_info& info, uint32_t sample_frequency);
     std::unordered_map<uint32_t, tr_staticmesh> read_static_meshes_tr4_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const ILevel::LoadCallbacks& callbacks, uint32_t num_statics = 70);
+    void read_room_vertices_tr1_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, tr3_room& room);
 }

--- a/trlevel/Level_tr1_pc.cpp
+++ b/trlevel/Level_tr1_pc.cpp
@@ -438,6 +438,7 @@ namespace trlevel
 
     void Level::load_tr1_pc_may_1996(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
+        skip(file, 4); // version number
         auto room_object_textures = read_vector<uint16_t, tr_object_texture_may_1996>(file);
 
         std::vector<uint8_t> textile_buffer;
@@ -559,6 +560,7 @@ namespace trlevel
             return load_tr1_pc_may_1996(file, activity, callbacks);
         }
 
+        skip(file, 4); // version number
         read_textiles_tr1_pc(file, activity, callbacks);
         read<uint32_t>(file);
 

--- a/trlevel/Level_tr1_psx.cpp
+++ b/trlevel/Level_tr1_psx.cpp
@@ -90,7 +90,7 @@ namespace trlevel
             skip(file, 2);
             if (NumDataWords > 0)
             {
-                read_room_vertices_tr1(activity, file, room);
+                read_room_vertices_tr1_psx(activity, file, room);
                 read_room_rectangles(activity, file, room);
                 read_room_triangles(activity, file, room);
                 read_room_sprites(activity, file, room);
@@ -413,7 +413,7 @@ namespace trlevel
     void Level::load_tr1_psx_aug_1996(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
         read_textiles_tr1_psx_aug_1996(file, activity, callbacks);
-        skip(file, 4);
+        skip(file, 4); // version 27
         _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr1_psx_room);
         _floor_data = read_floor_data(activity, file, callbacks);
         _mesh_data = read_mesh_data(activity, file, callbacks);
@@ -454,9 +454,13 @@ namespace trlevel
     {
         _num_textiles = 20;
         _textile4 = read_vector<tr_textile4>(file, _num_textiles);
-        _clut = read_vector<tr_clut>(file, 1024);
+        _clut = read_vector<tr_clut>(file, 2048);
 
-        file.seekg(721668, std::ios::beg);
+        // version (11)
+        skip(file, 4);
+
+        // Palette?
+        skip(file, 768);
 
         _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr1_psx_may_1996_room);
         _floor_data = read_floor_data(activity, file, callbacks);

--- a/trlevel/Level_tr1_psx.cpp
+++ b/trlevel/Level_tr1_psx.cpp
@@ -61,7 +61,7 @@ namespace trlevel
 
             if (NumDataWords > 0)
             {
-                read_room_vertices_tr1(activity, file, room);
+                read_room_vertices_tr1_psx(activity, file, room);
                 read_room_rectangles(activity, file, room);
                 read_room_triangles(activity, file, room);
                 read_room_sprites(activity, file, room);
@@ -120,6 +120,13 @@ namespace trlevel
             std::vector<int16_t> zones = read_vector<int16_t>(file, num_boxes * 4);
             log_file(activity, file, std::format("Read {} zones", zones.size()));
         }
+    }
+
+    void read_room_vertices_tr1_psx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, tr3_room& room)
+    {
+        log_file(activity, file, "Reading vertices");
+        room.data.vertices = convert_vertices(convert_psx_vertex_lighting(read_vector<int16_t, tr_room_vertex>(file)));
+        log_file(activity, file, std::format("Read {} vertices", room.data.vertices.size()));
     }
 
     void Level::generate_mesh_tr1_psx_may_1996(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream)

--- a/trlevel/Level_tr2_pc.cpp
+++ b/trlevel/Level_tr2_pc.cpp
@@ -95,6 +95,7 @@ namespace trlevel
 
     void Level::load_tr2_pc_e3(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
+        skip(file, 4); // version number
         read_palette_tr1(file, activity, callbacks);
         read_textiles_tr2_pc_e3(file, activity, callbacks);
 
@@ -151,6 +152,7 @@ namespace trlevel
             return load_tr2_pc_e3(file, activity, callbacks);
         }
 
+        skip(file, 4); // version number
         read_palette_tr2_3(file, activity, callbacks);
         read_textiles(activity, file, callbacks);
 

--- a/trlevel/Level_tr2_psx.cpp
+++ b/trlevel/Level_tr2_psx.cpp
@@ -128,7 +128,7 @@ namespace trlevel
             read_room_flags(activity, file, room);
         }
 
-        void load_tr2_psx_beta_room(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, tr3_room& room)
+        void load_tr2_psx_version_44_room(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, tr3_room& room)
         {
             room.info = read_room_info(activity, file);
             uint32_t NumDataWords = read_num_data_words(activity, file);
@@ -188,7 +188,7 @@ namespace trlevel
             read_room_flags(activity, file, room);
         }
 
-        void load_tr2_psx_opsm1_room(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, tr3_room& room)
+        void load_tr2_psx_version_38_room(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, tr3_room& room)
         {
             using namespace trlevel;
 
@@ -295,7 +295,7 @@ namespace trlevel
 
     }
 
-    void Level::generate_mesh_tr2_psx_beta(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream)
+    void Level::generate_mesh_tr2_psx_version_44(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream)
     {
         const auto start = stream.tellg();
 
@@ -346,7 +346,7 @@ namespace trlevel
         }
     }
 
-    void Level::generate_mesh_tr2_psx_opsm1(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream)
+    void Level::generate_mesh_tr2_psx_version_38(tr_mesh& mesh, std::basic_ispanstream<uint8_t>& stream)
     {
         const auto start = stream.tellg();
 
@@ -397,21 +397,14 @@ namespace trlevel
         }
     }
 
-    void Level::load_tr2_psx_beta(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    void Level::load_tr2_psx_version_44(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
-        skip(file, 12);
+        skip(file, 16);
         uint32_t textile_address = read<uint32_t>(file);
         file.seekg(textile_address + 8, std::ios::beg);
-        const uint32_t version = peek<uint32_t>(file);
-        if (version != 44)
-        {
-            file.seekg(4);
-            _platform_and_version.raw_version = 38;
-            return load_tr2_psx_opsm_1(file, activity, callbacks);
-        }
         skip(file, 4);
 
-        _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr2_psx_beta_room);
+        _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr2_psx_version_44_room);
         _floor_data = read_floor_data(activity, file, callbacks);
         _mesh_data = read_mesh_data(activity, file, callbacks);
         _mesh_pointers = read_mesh_pointers(activity, file, callbacks);
@@ -423,7 +416,7 @@ namespace trlevel
         _frames = read_frames(activity, file, callbacks);
         _models = read_models_psx(activity, file, callbacks);
         _static_meshes = read_static_meshes(activity, file, callbacks);
-        read_textiles_tr2_psx_beta(file, activity, callbacks);
+        read_textiles_tr2_psx_version_44(file, activity, callbacks);
         read_object_textures_tr2_psx(file, activity, callbacks);
         read_sprite_textures_psx(file, activity, callbacks);
         _sprite_sequences = read_sprite_sequences(activity, file, callbacks);
@@ -453,14 +446,14 @@ namespace trlevel
         callbacks.on_progress("Loading complete");
     }
 
-    void Level::load_tr2_psx_demo_70688(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    void Level::load_tr2_psx_version_42(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
-        skip(file, 12);
+        skip(file, 16);
         uint32_t textile_address = read<uint32_t>(file);
         file.seekg(textile_address + 8, std::ios::beg);
 
-        read_textiles_tr2_psx_demo_70688(file, activity, callbacks);
-        _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr2_psx_beta_room);
+        read_textiles_tr2_psx_version_42(file, activity, callbacks);
+        _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr2_psx_version_44_room);
         _floor_data = read_floor_data(activity, file, callbacks);
         _mesh_data = read_mesh_data(activity, file, callbacks);
         _mesh_pointers = read_mesh_pointers(activity, file, callbacks);
@@ -499,9 +492,9 @@ namespace trlevel
         callbacks.on_progress("Loading complete");
     }
 
-    void Level::load_tr2_psx_opsm_1(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    void Level::load_tr2_psx_version_38(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
-        skip(file, 12);
+        skip(file, 16);
         uint32_t textile_address = read<uint32_t>(file);
         file.seekg(textile_address + 8, std::ios::beg);
 
@@ -514,7 +507,7 @@ namespace trlevel
 
         skip(file, 4);
 
-        _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr2_psx_opsm1_room);
+        _rooms = read_rooms<uint16_t>(activity, file, callbacks, load_tr2_psx_version_38_room);
         _floor_data = read_floor_data(activity, file, callbacks);
         _mesh_data = read_mesh_data(activity, file, callbacks);
         _mesh_pointers = read_mesh_pointers(activity, file, callbacks);
@@ -563,13 +556,17 @@ namespace trlevel
 
     void Level::load_tr2_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
-        if (is_tr2_beta(_platform_and_version))
+        if (is_tr2_version_38(_platform_and_version))
         {
-            if (is_tr2_demo_70688(_platform_and_version))
-            {
-                return load_tr2_psx_demo_70688(file, activity, callbacks);
-            }
-            return load_tr2_psx_beta(file, activity, callbacks);
+            return load_tr2_psx_version_38(file, activity, callbacks);
+        }
+        else if (is_tr2_version_42(_platform_and_version))
+        {
+            return load_tr2_psx_version_42(file, activity, callbacks);
+        }
+        else if (is_tr2_version_44(_platform_and_version))
+        {
+            return load_tr2_psx_version_44(file, activity, callbacks);
         }
 
         // TR2 has sound data at the start of the file so must seek back to the start.
@@ -668,7 +665,7 @@ namespace trlevel
         log_file(activity, file, std::format("Read {} textile4s and {} clut", _textile4.size(), _clut.size()));
     }
 
-    void Level::read_textiles_tr2_psx_beta(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    void Level::read_textiles_tr2_psx_version_44(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
         callbacks.on_progress("Reading textiles");
         log_file(activity, file, "Reading textiles");
@@ -678,7 +675,7 @@ namespace trlevel
         log_file(activity, file, std::format("Read {} textile4s and {} clut", _textile4.size(), _clut.size()));
     }
 
-    void Level::read_textiles_tr2_psx_demo_70688(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
+    void Level::read_textiles_tr2_psx_version_42(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
         callbacks.on_progress("Reading textiles");
         log_file(activity, file, "Reading textiles");

--- a/trlevel/Level_tr3_pc.cpp
+++ b/trlevel/Level_tr3_pc.cpp
@@ -37,6 +37,7 @@ namespace trlevel
 
     void Level::load_tr3_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
+        skip(file, 4); // version number
         read_palette_tr2_3(file, activity, callbacks);
         _num_textiles = read_textiles(activity, file, callbacks);
 

--- a/trlevel/Level_tr3_psx.cpp
+++ b/trlevel/Level_tr3_psx.cpp
@@ -232,6 +232,7 @@ namespace trlevel
 
     void Level::load_tr3_psx(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
+        skip(file, 4); // version number
         read_sounds_psx(file, activity, callbacks, 11025);
         const bool ects = is_tr3_ects(_platform_and_version);
 

--- a/trlevel/Level_tr4_pc.cpp
+++ b/trlevel/Level_tr4_pc.cpp
@@ -96,6 +96,7 @@ namespace trlevel
 
     void Level::load_tr4_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
+        skip(file, 4); // version number
         _num_textiles = read_textiles_tr4_5(activity, file, callbacks);
         log_file(activity, file, "Reading and decompressing level data");
         callbacks.on_progress("Decompressing level data");
@@ -202,6 +203,7 @@ namespace trlevel
 
     void Level::load_tr4_pc_remastered(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
+        skip(file, 4); // version number
         _num_textiles = read_textiles_tr4_remastered(activity, file, callbacks);
         log_file(activity, file, "Reading level data");
         callbacks.on_progress("Processing level data");

--- a/trlevel/Level_tr5_pc.cpp
+++ b/trlevel/Level_tr5_pc.cpp
@@ -191,6 +191,7 @@ namespace trlevel
 
     void Level::load_tr5_pc(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
+        skip(file, 4); // version number
         _num_textiles = read_textiles_tr4_5(activity, file, callbacks);
         log_file(activity, file, "Reading Lara type");
         _lara_type = read<uint16_t>(file);
@@ -288,6 +289,7 @@ namespace trlevel
 
     void Level::load_tr5_pc_remastered(std::basic_ispanstream<uint8_t>& file, trview::Activity& activity, const LoadCallbacks& callbacks)
     {
+        skip(file, 4); // version number
         _num_textiles = read_textiles_tr5_remastered(activity, file, callbacks);
 
         log_file(activity, file, "Reading Lara type");

--- a/trview.app/Elements/TypeInfoLookup.cpp
+++ b/trview.app/Elements/TypeInfoLookup.cpp
@@ -28,7 +28,7 @@ namespace trview
             switch (version.version)
             {
             case trlevel::LevelVersion::Tomb1:
-                return is_tr1_aug_1996(version) ? "tr1_aug_1996" :
+                return is_tr1_version_27(version) ? "tr1_aug_1996" :
                        is_tr1_may_1996(version) ? "tr1_may_1996" :
                        version.is_tr2_saturn ? "tr2_saturn" : "tr1";
                 break;

--- a/trview.app/Elements/TypeInfoLookup.cpp
+++ b/trview.app/Elements/TypeInfoLookup.cpp
@@ -33,7 +33,7 @@ namespace trview
                        version.is_tr2_saturn ? "tr2_saturn" : "tr1";
                 break;
             case trlevel::LevelVersion::Tomb2:
-                return is_tr2_beta(version) ? "tr2_beta" : 
+                return is_tr2_version_44(version) ? "tr2_beta" :
                        is_tr2_e3(version) ? "tr2_e3" : "tr2";
                 break;
             case trlevel::LevelVersion::Tomb3:


### PR DESCRIPTION
Improve the version detection code for PlayStation levels specifically to check the actual version number instead of relying on the length of the sound header. This means seeking in to the right place in the file.

Also fix some issues with transparency and lighting on OSPM1 (Version 38).
Closes #1429 
Related to #1427 