### PR TITLE
Use std::span function to fix build break

### DIFF
--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -684,7 +684,8 @@ namespace trlevel
                 throw LevelLoadException();
             }
 
-            std::basic_ispanstream<uint8_t> file{ { *bytes } };
+            auto& bytes_value = *bytes;
+            std::basic_ispanstream<uint8_t> file{ { bytes_value } };
             file.exceptions(std::ios::failbit);
             log_file(activity, file, std::format("Opened file \"{}\"", _filename));
 
@@ -813,9 +814,10 @@ namespace trlevel
 
     void Level::load_sound_fx(trview::Activity& activity, const LoadCallbacks& callbacks)
     {
-        if (auto main = load_main_sfx())
+        if (const auto main = load_main_sfx())
         {
-            std::basic_ispanstream<uint8_t> sfx_file{ { *main } };
+            auto& bytes_value = *main;
+            std::basic_ispanstream<uint8_t> sfx_file{ bytes_value };
             sfx_file.exceptions(std::ios::failbit | std::ios::badbit | std::ios::eofbit);
 
             // Remastered has a sound map like structure at the start of main.sfx, so skip that if present:

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -685,7 +685,7 @@ namespace trlevel
             }
 
             auto& bytes_value = *bytes;
-            std::basic_ispanstream<uint8_t> file{ { bytes_value } };
+            std::basic_ispanstream<uint8_t> file{ bytes_value };
             file.exceptions(std::ios::failbit);
             log_file(activity, file, std::format("Opened file \"{}\"", _filename));
 

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -684,8 +684,7 @@ namespace trlevel
                 throw LevelLoadException();
             }
 
-            const auto& bytes_value = *bytes;
-            std::basic_ispanstream<uint8_t> file{ { bytes_value } };
+            std::basic_ispanstream<uint8_t> file{ { *bytes } };
             file.exceptions(std::ios::failbit);
             log_file(activity, file, std::format("Opened file \"{}\"", _filename));
 
@@ -814,7 +813,7 @@ namespace trlevel
 
     void Level::load_sound_fx(trview::Activity& activity, const LoadCallbacks& callbacks)
     {
-        if (const auto main = load_main_sfx())
+        if (auto main = load_main_sfx())
         {
             std::basic_ispanstream<uint8_t> sfx_file{ { *main } };
             sfx_file.exceptions(std::ios::failbit | std::ios::badbit | std::ios::eofbit);

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -5,6 +5,7 @@
 #include <ranges>
 #include <spanstream>
 #include <numeric>
+#include <span>
 
 #include "Level_common.h"
 #include "Level_psx.h"
@@ -684,8 +685,7 @@ namespace trlevel
                 throw LevelLoadException();
             }
 
-            auto& bytes_value = *bytes;
-            std::basic_ispanstream<uint8_t> file{ bytes_value };
+            std::basic_ispanstream<uint8_t> file{ std::span(*bytes) };
             file.exceptions(std::ios::failbit);
             log_file(activity, file, std::format("Opened file \"{}\"", _filename));
 
@@ -816,8 +816,7 @@ namespace trlevel
     {
         if (const auto main = load_main_sfx())
         {
-            auto& bytes_value = *main;
-            std::basic_ispanstream<uint8_t> sfx_file{ bytes_value };
+            std::basic_ispanstream<uint8_t> sfx_file{ std::span(*main) };
             sfx_file.exceptions(std::ios::failbit | std::ios::badbit | std::ios::eofbit);
 
             // Remastered has a sound map like structure at the start of main.sfx, so skip that if present:

--- a/trlevel/Level_common.inl
+++ b/trlevel/Level_common.inl
@@ -50,7 +50,7 @@ namespace trlevel
     std::vector<DataType> read_vector_compressed(std::basic_ispanstream<uint8_t>& file, uint32_t elements)
     {
         auto uncompressed_data = read_compressed(file);
-        std::basic_ispanstream<uint8_t> data_stream{ { uncompressed_data } };
+        std::basic_ispanstream<uint8_t> data_stream{ uncompressed_data };
         data_stream.exceptions(std::ios::failbit | std::ios::badbit | std::ios::eofbit);
         return read_vector<DataType>(data_stream, elements);
     }

--- a/trlevel/Level_common.inl
+++ b/trlevel/Level_common.inl
@@ -49,7 +49,7 @@ namespace trlevel
     template < typename DataType >
     std::vector<DataType> read_vector_compressed(std::basic_ispanstream<uint8_t>& file, uint32_t elements)
     {
-        const auto uncompressed_data = read_compressed(file);
+        auto uncompressed_data = read_compressed(file);
         std::basic_ispanstream<uint8_t> data_stream{ { uncompressed_data } };
         data_stream.exceptions(std::ios::failbit | std::ios::badbit | std::ios::eofbit);
         return read_vector<DataType>(data_stream, elements);

--- a/trlevel/Level_common.inl
+++ b/trlevel/Level_common.inl
@@ -50,7 +50,7 @@ namespace trlevel
     template < typename DataType >
     std::vector<DataType> read_vector_compressed(std::basic_ispanstream<uint8_t>& file, uint32_t elements)
     {
-        auto uncompressed_data = read_compressed(file);
+        const auto uncompressed_data = read_compressed(file);
         std::basic_ispanstream<uint8_t> data_stream{ std::span(uncompressed_data) };
         data_stream.exceptions(std::ios::failbit | std::ios::badbit | std::ios::eofbit);
         return read_vector<DataType>(data_stream, elements);

--- a/trlevel/Level_common.inl
+++ b/trlevel/Level_common.inl
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <bit>
+#include <span>
 
 namespace trlevel
 {
@@ -50,7 +51,7 @@ namespace trlevel
     std::vector<DataType> read_vector_compressed(std::basic_ispanstream<uint8_t>& file, uint32_t elements)
     {
         auto uncompressed_data = read_compressed(file);
-        std::basic_ispanstream<uint8_t> data_stream(uncompressed_data);
+        std::basic_ispanstream<uint8_t> data_stream{ std::span(uncompressed_data) };
         data_stream.exceptions(std::ios::failbit | std::ios::badbit | std::ios::eofbit);
         return read_vector<DataType>(data_stream, elements);
     }

--- a/trlevel/Level_common.inl
+++ b/trlevel/Level_common.inl
@@ -50,7 +50,7 @@ namespace trlevel
     std::vector<DataType> read_vector_compressed(std::basic_ispanstream<uint8_t>& file, uint32_t elements)
     {
         auto uncompressed_data = read_compressed(file);
-        std::basic_ispanstream<uint8_t> data_stream{ uncompressed_data };
+        std::basic_ispanstream<uint8_t> data_stream(uncompressed_data);
         data_stream.exceptions(std::ios::failbit | std::ios::badbit | std::ios::eofbit);
         return read_vector<DataType>(data_stream, elements);
     }

--- a/trlevel/Level_tr1_pc.cpp
+++ b/trlevel/Level_tr1_pc.cpp
@@ -5,6 +5,7 @@
 
 #include <filesystem>
 #include <ranges>
+#include <span>
 
 namespace trlevel
 {
@@ -424,14 +425,13 @@ namespace trlevel
     {
         std::filesystem::path wad_filename{ _filename };
         wad_filename.replace_extension("WAD");
-        auto wad_bytes = _files->load_file(wad_filename.string());
+        const auto wad_bytes = _files->load_file(wad_filename.string());
         if (!wad_bytes.has_value())
         {
             return;
         }
 
-        auto& bytes_value = *wad_bytes;
-        std::basic_ispanstream<uint8_t> wad_file{ bytes_value };
+        std::basic_ispanstream<uint8_t> wad_file{ std::span(*wad_bytes) };
         wad_file.exceptions(std::ios::failbit);
         log_file(activity, wad_file, std::format("Opened file \"{}\"", wad_filename.string()));
 
@@ -476,14 +476,13 @@ namespace trlevel
     {
         std::filesystem::path swd_filename{ _filename };
         swd_filename.replace_extension("SWD");
-        auto wad_bytes = _files->load_file(swd_filename);
+        const auto wad_bytes = _files->load_file(swd_filename);
         if (!wad_bytes.has_value())
         {
             return;
         }
 
-        auto& bytes_value = *wad_bytes;
-        std::basic_ispanstream<uint8_t> wad_file{ bytes_value };
+        std::basic_ispanstream<uint8_t> wad_file{ std::span(*wad_bytes) };
         wad_file.exceptions(std::ios::failbit);
         log_file(activity, wad_file, std::format("Opened file \"{}\"", swd_filename.string()));
 

--- a/trlevel/Level_tr1_pc.cpp
+++ b/trlevel/Level_tr1_pc.cpp
@@ -430,8 +430,7 @@ namespace trlevel
             return;
         }
 
-        const auto& bytes_value = *wad_bytes;
-        std::basic_ispanstream<uint8_t> wad_file{ { bytes_value } };
+        std::basic_ispanstream<uint8_t> wad_file{ { *wad_bytes } };
         wad_file.exceptions(std::ios::failbit);
         log_file(activity, wad_file, std::format("Opened file \"{}\"", wad_filename.string()));
 
@@ -482,8 +481,7 @@ namespace trlevel
             return;
         }
 
-        const auto& bytes_value = *wad_bytes;
-        std::basic_ispanstream<uint8_t> wad_file{ { bytes_value } };
+        std::basic_ispanstream<uint8_t> wad_file{ { *wad_bytes } };
         wad_file.exceptions(std::ios::failbit);
         log_file(activity, wad_file, std::format("Opened file \"{}\"", swd_filename.string()));
 

--- a/trlevel/Level_tr1_pc.cpp
+++ b/trlevel/Level_tr1_pc.cpp
@@ -430,7 +430,8 @@ namespace trlevel
             return;
         }
 
-        std::basic_ispanstream<uint8_t> wad_file{ { *wad_bytes } };
+        auto& bytes_value = *wad_bytes;
+        std::basic_ispanstream<uint8_t> wad_file{ bytes_value };
         wad_file.exceptions(std::ios::failbit);
         log_file(activity, wad_file, std::format("Opened file \"{}\"", wad_filename.string()));
 
@@ -481,7 +482,8 @@ namespace trlevel
             return;
         }
 
-        std::basic_ispanstream<uint8_t> wad_file{ { *wad_bytes } };
+        auto& bytes_value = *wad_bytes;
+        std::basic_ispanstream<uint8_t> wad_file{ bytes_value };
         wad_file.exceptions(std::ios::failbit);
         log_file(activity, wad_file, std::format("Opened file \"{}\"", swd_filename.string()));
 

--- a/trlevel/Level_tr1_psx.cpp
+++ b/trlevel/Level_tr1_psx.cpp
@@ -5,6 +5,7 @@
 
 #include <ranges>
 #include <format>
+#include <span>
 
 namespace trlevel
 {
@@ -411,8 +412,7 @@ namespace trlevel
                 memcpy(&sound_header.value()[sound_header->size() - 4], &data_size, 4);
                 sound_header->append_range(sound_data.value());
 
-                auto& bytes_value = *sound_header;
-                std::basic_ispanstream<uint8_t> sound_file{ bytes_value };
+                std::basic_ispanstream<uint8_t> sound_file{ std::span(*sound_header) };
                 sound_file.exceptions(std::ios::failbit);
 
                 skip(sound_file, 18);

--- a/trlevel/Level_tr1_psx.cpp
+++ b/trlevel/Level_tr1_psx.cpp
@@ -411,8 +411,7 @@ namespace trlevel
                 memcpy(&sound_header.value()[sound_header->size() - 4], &data_size, 4);
                 sound_header->append_range(sound_data.value());
 
-                const auto& bytes_value = *sound_header;
-                std::basic_ispanstream<uint8_t> sound_file{ { bytes_value } };
+                std::basic_ispanstream<uint8_t> sound_file{ { *sound_header } };
                 sound_file.exceptions(std::ios::failbit);
 
                 skip(sound_file, 18);

--- a/trlevel/Level_tr1_psx.cpp
+++ b/trlevel/Level_tr1_psx.cpp
@@ -411,7 +411,8 @@ namespace trlevel
                 memcpy(&sound_header.value()[sound_header->size() - 4], &data_size, 4);
                 sound_header->append_range(sound_data.value());
 
-                std::basic_ispanstream<uint8_t> sound_file{ { *sound_header } };
+                auto& bytes_value = *sound_header;
+                std::basic_ispanstream<uint8_t> sound_file{ bytes_value };
                 sound_file.exceptions(std::ios::failbit);
 
                 skip(sound_file, 18);

--- a/trlevel/Level_tr1_saturn.cpp
+++ b/trlevel/Level_tr1_saturn.cpp
@@ -9,6 +9,7 @@
 #include <filesystem>
 #include <map>
 #include <unordered_set>
+#include <span>
 
 #include "TileMapper.h"
 
@@ -524,13 +525,13 @@ namespace trlevel
             const std::unordered_map<std::string, std::function<void(std::basic_ispanstream<uint8_t>&)>>& loader_functions,
             const std::string& end_tag)
         {
-            auto bytes = files.load_file(path);
+            const auto bytes = files.load_file(path);
             if (!bytes.has_value())
             {
                 throw LevelLoadException();
             }
 
-            std::basic_ispanstream<uint8_t> file{ { *bytes } };
+            std::basic_ispanstream<uint8_t> file{ std::span(*bytes) };
             file.exceptions(std::ios::failbit);
 
             return load_saturn_tagfile(file, loader_functions, end_tag);

--- a/trlevel/Level_tr1_saturn.cpp
+++ b/trlevel/Level_tr1_saturn.cpp
@@ -530,8 +530,7 @@ namespace trlevel
                 throw LevelLoadException();
             }
 
-            const auto& bytes_value = *bytes;
-            std::basic_ispanstream<uint8_t> file{ { bytes_value } };
+            std::basic_ispanstream<uint8_t> file{ { *bytes } };
             file.exceptions(std::ios::failbit);
 
             return load_saturn_tagfile(file, loader_functions, end_tag);

--- a/trlevel/Level_tr4_pc.cpp
+++ b/trlevel/Level_tr4_pc.cpp
@@ -100,7 +100,7 @@ namespace trlevel
         _num_textiles = read_textiles_tr4_5(activity, file, callbacks);
         log_file(activity, file, "Reading and decompressing level data");
         callbacks.on_progress("Decompressing level data");
-        const std::vector<uint8_t> level_data = read_compressed(file);
+        std::vector<uint8_t> level_data = read_compressed(file);
         std::basic_ispanstream<uint8_t> data_stream{ { level_data } };
         callbacks.on_progress("Processing level data");
 
@@ -269,7 +269,7 @@ namespace trlevel
     void Level::load_ngle_sound_fx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const LoadCallbacks& callbacks)
     {
         const auto ngle_samples = read_sound_samples_ngle(activity, file, callbacks);
-        if (const auto main = load_main_sfx())
+        if (auto main = load_main_sfx())
         {
             std::basic_ispanstream<uint8_t> sfx_file{ { *main } };
             sfx_file.exceptions(std::ios::failbit | std::ios::badbit | std::ios::eofbit);

--- a/trlevel/Level_tr4_pc.cpp
+++ b/trlevel/Level_tr4_pc.cpp
@@ -271,7 +271,8 @@ namespace trlevel
         const auto ngle_samples = read_sound_samples_ngle(activity, file, callbacks);
         if (auto main = load_main_sfx())
         {
-            std::basic_ispanstream<uint8_t> sfx_file{ { *main } };
+            auto& bytes_value = *main;
+            std::basic_ispanstream<uint8_t> sfx_file{ bytes_value };
             sfx_file.exceptions(std::ios::failbit | std::ios::badbit | std::ios::eofbit);
 
             for (uint32_t i = 0; i < ngle_samples.size(); ++i)

--- a/trlevel/Level_tr4_pc.cpp
+++ b/trlevel/Level_tr4_pc.cpp
@@ -2,6 +2,7 @@
 #include "Level_common.h"
 
 #include <ranges>
+#include <span>
 
 namespace trlevel
 {
@@ -100,8 +101,8 @@ namespace trlevel
         _num_textiles = read_textiles_tr4_5(activity, file, callbacks);
         log_file(activity, file, "Reading and decompressing level data");
         callbacks.on_progress("Decompressing level data");
-        std::vector<uint8_t> level_data = read_compressed(file);
-        std::basic_ispanstream<uint8_t> data_stream{ { level_data } };
+        const std::vector<uint8_t> level_data = read_compressed(file);
+        std::basic_ispanstream<uint8_t> data_stream{ std::span(level_data) };
         callbacks.on_progress("Processing level data");
 
         {
@@ -269,10 +270,9 @@ namespace trlevel
     void Level::load_ngle_sound_fx(trview::Activity& activity, std::basic_ispanstream<uint8_t>& file, const LoadCallbacks& callbacks)
     {
         const auto ngle_samples = read_sound_samples_ngle(activity, file, callbacks);
-        if (auto main = load_main_sfx())
+        if (const auto main = load_main_sfx())
         {
-            auto& bytes_value = *main;
-            std::basic_ispanstream<uint8_t> sfx_file{ bytes_value };
+            std::basic_ispanstream<uint8_t> sfx_file{ std::span(*main) };
             sfx_file.exceptions(std::ios::failbit | std::ios::badbit | std::ios::eofbit);
 
             for (uint32_t i = 0; i < ngle_samples.size(); ++i)


### PR DESCRIPTION
After a VS update the creation of ispanstream has failed again.
Change to using the `std::span` function.
Closes #1441