### PR TITLE
Add a reusable model class

### DIFF
--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -154,11 +154,6 @@ namespace trlevel
         /// @returns Whether the entity was found.
         virtual bool find_first_entity_by_type(int16_t type, tr2_entity& entity) const = 0;
 
-        /// Get the true mesh from a type id. For example Lara's skin.
-        /// @param type The type id to check.
-        /// @returns The mesh index for the type.
-        virtual int16_t get_mesh_from_type_id(int16_t type) const = 0;
-
         virtual std::string name() const = 0;
 
         virtual uint32_t num_cameras() const = 0;

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -516,7 +516,8 @@ namespace trlevel
         uint32_t offset = frame_offset;
         tr2_frame frame;
 
-        // TODO: Catch all...
+        // Some models have a frames reference equal to the frames length. Presumably this
+        // means they don't have any frames, so just return default.
         if (offset >= _frames.size())
         {
             return frame;

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -515,6 +515,13 @@ namespace trlevel
     {
         uint32_t offset = frame_offset;
         tr2_frame frame;
+
+        // TODO: Catch all...
+        if (offset >= _frames.size())
+        {
+            return frame;
+        }
+
         frame.bb1x = _frames[offset++];
         frame.bb1y = _frames[offset++];
         frame.bb1z = _frames[offset++];
@@ -631,27 +638,6 @@ namespace trlevel
         }
         entity = *found;
         return true;
-    }
-
-    int16_t Level::get_mesh_from_type_id(int16_t type) const
-    {
-        if (type != 0 || get_version() < LevelVersion::Tomb3)
-        {
-            return type;
-        }
-        else if (get_version() > trlevel::LevelVersion::Tomb3)
-        {
-            if (is_tr4_opsm_90(_platform_and_version))
-            {
-                return LaraSkinTR4OPSM90;
-            }
-            return LaraSkinPostTR3;
-        }
-        else if (is_tr3_demo_55(_platform_and_version))
-        {
-            return LaraSkinTR3Demo55;
-        }
-        return LaraSkinTR3;
     }
 
     std::string Level::name() const

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -163,11 +163,6 @@ namespace trlevel
         /// @returns Whether the entity was found.
         virtual bool find_first_entity_by_type(int16_t type, tr2_entity& entity) const override;
 
-        /// Get the true mesh from a type id. For example Lara's skin.
-        /// @param type The type id to check.
-        /// @returns The mesh index for the type.
-        virtual int16_t get_mesh_from_type_id(int16_t type) const override;
-
         virtual std::string name() const override;
 
         virtual uint32_t num_cameras() const override;

--- a/trlevel/Mocks/ILevel.h
+++ b/trlevel/Mocks/ILevel.h
@@ -41,7 +41,6 @@ namespace trlevel
             MOCK_METHOD(bool, get_sprite_sequence_by_id, (int32_t, tr_sprite_sequence&), (const, override));
             MOCK_METHOD(std::optional<tr_sprite_texture>, get_sprite_texture, (uint32_t), (const, override));
             MOCK_METHOD(bool, find_first_entity_by_type, (int16_t, tr2_entity&), (const, override));
-            MOCK_METHOD(int16_t, get_mesh_from_type_id, (int16_t), (const, override));
             MOCK_METHOD(std::string, name, (), (const, override));
             MOCK_METHOD(uint32_t, num_cameras, (), (const, override));
             MOCK_METHOD(tr_camera, get_camera, (uint32_t), (const, override));

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -875,9 +875,9 @@ namespace trlevel
 
     struct tr2_frame
     {
-        int16_t bb1x, bb1y, bb1z;
-        int16_t bb2x, bb2y, bb2z;
-        int16_t offsetx, offsety, offsetz;
+        int16_t bb1x{ 0 }, bb1y{ 0 }, bb1z{ 0 };
+        int16_t bb2x{ 0 }, bb2y{ 0 }, bb2z{ 0 };
+        int16_t offsetx{ 0 }, offsety{ 0 }, offsetz{ 0 };
         std::vector<tr2_frame_rotation> values;
 
         DirectX::SimpleMath::Vector3 position() const

--- a/trview.app.tests/Elements/ItemTests.cpp
+++ b/trview.app.tests/Elements/ItemTests.cpp
@@ -2,7 +2,7 @@
 #include <trview.app/Mocks/Elements/IItem.h>
 #include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.app/Mocks/Geometry/IMesh.h>
-#include <trview.app/Mocks/Graphics/IMeshStorage.h>
+#include <trview.app/Mocks/Geometry/IModelStorage.h>
 #include <trlevel/Mocks/ILevel.h>
 #include <trview.tests.common/Mocks.h>
 
@@ -19,7 +19,7 @@ namespace
         {
             std::shared_ptr<trlevel::ILevel> level{ mock_shared<trlevel::mocks::MockLevel>() };
             IMesh::Source mesh_source = [](auto&&...) { return mock_shared<MockMesh>(); };
-            std::shared_ptr<IMeshStorage> mesh_storage = mock_shared<MockMeshStorage>();
+            std::shared_ptr<IModelStorage> model_storage = mock_shared<MockModelStorage>();
             trlevel::tr2_entity entity{};
             uint32_t index{ 0u };
             TypeInfo type{ .name = "Lara" };
@@ -29,7 +29,7 @@ namespace
 
             std::unique_ptr<Item> build()
             {
-                return std::make_unique<Item>(mesh_source, *level, entity, *mesh_storage, owning_level, index, type, triggers, room);
+                return std::make_unique<Item>(mesh_source, *level, entity, *model_storage, owning_level, index, type, triggers, room);
             }
 
             test_module& with_level(const std::shared_ptr<trlevel::ILevel>& level)

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -3,6 +3,7 @@
 #include <trview.graphics/mocks/IDevice.h>
 #include <trview.graphics/mocks/IShaderStorage.h>
 #include <trview.app/Mocks/Geometry/ITransparencyBuffer.h>
+#include <trview.app/Mocks/Geometry/IModelStorage.h>
 #include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
 #include <trview.app/Mocks/Graphics/ISelectionRenderer.h>
@@ -45,7 +46,8 @@ namespace
             std::shared_ptr<graphics::IShaderStorage> shader_storage{ mock_shared<MockShaderStorage>() };
             std::unique_ptr<trlevel::ILevel> level{ mock_unique<trlevel::mocks::MockLevel>() };
             std::shared_ptr<ILevelTextureStorage> level_texture_storage{ mock_shared<MockLevelTextureStorage>() };
-            std::unique_ptr<IMeshStorage> mesh_storage{ mock_unique<MockMeshStorage>() };
+            std::shared_ptr<IMeshStorage> mesh_storage{ mock_shared<MockMeshStorage>() };
+            std::shared_ptr<IModelStorage> model_storage{ mock_shared<MockModelStorage>() };
             std::unique_ptr<ITransparencyBuffer> transparency_buffer{ mock_unique<MockTransparencyBuffer>() };
             std::unique_ptr<ISelectionRenderer> selection_renderer{ mock_unique<MockSelectionRenderer>() };
             IItem::EntitySource entity_source{ [](auto&&...) { return mock_shared<MockItem>(); } };
@@ -64,7 +66,7 @@ namespace
             std::shared_ptr<Level> build()
             {
                 auto new_level = std::make_shared<Level>(device, shader_storage, level_texture_storage, std::move(transparency_buffer), std::move(selection_renderer), log, buffer_source, sound_storage, ngplus_switcher);
-                new_level->initialise(std::move(level), std::move(mesh_storage), entity_source, ai_source, room_source, trigger_source, light_source, camera_sink_source, sound_source_source, callbacks);
+                new_level->initialise(std::move(level), mesh_storage, model_storage, entity_source, ai_source, room_source, trigger_source, light_source, camera_sink_source, sound_source_source, callbacks);
                 return new_level;
             }
 

--- a/trview.app.tests/Elements/StaticMeshTests.cpp
+++ b/trview.app.tests/Elements/StaticMeshTests.cpp
@@ -1,7 +1,6 @@
 #include <trview.app/Elements/StaticMesh.h>
 #include <trview.app/Mocks/Geometry/IMesh.h>
 #include <trview.app/Mocks/Camera/ICamera.h>
-#include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
 
 using namespace trview;
 using namespace trview::mocks;
@@ -14,10 +13,10 @@ TEST(StaticMesh, BoundingBoxRendered)
 {
     auto actual_mesh = mock_shared<MockMesh>();
     auto bounding_mesh = mock_shared<MockMesh>();
-    EXPECT_CALL(*bounding_mesh, render(A<const Matrix&>(), A<const ILevelTextureStorage&>(), A<const Color&>(), A<float>(), A<Vector3>(), A<bool>(), A<bool>())).Times(1);
+    EXPECT_CALL(*bounding_mesh, render(A<const Matrix&>(),  A<const Color&>(), A<float>(), A<Vector3>(), A<bool>(), A<bool>())).Times(1);
 
     StaticMesh mesh({}, {}, actual_mesh, {}, {}, bounding_mesh);
-    mesh.render_bounding_box(NiceMock<MockCamera>{}, NiceMock<MockLevelTextureStorage>{}, Colour::White);
+    mesh.render_bounding_box(NiceMock<MockCamera>{}, Colour::White);
 }
 
 TEST(StaticMesh, OnChangedRaised)

--- a/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
+++ b/trview.app.tests/Graphics/LevelTextureStorageTests.cpp
@@ -61,27 +61,3 @@ TEST(LevelTextureStorage, PaletteNotLoadedTomb5)
     LevelTextureStorage subject(mock_shared<MockDevice>(), mock_unique<MockTextureStorage>());
     subject.load(level);
 }
-
-TEST(LevelTextureStorage, TexturesGenerated)
-{
-    std::vector<uint32_t> data;
-    data.resize(256 * 256, 0x000080ff);
-
-    auto device = mock_shared<MockDevice>();
-
-    std::vector<std::vector<uint32_t>> saved_data;
-    EXPECT_CALL(*device, create_texture_2D).Times(1).WillRepeatedly(testing::Invoke(
-        [&](auto&& desc, auto&& data)
-        {
-            const uint32_t* ptr = reinterpret_cast<const uint32_t*>(data.pSysMem);
-            saved_data.push_back({ ptr, ptr + 256 * 256 });
-            return nullptr;
-        }));
-    EXPECT_CALL(*device, create_shader_resource_view).Times(1);
-
-    LevelTextureStorage subject(device, mock_unique<MockTextureStorage>());
-
-    // 0: TRLE
-    ASSERT_EQ(saved_data.size(), 1u);
-    ASSERT_EQ(saved_data[0].size(), 65536u);
-}

--- a/trview.app.tests/Graphics/TextureStorage.cpp
+++ b/trview.app.tests/Graphics/TextureStorage.cpp
@@ -18,27 +18,3 @@ TEST(TextureStorage, KeysAreCaseInsensitive)
     auto texture = storage.lookup("test_key");
     ASSERT_EQ(texture.name(), "test");
 }
-
-TEST(TextureStorage, TexturesGenerated)
-{
-    std::vector<uint32_t> data;
-    data.resize(256 * 256, 0x000080ff);
-
-    auto device = mock_shared<MockDevice>();
-
-    std::vector<std::vector<uint32_t>> saved_data;
-    EXPECT_CALL(*device, create_texture_2D).Times(2).WillRepeatedly(
-        [&](auto&& desc, auto&& data)
-        {
-            const uint32_t* ptr = reinterpret_cast<const uint32_t*>(data.pSysMem);
-            saved_data.push_back({ ptr, ptr + 256 * 256 });
-            return nullptr;
-        });
-    EXPECT_CALL(*device, create_shader_resource_view).Times(2);
-
-    TextureStorage subject(device);
-
-    // 0: TRLE
-    ASSERT_EQ(saved_data.size(), 2u);
-    ASSERT_EQ(saved_data[0].size(), 65536u);
-}

--- a/trview.app.tests/Graphics/TextureStorage.cpp
+++ b/trview.app.tests/Graphics/TextureStorage.cpp
@@ -27,13 +27,13 @@ TEST(TextureStorage, TexturesGenerated)
     auto device = mock_shared<MockDevice>();
 
     std::vector<std::vector<uint32_t>> saved_data;
-    EXPECT_CALL(*device, create_texture_2D).Times(2).WillRepeatedly(testing::Invoke(
+    EXPECT_CALL(*device, create_texture_2D).Times(2).WillRepeatedly(
         [&](auto&& desc, auto&& data)
         {
             const uint32_t* ptr = reinterpret_cast<const uint32_t*>(data.pSysMem);
             saved_data.push_back({ ptr, ptr + 256 * 256 });
             return nullptr;
-        }));
+        });
     EXPECT_CALL(*device, create_shader_resource_view).Times(2);
 
     TextureStorage subject(device);

--- a/trview.app.tests/Graphics/TextureStorage.cpp
+++ b/trview.app.tests/Graphics/TextureStorage.cpp
@@ -18,3 +18,27 @@ TEST(TextureStorage, KeysAreCaseInsensitive)
     auto texture = storage.lookup("test_key");
     ASSERT_EQ(texture.name(), "test");
 }
+
+TEST(TextureStorage, TexturesGenerated)
+{
+    std::vector<uint32_t> data;
+    data.resize(256 * 256, 0x000080ff);
+
+    auto device = mock_shared<MockDevice>();
+
+    std::vector<std::vector<uint32_t>> saved_data;
+    EXPECT_CALL(*device, create_texture_2D).Times(2).WillRepeatedly(testing::Invoke(
+        [&](auto&& desc, auto&& data)
+        {
+            const uint32_t* ptr = reinterpret_cast<const uint32_t*>(data.pSysMem);
+            saved_data.push_back({ ptr, ptr + 256 * 256 });
+            return nullptr;
+        }));
+    EXPECT_CALL(*device, create_shader_resource_view).Times(2);
+
+    TextureStorage subject(device);
+
+    // 0: TRLE
+    ASSERT_EQ(saved_data.size(), 2u);
+    ASSERT_EQ(saved_data[0].size(), 65536u);
+}

--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -2,7 +2,6 @@
 #include <trview.app/Mocks/Graphics/ISelectionRenderer.h>
 #include <trview.app/Mocks/Routing/IWaypoint.h>
 #include <trview.app/Mocks/Camera/ICamera.h>
-#include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
 #include <trview.tests.common/Mocks.h>
 
 using namespace trview;
@@ -328,8 +327,7 @@ TEST(Route, Render)
     route->add(Vector3::Zero, Vector3::Down, 0);
  
     NiceMock<MockCamera> camera;
-    NiceMock<MockLevelTextureStorage> texture_storage;
-    route->render(camera, texture_storage, true);
+    route->render(camera, true);
 }
 
 TEST(Route, RenderDoesNotJoinWhenRouteLineDisabled)
@@ -365,8 +363,7 @@ TEST(Route, RenderDoesNotJoinWhenRouteLineDisabled)
     route->add(Vector3::Zero, Vector3::Down, 0);
 
     NiceMock<MockCamera> camera;
-    NiceMock<MockLevelTextureStorage> texture_storage;
-    route->render(camera, texture_storage, true);
+    route->render(camera, true);
 }
 
 TEST(Route, RenderShowsSelection)
@@ -375,11 +372,10 @@ TEST(Route, RenderShowsSelection)
     EXPECT_CALL(selection_renderer, render).Times(1);
 
     NiceMock<MockCamera> camera;
-    NiceMock<MockLevelTextureStorage> texture_storage;
 
     auto route = register_test_module().with_selection_renderer(std::move(selection_renderer_ptr)).build();
     route->add(Vector3::Zero, Vector3::Down, 0);
-    route->render(camera, texture_storage, true);
+    route->render(camera, true);
 }
 
 TEST(Route, RenderDoesNotShowSelection)
@@ -388,11 +384,10 @@ TEST(Route, RenderDoesNotShowSelection)
     EXPECT_CALL(selection_renderer, render).Times(0);
 
     NiceMock<MockCamera> camera;
-    NiceMock<MockLevelTextureStorage> texture_storage;
 
     auto route = register_test_module().with_selection_renderer(std::move(selection_renderer_ptr)).build();
     route->add(Vector3::Zero, Vector3::Down, 0);
-    route->render(camera, texture_storage, false);
+    route->render(camera, false);
 }
 
 TEST(Route, AddWaypointUsesColours)

--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -760,7 +760,7 @@ TEST(Viewer, SelectionRendered)
     ON_CALL(*level, texture_storage).WillByDefault(testing::Return(texture_storage));
     EXPECT_CALL(*level, render(A<const ICamera&>(), true)).Times(1);
     auto route = mock_shared<MockRoute>();
-    EXPECT_CALL(*route, render(A<const ICamera&>(), A<const ILevelTextureStorage&>(), true)).Times(1);
+    EXPECT_CALL(*route, render(A<const ICamera&>(), true)).Times(1);
 
     viewer->open(level, ILevel::OpenMode::Full);
     viewer->set_route(route);
@@ -780,7 +780,7 @@ TEST(Viewer, SelectionNotRendered)
     ON_CALL(*level, texture_storage).WillByDefault(testing::Return(texture_storage));
     EXPECT_CALL(*level, render(A<const ICamera&>(), false)).Times(1);
     auto route = mock_shared<MockRoute>();
-    EXPECT_CALL(*route, render(A<const ICamera&>(), A<const ILevelTextureStorage&>(), false)).Times(1);
+    EXPECT_CALL(*route, render(A<const ICamera&>(), false)).Times(1);
 
     viewer->set_show_selection(false);
     viewer->open(level, ILevel::OpenMode::Full);

--- a/trview.app/Elements/CameraSink/CameraSink.cpp
+++ b/trview.app/Elements/CameraSink/CameraSink.cpp
@@ -86,7 +86,7 @@ namespace trview
         return _position;
     }
 
-    void CameraSink::render(const ICamera& camera, const ILevelTextureStorage&, const Color&)
+    void CameraSink::render(const ICamera& camera, const Color&)
     {
         if (!_visible)
         {

--- a/trview.app/Elements/CameraSink/CameraSink.h
+++ b/trview.app/Elements/CameraSink/CameraSink.h
@@ -24,7 +24,7 @@ namespace trview
         virtual bool persistent() const override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
         virtual DirectX::SimpleMath::Vector3 position() const override;
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
+        void render(const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         virtual std::weak_ptr<IRoom> room() const override;
         virtual void set_type(Type type) override;
         virtual void set_visible(bool value) override;

--- a/trview.app/Elements/IItem.h
+++ b/trview.app/Elements/IItem.h
@@ -8,19 +8,19 @@
 #include <trlevel/trtypes.h>
 #include "../Geometry/IRenderable.h"
 #include "../Geometry/PickResult.h"
-#include "../Graphics/IMeshStorage.h"
 
 namespace trview
 {
     struct ITrigger;
     struct IRoom;
+    struct IModelStorage;
 
     struct IItem : public IRenderable
     {
         using EntitySource =
-            std::function<std::shared_ptr<IItem> (const trlevel::ILevel&, const trlevel::tr2_entity&, uint32_t, const std::vector<std::weak_ptr<ITrigger>>&, const IMeshStorage&, const std::weak_ptr<ILevel>&, const std::weak_ptr<IRoom>&)>;
+            std::function<std::shared_ptr<IItem> (const trlevel::ILevel&, const trlevel::tr2_entity&, uint32_t, const std::vector<std::weak_ptr<ITrigger>>&, const IModelStorage&, const std::weak_ptr<ILevel>&, const std::weak_ptr<IRoom>&)>;
         using AiSource =
-            std::function<std::shared_ptr<IItem>(const trlevel::ILevel&, const trlevel::tr4_ai_object&, uint32_t, const IMeshStorage&, const std::weak_ptr<ILevel>&, const std::weak_ptr<IRoom>&)>;
+            std::function<std::shared_ptr<IItem>(const trlevel::ILevel&, const trlevel::tr4_ai_object&, uint32_t, const IModelStorage&, const std::weak_ptr<ILevel>&, const std::weak_ptr<IRoom>&)>;
 
         Event<> on_changed;
 

--- a/trview.app/Elements/ILight.h
+++ b/trview.app/Elements/ILight.h
@@ -36,7 +36,7 @@ namespace trview
         virtual float radius() const = 0;
         virtual float density() const = 0;
         virtual void set_position(const DirectX::SimpleMath::Vector3& position) = 0;
-        virtual void render_direction(const ICamera& camera, const ILevelTextureStorage& texture_storage) = 0;
+        virtual void render_direction(const ICamera& camera) = 0;
         virtual trlevel::LevelVersion level_version() const = 0;
     };
 

--- a/trview.app/Elements/IStaticMesh.h
+++ b/trview.app/Elements/IStaticMesh.h
@@ -9,7 +9,6 @@
 
 namespace trview
 {
-    struct ILevelTextureStorage;
     struct ITransparencyBuffer;
     struct IRoom;
     struct ILevel;
@@ -26,8 +25,8 @@ namespace trview
         using MeshSource = std::function<std::shared_ptr<IStaticMesh>(const trlevel::tr3_room_staticmesh&, const trlevel::tr_staticmesh&, const std::shared_ptr<IMesh>&, const std::shared_ptr<IRoom>&, const std::weak_ptr<ILevel>&)>;
 
         virtual ~IStaticMesh() = 0;
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) = 0;
-        virtual void render_bounding_box(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) = 0;
+        virtual void render(const ICamera& camera, const DirectX::SimpleMath::Color& colour) = 0;
+        virtual void render_bounding_box(const ICamera& camera, const DirectX::SimpleMath::Color& colour) = 0;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) = 0;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
 

--- a/trview.app/Elements/ITrigger.h
+++ b/trview.app/Elements/ITrigger.h
@@ -2,6 +2,9 @@
 
 #include <cstdint>
 #include <vector>
+
+#include <trlevel/LevelVersion.h>
+
 #include <trview.app/Geometry/IRenderable.h>
 #include <trview.app/Geometry/TransparentTriangle.h>
 #include <trview.app/Geometry/PickResult.h>

--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -4,12 +4,12 @@
 #include <trlevel/ILevel.h>
 #include <trlevel/trtypes.h>
 
-#include "../Graphics/ILevelTextureStorage.h"
-#include "../Graphics/IMeshStorage.h"
 #include "../Camera/ICamera.h"
 #include "../Geometry/Matrix.h"
 #include "../Geometry/IMesh.h"
 #include "../Geometry/TransparencyBuffer.h"
+#include "../Geometry/Model/IModel.h"
+#include "../Geometry/Model/IModelStorage.h"
 #include "IRoom.h"
 
 using namespace Microsoft::WRL;
@@ -64,33 +64,30 @@ namespace trview
     {
     }
 
-    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room)
-        : Item(mesh_source, mesh_storage, level, owning_level, room, number, entity.TypeID, entity.position(), entity.Angle, level.get_version() >= trlevel::LevelVersion::Tomb4 ? entity.Intensity2 : 0, type, triggers, entity.Flags)
+    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IModelStorage& model_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room)
+        : Item(mesh_source, model_storage, level, owning_level, room, number, entity.TypeID, entity.position(), entity.Angle, level.get_version() >= trlevel::LevelVersion::Tomb4 ? entity.Intensity2 : 0, type, triggers, entity.Flags)
     {
         
     }
 
-    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room)
-        : Item(mesh_source, mesh_storage, level, owning_level, room, number, entity.type_id, entity.position(), entity.angle, entity.ocb, type, triggers, entity.flags)
+    Item::Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IModelStorage& model_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room)
+        : Item(mesh_source, model_storage, level, owning_level, room, number, entity.type_id, entity.position(), entity.angle, entity.ocb, type, triggers, entity.flags)
     {
     }
 
-    Item::Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id,
+    Item::Item(const IMesh::Source& mesh_source, const IModelStorage& model_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id,
         const Vector3& position, int32_t angle, int32_t ocb, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags)
         : _room(room), _number(number), _type(type), _triggers(triggers), _type_id(type_id), _ocb(ocb), _flags(flags), _level(owning_level), _angle(angle)
     {
-        // Extract the meshes required from the model.
-        load_meshes(level, type_id, mesh_storage);
+        _model = model_storage.find_by_type_id(type_id);
 
-        trlevel::tr_model model;
         trlevel::tr_sprite_sequence sprite;
-
-        if (level.get_model_by_id(type_id, model))
+        
+        if (_model.lock())
         {
             // Set up world matrix.
             _world = Matrix::CreateRotationY((angle / 16384.0f) * XM_PIDIV2) *
                 Matrix::CreateTranslation(position);
-            load_model(model, level);
         }
         else if (level.get_sprite_sequence_by_id(type_id, sprite))
         {
@@ -104,105 +101,7 @@ namespace trview
         apply_ocb_adjustment(level.get_version(), ocb, is_pickup());
     }
 
-    void Item::load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage)
-    {
-        trlevel::tr_model model;
-        if (level.get_model_by_id(level.get_mesh_from_type_id(type_id), model))
-        {
-            if (level.platform_and_version().platform == trlevel::Platform::PSX && 
-                equals_any(level.platform_and_version().version, trlevel::LevelVersion::Tomb4, trlevel::LevelVersion::Tomb5))
-            {
-                const uint32_t end_pointer = static_cast<uint32_t>(model.StartingMesh + model.NumMeshes * 2);
-                for (uint32_t mesh_pointer = model.StartingMesh; mesh_pointer < end_pointer; mesh_pointer += 2)
-                {
-                    auto mesh = mesh_storage.mesh(mesh_pointer);
-                    if (mesh)
-                    {
-                        _meshes.push_back(mesh);
-                    }
-                }
-            }
-            else
-            {
-                const uint32_t end_pointer = static_cast<uint32_t>(model.StartingMesh + model.NumMeshes);
-                for (uint32_t mesh_pointer = model.StartingMesh; mesh_pointer < end_pointer; ++mesh_pointer)
-                {
-                    auto mesh = mesh_storage.mesh(mesh_pointer);
-                    if (mesh)
-                    {
-                        _meshes.push_back(mesh);
-                    }
-                }
-            }
-        }
-    }
-
-    void Item::load_model(const trlevel::tr_model& model, const trlevel::ILevel& level)
-    {
-        using namespace DirectX;
-        using namespace DirectX::SimpleMath;
-
-        auto get_rotate = [](const trlevel::tr2_frame_rotation& r)
-        {
-            return Matrix::CreateFromYawPitchRoll(r.y, r.x, r.z);
-        };
-
-        if (model.NumMeshes > 0)
-        {
-            // Load the frames.
-            auto frame = level.get_frame(trlevel::has_double_frames(level.platform_and_version()) ? model.FrameOffset : model.FrameOffset / 2, model.NumMeshes);
-
-            uint32_t frame_offset = 0;
-
-            auto initial_frame = frame.values[frame_offset++];
-
-            Matrix initial_rotation = get_rotate(initial_frame);
-            Matrix initial_frame_offset = Matrix::CreateTranslation(frame.position());
-
-            Matrix previous_world = initial_rotation * initial_frame_offset;
-            _world_transforms.push_back(previous_world);
-
-            std::stack<Matrix> world_stack;
-
-            // Build the mesh tree.
-            // Request one less node than we have meshes as the first mesh is at the same position as the entity.
-            auto mesh_nodes = level.get_meshtree(model.MeshTree, model.NumMeshes - 1);
-
-            for (const auto& node : mesh_nodes)
-            {
-                Matrix parent_world = previous_world;
-
-                if (node.Flags & 0x1)
-                {
-                    if (!world_stack.empty())
-                    {
-                        parent_world = world_stack.top();
-                        world_stack.pop();
-                    }
-                    else
-                    {
-                        parent_world = Matrix::Identity;
-                    }
-                }
-                if (node.Flags & 0x2)
-                {
-                    world_stack.push(parent_world);
-                }
-
-                // Get the rotation from the frames.
-                // Rotations are performed in Y, X, Z order.
-                auto rotation = frame.values[frame_offset++];
-                Matrix rotation_matrix = get_rotate(rotation);
-                Matrix translation_matrix = Matrix::CreateTranslation(node.position());
-                Matrix node_transform = rotation_matrix * translation_matrix * parent_world;
-
-                _world_transforms.push_back(node_transform);
-                previous_world = node_transform;
-            }
-        }
-    }
-
-    void Item::render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour)
+    void Item::render(const ICamera& camera, const DirectX::SimpleMath::Color& colour)
     {
         if (!_visible)
         {
@@ -211,16 +110,15 @@ namespace trview
 
         using namespace DirectX::SimpleMath;
 
-        for (uint32_t i = 0; i < _meshes.size(); ++i)
+        if (auto model = _model.lock())
         {
-            auto wvp = _world_transforms[i] * _world * camera.view_projection();
-            _meshes[i]->render(wvp, texture_storage, colour);
+            model->render(_world, camera.view_projection(), colour);
         }
 
         if (_sprite_mesh)
         {
             auto wvp = create_billboard(_position, _offset, _scale, camera) * camera.view_projection();
-            _sprite_mesh->render(wvp, texture_storage, colour);
+            _sprite_mesh->render(wvp, colour);
         }
     }
 
@@ -241,12 +139,9 @@ namespace trview
             return;
         }
 
-        for (uint32_t i = 0; i < _meshes.size(); ++i)
+        if (auto model = _model.lock())
         {
-            for (const auto& triangle : _meshes[i]->transparent_triangles())
-            {
-                transparency.add(triangle.transform(_world_transforms[i] * _world, colour, true));
-            }
+            model->render_transparency(_world, transparency, colour);
         }
 
         if (_sprite_mesh)
@@ -264,7 +159,7 @@ namespace trview
         // Check against some sort of bounding box (based on the mesh?)
         // Test against bounding box for the room first, to avoid more expensive mesh-ray intersection
         float box_distance = 0;
-        if (!_bounding_box.Intersects(position, direction, box_distance))
+        if (!bounding_box().Intersects(position, direction, box_distance))
         {
             return PickResult();
         }
@@ -281,50 +176,16 @@ namespace trview
             return result;
         }
 
-        using namespace DirectX;
-        using namespace DirectX::SimpleMath;
-
-        std::vector<uint32_t> pick_meshes;
-
-        // Check each of the meshes in the object.
-        for (uint32_t i = 0; i < _meshes.size(); ++i)
+        if (auto model = _model.lock())
         {
-            // Try and pick against the bounding box.
-            float obb_distance = 0;
-            if (_oriented_boxes[i].Intersects(position, direction, obb_distance))
+            auto result = model->pick(_world, position, direction);
+            if (result.hit)
             {
-                // Pick against the triangles in this mesh.
-                pick_meshes.push_back(i);
+                result.item = std::const_pointer_cast<IItem>(shared_from_this());
+                return result;
             }
         }
-
-        if (pick_meshes.empty())
-        {
-            return PickResult();
-        }
-
-        PickResult result;
-        result.type = PickResult::Type::Entity;
-        result.item = std::const_pointer_cast<IItem>(shared_from_this());
-
-        for (auto i : pick_meshes)
-        {
-            // Transform the position and the direction into mesh space.
-            auto transform = (_world_transforms[i] * _world).Invert();
-            auto transformed_position = Vector3::Transform(position, transform);
-            auto transformed_direction = Vector3::TransformNormal(direction, transform);
-
-            // Pick against mesh.
-            auto mesh_result = _meshes[i]->pick(transformed_position, transformed_direction);
-            if (mesh_result.hit && mesh_result.distance < result.distance)
-            {
-                result.hit = true;
-                result.distance = mesh_result.distance;
-                result.position = position + direction * mesh_result.distance;
-            }
-        }
-
-        return result;
+        return {};
     }
 
     void Item::generate_bounding_box()
@@ -332,43 +193,15 @@ namespace trview
         using namespace DirectX;
 
         // Sprite meshes not yet handled.
-        if (_meshes.empty())
+        const auto model = _model.lock();
+        if (!model && _sprite_mesh)
         {
-            if (_sprite_mesh)
-            {
-                float width = _scale._11;
-                float height = _scale._22;
-                BoundingSphere sphere(_position, sqrt(width * width + height * height) * 0.5f);
-                sphere.Transform(sphere, _offset);
-                BoundingBox::CreateFromSphere(_bounding_box, sphere);
-            }
-            return;
+            float width = _scale._11;
+            float height = _scale._22;
+            BoundingSphere sphere(_position, sqrt(width * width + height * height) * 0.5f);
+            sphere.Transform(sphere, _offset);
+            BoundingBox::CreateFromSphere(_bounding_box, sphere);
         }
-
-        using namespace DirectX::SimpleMath;
-
-        // Remove any stored boxes so they can be created.
-        _oriented_boxes.clear();
-
-        // The entity bounding box is based on the bounding boxes of the meshes it contains.
-        // Allocate space for all of the corners.
-        std::vector<Vector3> corners(_meshes.size() * 8);
-
-        for (uint32_t i = 0; i < _meshes.size(); ++i)
-        {
-            // Get the box for the mesh.
-            auto box = _meshes[i]->bounding_box();
-
-            // Transform the box by the model transform. Store this box for later picking.
-            BoundingOrientedBox oriented_box;
-            BoundingOrientedBox::CreateFromBoundingBox(oriented_box, box);
-            oriented_box.Transform(oriented_box, _world_transforms[i] * _world);
-            oriented_box.GetCorners(&corners[i * 8]);
-            _oriented_boxes.push_back(oriented_box);
-        }
-
-        // Create an axis-aligned BB from the points of the oriented ones.
-        BoundingBox::CreateFromPoints(_bounding_box, corners.size(), &corners[0], sizeof(Vector3));
     }
 
     void Item::apply_ocb_adjustment(trlevel::LevelVersion version, uint32_t ocb, bool is_pickup)
@@ -378,20 +211,27 @@ namespace trview
             return;
         }
 
-        using namespace DirectX::SimpleMath;
-        Matrix offset = Matrix::CreateTranslation(0, -_bounding_box.Extents.y, 0);
-        _world *= offset;
-
-        for (auto& obb : _oriented_boxes)
+        float height = _bounding_box.Extents.y;
+        if (auto model = _model.lock())
         {
-            obb.Transform(obb, offset);
+            height = model->bounding_box().Extents.y;
         }
+
+        using namespace DirectX::SimpleMath;
+        Matrix offset = Matrix::CreateTranslation(0, -height, 0);
+        _world *= offset;
         _bounding_box.Transform(_bounding_box, offset);
         _needs_ocb_adjustment = true;
     }
 
     DirectX::BoundingBox Item::bounding_box() const
     {
+        if (auto model = _model.lock())
+        {
+            BoundingBox transformed_box;
+            model->bounding_box().Transform(transformed_box, _world);
+            return transformed_box;
+        }
         return _bounding_box;
     }
 
@@ -410,11 +250,6 @@ namespace trview
     {
         auto offset = Matrix::CreateTranslation(0, amount, 0);
         _world *= offset;
-
-        for (auto& obb : _oriented_boxes)
-        {
-            obb.Transform(obb, offset);
-        }
         _bounding_box.Transform(_bounding_box, offset);
     }
 

--- a/trview.app/Elements/Item.h
+++ b/trview.app/Elements/Item.h
@@ -22,17 +22,16 @@ namespace trlevel
 
 namespace trview
 {
-    struct IMeshStorage;
-    struct ILevelTextureStorage;
     struct ICamera;
+    struct IModel;
 
     class Item final : public IItem, public std::enable_shared_from_this<IItem>
     {
     public:
-        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room);
-        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IMeshStorage& mesh_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room);
+        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr2_entity& entity, const IModelStorage& model_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room);
+        explicit Item(const IMesh::Source& mesh_source, const trlevel::ILevel& level, const trlevel::tr4_ai_object& entity, const IModelStorage& model_storage, const std::weak_ptr<ILevel>& owning_level, uint32_t number, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, const std::weak_ptr<IRoom>& room);
         virtual ~Item() = default;
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
+        void render(const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         std::weak_ptr<IRoom> room() const override;
         virtual uint32_t number() const override;
 
@@ -60,18 +59,16 @@ namespace trview
         void set_ng_plus(bool value) override;
         std::optional<bool> ng_plus() const override;
     private:
-        Item(const IMesh::Source& mesh_source, const IMeshStorage& mesh_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags);
+        Item(const IMesh::Source& mesh_source, const IModelStorage& model_storage, const trlevel::ILevel& level, const std::weak_ptr<ILevel>& owning_level, const std::weak_ptr<IRoom>& room, uint32_t number, uint16_t type_id, const DirectX::SimpleMath::Vector3& position, int32_t angle, int32_t ocb, const TypeInfo& type, const std::vector<std::weak_ptr<ITrigger>>& triggers, uint16_t flags);
 
-        void load_meshes(const trlevel::ILevel& level, int16_t type_id, const IMeshStorage& mesh_storage);
-        void load_model(const trlevel::tr_model& model, const trlevel::ILevel& level);
         void generate_bounding_box();
         void apply_ocb_adjustment(trlevel::LevelVersion version, uint32_t ocb, bool is_pickup);
         bool is_pickup() const;
 
         DirectX::SimpleMath::Matrix               _world;
-        std::vector<std::shared_ptr<IMesh>>       _meshes;
         std::shared_ptr<IMesh>                    _sprite_mesh;
-        std::vector<DirectX::SimpleMath::Matrix>  _world_transforms;
+        std::weak_ptr<IModel>                     _model;
+
         std::weak_ptr<IRoom>                      _room;
         uint32_t                                  _number;
 
@@ -81,7 +78,6 @@ namespace trview
         DirectX::SimpleMath::Vector3              _position;
 
         DirectX::BoundingBox                      _bounding_box;
-        std::vector<DirectX::BoundingOrientedBox> _oriented_boxes;
         bool                                      _visible{ true };
         bool _needs_ocb_adjustment{ false };
         TypeInfo _type;

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -109,6 +109,7 @@ namespace trview
         void initialise(
             std::shared_ptr<trlevel::ILevel> level,
             std::shared_ptr<IMeshStorage> mesh_storage,
+            std::shared_ptr<IModelStorage> model_storage,
             const IItem::EntitySource& entity_source,
             const IItem::AiSource& ai_source,
             const IRoom::Source& room_source,
@@ -132,7 +133,7 @@ namespace trview
     private:
         void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage);
         void generate_triggers(const ITrigger::Source& trigger_source);
-        void generate_entities(const trlevel::ILevel& level, const IItem::EntitySource& entity_source, const IItem::AiSource& ai_source, const IMeshStorage& mesh_storage);
+        void generate_entities(const trlevel::ILevel& level, const IItem::EntitySource& entity_source, const IItem::AiSource& ai_source, const IModelStorage& model_storage);
         void regenerate_neighbours();
         void generate_neighbours(std::set<uint16_t>& results, uint16_t selected_room, int32_t max_depth);
         void generate_lights(const trlevel::ILevel& level, const ILight::Source& light_source);
@@ -230,6 +231,7 @@ namespace trview
         bool _ng{ false };
         std::shared_ptr<trlevel::IPack> _pack;
         trlevel::PlatformAndVersion _platform_and_version;
+        std::shared_ptr<IModelStorage> _model_storage;
     };
 
     /// Find the first item with the type id specified.

--- a/trview.app/Elements/Light.cpp
+++ b/trview.app/Elements/Light.cpp
@@ -33,7 +33,7 @@ namespace trview
         return _type;
     }
 
-    void Light::render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const Color&)
+    void Light::render(const ICamera& camera, const Color&)
     {
         if (!_visible)
         {
@@ -44,10 +44,10 @@ namespace trview
         auto wvp = world * camera.view_projection();
         auto light_direction = Vector3::TransformNormal(camera.position() - _position, world.Invert());
         light_direction.Normalize();
-        _mesh->render(wvp, texture_storage, _colour, 1.0f, light_direction);
+        _mesh->render(wvp, _colour, 1.0f, light_direction);
     }
 
-    void Light::render_direction(const ICamera& camera, const ILevelTextureStorage& texture_storage)
+    void Light::render_direction(const ICamera& camera)
     {
         if (!_visible)
         {
@@ -75,7 +75,7 @@ namespace trview
                 _mesh->render(
                     Matrix::CreateScale(0.05f) * 
                     Matrix::CreateTranslation(_position + step * static_cast<float>(i)) *
-                    camera.view_projection(), texture_storage, _colour, 1.0f, light_direction);
+                    camera.view_projection(), _colour, 1.0f, light_direction);
             }
         }
     }

--- a/trview.app/Elements/Light.h
+++ b/trview.app/Elements/Light.h
@@ -22,8 +22,8 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 direction() const override;
         std::weak_ptr<ILevel> level() const override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
-        virtual void render_direction(const ICamera& camera, const ILevelTextureStorage& texture_storage) override;
+        void render(const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
+        void render_direction(const ICamera& camera) override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;

--- a/trview.app/Elements/Remastered/INgPlusSwitcher.h
+++ b/trview.app/Elements/Remastered/INgPlusSwitcher.h
@@ -9,7 +9,7 @@ namespace trview
 {
     struct IItem;
     struct ILevel;
-    struct IMeshStorage;
+    struct IModelStorage;
 
     struct INgPlusSwitcher
     {
@@ -17,6 +17,6 @@ namespace trview
         virtual std::unordered_map<uint16_t, std::shared_ptr<IItem>> create_for_level(
             const std::shared_ptr<ILevel>& level,
             const trlevel::ILevel& tr_level,
-            const IMeshStorage& mesh_storage) const = 0;
+            const IModelStorage& model_storage) const = 0;
     };
 }

--- a/trview.app/Elements/Remastered/NgPlusSwitcher.cpp
+++ b/trview.app/Elements/Remastered/NgPlusSwitcher.cpp
@@ -49,7 +49,7 @@ namespace trview
         }
     }
 
-    std::unordered_map<uint16_t, std::shared_ptr<IItem>> NgPlusSwitcher::create_for_level(const std::shared_ptr<ILevel>& level, const trlevel::ILevel& tr_level, const IMeshStorage& mesh_storage) const
+    std::unordered_map<uint16_t, std::shared_ptr<IItem>> NgPlusSwitcher::create_for_level(const std::shared_ptr<ILevel>& level, const trlevel::ILevel& tr_level, const IModelStorage& model_storage) const
     {
         const auto game_mapping = _item_mapping.find(level->version());
         if (game_mapping == _item_mapping.end())
@@ -78,7 +78,7 @@ namespace trview
             {
                 auto entity = tr_level.get_entity(entry.first);
                 entity.TypeID = entry.second;
-                auto item = _item_source(tr_level, entity, entry.first, existing_item->triggers(), mesh_storage, level, existing_item->room());
+                auto item = _item_source(tr_level, entity, entry.first, existing_item->triggers(), model_storage, level, existing_item->room());
                 item->set_ng_plus(true);
                 results[entry.first] = item;
             }

--- a/trview.app/Elements/Remastered/NgPlusSwitcher.h
+++ b/trview.app/Elements/Remastered/NgPlusSwitcher.h
@@ -17,7 +17,7 @@ namespace trview
     public:
         NgPlusSwitcher(const IItem::EntitySource& item_source);
         virtual ~NgPlusSwitcher() = default;
-        std::unordered_map<uint16_t, std::shared_ptr<IItem>> create_for_level(const std::shared_ptr<ILevel>& level, const trlevel::ILevel& tr_level, const IMeshStorage& mesh_storage) const override;
+        std::unordered_map<uint16_t, std::shared_ptr<IItem>> create_for_level(const std::shared_ptr<ILevel>& level, const trlevel::ILevel& tr_level, const IModelStorage& model_storage) const override;
     private:
         std::unordered_map<trlevel::LevelVersion,
             std::unordered_map<std::string,

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -250,18 +250,18 @@ namespace trview
                 {
                     if (mesh.first == _index || (visible_rooms.find(mesh.first) == visible_rooms.end() || _index < mesh.first))
                     {
-                        mesh.second->render(_room_offset * camera.view_projection(), *_texture_storage, colour, 1.0f, Vector3::Zero, has_flag(render_filter, RenderFilter::AllGeometry));
+                        mesh.second->render(_room_offset * camera.view_projection(), colour, 1.0f, Vector3::Zero, has_flag(render_filter, RenderFilter::AllGeometry));
                     }
                 }
             }
             else
             {
-                _mesh->render(_room_offset * camera.view_projection(), *_texture_storage, colour, 1.0f, Vector3::Zero, false, !has_flag(render_filter, RenderFilter::Lighting));
+                _mesh->render(_room_offset * camera.view_projection(), colour, 1.0f, Vector3::Zero, false, !has_flag(render_filter, RenderFilter::Lighting));
                 for (const auto& mesh : _static_meshes)
                 {
                     if (mesh->visible())
                     {
-                        mesh->render(camera, *_texture_storage, colour);
+                        mesh->render(camera, colour);
                     }
                 }
             }
@@ -274,7 +274,7 @@ namespace trview
     {
         for (const auto& mesh : _static_meshes)
         {
-            mesh->render_bounding_box(camera, *_texture_storage, Colour::White);
+            mesh->render_bounding_box(camera, Colour::White);
         }
     }
 
@@ -285,10 +285,10 @@ namespace trview
         {
             if (auto light_ptr = light.lock())
             {
-                light_ptr->render(camera, *_texture_storage, Colour::White);
+                light_ptr->render(camera, Colour::White);
                 if (light_ptr == selected)
                 {
-                    light_ptr->render_direction(camera, *_texture_storage);
+                    light_ptr->render_direction(camera);
                 }
             }
         }
@@ -300,7 +300,7 @@ namespace trview
         {
             if (auto camera_sink_ptr = camera_sink.lock())
             {
-                camera_sink_ptr->render(camera, *_texture_storage, Colour::White);
+                camera_sink_ptr->render(camera, Colour::White);
             }
         }
     }
@@ -325,7 +325,7 @@ namespace trview
                 const auto ng = entity_ptr->ng_plus();
                 if (!ng.has_value() || ng.value() == has_flag(render_filter, RenderFilter::NgPlus))
                 {
-                    entity_ptr->render(camera, *_texture_storage, colour);
+                    entity_ptr->render(camera, colour);
                 }
             }
         }

--- a/trview.app/Elements/SoundSource/SoundSource.cpp
+++ b/trview.app/Elements/SoundSource/SoundSource.cpp
@@ -100,7 +100,7 @@ namespace trview
         return _range;
     }
 
-    void SoundSource::render(const ICamera& camera, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&)
+    void SoundSource::render(const ICamera& camera, const DirectX::SimpleMath::Color&)
     {
         if (!_visible)
         {

--- a/trview.app/Elements/SoundSource/SoundSource.h
+++ b/trview.app/Elements/SoundSource/SoundSource.h
@@ -28,7 +28,7 @@ namespace trview
         uint8_t pitch() const override;
         DirectX::SimpleMath::Vector3 position() const override;
         uint8_t range() const override;
-        void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
+        void render(const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         std::optional<int16_t> sample() const override;
         void set_visible(bool value) override;
         bool visible() const override;

--- a/trview.app/Elements/StaticMesh.cpp
+++ b/trview.app/Elements/StaticMesh.cpp
@@ -46,7 +46,7 @@ namespace trview
         _world = Matrix::CreateRotationY(_rotation) * Matrix::CreateTranslation(_position);
     }
 
-    void StaticMesh::render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour)
+    void StaticMesh::render(const ICamera& camera, const DirectX::SimpleMath::Color& colour)
     {
         if (!_mesh)
         {
@@ -57,17 +57,17 @@ namespace trview
         {
             _world = create_billboard(_position, Vector3(), _scale, camera);
         }
-        _mesh->render(_world * camera.view_projection(), texture_storage, colour);
+        _mesh->render(_world * camera.view_projection(), colour);
     }
 
-    void StaticMesh::render_bounding_box(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour)
+    void StaticMesh::render_bounding_box(const ICamera& camera, const DirectX::SimpleMath::Color& colour)
     {
         if (_type == Type::Mesh)
         {
             const auto size = (_collision.Extents * 2.0f) / trlevel::Scale;
             const auto adjust = _collision.Center / trlevel::Scale;
             const auto wvp = Matrix::CreateScale(size) * Matrix::CreateTranslation(adjust) * _world * camera.view_projection();
-            _bounding_mesh->render(wvp, texture_storage, colour);
+            _bounding_mesh->render(wvp, colour);
         }
     }
 

--- a/trview.app/Elements/StaticMesh.h
+++ b/trview.app/Elements/StaticMesh.h
@@ -10,8 +10,8 @@ namespace trview
         StaticMesh(const trlevel::tr3_room_staticmesh& static_mesh, const trlevel::tr_staticmesh& level_static_mesh, const std::shared_ptr<IMesh>& mesh, const std::weak_ptr<IRoom>& room, const std::weak_ptr<ILevel>& level, const std::shared_ptr<IMesh>& bounding_mesh);
         StaticMesh(const trlevel::tr_room_sprite& room_sprite, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Matrix& scale, std::shared_ptr<IMesh> mesh, const std::weak_ptr<IRoom>& room, const std::weak_ptr<ILevel>& level);
         virtual ~StaticMesh() = default;
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
-        virtual void render_bounding_box(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
+        void render(const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
+        void render_bounding_box(const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
 

--- a/trview.app/Elements/Trigger.cpp
+++ b/trview.app/Elements/Trigger.cpp
@@ -135,7 +135,7 @@ namespace trview
         return PickResult();
     }
 
-    void Trigger::render(const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&)
+    void Trigger::render(const ICamera&, const DirectX::SimpleMath::Color&)
     {
     }
 

--- a/trview.app/Elements/Trigger.h
+++ b/trview.app/Elements/Trigger.h
@@ -33,7 +33,7 @@ namespace trview
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
         virtual void set_position(const DirectX::SimpleMath::Vector3& position) override;
         virtual DirectX::SimpleMath::Vector3 position() const override;
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
+        void render(const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         virtual bool visible() const override;
         virtual void set_visible(bool value) override;

--- a/trview.app/Geometry/IMesh.h
+++ b/trview.app/Geometry/IMesh.h
@@ -19,7 +19,6 @@ namespace trview
         virtual ~IMesh() = 0;
 
         virtual void render(const DirectX::SimpleMath::Matrix& world_view_projection,
-            const ILevelTextureStorage& texture_storage,
             const DirectX::SimpleMath::Color& colour,
             float light_intensity = 1.0f,
             DirectX::SimpleMath::Vector3 light_direction = DirectX::SimpleMath::Vector3::Zero,

--- a/trview.app/Geometry/IRenderable.h
+++ b/trview.app/Geometry/IRenderable.h
@@ -6,7 +6,6 @@
 namespace trview
 {
     struct ICamera;
-    struct ILevelTextureStorage;
 
     /// Interface for something that can be rendered by the viewer.
     struct IRenderable
@@ -16,9 +15,8 @@ namespace trview
 
         /// Render non-transparent faces of the object.
         /// @param camera The current camera to render with.
-        /// @param texture_storage The current texture storage instance.
         /// @param colour The colour tint to use to render the object.
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) = 0;
+        virtual void render(const ICamera& camera, const DirectX::SimpleMath::Color& colour) = 0;
 
         /// Populate the transparency buffer with the transparent faces for the object.
         /// @param transparency The transparency buffer to populate.

--- a/trview.app/Geometry/ITransparencyBuffer.h
+++ b/trview.app/Geometry/ITransparencyBuffer.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <trview.app/Geometry/TransparentTriangle.h>
-#include <trview.app/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Camera/ICamera.h>
 
 namespace trview
@@ -23,7 +22,7 @@ namespace trview
         /// @param camera The current camera.
         /// @param texture_storage Texture storage for the level.
         /// @param ignore_blend Optional. Set to true to render this without transparency.
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool ignore_blend = false) = 0;
+        virtual void render(const ICamera& camera, bool ignore_blend = false) = 0;
 
         // Reset the triangles buffer.
         virtual void reset() = 0;

--- a/trview.app/Geometry/Mesh.h
+++ b/trview.app/Geometry/Mesh.h
@@ -25,7 +25,8 @@ namespace trview
              const std::vector<std::vector<uint32_t>>& indices, 
              const std::vector<uint32_t>& untextured_indices,
              const std::vector<TransparentTriangle>& transparent_triangles,
-             const std::vector<Triangle>& collision_triangles);
+             const std::vector<Triangle>& collision_triangles,
+             const std::shared_ptr<ITextureStorage>& texture_storage);
 
         /// Create a mesh using the specified vertices and indices.
         /// @param transparent_triangles The triangles to use to create the mesh.
@@ -35,7 +36,6 @@ namespace trview
         virtual ~Mesh() = default;
 
         virtual void render(const DirectX::SimpleMath::Matrix& world_view_projection,
-            const ILevelTextureStorage& texture_storage,
             const DirectX::SimpleMath::Color& colour,
             float light_intensity = 1.0f,
             DirectX::SimpleMath::Vector3 light_direction = DirectX::SimpleMath::Vector3::Zero,
@@ -66,5 +66,6 @@ namespace trview
         std::vector<TransparentTriangle>                  _transparent_triangles;
         std::vector<Triangle>                             _collision_triangles;
         DirectX::BoundingBox                              _bounding_box;
+        std::weak_ptr<ITextureStorage>                    _texture_storage;
     };
 }

--- a/trview.app/Geometry/Model/IModel.h
+++ b/trview.app/Geometry/Model/IModel.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "../PickResult.h"
+
+namespace trview
+{
+    struct ITransparencyBuffer;
+    struct IMesh;
+    struct IModel
+    {
+        using Source = std::function<std::shared_ptr<IModel>(const trlevel::tr_model&, const std::vector<std::shared_ptr<IMesh>>&, const std::vector<DirectX::SimpleMath::Matrix>&)>;
+
+        virtual ~IModel() = 0;
+        virtual DirectX::BoundingBox bounding_box() const = 0;
+        virtual PickResult pick(const DirectX::SimpleMath::Matrix& world, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
+        virtual void render(const DirectX::SimpleMath::Matrix& world, const DirectX::SimpleMath::Matrix& view_projection, const DirectX::SimpleMath::Color& colour) = 0;
+        virtual void render_transparency(const DirectX::SimpleMath::Matrix& world, ITransparencyBuffer& transparency, const DirectX::SimpleMath::Color& colour) = 0;
+        virtual uint32_t type_id() const = 0;
+    };
+}

--- a/trview.app/Geometry/Model/IModelStorage.h
+++ b/trview.app/Geometry/Model/IModelStorage.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace trview
+{
+    struct IModel;
+    struct IModelStorage
+    {
+        virtual ~IModelStorage() = 0;
+        virtual std::weak_ptr<IModel> find_by_type_id(uint16_t type_id) const = 0;
+    };
+}

--- a/trview.app/Geometry/Model/Model.cpp
+++ b/trview.app/Geometry/Model/Model.cpp
@@ -1,0 +1,127 @@
+#include "Model.h"
+#include "../ITransparencyBuffer.h"
+
+namespace trview
+{
+    IModel::~IModel()
+    {
+    }
+
+    Model::Model(const trlevel::tr_model& model, const std::vector<std::shared_ptr<IMesh>>& meshes, const std::vector<DirectX::SimpleMath::Matrix>& transforms)
+        : _meshes(meshes), _world_transforms(transforms), _model(model)
+    {
+        generate_bounding_box();
+    }
+
+    DirectX::BoundingBox Model::bounding_box() const
+    {
+        return _bounding_box;
+    }
+
+    PickResult Model::pick(const DirectX::SimpleMath::Matrix& world, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const
+    {
+        using namespace DirectX;
+        using namespace DirectX::SimpleMath;
+
+        std::vector<uint32_t> pick_meshes;
+
+        // Check each of the meshes in the object.
+        for (uint32_t i = 0; i < _meshes.size(); ++i)
+        {
+            // Transform the position and the direction into mesh space.
+            const auto transform = world.Invert();
+            const auto transformed_position = Vector3::Transform(position, transform);
+            const auto transformed_direction = Vector3::TransformNormal(direction, transform);
+
+            // Try and pick against the bounding box.
+            float obb_distance = 0;
+            if (_oriented_boxes[i].Intersects(transformed_position, transformed_direction, obb_distance))
+            {
+                // Pick against the triangles in this mesh.
+                pick_meshes.push_back(i);
+            }
+        }
+
+        if (pick_meshes.empty())
+        {
+            return PickResult();
+        }
+
+        PickResult result;
+        result.type = PickResult::Type::Entity;
+
+        for (auto i : pick_meshes)
+        {
+            // Transform the position and the direction into mesh space.
+            const auto transform = (_world_transforms[i] * world).Invert();
+            const auto transformed_position = Vector3::Transform(position, transform);
+            const auto transformed_direction = Vector3::TransformNormal(direction, transform);
+
+            // Pick against mesh.
+            auto mesh_result = _meshes[i]->pick(transformed_position, transformed_direction);
+            if (mesh_result.hit && mesh_result.distance < result.distance)
+            {
+                result.hit = true;
+                result.distance = mesh_result.distance;
+                result.position = position + direction * mesh_result.distance;
+            }
+        }
+
+        return result;
+    }
+
+    void Model::render(const DirectX::SimpleMath::Matrix& world, const DirectX::SimpleMath::Matrix& view_projection, const DirectX::SimpleMath::Color& colour)
+    {
+        for (uint32_t i = 0; i < _meshes.size(); ++i)
+        {
+            auto wvp = _world_transforms[i] * world * view_projection;
+            _meshes[i]->render(wvp, colour);
+        }
+    }
+
+    void Model::render_transparency(const DirectX::SimpleMath::Matrix& world, ITransparencyBuffer& transparency, const DirectX::SimpleMath::Color& colour)
+    {
+        for (uint32_t i = 0; i < _meshes.size(); ++i)
+        {
+            for (const auto& triangle : _meshes[i]->transparent_triangles())
+            {
+                transparency.add(triangle.transform(_world_transforms[i] * world, colour, true));
+            }
+        }
+    }
+
+    uint32_t Model::type_id() const
+    {
+        return _model.ID;
+    }
+
+    void Model::generate_bounding_box()
+    {
+        using namespace DirectX;
+        using namespace DirectX::SimpleMath;
+
+        // Remove any stored boxes so they can be created.
+        _oriented_boxes.clear();
+
+        // The entity bounding box is based on the bounding boxes of the meshes it contains.
+        // Allocate space for all of the corners.
+        std::vector<Vector3> corners(_meshes.size() * 8);
+
+        for (uint32_t i = 0; i < _meshes.size(); ++i)
+        {
+            // Get the box for the mesh.
+            auto box = _meshes[i]->bounding_box();
+
+            // Transform the box by the model transform. Store this box for later picking.
+            BoundingOrientedBox oriented_box;
+            BoundingOrientedBox::CreateFromBoundingBox(oriented_box, box);
+            oriented_box.Transform(oriented_box, _world_transforms[i]);
+            oriented_box.GetCorners(&corners[i * 8]);
+            _oriented_boxes.push_back(oriented_box);
+        }
+
+        // Create an axis-aligned BB from the points of the oriented ones.
+        BoundingBox::CreateFromPoints(_bounding_box, corners.size(), &corners[0], sizeof(Vector3));
+    }
+}
+

--- a/trview.app/Geometry/Model/Model.cpp
+++ b/trview.app/Geometry/Model/Model.cpp
@@ -120,8 +120,11 @@ namespace trview
             _oriented_boxes.push_back(oriented_box);
         }
 
-        // Create an axis-aligned BB from the points of the oriented ones.
-        BoundingBox::CreateFromPoints(_bounding_box, corners.size(), &corners[0], sizeof(Vector3));
+        if (!corners.empty())
+        {
+            // Create an axis-aligned BB from the points of the oriented ones.
+            BoundingBox::CreateFromPoints(_bounding_box, corners.size(), &corners[0], sizeof(Vector3));
+        }
     }
 }
 

--- a/trview.app/Geometry/Model/Model.h
+++ b/trview.app/Geometry/Model/Model.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "../IMesh.h"
+#include "IModel.h"
+
+namespace trview
+{
+    class Model final : public IModel
+    {
+    public:
+        explicit Model(const trlevel::tr_model& model, const std::vector<std::shared_ptr<IMesh>>& meshes, const std::vector<DirectX::SimpleMath::Matrix>& transforms);
+        virtual ~Model() = default;
+        DirectX::BoundingBox bounding_box() const override;
+        PickResult pick(const DirectX::SimpleMath::Matrix& world, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
+        void render(const DirectX::SimpleMath::Matrix& world, const DirectX::SimpleMath::Matrix& view_projection, const DirectX::SimpleMath::Color& colour) override;
+        void render_transparency(const DirectX::SimpleMath::Matrix& world, ITransparencyBuffer& transparency, const DirectX::SimpleMath::Color& colour) override;
+        uint32_t type_id() const override;
+    private:
+        void generate_bounding_box();
+
+        std::vector<std::shared_ptr<IMesh>>       _meshes;
+        std::vector<DirectX::SimpleMath::Matrix>  _world_transforms;
+        DirectX::BoundingBox                      _bounding_box;
+        std::vector<DirectX::BoundingOrientedBox> _oriented_boxes;
+        trlevel::tr_model                         _model;
+    };
+}
+

--- a/trview.app/Geometry/Model/ModelStorage.cpp
+++ b/trview.app/Geometry/Model/ModelStorage.cpp
@@ -176,6 +176,10 @@ namespace trview
         for (uint32_t i = 0; i < level.num_models(); ++i)
         {
             const auto model = level.get_model(i);
+            if (model.NumMeshes > 0xff00)
+            {
+                continue;
+            }
 
             std::vector<std::shared_ptr<IMesh>> meshes;
 

--- a/trview.app/Geometry/Model/ModelStorage.cpp
+++ b/trview.app/Geometry/Model/ModelStorage.cpp
@@ -1,0 +1,224 @@
+#include "ModelStorage.h"
+#include "../../Graphics/IMeshStorage.h"
+
+namespace trview
+{
+    namespace
+    {
+        constexpr int16_t LaraSkinTR3 = 315;
+        constexpr int16_t LaraSkinTR3Demo55 = 275;
+        constexpr int16_t LaraSkinPostTR3 = 8;
+        constexpr int16_t LaraSkinTR4OPSM90 = 10;
+
+        int16_t get_skin_id(const trlevel::PlatformAndVersion& version, int16_t type)
+        {
+            using namespace trlevel;
+            if (type != 0 || version.version < LevelVersion::Tomb3)
+            {
+                return type;
+            }
+            else if (version.version > trlevel::LevelVersion::Tomb3)
+            {
+                if (is_tr4_opsm_90(version))
+                {
+                    return LaraSkinTR4OPSM90;
+                }
+                return LaraSkinPostTR3;
+            }
+            else if (is_tr3_demo_55(version))
+            {
+                return LaraSkinTR3Demo55;
+            }
+            return LaraSkinTR3;
+        }
+
+        bool is_skin_id(const trlevel::PlatformAndVersion& version, int16_t type)
+        {
+            using namespace trlevel;
+            if (version.version < LevelVersion::Tomb3)
+            {
+                return false;
+            }
+            else if (version.version > trlevel::LevelVersion::Tomb3)
+            {
+                if (is_tr4_opsm_90(version))
+                {
+                    if (type == LaraSkinTR4OPSM90)
+                    {
+                        return true;
+                    }
+                }
+                else if (type == LaraSkinPostTR3)
+                {
+                    return true;
+                }
+            }
+            else if (is_tr3_demo_55(version))
+            {
+                if (type == LaraSkinTR3Demo55)
+                {
+                    return true;
+                }
+            }
+
+            if (type == LaraSkinTR3)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        std::vector<DirectX::SimpleMath::Matrix> load_transforms(
+            const trlevel::tr_model& model,
+            const trlevel::ILevel& level)
+        {
+            using namespace DirectX;
+            using namespace DirectX::SimpleMath;
+
+            auto get_rotate = [](const trlevel::tr2_frame_rotation& r)
+                {
+                    return Matrix::CreateFromYawPitchRoll(r.y, r.x, r.z);
+                };
+
+            trlevel::tr_model actual_model = model;
+            if (is_skin_id(level.platform_and_version(), static_cast<int16_t>(model.ID)))
+            {
+                level.get_model_by_id(0, actual_model);
+            }
+
+            std::vector<Matrix> transforms;
+            if (actual_model.NumMeshes > 0)
+            {
+                // Load the frames.
+                auto frame = level.get_frame(trlevel::has_double_frames(level.platform_and_version()) ? actual_model.FrameOffset : actual_model.FrameOffset / 2, actual_model.NumMeshes);
+
+                // TODO: Safe frame
+                if (frame.values.empty())
+                {
+                    for (int32_t t = 0; t < actual_model.NumMeshes; ++t)
+                    {
+                        transforms.push_back(Matrix::Identity);
+                    }
+                    return transforms;
+                }
+
+                uint32_t frame_offset = 0;
+
+                auto initial_frame = frame.values[frame_offset++];
+
+                Matrix initial_rotation = get_rotate(initial_frame);
+                Matrix initial_frame_offset = Matrix::CreateTranslation(frame.position());
+
+                Matrix previous_world = initial_rotation * initial_frame_offset;
+                transforms.push_back(previous_world);
+
+                std::stack<Matrix> world_stack;
+
+                // Build the mesh tree.
+                // Request one less node than we have meshes as the first mesh is at the same position as the entity.
+                auto mesh_nodes = level.get_meshtree(actual_model.MeshTree, actual_model.NumMeshes - 1);
+
+                for (const auto& node : mesh_nodes)
+                {
+                    Matrix parent_world = previous_world;
+
+                    if (node.Flags & 0x1)
+                    {
+                        if (!world_stack.empty())
+                        {
+                            parent_world = world_stack.top();
+                            world_stack.pop();
+                        }
+                        else
+                        {
+                            parent_world = Matrix::Identity;
+                        }
+                    }
+                    if (node.Flags & 0x2)
+                    {
+                        world_stack.push(parent_world);
+                    }
+
+                    // Get the rotation from the frames.
+                    // Rotations are performed in Y, X, Z order.
+                    auto rotation = frame.values[frame_offset++];
+                    Matrix rotation_matrix = get_rotate(rotation);
+                    Matrix translation_matrix = Matrix::CreateTranslation(node.position());
+                    Matrix node_transform = rotation_matrix * translation_matrix * parent_world;
+
+                    transforms.push_back(node_transform);
+                    previous_world = node_transform;
+                }
+            }
+            return transforms;
+        }
+    }
+
+    IModelStorage::~IModelStorage()
+    {
+    }
+
+    ModelStorage::ModelStorage(const std::shared_ptr<IMeshStorage>& mesh_storage,
+        const IModel::Source& model_source,
+        const trlevel::ILevel& level)
+        : _platform_and_version(level.platform_and_version())
+    {
+        load_models(mesh_storage, model_source, level);
+    }
+
+    void ModelStorage::load_models(const std::shared_ptr<IMeshStorage>& mesh_storage, const IModel::Source& model_source, const trlevel::ILevel& level)
+    {
+
+        using namespace DirectX::SimpleMath;
+
+        const auto version = level.platform_and_version();
+        for (uint32_t i = 0; i < level.num_models(); ++i)
+        {
+            const auto model = level.get_model(i);
+
+            std::vector<std::shared_ptr<IMesh>> meshes;
+
+            if (version.platform == trlevel::Platform::PSX && equals_any(version.version, trlevel::LevelVersion::Tomb4, trlevel::LevelVersion::Tomb5))
+            {
+                const uint32_t end_pointer = static_cast<uint32_t>(model.StartingMesh + model.NumMeshes * 2);
+                for (uint32_t mesh_pointer = model.StartingMesh; mesh_pointer < end_pointer; mesh_pointer += 2)
+                {
+                    auto mesh = mesh_storage->mesh(mesh_pointer);
+                    if (mesh)
+                    {
+                        meshes.push_back(mesh);
+                    }
+                }
+            }
+            else
+            {
+                const uint32_t end_pointer = static_cast<uint32_t>(model.StartingMesh + model.NumMeshes);
+                for (uint32_t mesh_pointer = model.StartingMesh; mesh_pointer < end_pointer; ++mesh_pointer)
+                {
+                    auto mesh = mesh_storage->mesh(mesh_pointer);
+                    if (mesh)
+                    {
+                        meshes.push_back(mesh);
+                    }
+                }
+            }
+
+            auto transforms = load_transforms(model, level);
+            _models.push_back(model_source(model, meshes, transforms));
+        }
+    }
+
+    std::weak_ptr<IModel> ModelStorage::find_by_type_id(uint16_t type_id) const
+    {
+        const uint16_t updated_type_id = get_skin_id(_platform_and_version, type_id);
+        for (const auto& model : _models)
+        {
+            if (model->type_id() == updated_type_id)
+            {
+                return model;
+            }
+        }
+        return {};
+    }
+}

--- a/trview.app/Geometry/Model/ModelStorage.h
+++ b/trview.app/Geometry/Model/ModelStorage.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <trlevel/ILevel.h>
+
+#include "IModelStorage.h"
+#include "IModel.h"
+
+namespace trview
+{
+    struct IMeshStorage;
+    class ModelStorage final : public IModelStorage
+    {
+    public:
+        explicit ModelStorage(const std::shared_ptr<IMeshStorage>& mesh_storage,
+            const IModel::Source& model_source,
+            const trlevel::ILevel& level);
+        virtual ~ModelStorage() = default;
+        std::weak_ptr<IModel> find_by_type_id(uint16_t type_id) const override;
+    private:
+        void load_models(const std::shared_ptr<IMeshStorage>& mesh_storage, 
+            const IModel::Source& model_source,
+            const trlevel::ILevel& level);
+
+        std::vector<std::shared_ptr<IModel>> _models;
+        trlevel::PlatformAndVersion _platform_and_version;
+    };
+}

--- a/trview.app/Geometry/TransparencyBuffer.h
+++ b/trview.app/Geometry/TransparencyBuffer.h
@@ -11,7 +11,7 @@
 
 namespace trview
 {
-    struct ILevelTextureStorage;
+    struct ITextureStorage;
     struct ICamera;
 
     // Collects transparent triangles to be rendered and provides
@@ -19,28 +19,28 @@ namespace trview
     class TransparencyBuffer final : public ITransparencyBuffer
     {
     public:
-        explicit TransparencyBuffer(const std::shared_ptr<graphics::IDevice>& device);
+        explicit TransparencyBuffer(const std::shared_ptr<graphics::IDevice>& device, const std::weak_ptr<ITextureStorage>& level_texture_storage);
         TransparencyBuffer(const TransparencyBuffer&) = delete;
         TransparencyBuffer& operator=(const TransparencyBuffer&) = delete;
 
         // Add a triangle to the transparency buffer. The triangle will be added to the end
         // of the collection.
         // triangle: The triangle to add.
-        void add(const TransparentTriangle& triangle);
+        void add(const TransparentTriangle& triangle) override;
 
         // Sort the accumulated transparent triangles in order of farthest to
         // nearest, based on the position of the camera.
         // eye_position: The position of the camera.
-        void sort(const DirectX::SimpleMath::Vector3& eye_position);
+        void sort(const DirectX::SimpleMath::Vector3& eye_position) override;
 
         /// Render the accumulated transparent triangles. Sort should be called before this function is called.
         /// @param camera The current camera.
         /// @param texture_storage Texture storage for the level.
         /// @param ignore_blend Optional. Set to true to render this without transparency.
-        void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool ignore_blend = false);
+        void render(const ICamera& camera, bool ignore_blend = false) override;
 
         // Reset the triangles buffer.
-        void reset();
+        void reset() override;
     private:
         void create_buffer();
         void create_matrix_buffer();
@@ -66,5 +66,6 @@ namespace trview
 
         std::vector<TextureRun> _texture_run;
         graphics::Texture _untextured;
+        std::weak_ptr<ITextureStorage> _texture_storage;
     };
 }

--- a/trview.app/Graphics/ILevelTextureStorage.h
+++ b/trview.app/Graphics/ILevelTextureStorage.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <vector>
 #include <SimpleMath.h>
 
 #include "ITextureStorage.h"
@@ -13,27 +14,14 @@ namespace trview
         using Source = std::function<std::shared_ptr<ILevelTextureStorage>(const trlevel::ILevel&)>;
 
         virtual ~ILevelTextureStorage() = 0;
-
         virtual graphics::Texture texture(uint32_t texture_index) const = 0;
-
         virtual graphics::Texture opaque_texture(uint32_t texture_index) const = 0;
-
-        virtual graphics::Texture untextured() const = 0;
-
         virtual DirectX::SimpleMath::Vector2 uv(uint32_t texture_index, uint32_t uv_index) const = 0;
-
         virtual uint32_t tile(uint32_t texture_index) const = 0;
-
         virtual uint32_t num_tiles() const = 0;
-
         virtual uint16_t attribute(uint32_t texture_index) const = 0;
-
         virtual DirectX::SimpleMath::Color palette_from_texture(uint32_t texture) const = 0;
-
-        virtual graphics::Texture geometry_texture() const = 0;
-
         virtual uint32_t num_object_textures() const = 0;
-
         virtual trlevel::PlatformAndVersion platform_and_version() const = 0;
     };
 }

--- a/trview.app/Graphics/ISectorHighlight.h
+++ b/trview.app/Graphics/ISectorHighlight.h
@@ -3,7 +3,6 @@
 #include <trview.graphics/IDevice.h>
 #include <trview.app/Elements/ISector.h>
 #include <trview.app/Camera/ICamera.h>
-#include "ILevelTextureStorage.h"
 
 namespace trview
 {
@@ -11,6 +10,6 @@ namespace trview
     {
         virtual ~ISectorHighlight() = 0;
         virtual void set_sector(const std::shared_ptr<ISector>& sector, const DirectX::SimpleMath::Matrix& room_offset) = 0;
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage) = 0;
+        virtual void render(const ICamera& camera) = 0;
     };
 }

--- a/trview.app/Graphics/ISelectionRenderer.h
+++ b/trview.app/Graphics/ISelectionRenderer.h
@@ -13,6 +13,6 @@ namespace trview
         /// @param camera The current camera.
         /// @param selected_item The entity to outline.
         /// @param outline_colour The outline colour
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, IRenderable& selected_item, const DirectX::SimpleMath::Color& outline_colour) = 0;
+        virtual void render(const ICamera& camera, IRenderable& selected_item, const DirectX::SimpleMath::Color& outline_colour) = 0;
     };
 }

--- a/trview.app/Graphics/ITextureStorage.h
+++ b/trview.app/Graphics/ITextureStorage.h
@@ -9,8 +9,13 @@ namespace trview
     struct ITextureStorage
     {
         virtual ~ITextureStorage() = 0;
+        virtual void add_texture(const std::vector<uint32_t>& pixels, uint32_t width, uint32_t height) = 0;
         virtual graphics::Texture coloured(uint32_t colour) const = 0;
+        virtual graphics::Texture geometry_texture() const = 0;
         virtual graphics::Texture lookup(const std::string& key) const = 0;
+        virtual uint32_t num_textures() const = 0;
         virtual void store(const std::string& key, const graphics::Texture& texture) = 0;
+        virtual graphics::Texture texture(uint32_t tile_index) const = 0;
+        virtual graphics::Texture untextured() const = 0;
     };
 }

--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -25,7 +25,7 @@ namespace trview
         virtual graphics::Texture untextured() const override;
         virtual DirectX::SimpleMath::Vector2 uv(uint32_t texture_index, uint32_t uv_index) const override;
         virtual uint32_t          tile(uint32_t texture_index) const override;
-        virtual uint32_t          num_textures() const override; 
+        uint32_t num_textures() const override; 
         virtual uint32_t          num_tiles() const override;
         virtual uint16_t attribute(uint32_t texture_index) const override;
         virtual DirectX::SimpleMath::Color palette_from_texture(uint32_t texture) const override;
@@ -38,9 +38,7 @@ namespace trview
         void determine_texture_mode();
 
         std::weak_ptr<trlevel::ILevel> _level;
-
         std::shared_ptr<graphics::IDevice> _device;
-        
         std::vector<graphics::Texture> _opaque_tiles;
         std::vector<trlevel::tr_object_texture> _object_textures;
         std::unique_ptr<ITextureStorage> _texture_storage;

--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -16,6 +16,7 @@ namespace trview
     public:
         explicit LevelTextureStorage(const std::shared_ptr<graphics::IDevice>& device, std::unique_ptr<ITextureStorage> texture_storage);
         virtual ~LevelTextureStorage() = default;
+        void add_texture(const std::vector<uint32_t>& pixels, uint32_t width, uint32_t height) override;
         virtual graphics::Texture texture(uint32_t tile_index) const override;
         virtual graphics::Texture opaque_texture(uint32_t texture_index) const override;
         virtual graphics::Texture coloured(uint32_t colour) const override;
@@ -24,6 +25,7 @@ namespace trview
         virtual graphics::Texture untextured() const override;
         virtual DirectX::SimpleMath::Vector2 uv(uint32_t texture_index, uint32_t uv_index) const override;
         virtual uint32_t          tile(uint32_t texture_index) const override;
+        virtual uint32_t          num_textures() const override; 
         virtual uint32_t          num_tiles() const override;
         virtual uint16_t attribute(uint32_t texture_index) const override;
         virtual DirectX::SimpleMath::Color palette_from_texture(uint32_t texture) const override;
@@ -38,11 +40,10 @@ namespace trview
         std::weak_ptr<trlevel::ILevel> _level;
 
         std::shared_ptr<graphics::IDevice> _device;
-        std::vector<graphics::Texture> _tiles;
+        
         std::vector<graphics::Texture> _opaque_tiles;
         std::vector<trlevel::tr_object_texture> _object_textures;
         std::unique_ptr<ITextureStorage> _texture_storage;
-        mutable graphics::Texture _untextured_texture;
         std::array<DirectX::SimpleMath::Color, 256> _palette;
         trlevel::PlatformAndVersion _platform_and_version;
 
@@ -52,6 +53,5 @@ namespace trview
             Custom
         };
         TextureMode _texture_mode{ TextureMode::Official };
-        graphics::Texture _geometry_texture;
     };
 }

--- a/trview.app/Graphics/SectorHighlight.cpp
+++ b/trview.app/Graphics/SectorHighlight.cpp
@@ -25,7 +25,7 @@ namespace trview
         _mesh.reset();
     }
 
-    void SectorHighlight::render(const ICamera& camera, const ILevelTextureStorage& texture_storage)
+    void SectorHighlight::render(const ICamera& camera)
     {
         if (!_sector)
         {
@@ -59,6 +59,6 @@ namespace trview
             _mesh = _mesh_source(vertices, std::vector<std::vector<uint32_t>>(), indices, std::vector<TransparentTriangle>(), std::vector<Triangle>());
         }
 
-        _mesh->render(_room_offset * camera.view_projection(), texture_storage, Color(1,1,1));
+        _mesh->render(_room_offset * camera.view_projection(), Color(1,1,1));
     }
 }

--- a/trview.app/Graphics/SectorHighlight.h
+++ b/trview.app/Graphics/SectorHighlight.h
@@ -11,7 +11,7 @@ namespace trview
         explicit SectorHighlight(const IMesh::Source& mesh_source);
         virtual ~SectorHighlight() = default;
         virtual void set_sector(const std::shared_ptr<ISector>& sector, const DirectX::SimpleMath::Matrix& room_offset) override;
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage) override;
+        void render(const ICamera& camera) override;
     private:
         DirectX::SimpleMath::Matrix _room_offset;
         std::shared_ptr<ISector> _sector;

--- a/trview.app/Graphics/SelectionRenderer.cpp
+++ b/trview.app/Graphics/SelectionRenderer.cpp
@@ -9,7 +9,6 @@
 
 #include <trview.app/Geometry/IRenderable.h>
 #include <trview.app/Camera/ICamera.h>
-#include "ILevelTextureStorage.h"
 
 using namespace Microsoft::WRL;
 using namespace DirectX::SimpleMath;
@@ -119,7 +118,7 @@ namespace trview
         _scale_buffer = device.create_buffer(scale_desc, std::optional<D3D11_SUBRESOURCE_DATA>());
     }
 
-    void SelectionRenderer::render(const ICamera& camera, const ILevelTextureStorage& texture_storage, IRenderable& selected_item, const DirectX::SimpleMath::Color& outline_colour)
+    void SelectionRenderer::render(const ICamera& camera, IRenderable& selected_item, const DirectX::SimpleMath::Color& outline_colour)
     {
         auto context = _device->context();
 
@@ -145,13 +144,13 @@ namespace trview
             // Draw the regular faces of the item with a black colouring.
             const bool was_visible = selected_item.visible();
             selected_item.set_visible(true);
-            selected_item.render(camera, texture_storage, IRenderable::SelectionFill);
+            selected_item.render(camera, IRenderable::SelectionFill);
 
             // Also render the transparent parts of the meshes, again with black.
             _transparency->reset();
             selected_item.get_transparent_triangles(*_transparency, camera, IRenderable::SelectionFill);
             _transparency->sort(camera.rendering_position());
-            _transparency->render(camera, texture_storage, true);
+            _transparency->render(camera, true);
             selected_item.set_visible(was_visible);
         }
 

--- a/trview.app/Graphics/SelectionRenderer.h
+++ b/trview.app/Graphics/SelectionRenderer.h
@@ -27,7 +27,6 @@ namespace trview
 
     struct IRenderable;
     struct ICamera;
-    struct ILevelTextureStorage;
 
     /// Draws an outline around an object.
     class SelectionRenderer final : public ISelectionRenderer
@@ -45,7 +44,7 @@ namespace trview
         /// Render the outline around the specified object.
         /// @param camera The current camera.
         /// @param selected_item The entity to outline.
-        void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, IRenderable& selected_item, const DirectX::SimpleMath::Color& outline_colour);
+        void render(const ICamera& camera, IRenderable& selected_item, const DirectX::SimpleMath::Color& outline_colour);
     private:
         /// Create vertex, index and parameter buffers.
         /// @param device The device to use to create the buffers.

--- a/trview.app/Graphics/TextureStorage.cpp
+++ b/trview.app/Graphics/TextureStorage.cpp
@@ -10,11 +10,35 @@ namespace trview
     TextureStorage::TextureStorage(const std::shared_ptr<graphics::IDevice>& device)
         : _device(device)
     {
+        _untextured_texture = coloured(0xffffffff);
+        // Generate the TRLE texture.
+        std::vector<uint32_t> pixels(256 * 256, 0xffffffff);
+        for (int x = 0; x < 256; ++x)
+        {
+            pixels[x] = 0xff000000;
+            pixels[x + 255 * 256] = 0xff000000;
+        }
+        for (int y = 0; y < 256; ++y)
+        {
+            pixels[y * 256] = 0xff000000;
+            pixels[y * 256 + 255] = 0xff000000;
+        }
+        _geometry_texture = graphics::Texture(*_device, 256, 256, pixels);
+    }
+
+    void TextureStorage::add_texture(const std::vector<uint32_t>& pixels, uint32_t width, uint32_t height)
+    {
+        _tiles.emplace_back(*_device, width, height, pixels);
     }
 
     graphics::Texture TextureStorage::coloured(uint32_t colour) const
     {
         return graphics::Texture(*_device, 1, 1, std::vector<uint32_t>(1, colour));
+    }
+
+    graphics::Texture TextureStorage::geometry_texture() const
+    {
+        return _geometry_texture;
     }
 
     graphics::Texture TextureStorage::lookup(const std::string& key) const
@@ -27,8 +51,23 @@ namespace trview
         return found->second;
     }
 
+    uint32_t TextureStorage::num_textures() const
+    {
+        return static_cast<uint32_t>(_tiles.size());
+    }
+
     void TextureStorage::store(const std::string& key, const graphics::Texture& texture)
     {
         _textures.insert({ to_lowercase(key), texture });
+    }
+
+    graphics::Texture TextureStorage::texture(uint32_t tile_index) const
+    {
+        return _tiles[tile_index];
+    }
+
+    graphics::Texture TextureStorage::untextured() const
+    {
+        return _untextured_texture;
     }
 }

--- a/trview.app/Graphics/TextureStorage.h
+++ b/trview.app/Graphics/TextureStorage.h
@@ -11,11 +11,19 @@ namespace trview
     public:
         explicit TextureStorage(const std::shared_ptr<graphics::IDevice>& device);
         virtual ~TextureStorage() = default;
-        virtual graphics::Texture coloured(uint32_t colour) const override;
-        virtual graphics::Texture lookup(const std::string& key) const override;
-        virtual void store(const std::string& key, const graphics::Texture& texture) override;
+        void add_texture(const std::vector<uint32_t>& pixels, uint32_t width, uint32_t height) override;
+        graphics::Texture coloured(uint32_t colour) const override;
+        graphics::Texture geometry_texture() const override;
+        graphics::Texture lookup(const std::string& key) const override;
+        uint32_t num_textures() const override;
+        void store(const std::string& key, const graphics::Texture& texture) override;
+        graphics::Texture texture(uint32_t tile_index) const override;
+        graphics::Texture untextured() const override;
     private:
         std::shared_ptr<graphics::IDevice> _device;
         std::unordered_map<std::string, graphics::Texture> _textures;
+        graphics::Texture _geometry_texture;
+        std::vector<graphics::Texture> _tiles;
+        mutable graphics::Texture _untextured_texture;
     };
 }

--- a/trview.app/Mocks/Elements/ICameraSink.h
+++ b/trview.app/Mocks/Elements/ICameraSink.h
@@ -21,7 +21,7 @@ namespace trview
             MOCK_METHOD(bool, persistent, (), (const, override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(std::weak_ptr<IRoom>, room, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(void, set_type, (Type), (override));

--- a/trview.app/Mocks/Elements/IItem.h
+++ b/trview.app/Mocks/Elements/IItem.h
@@ -11,7 +11,7 @@ namespace trview
         {
             MockItem();
             virtual ~MockItem();
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(bool, visible, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));

--- a/trview.app/Mocks/Elements/ILight.h
+++ b/trview.app/Mocks/Elements/ILight.h
@@ -10,7 +10,7 @@ namespace trview
         {
             MockLight();
             virtual ~MockLight();
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(bool, visible, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));
@@ -34,7 +34,7 @@ namespace trview
             MOCK_METHOD(float, radius, (), (const override));
             MOCK_METHOD(float, density, (), (const, override));
             MOCK_METHOD(void, set_position, (const DirectX::SimpleMath::Vector3&), (override));
-            MOCK_METHOD(void, render_direction, (const ICamera&, const ILevelTextureStorage&), (override));
+            MOCK_METHOD(void, render_direction, (const ICamera&), (override));
             MOCK_METHOD(trlevel::LevelVersion, level_version, (), (const, override));
 
             bool _visible_state{ false };

--- a/trview.app/Mocks/Elements/INgPlusSwitcher.h
+++ b/trview.app/Mocks/Elements/INgPlusSwitcher.h
@@ -10,7 +10,7 @@ namespace trview
         {
             MockNgPlusSwitcher();
             ~MockNgPlusSwitcher();
-            MOCK_METHOD((std::unordered_map<uint16_t, std::shared_ptr<IItem>>), create_for_level, (const std::shared_ptr<ILevel>&, const trlevel::ILevel&, const IMeshStorage& mesh_storage), (const, override));
+            MOCK_METHOD((std::unordered_map<uint16_t, std::shared_ptr<IItem>>), create_for_level, (const std::shared_ptr<ILevel>&, const trlevel::ILevel&, const IModelStorage&), (const, override));
         };
     }
 }

--- a/trview.app/Mocks/Elements/ISoundSource.h
+++ b/trview.app/Mocks/Elements/ISoundSource.h
@@ -20,7 +20,7 @@ namespace trview
             MOCK_METHOD(uint8_t, pitch, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(uint8_t, range, (), (const, override));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(std::optional<int16_t>, sample, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(bool, visible, (), (const, override));

--- a/trview.app/Mocks/Elements/IStaticMesh.h
+++ b/trview.app/Mocks/Elements/IStaticMesh.h
@@ -11,8 +11,8 @@ namespace trview
             MockStaticMesh();
             virtual ~MockStaticMesh();
             MOCK_METHOD(DirectX::BoundingBox, collision, (), (const, override));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
-            MOCK_METHOD(void, render_bounding_box, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, render_bounding_box, (const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));

--- a/trview.app/Mocks/Elements/ITrigger.h
+++ b/trview.app/Mocks/Elements/ITrigger.h
@@ -10,7 +10,7 @@ namespace trview
         {
             MockTrigger();
             virtual ~MockTrigger();
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(bool, visible, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));

--- a/trview.app/Mocks/Geometry/IMesh.h
+++ b/trview.app/Mocks/Geometry/IMesh.h
@@ -10,7 +10,7 @@ namespace trview
         {
             MockMesh();
             virtual ~MockMesh();
-            MOCK_METHOD(void, render, (const DirectX::SimpleMath::Matrix&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&, float, DirectX::SimpleMath::Vector3, bool, bool), (override));
+            MOCK_METHOD(void, render, (const DirectX::SimpleMath::Matrix&, const DirectX::SimpleMath::Color&, float, DirectX::SimpleMath::Vector3, bool, bool), (override));
             MOCK_METHOD(void, render, (const DirectX::SimpleMath::Matrix&, const graphics::Texture&, const DirectX::SimpleMath::Color&, float, DirectX::SimpleMath::Vector3), (override));
             MOCK_METHOD(std::vector<TransparentTriangle>, transparent_triangles, (), (const, override));
             MOCK_METHOD(const DirectX::BoundingBox&, bounding_box, (), (const, override));

--- a/trview.app/Mocks/Geometry/IModelStorage.h
+++ b/trview.app/Mocks/Geometry/IModelStorage.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "../../Geometry/Model/IModelStorage.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockModelStorage : public IModelStorage
+        {
+            MockModelStorage();
+            virtual ~MockModelStorage();
+            MOCK_METHOD(std::weak_ptr<IModel>, find_by_type_id, (uint16_t), (const, override));
+        };
+    }
+}

--- a/trview.app/Mocks/Geometry/ITransparencyBuffer.h
+++ b/trview.app/Mocks/Geometry/ITransparencyBuffer.h
@@ -12,7 +12,7 @@ namespace trview
             virtual ~MockTransparencyBuffer();
             MOCK_METHOD(void, add, (const TransparentTriangle&), (override));
             MOCK_METHOD(void, sort, (const DirectX::SimpleMath::Vector3&), (override));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));
+            MOCK_METHOD(void, render, (const ICamera&, bool), (override));
             MOCK_METHOD(void, reset, (), (override));
         };
     }

--- a/trview.app/Mocks/Graphics/ILevelTextureStorage.h
+++ b/trview.app/Mocks/Graphics/ILevelTextureStorage.h
@@ -10,6 +10,7 @@ namespace trview
         {
             MockLevelTextureStorage();
             virtual ~MockLevelTextureStorage();
+            MOCK_METHOD(void, add_texture, (const std::vector<uint32_t>&, uint32_t, uint32_t), (override));
             MOCK_METHOD(graphics::Texture, coloured, (uint32_t), (const, override));
             MOCK_METHOD(graphics::Texture, lookup, (const std::string&), (const, override));
             MOCK_METHOD(void, store, (const std::string&, const graphics::Texture&), (override));
@@ -18,6 +19,7 @@ namespace trview
             MOCK_METHOD(graphics::Texture, untextured, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector2, uv, (uint32_t, uint32_t), (const, override));
             MOCK_METHOD(uint32_t, tile, (uint32_t), (const, override));
+            MOCK_METHOD(uint32_t, num_textures, (), (const, override));
             MOCK_METHOD(uint32_t, num_tiles, (), (const, override));
             MOCK_METHOD(uint16_t, attribute, (uint32_t), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Color, palette_from_texture, (uint32_t), (const, override));

--- a/trview.app/Mocks/Graphics/ISectorHighlight.h
+++ b/trview.app/Mocks/Graphics/ISectorHighlight.h
@@ -11,7 +11,7 @@ namespace trview
             MockSectorHighlight();
             virtual ~MockSectorHighlight();
             MOCK_METHOD(void, set_sector, (const std::shared_ptr<ISector>&, const DirectX::SimpleMath::Matrix&), (override));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&), (override));
+            MOCK_METHOD(void, render, (const ICamera&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Graphics/ISelectionRenderer.h
+++ b/trview.app/Mocks/Graphics/ISelectionRenderer.h
@@ -10,7 +10,7 @@ namespace trview
         {
             MockSelectionRenderer();
             virtual ~MockSelectionRenderer();
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, IRenderable&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, IRenderable&, const DirectX::SimpleMath::Color&), (override));
         };
     }
 }

--- a/trview.app/Mocks/Graphics/ITextureStorage.h
+++ b/trview.app/Mocks/Graphics/ITextureStorage.h
@@ -10,9 +10,14 @@ namespace trview
         {
             MockTextureStorage();
             virtual ~MockTextureStorage();
+            MOCK_METHOD(void, add_texture, (const std::vector<uint32_t>&, uint32_t, uint32_t), (override));
             MOCK_METHOD(graphics::Texture, coloured, (uint32_t), (const, override));
+            MOCK_METHOD(graphics::Texture, geometry_texture, (), (const, override));
             MOCK_METHOD(graphics::Texture, lookup, (const std::string&), (const, override));
+            MOCK_METHOD(uint32_t, num_textures, (), (const, override));
             MOCK_METHOD(void, store, (const std::string&, const graphics::Texture&), (override));
+            MOCK_METHOD(graphics::Texture, texture, (uint32_t), (const, override));
+            MOCK_METHOD(graphics::Texture, untextured, (), (const, override));
         };
     }
 }

--- a/trview.app/Mocks/Mocks.cpp
+++ b/trview.app/Mocks/Mocks.cpp
@@ -15,6 +15,7 @@
 #include "Geometry/IMesh.h"
 #include "Geometry/IPicking.h"
 #include "Geometry/ITransparencyBuffer.h"
+#include "Geometry/IModelStorage.h"
 #include "Graphics/ILevelTextureStorage.h"
 #include "Graphics/IMeshStorage.h"
 #include "Graphics/ISectorHighlight.h"
@@ -309,5 +310,8 @@ namespace trview
 
         MockDiffWindowManager::MockDiffWindowManager() {};
         MockDiffWindowManager::~MockDiffWindowManager() {};
+
+        MockModelStorage::MockModelStorage() {};
+        MockModelStorage::~MockModelStorage() {};
     }
 }

--- a/trview.app/Mocks/Routing/IRandomizerRoute.h
+++ b/trview.app/Mocks/Routing/IRandomizerRoute.h
@@ -29,7 +29,7 @@ namespace trview
             MOCK_METHOD(void, reload, (const std::shared_ptr<IFiles>&, const UserSettings&), (override));
             MOCK_METHOD(void, remove, (uint32_t), (override));
             MOCK_METHOD(void, remove, (const std::shared_ptr<IWaypoint>&), (override));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));
+            MOCK_METHOD(void, render, (const ICamera&, bool), (override));
             MOCK_METHOD(void, save, (const std::shared_ptr<IFiles>&, const UserSettings&), (override));
             MOCK_METHOD(void, save_as, (const std::shared_ptr<IFiles>&, const std::string&, const UserSettings&), (override));
             MOCK_METHOD(uint32_t, selected_waypoint, (), (const, override));

--- a/trview.app/Mocks/Routing/IRoute.h
+++ b/trview.app/Mocks/Routing/IRoute.h
@@ -27,7 +27,7 @@ namespace trview
             MOCK_METHOD(void, reload, (const std::shared_ptr<IFiles>&, const UserSettings&), (override));
             MOCK_METHOD(void, remove, (uint32_t), (override));
             MOCK_METHOD(void, remove, (const std::shared_ptr<IWaypoint>&), (override));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, bool), (override));
+            MOCK_METHOD(void, render, (const ICamera&, bool), (override));
             MOCK_METHOD(void, save, (const std::shared_ptr<IFiles>&, const UserSettings&), (override));
             MOCK_METHOD(void, save_as, (const std::shared_ptr<IFiles>&, const std::string&, const UserSettings&), (override));
             MOCK_METHOD(uint32_t, selected_waypoint, (), (const, override));

--- a/trview.app/Mocks/Routing/IWaypoint.h
+++ b/trview.app/Mocks/Routing/IWaypoint.h
@@ -29,8 +29,8 @@ namespace trview
             MOCK_METHOD(void, set_waypoint_colour, (const Colour&), (override));
             MOCK_METHOD(void, set_save_file, (const std::vector<uint8_t>&), (override));
             MOCK_METHOD(void, set_trigger, (const std::weak_ptr<ITrigger>&), (override));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
-            MOCK_METHOD(void, render_join, (const IWaypoint&, const ICamera&, const ILevelTextureStorage&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, render_join, (const IWaypoint&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(bool, visible, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));

--- a/trview.app/Mocks/Tools/ICompass.h
+++ b/trview.app/Mocks/Tools/ICompass.h
@@ -10,7 +10,7 @@ namespace trview
         {
             MockCompass();
             virtual ~MockCompass();
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&), (override));
+            MOCK_METHOD(void, render, (const ICamera&), (override));
             MOCK_METHOD(bool, pick, (const Point&, const Size&, Axis&), (override));
             MOCK_METHOD(void, set_visible, (bool), (override));
         };

--- a/trview.app/Mocks/Tools/IMeasure.h
+++ b/trview.app/Mocks/Tools/IMeasure.h
@@ -13,7 +13,7 @@ namespace trview
             MOCK_METHOD(void, reset, (), (override));
             MOCK_METHOD(bool, add, (const DirectX::SimpleMath::Vector3&), (override));
             MOCK_METHOD(void, set, (const DirectX::SimpleMath::Vector3&), (override));
-            MOCK_METHOD(void, render, (const ICamera&, const ILevelTextureStorage&), (override));
+            MOCK_METHOD(void, render, (const ICamera&), (override));
             MOCK_METHOD(std::string, distance, (), (const, override));
             MOCK_METHOD(bool, measuring, (), (const, override));
             MOCK_METHOD(void, set_visible, (bool), (override));

--- a/trview.app/Routing/IRoute.h
+++ b/trview.app/Routing/IRoute.h
@@ -126,7 +126,7 @@ namespace trview
         /// <param name="camera">The camera to use to render.</param>
         /// <param name="texture_storage">Texture storage for the mesh.</param>
         /// <param name="show_selection">Whether to show the selection outline.</param>
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) = 0;
+        virtual void render(const ICamera& camera, bool show_selection) = 0;
         virtual void save(const std::shared_ptr<IFiles>& files, const UserSettings& settings) = 0;
         virtual void save_as(const std::shared_ptr<IFiles>& files, const std::string& filename, const UserSettings& settings) = 0;
         /// <summary>

--- a/trview.app/Routing/IWaypoint.h
+++ b/trview.app/Routing/IWaypoint.h
@@ -87,7 +87,7 @@ namespace trview
         /// <param name="camera">The camera to use to render.</param>
         /// <param name="texture_storage">The texture storage to use to render.</param>
         /// <param name="colour">The colour for the join.</param>
-        virtual void render_join(const IWaypoint& next_waypoint, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) = 0;
+        virtual void render_join(const IWaypoint& next_waypoint, const ICamera& camera, const DirectX::SimpleMath::Color& colour) = 0;
         /// <summary>
         /// Get the contents of the attached save file.
         /// </summary>

--- a/trview.app/Routing/RandomizerRoute.cpp
+++ b/trview.app/Routing/RandomizerRoute.cpp
@@ -270,9 +270,9 @@ namespace trview
         update_waypoints();
     }
 
-    void RandomizerRoute::render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection)
+    void RandomizerRoute::render(const ICamera& camera, bool show_selection)
     {
-        return _route->render(camera, texture_storage, show_selection);
+        return _route->render(camera, show_selection);
     }
 
     void RandomizerRoute::save(const std::shared_ptr<IFiles>& files, const UserSettings& settings)

--- a/trview.app/Routing/RandomizerRoute.h
+++ b/trview.app/Routing/RandomizerRoute.h
@@ -36,7 +36,7 @@ namespace trview
         void reload(const std::shared_ptr<IFiles>& files, const UserSettings& settings) override;
         void remove(uint32_t index) override;
         void remove(const std::shared_ptr<IWaypoint>& waypoint) override;
-        void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) override;
+        void render(const ICamera& camera, bool show_selection) override;
         void save(const std::shared_ptr<IFiles>& files, const UserSettings& settings) override;
         void save_as(const std::shared_ptr<IFiles>& files, const std::string& filename, const UserSettings& settings) override;
         uint32_t selected_waypoint() const override;

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -265,22 +265,22 @@ namespace trview
         remove(static_cast<uint32_t>(found - _waypoints.begin()));
     }
 
-    void Route::render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection)
+    void Route::render(const ICamera& camera, bool show_selection)
     {
         for (std::size_t i = 0; i < _waypoints.size(); ++i)
         {
             auto& waypoint = _waypoints[i];
-            waypoint->render(camera, texture_storage, _waypoint_colour);
+            waypoint->render(camera, _waypoint_colour);
             if (_show_route_line && i < _waypoints.size() - 1)
             {
-                waypoint->render_join(*_waypoints[i + 1], camera, texture_storage, _colour);
+                waypoint->render_join(*_waypoints[i + 1], camera, _colour);
             }
         }
 
         // Render selected waypoint...
         if (show_selection && _selected_index < _waypoints.size())
         {
-            _selection_renderer->render(camera, texture_storage, *_waypoints[_selected_index], Colour::White);
+            _selection_renderer->render(camera, *_waypoints[_selected_index], Colour::White);
         }
     }
 

--- a/trview.app/Routing/Route.h
+++ b/trview.app/Routing/Route.h
@@ -35,7 +35,7 @@ namespace trview
         void reload(const std::shared_ptr<IFiles>& files, const UserSettings& settings) override;
         virtual void remove(uint32_t index) override;
         void remove(const std::shared_ptr<IWaypoint>& waypoint) override;
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, bool show_selection) override;
+        void render(const ICamera& camera, bool show_selection) override;
         void save(const std::shared_ptr<IFiles>& files, const UserSettings& settings) override;
         void save_as(const std::shared_ptr<IFiles>& files, const std::string& filename, const UserSettings& settings) override;
         virtual uint32_t selected_waypoint() const override;

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -23,7 +23,7 @@ namespace trview
     {
     }
 
-    void Waypoint::render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const Color& colour)
+    void Waypoint::render(const ICamera& camera, const Color& colour)
     {
         Matrix rotation = calculate_waypoint_rotation();
 
@@ -33,17 +33,17 @@ namespace trview
         light_direction.Normalize();
 
         auto pole_wvp = pole_world * camera.view_projection();
-        _mesh->render(pole_wvp, texture_storage, colour, 0.75f, light_direction);
+        _mesh->render(pole_wvp, colour, 0.75f, light_direction);
 
         // The light blob.
         auto blob_wvp = Matrix::CreateScale(PoleThickness, PoleThickness, PoleThickness) * Matrix::CreateTranslation(-Vector3(0, PoleLength + PoleThickness * 0.5f, 0)) * rotation * Matrix::CreateTranslation(_position) * camera.view_projection();
-        _mesh->render(blob_wvp, texture_storage, colour == IRenderable::SelectionFill ? colour : static_cast<Color>(_route_colour));
+        _mesh->render(blob_wvp, colour == IRenderable::SelectionFill ? colour : static_cast<Color>(_route_colour));
 
         const auto window_size = camera.view_size();
         _screen_position = XMVector3Project(blob_position(), 0, 0, window_size.width, window_size.height, 0, 1.0f, camera.projection(), camera.view(), Matrix::Identity);
     }
 
-    void Waypoint::render_join(const IWaypoint& next_waypoint, const ICamera& camera, const ILevelTextureStorage& texture_storage, const Color& colour)
+    void Waypoint::render_join(const IWaypoint& next_waypoint, const ICamera& camera, const Color& colour)
     {
         const auto current = blob_position();
         const auto next_waypoint_pos = next_waypoint.blob_position();
@@ -55,7 +55,7 @@ namespace trview
             : Matrix(XMMatrixLookAtRH(mid, next_waypoint_pos, Vector3::Up)).Invert();
         const auto length = to.Length();
         const auto to_wvp = Matrix::CreateScale(RopeThickness, RopeThickness, length) * matrix * camera.view_projection();
-        _mesh->render(to_wvp, texture_storage, colour);
+        _mesh->render(to_wvp, colour);
     }
 
     void Waypoint::get_transparent_triangles(ITransparencyBuffer&, const ICamera&, const Color&)

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -24,8 +24,8 @@ namespace trview
         /// <param name="route_colour">The colour of the route.</param>
         explicit Waypoint(std::shared_ptr<IMesh> mesh, const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& normal, uint32_t room, Type type, uint32_t index, const Colour& route_colour, const Colour& stick_colour);
         virtual ~Waypoint() = default;
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
-        virtual void render_join(const IWaypoint& next_waypoint, const ICamera& camera, const ILevelTextureStorage& texture_storage, const DirectX::SimpleMath::Color& colour) override;
+        void render(const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
+        void render_join(const IWaypoint& next_waypoint, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         virtual void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         virtual DirectX::BoundingBox bounding_box() const override;
         virtual DirectX::SimpleMath::Vector3 position() const override;

--- a/trview.app/Tools/Compass.cpp
+++ b/trview.app/Tools/Compass.cpp
@@ -48,7 +48,7 @@ namespace trview
     {
     }
 
-    void Compass::render(const ICamera& camera, const ILevelTextureStorage& texture_storage)
+    void Compass::render(const ICamera& camera)
     {
         if (!_visible)
         {
@@ -73,21 +73,21 @@ namespace trview
             const float thickness = 0.015f;
             const auto scale = Matrix::CreateScale(thickness, 1.0f, thickness);
 
-            _mesh->render(scale * view_projection, texture_storage, Color(1.0f, 0.0f, 0.0f));
-            _mesh->render(scale * Matrix::CreateRotationZ(maths::HalfPi) * view_projection, texture_storage, Color(0.0f, 1.0f, 0.0f));
-            _mesh->render(scale * Matrix::CreateRotationX(maths::HalfPi) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
+            _mesh->render(scale * view_projection, Color(1.0f, 0.0f, 0.0f));
+            _mesh->render(scale * Matrix::CreateRotationZ(maths::HalfPi) * view_projection, Color(0.0f, 1.0f, 0.0f));
+            _mesh->render(scale * Matrix::CreateRotationX(maths::HalfPi) * view_projection, Color(0.0f, 0.0f, 1.0f));
 
             // Nodules for each direction - they can be clicked.
             const auto nodule_scale = Matrix::CreateScale(0.05f);
             // Y
-            _mesh->render(nodule_scale * Matrix::CreateTranslation(0, 0.5f, 0) * view_projection, texture_storage, Color(1.0f, 0.0f, 0.0f));
-            _mesh->render(nodule_scale * Matrix::CreateTranslation(0, -0.5f, 0) * view_projection, texture_storage, Color(1.0f, 0.0f, 0.0f));
+            _mesh->render(nodule_scale * Matrix::CreateTranslation(0, 0.5f, 0) * view_projection, Color(1.0f, 0.0f, 0.0f));
+            _mesh->render(nodule_scale * Matrix::CreateTranslation(0, -0.5f, 0) * view_projection, Color(1.0f, 0.0f, 0.0f));
             // X
-            _mesh->render(nodule_scale * Matrix::CreateTranslation(0.5f, 0, 0) * view_projection, texture_storage, Color(0.0f, 1.0f, 0.0f));
-            _mesh->render(nodule_scale * Matrix::CreateTranslation(-0.5f, 0, 0) * view_projection, texture_storage, Color(0.0f, 1.0f, 0.0f));
+            _mesh->render(nodule_scale * Matrix::CreateTranslation(0.5f, 0, 0) * view_projection, Color(0.0f, 1.0f, 0.0f));
+            _mesh->render(nodule_scale * Matrix::CreateTranslation(-0.5f, 0, 0) * view_projection, Color(0.0f, 1.0f, 0.0f));
             // Z
-            _mesh->render(nodule_scale * Matrix::CreateTranslation(0, 0, 0.5f) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
-            _mesh->render(nodule_scale * Matrix::CreateTranslation(0, 0, -0.5f) * view_projection, texture_storage, Color(0.0f, 0.0f, 1.0f));
+            _mesh->render(nodule_scale * Matrix::CreateTranslation(0, 0, 0.5f) * view_projection, Color(0.0f, 0.0f, 1.0f));
+            _mesh->render(nodule_scale * Matrix::CreateTranslation(0, 0, -0.5f) * view_projection, Color(0.0f, 0.0f, 1.0f));
         }
 
         auto screen_size = camera.view_size();

--- a/trview.app/Tools/Compass.h
+++ b/trview.app/Tools/Compass.h
@@ -8,8 +8,6 @@
 
 namespace trview
 {
-    struct ILevelTextureStorage;
-
     /// The compass shows the X, Y and Z axes.
     class Compass final : public ICompass
     {
@@ -22,17 +20,17 @@ namespace trview
         /// Render the compass.
         /// @param camera The current camera being used to view the level.
         /// @param texture_storage The texture storage instance to use.
-        void render(const ICamera& camera, const ILevelTextureStorage& texture_storage);
+        void render(const ICamera& camera) override;
 
         /// Pick against the compass points.
         /// @param mouse_position The mouse position in screen space.
         /// @param screen_size The screen size.
         /// @param axis The axis that was hovered over.
-        bool pick(const Point& mouse_position, const Size& screen_size, Axis& axis);
+        bool pick(const Point& mouse_position, const Size& screen_size, Axis& axis) override;
 
         /// Set whether the compass is visible.
         /// @param value Whether to render the compass.
-        void set_visible(bool value);
+        void set_visible(bool value) override;
     private:
         std::shared_ptr<graphics::IDevice> _device;
         std::unique_ptr<graphics::IRenderTarget> _render_target;

--- a/trview.app/Tools/ICompass.h
+++ b/trview.app/Tools/ICompass.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <trview.app/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Camera/Camera.h>
 
 #include <trview.common/Point.h>
@@ -25,8 +24,7 @@ namespace trview
 
         /// Render the compass.
         /// @param camera The current camera being used to view the level.
-        /// @param texture_storage The texture storage instance to use.
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage) = 0;
+        virtual void render(const ICamera& camera) = 0;
 
         /// Pick against the compass points.
         /// @param mouse_position The mouse position in screen space.

--- a/trview.app/Tools/IMeasure.h
+++ b/trview.app/Tools/IMeasure.h
@@ -3,7 +3,6 @@
 #include <SimpleMath.h>
 #include <trview.common/Event.h>
 #include <trview.app/Camera/ICamera.h>
-#include <trview.app/Graphics/ILevelTextureStorage.h>
 
 namespace trview
 {
@@ -34,8 +33,7 @@ namespace trview
 
         /// Render the measurement.
         /// @param camera The camera being used to render the scene.
-        /// @param texture_storage Texture storage for the level.
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage) = 0;
+        virtual void render(const ICamera& camera) = 0;
 
         /// Get the current text version of the distance measured.
         /// @returns The text version of the distance.

--- a/trview.app/Tools/Measure.cpp
+++ b/trview.app/Tools/Measure.cpp
@@ -50,7 +50,7 @@ namespace trview
         on_distance((_end.value() - _start.value()).Length());
     }
 
-    void Measure::render(const ICamera& camera, const ILevelTextureStorage& texture_storage)
+    void Measure::render(const ICamera& camera)
     {
         if (!_start.has_value() || !_end.has_value() || !_visible)
         {
@@ -83,11 +83,11 @@ namespace trview
         {
             auto pos = _start.value() + to * 0.25f * static_cast<float>(i);
             auto wvp = scale * Matrix::CreateTranslation(pos) * view_projection;
-            _mesh->render(wvp, texture_storage, Color(1.0f, 1.0f, 1.0f));
+            _mesh->render(wvp, Color(1.0f, 1.0f, 1.0f));
         }
 
         auto wvp = scale * Matrix::CreateTranslation(_end.value()) * view_projection;
-        _mesh->render(wvp, texture_storage, Color(1.0f, 1.0f, 1.0f));
+        _mesh->render(wvp, Color(1.0f, 1.0f, 1.0f));
 
         const auto window_size = camera.view_size();
 

--- a/trview.app/Tools/Measure.h
+++ b/trview.app/Tools/Measure.h
@@ -30,8 +30,7 @@ namespace trview
 
         /// Render the measurement.
         /// @param camera The camera being used to render the scene.
-        /// @param texture_storage Texture storage for the level.
-        virtual void render(const ICamera& camera, const ILevelTextureStorage& texture_storage) override;
+        void render(const ICamera& camera) override;
 
         /// Get the current text version of the distance measured.
         /// @returns The text version of the distance.

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -889,16 +889,16 @@ namespace trview
             level->render(*_camera, _show_selection);
             auto texture_storage = level->texture_storage();
 
-            _sector_highlight->render(*_camera, *texture_storage);
-            _measure->render(*_camera, *texture_storage);
+            _sector_highlight->render(*_camera);
+            _measure->render(*_camera);
 
             if (_show_route)
             {
-                _route->render(*_camera, *texture_storage, _show_selection);
+                _route->render(*_camera, _show_selection);
             }
 
             level->render_transparency(*_camera);
-            _compass->render(*_camera, *texture_storage);
+            _compass->render(*_camera);
         }
     }
 

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -43,6 +43,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Geometry\IRenderable.cpp" />
     <ClCompile Include="Geometry\Matrix.cpp" />
     <ClCompile Include="Geometry\Mesh.cpp" />
+    <ClCompile Include="Geometry\Model\Model.cpp" />
+    <ClCompile Include="Geometry\Model\ModelStorage.cpp" />
     <ClCompile Include="Geometry\Picking.cpp" />
     <ClCompile Include="Geometry\PickResult.cpp" />
     <ClCompile Include="Geometry\TransparencyBuffer.cpp" />
@@ -93,12 +95,17 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Elements\Remastered\NgPlusSwitcher.h" />
     <ClInclude Include="Elements\SoundSource\ISoundSource.h" />
     <ClInclude Include="Elements\SoundSource\SoundSource.h" />
+    <ClInclude Include="Geometry\Model\IModel.h" />
+    <ClInclude Include="Geometry\Model\IModelStorage.h" />
+    <ClInclude Include="Geometry\Model\Model.h" />
+    <ClInclude Include="Geometry\Model\ModelStorage.h" />
     <ClInclude Include="Lua\Camera\Lua_Camera.h" />
     <ClInclude Include="Lua\Scriptable\IScriptable.h" />
     <ClInclude Include="Lua\Scriptable\Scriptable.h" />
     <ClInclude Include="Menus\ImGuiFileMenu.h" />
     <ClInclude Include="Mocks\Elements\INgPlusSwitcher.h" />
     <ClInclude Include="Mocks\Elements\ISoundSource.h" />
+    <ClInclude Include="Mocks\Geometry\IModelStorage.h" />
     <ClInclude Include="Mocks\Lua\IScriptable.h" />
     <ClInclude Include="Mocks\Sound\ISound.h" />
     <ClInclude Include="Mocks\Sound\ISoundStorage.h" />

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -377,6 +377,12 @@
     <ClCompile Include="Windows\Pack\PackWindowManager.cpp">
       <Filter>Windows\Pack</Filter>
     </ClCompile>
+    <ClCompile Include="Geometry\Model\Model.cpp">
+      <Filter>Geometry\Model</Filter>
+    </ClCompile>
+    <ClCompile Include="Geometry\Model\ModelStorage.cpp">
+      <Filter>Geometry\Model</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -1258,6 +1264,21 @@
     <ClInclude Include="Mocks\Windows\IPackWindow.h">
       <Filter>Mocks\Windows</Filter>
     </ClInclude>
+    <ClInclude Include="Geometry\Model\IModel.h">
+      <Filter>Geometry\Model</Filter>
+    </ClInclude>
+    <ClInclude Include="Geometry\Model\Model.h">
+      <Filter>Geometry\Model</Filter>
+    </ClInclude>
+    <ClInclude Include="Geometry\Model\IModelStorage.h">
+      <Filter>Geometry\Model</Filter>
+    </ClInclude>
+    <ClInclude Include="Geometry\Model\ModelStorage.h">
+      <Filter>Geometry\Model</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\Geometry\IModelStorage.h">
+      <Filter>Mocks\Geometry</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">
@@ -1481,6 +1502,9 @@
     </Filter>
     <Filter Include="Windows\Pack">
       <UniqueIdentifier>{2309c42b-f2ee-4516-88c1-62a8182b467f}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Geometry\Model">
+      <UniqueIdentifier>{03a8e721-8c98-438d-a8eb-c67a9e88e956}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Move the 'model' (collection of meshes) logic out of the `Item` class and into the new `Model` class. Stored in `ModelStorage` the `Item`, they are all generated on level load and requested by `Item`.

This can be used next for the model viewer.

Also when doing this a lot of the references to `ITextureStorage/ILevelTextureStorage` have been removed as it can be provided directly to the mesh on creation via the mesh source.

Related to #1435 