### PR TITLE
Flyby camera support

### DIFF
--- a/trlevel/ILevel.h
+++ b/trlevel/ILevel.h
@@ -179,5 +179,6 @@ namespace trlevel
         virtual std::vector<int16_t> sound_map() const = 0;
         virtual bool trng() const = 0;
         virtual std::weak_ptr<IPack> pack() const = 0;
+        virtual std::vector<tr4_flyby_camera> flyby_cameras() const = 0;
     };
 }

--- a/trlevel/Level.cpp
+++ b/trlevel/Level.cpp
@@ -992,6 +992,11 @@ namespace trlevel
         return _pack;
     }
 
+    std::vector<tr4_flyby_camera> Level::flyby_cameras() const
+    {
+        return _flyby_cameras;
+    }
+
     void Level::generate_sounds(const LoadCallbacks& callbacks)
     {
         callbacks.on_progress("Generating sounds");

--- a/trlevel/Level.h
+++ b/trlevel/Level.h
@@ -175,6 +175,7 @@ namespace trlevel
         bool trng() const override;
         PlatformAndVersion platform_and_version() const override;
         std::weak_ptr<IPack> pack() const override;
+        std::vector<tr4_flyby_camera> flyby_cameras() const override;
     private:
         void generate_meshes(const std::vector<uint16_t>& mesh_data);
         tr_colour4 colour_from_object_texture(uint32_t texture) const;
@@ -295,6 +296,7 @@ namespace trlevel
         std::string _name;
 
         std::vector<tr_camera> _cameras;
+        std::vector<tr4_flyby_camera> _flyby_cameras;
         std::vector<tr_sound_source>    _sound_sources;
         std::vector<tr_x_sound_details> _sound_details;
         std::vector<int16_t> _sound_map;

--- a/trlevel/Level_tr4_pc.cpp
+++ b/trlevel/Level_tr4_pc.cpp
@@ -133,7 +133,7 @@ namespace trlevel
             _sprite_textures = read_sprite_textures(activity, data_stream, callbacks);
             _sprite_sequences = read_sprite_sequences(activity, data_stream, callbacks);
             _cameras = read_cameras(activity, data_stream, callbacks);
-            read_flyby_cameras(activity, data_stream, callbacks);
+            _flyby_cameras = read_flyby_cameras(activity, data_stream, callbacks);
 
             _sound_sources = read_sound_sources(activity, data_stream, callbacks);
             const auto boxes = read_boxes(activity, data_stream, callbacks);

--- a/trlevel/Level_tr4_psx.cpp
+++ b/trlevel/Level_tr4_psx.cpp
@@ -748,6 +748,7 @@ namespace trlevel
         skip(file, info.boxes_length + info.overlaps_length);
         skip(file, 2 * (info.ground_zone_length + info.ground_zone_length2 + info.ground_zone_length3 + info.ground_zone_length4 + info.ground_zone_length5));
         _cameras = read_vector<tr_camera>(file, info.num_cameras);
+        _flyby_cameras = read_vector<tr4_flyby_camera>(file, info.num_flyby_cameras);
         _frames = read_frames(activity, file, start, info, callbacks);
         _models = read_models(activity, file, start, info, callbacks, model_count(_platform_and_version));
         _static_meshes = read_static_meshes_tr4_psx(activity, file, callbacks, 60);
@@ -805,7 +806,7 @@ namespace trlevel
             uint32_t ground_zone_length4;
             uint32_t ground_zone_length5;
             uint32_t num_cameras;
-            char     unknown_5a[4];
+            uint32_t num_flyby_cameras;
             int      camera_length;
             uint32_t unknown_6;
             uint16_t num_ai_objects;
@@ -851,7 +852,7 @@ namespace trlevel
             .ground_zone_length4 = opsm_info.ground_zone_length4,
             .ground_zone_length5 = opsm_info.ground_zone_length5,
             .num_cameras = opsm_info.num_cameras,
-            .unknown_6 = opsm_info.unknown_6,
+            .num_flyby_cameras = opsm_info.num_flyby_cameras,
             .num_ai_objects = opsm_info.num_ai_objects
         };
 
@@ -915,7 +916,7 @@ namespace trlevel
         skip(file, info.boxes_length + info.overlaps_length);
         skip(file, 2 * (info.ground_zone_length + info.ground_zone_length2 + info.ground_zone_length3 + info.ground_zone_length4 + info.ground_zone_length5));
         _cameras = read_vector<tr_camera>(file, info.num_cameras);
-        skip(file, info.unknown_6);
+        _flyby_cameras = read_vector<tr4_flyby_camera>(file, info.num_flyby_cameras);
         info.models_offset = static_cast<uint32_t>(file.tellg());
         _models = read_models(activity, file, start, info, callbacks, model_count(_platform_and_version));
         _static_meshes = read_static_meshes_tr4_psx(activity, file, callbacks, 60);

--- a/trlevel/Level_tr5_dc.cpp
+++ b/trlevel/Level_tr5_dc.cpp
@@ -239,7 +239,7 @@ namespace trlevel
         {
             DreamcastPage page{ file };
             _cameras = read_cameras(activity, file, callbacks);
-            read_flyby_cameras(activity, file, callbacks);
+            _flyby_cameras = read_flyby_cameras(activity, file, callbacks);
         }
 
         {

--- a/trlevel/Level_tr5_pc.cpp
+++ b/trlevel/Level_tr5_pc.cpp
@@ -238,7 +238,7 @@ namespace trlevel
         _sprite_textures = read_sprite_textures(activity, file, callbacks);
         _sprite_sequences = read_sprite_sequences(activity, file, callbacks);
         _cameras = read_cameras(activity, file, callbacks);
-        read_flyby_cameras(activity, file, callbacks);
+        _flyby_cameras = read_flyby_cameras(activity, file, callbacks);
         _sound_sources = read_sound_sources(activity, file, callbacks);
 
         const auto boxes = read_boxes(activity, file, callbacks);
@@ -315,7 +315,7 @@ namespace trlevel
         _sprite_textures = read_sprite_textures(activity, file, callbacks);
         _sprite_sequences = read_sprite_sequences(activity, file, callbacks);
         _cameras = read_cameras(activity, file, callbacks);
-        read_flyby_cameras(activity, file, callbacks);
+        _flyby_cameras = read_flyby_cameras(activity, file, callbacks);
         _sound_sources = read_sound_sources(activity, file, callbacks);
 
         const auto boxes = read_boxes(activity, file, callbacks);

--- a/trlevel/Level_tr5_psx.cpp
+++ b/trlevel/Level_tr5_psx.cpp
@@ -187,6 +187,7 @@ namespace trlevel
         skip(file, info.boxes_length + info.overlaps_length);
         skip(file, 2 * (info.ground_zone_length + info.ground_zone_length2 + info.ground_zone_length3 + info.ground_zone_length4 + info.ground_zone_length5));
         _cameras = read_vector<tr_camera>(file, info.num_cameras);
+        _flyby_cameras = read_vector<tr4_flyby_camera>(file, info.num_flyby_cameras);
         _frames = read_frames(activity, file, start, info, callbacks);
         _models = read_models(activity, file, start, info, callbacks, model_count(_platform_and_version));
         _static_meshes = read_static_meshes_tr4_psx(activity, file, callbacks, static_count(_platform_and_version));

--- a/trlevel/Mocks/ILevel.h
+++ b/trlevel/Mocks/ILevel.h
@@ -52,6 +52,7 @@ namespace trlevel
             MOCK_METHOD(bool, trng, (), (const, override));
             MOCK_METHOD(PlatformAndVersion, platform_and_version, (), (const, override));
             MOCK_METHOD(std::weak_ptr<IPack>, pack, (), (const, override));
+            MOCK_METHOD(std::vector<tr4_flyby_camera>, flyby_cameras, (), (const, override));
         };
     }
 }

--- a/trlevel/trtypes.h
+++ b/trlevel/trtypes.h
@@ -798,9 +798,9 @@ namespace trlevel
         uint32_t ground_zone_length4;
         uint32_t ground_zone_length5;
         uint32_t num_cameras;
-        char     unknown_5a[4];
+        uint32_t num_flyby_cameras;
         int      camera_length;
-        uint32_t unknown_6;
+        uint32_t flyby_camera_size;
         uint16_t num_ai_objects;
         char     unknown_7[38];
     };

--- a/trview.app.tests/Elements/FlybyTests.cpp
+++ b/trview.app.tests/Elements/FlybyTests.cpp
@@ -20,9 +20,11 @@ namespace
             std::vector<tr4_flyby_camera> nodes;
             uint32_t number{ 0u };
 
-            Flyby build()
+            std::shared_ptr<Flyby> build()
             {
-                return Flyby(flyby_node_source, mesh_source, mesh, nodes, number);
+                auto flyby = std::make_shared<Flyby>(mesh, number);
+                flyby->initialise(flyby_node_source, mesh_source, nodes);
+                return flyby;
             }
         };
 
@@ -35,9 +37,9 @@ TEST(Flyby, SetVisible)
     auto flyby = register_test_module().build();
 
     bool raised = false;
-    auto token = flyby.on_changed += capture_called(raised);
+    auto token = flyby->on_changed += capture_called(raised);
 
-    flyby.set_visible(true);
+    flyby->set_visible(true);
 
     ASSERT_TRUE(raised);
 }

--- a/trview.app.tests/Elements/FlybyTests.cpp
+++ b/trview.app.tests/Elements/FlybyTests.cpp
@@ -1,0 +1,41 @@
+#include <trview.app/Elements/Flyby/Flyby.h>
+#include <trview.tests.common/Event.h>
+
+using namespace trlevel;
+using namespace trview;
+using namespace trview::mocks;
+using namespace trview::tests;
+using namespace DirectX::SimpleMath;
+
+namespace
+{
+    auto register_test_module()
+    {
+        struct test_module
+        {
+            IMesh::Source mesh_source{ [](auto&&...) { return mock_shared<MockMesh>(); } };
+            std::shared_ptr<IMesh> mesh{ mock_shared<MockMesh>() };
+            std::vector<tr4_flyby_camera> nodes;
+            uint32_t number{ 0u };
+
+            Flyby build()
+            {
+                return Flyby(mesh_source, mesh, nodes, number);
+            }
+        };
+
+        return test_module{};
+    }
+}
+
+TEST(Flyby, SetVisible)
+{
+    auto flyby = register_test_module().build();
+
+    bool raised = false;
+    auto token = flyby.on_changed += capture_called(raised);
+
+    flyby.set_visible(true);
+
+    ASSERT_TRUE(raised);
+}

--- a/trview.app.tests/Elements/FlybyTests.cpp
+++ b/trview.app.tests/Elements/FlybyTests.cpp
@@ -1,5 +1,6 @@
 #include <trview.app/Elements/Flyby/Flyby.h>
 #include <trview.tests.common/Event.h>
+#include <trview.app/Mocks/Elements/IFlybyNode.h>
 
 using namespace trlevel;
 using namespace trview;
@@ -13,6 +14,7 @@ namespace
     {
         struct test_module
         {
+            IFlybyNode::Source flyby_node_source{ [](auto&&...) { return mock_shared<MockFlybyNode>(); } };
             IMesh::Source mesh_source{ [](auto&&...) { return mock_shared<MockMesh>(); } };
             std::shared_ptr<IMesh> mesh{ mock_shared<MockMesh>() };
             std::vector<tr4_flyby_camera> nodes;
@@ -20,7 +22,7 @@ namespace
 
             Flyby build()
             {
-                return Flyby(mesh_source, mesh, nodes, number);
+                return Flyby(flyby_node_source, mesh_source, mesh, nodes, number);
             }
         };
 

--- a/trview.app.tests/Elements/FlybyTests.cpp
+++ b/trview.app.tests/Elements/FlybyTests.cpp
@@ -1,6 +1,7 @@
 #include <trview.app/Elements/Flyby/Flyby.h>
 #include <trview.tests.common/Event.h>
 #include <trview.app/Mocks/Elements/IFlybyNode.h>
+#include <trview.app/Mocks/Elements/ILevel.h>
 
 using namespace trlevel;
 using namespace trview;
@@ -18,10 +19,11 @@ namespace
             IMesh::Source mesh_source{ [](auto&&...) { return mock_shared<MockMesh>(); } };
             std::shared_ptr<IMesh> mesh{ mock_shared<MockMesh>() };
             std::vector<tr4_flyby_camera> nodes;
+            std::shared_ptr<trview::ILevel> level{ mock_shared<MockLevel>() };
 
             std::shared_ptr<Flyby> build()
             {
-                auto flyby = std::make_shared<Flyby>(mesh);
+                auto flyby = std::make_shared<Flyby>(mesh, level);
                 flyby->initialise(flyby_node_source, mesh_source, nodes);
                 return flyby;
             }

--- a/trview.app.tests/Elements/FlybyTests.cpp
+++ b/trview.app.tests/Elements/FlybyTests.cpp
@@ -18,11 +18,10 @@ namespace
             IMesh::Source mesh_source{ [](auto&&...) { return mock_shared<MockMesh>(); } };
             std::shared_ptr<IMesh> mesh{ mock_shared<MockMesh>() };
             std::vector<tr4_flyby_camera> nodes;
-            uint32_t number{ 0u };
 
             std::shared_ptr<Flyby> build()
             {
-                auto flyby = std::make_shared<Flyby>(mesh, number);
+                auto flyby = std::make_shared<Flyby>(mesh);
                 flyby->initialise(flyby_node_source, mesh_source, nodes);
                 return flyby;
             }

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -7,6 +7,7 @@
 #include <trview.app/Mocks/Graphics/ILevelTextureStorage.h>
 #include <trview.app/Mocks/Graphics/IMeshStorage.h>
 #include <trview.app/Mocks/Graphics/ISelectionRenderer.h>
+#include <trview.app/Mocks/Elements/IFlyby.h>
 #include <trview.app/Mocks/Elements/IItem.h>
 #include <trview.app/Mocks/Elements/IRoom.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
@@ -62,11 +63,12 @@ namespace
             ISoundSource::Source sound_source_source{ [](auto&&...) { return mock_shared<MockSoundSource>(); } };
             std::shared_ptr<ISoundStorage> sound_storage{ mock_shared<MockSoundStorage>() };
             std::shared_ptr<INgPlusSwitcher> ngplus_switcher{ mock_shared<MockNgPlusSwitcher>() };
+            IFlyby::Source flyby_source{ [](auto&&...) { return mock_shared<MockFlyby>(); } };
 
             std::shared_ptr<Level> build()
             {
                 auto new_level = std::make_shared<Level>(device, shader_storage, level_texture_storage, std::move(transparency_buffer), std::move(selection_renderer), log, buffer_source, sound_storage, ngplus_switcher);
-                new_level->initialise(std::move(level), mesh_storage, model_storage, entity_source, ai_source, room_source, trigger_source, light_source, camera_sink_source, sound_source_source, callbacks);
+                new_level->initialise(std::move(level), mesh_storage, model_storage, entity_source, ai_source, room_source, trigger_source, light_source, camera_sink_source, sound_source_source, flyby_source, callbacks);
                 return new_level;
             }
 

--- a/trview.app.tests/Windows/WindowsTests.cpp
+++ b/trview.app.tests/Windows/WindowsTests.cpp
@@ -567,6 +567,8 @@ TEST(Windows, SetLevel)
 {
     auto [cameras_ptr, cameras] = create_mock<MockCameraSinkWindowManager>();
     EXPECT_CALL(cameras, set_camera_sinks).Times(1);
+    EXPECT_CALL(cameras, set_flybys).Times(1);
+    EXPECT_CALL(cameras, set_platform_and_version).Times(1);
     auto [items_ptr, items] = create_mock<MockItemsWindowManager>();
     EXPECT_CALL(items, set_items).Times(1);
     EXPECT_CALL(items, set_triggers).Times(1);
@@ -860,6 +862,8 @@ TEST(Windows, WindowsRendered)
 
 TEST(Windows, WindowsUpdated)
 {
+    auto [cameras_ptr, cameras] = create_mock<MockCameraSinkWindowManager>();
+    EXPECT_CALL(cameras, update).Times(1);
     auto [items_ptr, items] = create_mock<MockItemsWindowManager>();
     EXPECT_CALL(items, update).Times(1);
     auto [lights_ptr, lights] = create_mock<MockLightsWindowManager>();
@@ -875,6 +879,7 @@ TEST(Windows, WindowsUpdated)
     auto [triggers_ptr, triggers] = create_mock<MockTriggersWindowManager>();
     EXPECT_CALL(triggers, update).Times(1);
     auto windows = register_test_module()
+        .with_camera_sinks(std::move(cameras_ptr))
         .with_items(std::move(items_ptr))
         .with_lights(std::move(lights_ptr))
         .with_plugins(std::move(plugins_ptr))

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="CameraSinkWindowManagerTests.cpp" />
     <ClCompile Include="Camera\CameraInputTests.cpp" />
     <ClCompile Include="Elements\CameraSinkTests.cpp" />
+    <ClCompile Include="Elements\FlybyTests.cpp" />
     <ClCompile Include="Elements\ItemTests.cpp" />
     <ClCompile Include="Elements\LevelTests.cpp" />
     <ClCompile Include="Elements\LightTests.cpp" />

--- a/trview.app.tests/trview.app.tests.vcxproj.filters
+++ b/trview.app.tests/trview.app.tests.vcxproj.filters
@@ -217,6 +217,9 @@
     <ClCompile Include="Windows\AboutWindowManagerTests.cpp">
       <Filter>Windows</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\FlybyTests.cpp">
+      <Filter>Elements</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Input">

--- a/trview.app.ui.tests/CameraSinkWindowTests.cpp
+++ b/trview.app.ui.tests/CameraSinkWindowTests.cpp
@@ -6,6 +6,7 @@
 #include <trview.app/Windows/CameraSink/CameraSinkWindow.h>
 #include <trview.common/Mocks/Windows/IClipboard.h>
 #include <trview.tests.common/Mocks.h>
+#include <trview.app/Mocks/Camera/ICamera.h>
 
 using namespace testing;
 using namespace trview;
@@ -21,10 +22,11 @@ namespace
             struct test_module
             {
                 std::shared_ptr<IClipboard> clipboard{ mock_shared<MockClipboard>() };
+                std::shared_ptr<ICamera> camera{ mock_shared<MockCamera>() };
 
                 std::unique_ptr<CameraSinkWindow> build()
                 {
-                    return std::make_unique<CameraSinkWindow>(clipboard);
+                    return std::make_unique<CameraSinkWindow>(clipboard, camera);
                 }
             };
 

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -308,6 +308,7 @@ namespace trview
         _token_store += _viewer->on_waypoint_selected += [this](auto index) { select_waypoint(index); };
         _token_store += _viewer->on_waypoint_removed += [this](auto index) { remove_waypoint(index); };
         _token_store += _viewer->on_camera_sink_selected += [this](const auto& camera_sink) { select_camera_sink(camera_sink); };
+        _token_store += _viewer->on_flyby_node_selected += [this](const auto& flyby_node) { select_flyby_node(flyby_node); };
         _token_store += _viewer->on_settings += [this](auto&& settings)
         {
             _settings = settings;

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -6,6 +6,7 @@
 
 #include "Resources/resource.h"
 #include "Elements/SoundSource/ISoundSource.h"
+#include "Elements/Flyby/IFlybyNode.h"
 
 using namespace DirectX::SimpleMath;
 
@@ -74,6 +75,7 @@ namespace trview
         setup_view_menu();
 
         _token_store += _windows->on_camera_sink_selected += [this](const auto& sink) {  select_camera_sink(sink); };
+        _token_store += _windows->on_flyby_node_selected += [this](const auto& node) { select_flyby_node(node); };
         _token_store += _windows->on_trigger_selected += [this](const auto& trigger) { select_trigger(trigger); };
         _token_store += _windows->on_scene_changed += [this]() { _viewer->set_scene_changed(); };
         _token_store += _windows->on_item_selected += [this](const auto& item) { select_item(item); };
@@ -934,5 +936,21 @@ namespace trview
         {
             _viewer->open(_level, ILevel::OpenMode::Reload);
         }
+    }
+
+    void Application::select_flyby_node(const std::weak_ptr<IFlybyNode>& node)
+    {
+        // const auto [flyby_node_ptr, level] = get_entity_and_level(node);
+        // if (!flyby_node_ptr || !level)
+        // {
+        //     return;
+        // }
+
+        // _viewer->open(level, ILevel::OpenMode::Reload);
+        // select_room(flyby_node_ptr->room());
+        auto flyby_node_ptr = node.lock();
+        // level->set_selected_flyby_node(node);
+        _viewer->select_flyby_node(node);
+        _windows->select(node);
     }
 }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -941,16 +941,14 @@ namespace trview
 
     void Application::select_flyby_node(const std::weak_ptr<IFlybyNode>& node)
     {
-        // const auto [flyby_node_ptr, level] = get_entity_and_level(node);
-        // if (!flyby_node_ptr || !level)
-        // {
-        //     return;
-        // }
+        const auto [flyby_node_ptr, level] = get_entity_and_level(node);
+        if (!flyby_node_ptr || !level)
+        {
+            return;
+        }
 
-        // _viewer->open(level, ILevel::OpenMode::Reload);
-        // select_room(flyby_node_ptr->room());
-        auto flyby_node_ptr = node.lock();
-        // level->set_selected_flyby_node(node);
+        _viewer->open(level, ILevel::OpenMode::Reload);
+        level->set_selected_flyby_node(node);
         _viewer->select_flyby_node(node);
         _windows->select(node);
     }

--- a/trview.app/Application.h
+++ b/trview.app/Application.h
@@ -120,6 +120,7 @@ namespace trview
         void select_sound_source(const std::weak_ptr<ISoundSource>& sound_source);
         void check_load();
         void end_diff(const std::weak_ptr<ILevel>& level);
+        void select_flyby_node(const std::weak_ptr<IFlybyNode>& node);
 
         TokenStore _token_store;
 

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -23,6 +23,7 @@
 
 #include "Elements/TypeInfoLookup.h"
 #include "Elements/CameraSink/CameraSink.h"
+#include "Elements/Flyby/Flyby.h"
 #include "Elements/Item.h"
 #include "Elements/Light.h"
 #include "Elements/Trigger.h"
@@ -247,6 +248,9 @@ namespace trview
         const auto sound_source = [=](auto&&... args) { return create_sound(args...); };
         const auto sound_source_source = [=](auto&&... args) { return std::make_shared<SoundSource>(cube_mesh, texture_storage, args...); };
 
+        const auto flyby_mesh = create_frustum_mesh(default_mesh_source);
+        const auto flyby_source = [=](auto&&... args) { return std::make_shared<Flyby>(flyby_mesh, args...); };
+
         auto decrypter = std::make_shared<trlevel::Decrypter>();
         auto trlevel_pack_source = [=](auto&&... args) { return std::make_shared<trlevel::Level>(args..., files, decrypter, log); };
         const auto pack_source = [=](auto&&... args)
@@ -330,6 +334,7 @@ namespace trview
                     light_source,
                     camera_sink_source,
                     sound_source_source,
+                    flyby_source,
                     callbacks);
 
                 return new_level;
@@ -367,6 +372,7 @@ namespace trview
             std::make_unique<CameraControls>(),
             std::make_unique<Toolbar>(plugins));
 
+        const auto camera = std::make_shared<Camera>(window.size());
         auto viewer = std::make_unique<Viewer>(
             window,
             device,
@@ -382,14 +388,14 @@ namespace trview
             device_window_source,
             std::make_unique<SectorHighlight>(default_mesh_source),
             clipboard,
-            std::make_shared<Camera>(window.size()));
+            camera);
 
         auto triggers_window_source = [=]() { return std::make_shared<TriggersWindow>(clipboard); };
         auto route_window_source = [=]() { return std::make_shared<RouteWindow>(clipboard, dialogs, files); };
         auto lights_window_source = [=]() { return std::make_shared<LightsWindow>(clipboard); };
 
         auto log_window_source = [=]() { return std::make_shared<LogWindow>(log, dialogs, files); };
-        auto camera_sink_window_source = [=]() { return std::make_shared<CameraSinkWindow>(clipboard); };
+        auto camera_sink_window_source = [=]() { return std::make_shared<CameraSinkWindow>(clipboard, camera); };
 
         auto textures_window_source = [=]() { return std::make_shared<TexturesWindow>(); };
         auto console_source = [=]() { return std::make_shared<Console>(dialogs, plugins, fonts); };

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -251,7 +251,12 @@ namespace trview
 
         const auto flyby_node_source = [=](auto&&... args) { return std::make_shared<FlybyNode>(args...); };
         const auto flyby_mesh = create_frustum_mesh(default_mesh_source);
-        const auto flyby_source = [=](auto&&... args) { return std::make_shared<Flyby>(flyby_node_source, default_mesh_source, flyby_mesh, args...); };
+        const auto flyby_source = [=](auto&& nodes, auto&& index)
+            { 
+                auto flyby = std::make_shared<Flyby>(flyby_mesh, index);
+                flyby->initialise(flyby_node_source, default_mesh_source, nodes);
+                return flyby;
+            };
 
         auto decrypter = std::make_shared<trlevel::Decrypter>();
         auto trlevel_pack_source = [=](auto&&... args) { return std::make_shared<trlevel::Level>(args..., files, decrypter, log); };

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -24,6 +24,7 @@
 #include "Elements/TypeInfoLookup.h"
 #include "Elements/CameraSink/CameraSink.h"
 #include "Elements/Flyby/Flyby.h"
+#include "Elements/Flyby/FlybyNode.h"
 #include "Elements/Item.h"
 #include "Elements/Light.h"
 #include "Elements/Trigger.h"
@@ -248,8 +249,9 @@ namespace trview
         const auto sound_source = [=](auto&&... args) { return create_sound(args...); };
         const auto sound_source_source = [=](auto&&... args) { return std::make_shared<SoundSource>(cube_mesh, texture_storage, args...); };
 
+        const auto flyby_node_source = [=](auto&&... args) { return std::make_shared<FlybyNode>(args...); };
         const auto flyby_mesh = create_frustum_mesh(default_mesh_source);
-        const auto flyby_source = [=](auto&&... args) { return std::make_shared<Flyby>(default_mesh_source, flyby_mesh, args...); };
+        const auto flyby_source = [=](auto&&... args) { return std::make_shared<Flyby>(flyby_node_source, default_mesh_source, flyby_mesh, args...); };
 
         auto decrypter = std::make_shared<trlevel::Decrypter>();
         auto trlevel_pack_source = [=](auto&&... args) { return std::make_shared<trlevel::Level>(args..., files, decrypter, log); };

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -249,7 +249,7 @@ namespace trview
         const auto sound_source_source = [=](auto&&... args) { return std::make_shared<SoundSource>(cube_mesh, texture_storage, args...); };
 
         const auto flyby_mesh = create_frustum_mesh(default_mesh_source);
-        const auto flyby_source = [=](auto&&... args) { return std::make_shared<Flyby>(flyby_mesh, args...); };
+        const auto flyby_source = [=](auto&&... args) { return std::make_shared<Flyby>(default_mesh_source, flyby_mesh, args...); };
 
         auto decrypter = std::make_shared<trlevel::Decrypter>();
         auto trlevel_pack_source = [=](auto&&... args) { return std::make_shared<trlevel::Level>(args..., files, decrypter, log); };

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -251,9 +251,9 @@ namespace trview
 
         const auto flyby_node_source = [=](auto&&... args) { return std::make_shared<FlybyNode>(args...); };
         const auto flyby_mesh = create_frustum_mesh(default_mesh_source);
-        const auto flyby_source = [=](auto&& nodes)
+        const auto flyby_source = [=](auto&& nodes, auto&& level)
             { 
-                auto flyby = std::make_shared<Flyby>(flyby_mesh);
+                auto flyby = std::make_shared<Flyby>(flyby_mesh, level);
                 flyby->initialise(flyby_node_source, default_mesh_source, nodes);
                 return flyby;
             };

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -251,9 +251,9 @@ namespace trview
 
         const auto flyby_node_source = [=](auto&&... args) { return std::make_shared<FlybyNode>(args...); };
         const auto flyby_mesh = create_frustum_mesh(default_mesh_source);
-        const auto flyby_source = [=](auto&& nodes, auto&& index)
+        const auto flyby_source = [=](auto&& nodes)
             { 
-                auto flyby = std::make_shared<Flyby>(flyby_mesh, index);
+                auto flyby = std::make_shared<Flyby>(flyby_mesh);
                 flyby->initialise(flyby_node_source, default_mesh_source, nodes);
                 return flyby;
             };

--- a/trview.app/Camera/Camera.cpp
+++ b/trview.app/Camera/Camera.cpp
@@ -39,6 +39,11 @@ namespace trview
         return _forward;
     }
 
+    float Camera::fov() const
+    {
+        return _fov;
+    }
+
     const DirectX::BoundingFrustum Camera::frustum() const
     {
         return _bounding_frustum;
@@ -69,6 +74,11 @@ namespace trview
     float Camera::rotation_pitch() const
     {
         return _rotation_pitch;
+    }
+
+    float Camera::rotation_roll() const
+    {
+        return _rotation_roll;
     }
 
     float Camera::rotation_yaw() const

--- a/trview.app/Camera/Camera.cpp
+++ b/trview.app/Camera/Camera.cpp
@@ -395,4 +395,18 @@ namespace trview
     {
         return _mode;
     }
+
+    void Camera::set_forward(const DirectX::SimpleMath::Vector3& forward)
+    {
+        _forward = forward;
+        _up = Vector3::Down;
+        calculate_view_matrix();
+    }
+
+    void Camera::set_rotation_roll(float roll)
+    {
+        _rotation_roll = roll;
+        _up = Vector3::Transform(Vector3::Down, Matrix::CreateRotationZ(DirectX::XMConvertToRadians(roll)));
+        calculate_view_matrix();
+    }
 }

--- a/trview.app/Camera/Camera.h
+++ b/trview.app/Camera/Camera.h
@@ -27,12 +27,14 @@ namespace trview
         explicit Camera(const Size& size);
         virtual ~Camera() = default;
         virtual DirectX::SimpleMath::Vector3 forward() const override;
+        float fov() const override;
         virtual const DirectX::BoundingFrustum frustum() const override;
         virtual DirectX::SimpleMath::Vector3 position() const override;
         virtual DirectX::SimpleMath::Vector3 rendering_position() const override;
         virtual const DirectX::SimpleMath::Matrix projection() const override;
         virtual ProjectionMode projection_mode() const override;
         virtual float rotation_pitch() const override;
+        float rotation_roll() const override;
         virtual float rotation_yaw() const override;
         virtual void rotate_to_pitch(float rotation) override;
         virtual void rotate_to_yaw(float rotation) override;

--- a/trview.app/Camera/Camera.h
+++ b/trview.app/Camera/Camera.h
@@ -56,6 +56,8 @@ namespace trview
         void reset() override;
         DirectX::SimpleMath::Vector3 target() const override;
         Mode mode() const override;
+        void set_forward(const DirectX::SimpleMath::Vector3& forward) override;
+        void set_rotation_roll(float roll) override;
     private:
         /// Calculate the bounding frustum based on the view and projection matrices.
         void calculate_bounding_frustum();
@@ -79,14 +81,16 @@ namespace trview
 
         const float default_pitch = -0.78539f;
         const float default_yaw = 0.0f;
+        const float default_roll = 0.0f;
         const float default_zoom = 8.0f;
         static constexpr float default_fov = 45;
 
         DirectX::SimpleMath::Vector3 _position;
-        DirectX::SimpleMath::Vector3 _forward;
+        DirectX::SimpleMath::Vector3 _forward{ DirectX::SimpleMath::Vector3::Backward };
         DirectX::SimpleMath::Vector3 _up;
         float _rotation_yaw{ default_yaw };
         float _rotation_pitch{ default_pitch };
+        float _rotation_roll{ default_roll };
         float _zoom{ default_zoom };
         ProjectionMode _projection_mode{ ProjectionMode::Perspective };
         std::optional<float> _last_rotation;

--- a/trview.app/Camera/ICamera.h
+++ b/trview.app/Camera/ICamera.h
@@ -33,6 +33,8 @@ namespace trview
         /// @returns The forward direction.
         virtual DirectX::SimpleMath::Vector3 forward() const = 0;
 
+        virtual float fov() const = 0;
+
         /// Get the bounding frustum for the camera. This is a left handed frustum and can be used for culling.
         /// @returns The bounding frustum.
         virtual const DirectX::BoundingFrustum frustum() const = 0;
@@ -56,6 +58,8 @@ namespace trview
         /// Gets the pitch rotation of the camera in radians.
         /// @returns The pitch rotation.
         virtual float rotation_pitch() const = 0;
+
+        virtual float rotation_roll() const = 0;
 
         /// Gets the yaw rotation of the camera in radians.
         /// @returns The yaw rotation.

--- a/trview.app/Camera/ICamera.h
+++ b/trview.app/Camera/ICamera.h
@@ -131,6 +131,10 @@ namespace trview
 
         virtual Mode mode() const = 0;
 
+        virtual void set_forward(const DirectX::SimpleMath::Vector3& forward) = 0;
+
+        virtual void set_rotation_roll(float roll) = 0;
+
         /// Event raised when the view of the camera has changed.
         Event<> on_view_changed;
         Event<Mode> on_mode_changed;

--- a/trview.app/Elements/Flyby/Flyby.cpp
+++ b/trview.app/Elements/Flyby/Flyby.cpp
@@ -60,10 +60,13 @@ namespace trview
             _mesh->render(wvp, _colour, 1.0f, light_direction);
         }
 
-        const auto pos = to_position(_camera_nodes[0]);
-        auto light_direction = Vector3::TransformNormal(camera.position() - pos, Matrix::Identity);
-        light_direction.Normalize();
-        _path_mesh->render(camera.view_projection(), _colour, 1.0f, light_direction);
+        if (_path_mesh)
+        {
+            const auto pos = to_position(_camera_nodes[0]);
+            auto light_direction = Vector3::TransformNormal(camera.position() - pos, Matrix::Identity);
+            light_direction.Normalize();
+            _path_mesh->render(camera.view_projection(), _colour, 1.0f, light_direction);
+        }
     }
 
     void Flyby::get_transparent_triangles(ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&)
@@ -78,6 +81,7 @@ namespace trview
     void Flyby::set_visible(bool value)
     {
         _visible = value;
+        on_changed();
     }
 
     std::vector<trlevel::tr4_flyby_camera> Flyby::nodes() const
@@ -128,6 +132,11 @@ namespace trview
 
     void Flyby::generate_path(const IMesh::Source& mesh_source)
     {
+        if (_camera_nodes.empty())
+        {
+            return;
+        }
+
         // Samples per node - probably need more.
         const int path_samples = 10;
         const int num_vertices = 10;

--- a/trview.app/Elements/Flyby/Flyby.cpp
+++ b/trview.app/Elements/Flyby/Flyby.cpp
@@ -1,0 +1,139 @@
+#include "Flyby.h"
+
+namespace trview
+{
+    using namespace DirectX;
+    using namespace DirectX::SimpleMath;
+
+    namespace
+    {
+        Vector3 to_vector(int32_t x, int32_t y, int32_t z)
+        {
+            return Vector3(static_cast<float>(x), static_cast<float>(y), static_cast<float>(z)) / trlevel::Scale;
+        }
+
+        Vector3 to_position(const trlevel::tr4_flyby_camera& node)
+        {
+            return to_vector(node.x, node.y, node.z);
+        }
+
+        Vector3 to_direction(const trlevel::tr4_flyby_camera& node)
+        {
+            return to_vector(node.dx, node.dy, node.dz);
+        }
+    }
+
+    IFlyby::~IFlyby()
+    {
+    }
+
+    Flyby::Flyby(const std::shared_ptr<IMesh>& mesh, const std::vector<trlevel::tr4_flyby_camera>& camera_nodes, uint32_t index)
+        : _mesh(mesh), _camera_nodes(camera_nodes), _index(index)
+    {
+        _colour = Color(
+            static_cast<float>(rand()) / RAND_MAX,
+            static_cast<float>(rand()) / RAND_MAX,
+            static_cast<float>(rand()) / RAND_MAX);
+    }
+
+    void Flyby::render(const ICamera& camera, const DirectX::SimpleMath::Color&)
+    {
+        if (!_visible)
+        {
+            return;
+        }
+
+        for (const auto& node : _camera_nodes)
+        {
+            auto position = to_position(node);
+            Vector3 target = to_direction(node);
+            Vector3 direction;
+            (target - position).Normalize(direction);
+            const Vector3 angles = Quaternion::FromToRotation(Vector3::Backward, direction).ToEuler();
+            const Matrix rotation = Matrix::CreateFromYawPitchRoll(angles.y, angles.x, DirectX::XMConvertToRadians(static_cast<float>(node.roll) / 182.0f));
+            const auto world = Matrix::CreateScale(0.2f) * rotation * Matrix::CreateTranslation(position);
+            const auto wvp = world * camera.view_projection();
+            auto light_direction = Vector3::TransformNormal(camera.position() - position, world.Invert());
+            light_direction.Normalize();
+
+            _mesh->render(wvp, _colour, 1.0f, light_direction);
+        }
+    }
+
+    void Flyby::get_transparent_triangles(ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&)
+    {
+    }
+
+    bool Flyby::visible() const
+    {
+        return _visible;
+    }
+
+    void Flyby::set_visible(bool value)
+    {
+        _visible = value;
+    }
+
+    std::vector<trlevel::tr4_flyby_camera> Flyby::nodes() const
+    {
+        return _camera_nodes;
+    }
+
+    uint32_t Flyby::number() const
+    {
+        return _index;
+    }
+
+    [[nodiscard]] IFlyby::CameraState Flyby::update_state(const CameraState& base_state, float delta) const
+    {
+        CameraState state = base_state;
+
+        // 1. Check for invalid state (ended, etc).
+        if (state.state == CameraState::State::Ended)
+        {
+            return state;
+        }
+
+        // 2. Advance time
+        state.t += delta * (30 * (static_cast<float>(state.speed) / 65535.0f));
+
+        // 3. Check for state changed (new node etc)
+        if (state.t >= 1.0f)
+        {
+            ++state.index;
+            if (_camera_nodes[state.index].flags & 0x80)
+            {
+                state.index = _camera_nodes[state.index].timer;
+            }
+            state.t = 0;
+        }
+
+        // 4. Check for the end
+        if (state.index >= _camera_nodes.size() - 1) 
+        {
+            state.state = CameraState::State::Ended;
+            return state;
+        }
+
+        // 5. Calculate outputs
+        const int next_step = state.index + 1;
+        const float t = state.t;
+
+        const auto n0 = state.index == 0 ? _camera_nodes[state.index] : _camera_nodes[state.index - 1];
+        const auto n1 = _camera_nodes[state.index];
+        const auto n2 = _camera_nodes[next_step];
+        const auto n3 = (next_step == _camera_nodes.size() - 1) ? _camera_nodes[next_step] : _camera_nodes[next_step + 1];
+        state.position = Vector3::CatmullRom(to_position(n0), to_position(n1), to_position(n2), to_position(n3), t);
+        Vector3 target = Vector3::CatmullRom(to_direction(n0), to_direction(n1), to_direction(n2), to_direction(n3), t);
+        state.raw_direction = target;
+        (target - state.position).Normalize(state.direction);
+
+        state.roll = (n1.roll + (n2.roll - n1.roll) * t) / -182.0f;
+        state.fov = (n1.fov + (n2.fov - n1.fov) * t) / 182.0f;
+        state.speed = n1.speed + (n2.speed - n1.speed) * t;
+        state.timer = n1.timer;
+        state.room_id = n1.room_id;
+        state.flags = n1.flags;
+        return state;
+    }
+}

--- a/trview.app/Elements/Flyby/Flyby.cpp
+++ b/trview.app/Elements/Flyby/Flyby.cpp
@@ -10,13 +10,14 @@ namespace trview
     {
     }
 
-    Flyby::Flyby(const std::shared_ptr<IMesh>& mesh, uint32_t index)
-        : _mesh(mesh), _index(index)
+    Flyby::Flyby(const std::shared_ptr<IMesh>& mesh)
+        : _mesh(mesh)
     {
     }
 
     void Flyby::initialise(const IFlybyNode::Source& flyby_node_source, const IMesh::Source& mesh_source, const std::vector<trlevel::tr4_flyby_camera>& camera_nodes)
     {
+        _index = camera_nodes.empty() ? 0u : camera_nodes.front().sequence;
         _camera_nodes = camera_nodes | std::views::transform([&](auto&& n) { return flyby_node_source(n, weak_from_this()); }) | std::ranges::to<std::vector>();
         _colour = Color(
             static_cast<float>(rand()) / RAND_MAX,

--- a/trview.app/Elements/Flyby/Flyby.cpp
+++ b/trview.app/Elements/Flyby/Flyby.cpp
@@ -10,10 +10,14 @@ namespace trview
     {
     }
 
-    Flyby::Flyby(const IFlybyNode::Source& flyby_node_source, const IMesh::Source& mesh_source, const std::shared_ptr<IMesh>& mesh, const std::vector<trlevel::tr4_flyby_camera>& camera_nodes, uint32_t index)
+    Flyby::Flyby(const std::shared_ptr<IMesh>& mesh, uint32_t index)
         : _mesh(mesh), _index(index)
     {
-        _camera_nodes = camera_nodes | std::views::transform([&](auto&& n) { return flyby_node_source(n); }) | std::ranges::to<std::vector>();
+    }
+
+    void Flyby::initialise(const IFlybyNode::Source& flyby_node_source, const IMesh::Source& mesh_source, const std::vector<trlevel::tr4_flyby_camera>& camera_nodes)
+    {
+        _camera_nodes = camera_nodes | std::views::transform([&](auto&& n) { return flyby_node_source(n, weak_from_this()); }) | std::ranges::to<std::vector>();
         _colour = Color(
             static_cast<float>(rand()) / RAND_MAX,
             static_cast<float>(rand()) / RAND_MAX,

--- a/trview.app/Elements/Flyby/Flyby.cpp
+++ b/trview.app/Elements/Flyby/Flyby.cpp
@@ -244,4 +244,26 @@ namespace trview
         state.room_id = n1->room();
         state.flags = n1->flags();
     }
+
+    PickResult Flyby::pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const
+    {
+        PickResult result{};
+
+        for (const auto& node : _camera_nodes)
+        {
+            BoundingSphere sphere(node->position(), 0.125f);
+
+            float distance = 0;
+            if (sphere.Intersects(position, direction, distance))
+            {
+                result.distance = distance;
+                result.hit = true;
+                result.position = position + direction * distance;
+                result.type = PickResult::Type::FlybyNode;
+                result.flyby_node = std::const_pointer_cast<IFlybyNode>(node);
+            }
+        }
+
+        return result;
+    }
 }

--- a/trview.app/Elements/Flyby/Flyby.cpp
+++ b/trview.app/Elements/Flyby/Flyby.cpp
@@ -60,15 +60,10 @@ namespace trview
             _mesh->render(wvp, _colour, 1.0f, light_direction);
         }
 
-        for (const auto& pos : _temp)
-        {
-            // const auto world = Matrix::CreateScale(0.05f) * Matrix::CreateTranslation(pos);
-            const auto world = Matrix::Identity;
-            const auto wvp = world * camera.view_projection();
-            auto light_direction = Vector3::TransformNormal(camera.position() - pos, world.Invert());
-            light_direction.Normalize();
-            _path_mesh->render(wvp, _colour, 1.0f, light_direction);
-        }
+        const auto pos = to_position(_camera_nodes[0]);
+        auto light_direction = Vector3::TransformNormal(camera.position() - pos, Matrix::Identity);
+        light_direction.Normalize();
+        _path_mesh->render(camera.view_projection(), _colour, 1.0f, light_direction);
     }
 
     void Flyby::get_transparent_triangles(ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&)
@@ -190,7 +185,6 @@ namespace trview
                     Matrix::CreateRotationZ(v * (DirectX::g_XMTwoPi.f[0] / static_cast<float>(num_vertices))) *
                     Matrix::CreateFromQuaternion(Quaternion::FromToRotation(Vector3::Backward, direction));
                 const Vector3 pos = at + Vector3::TransformNormal(Vector3(0, width, 0), rotation);
-                _temp.push_back(pos);
                 vertices.push_back({ .pos = pos, .colour = Colour::White });
             }
 

--- a/trview.app/Elements/Flyby/Flyby.cpp
+++ b/trview.app/Elements/Flyby/Flyby.cpp
@@ -10,15 +10,15 @@ namespace trview
     {
     }
 
-    Flyby::Flyby(const std::shared_ptr<IMesh>& mesh)
-        : _mesh(mesh)
+    Flyby::Flyby(const std::shared_ptr<IMesh>& mesh, const std::weak_ptr<ILevel>& level)
+        : _mesh(mesh), _level(level)
     {
     }
 
     void Flyby::initialise(const IFlybyNode::Source& flyby_node_source, const IMesh::Source& mesh_source, const std::vector<trlevel::tr4_flyby_camera>& camera_nodes)
     {
         _index = camera_nodes.empty() ? 0u : camera_nodes.front().sequence;
-        _camera_nodes = camera_nodes | std::views::transform([&](auto&& n) { return flyby_node_source(n, weak_from_this()); }) | std::ranges::to<std::vector>();
+        _camera_nodes = camera_nodes | std::views::transform([&](auto&& n) { return flyby_node_source(n, weak_from_this(), _level); }) | std::ranges::to<std::vector>();
         _colour = Color(
             static_cast<float>(rand()) / RAND_MAX,
             static_cast<float>(rand()) / RAND_MAX,
@@ -71,6 +71,11 @@ namespace trview
     {
         _visible = value;
         on_changed();
+    }
+
+    std::weak_ptr<ILevel> Flyby::level() const
+    {
+        return _level;
     }
 
     std::vector<std::weak_ptr<IFlybyNode>> Flyby::nodes() const

--- a/trview.app/Elements/Flyby/Flyby.h
+++ b/trview.app/Elements/Flyby/Flyby.h
@@ -23,6 +23,7 @@ namespace trview
         bool visible() const override;
         void set_visible(bool value) override;
         [[nodiscard]] CameraState update_state(const CameraState& state, float delta) const override;
+        PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const override;
     private:
         void generate_path(const IMesh::Source& mesh_source);
         void state_at(CameraState& state) const;

--- a/trview.app/Elements/Flyby/Flyby.h
+++ b/trview.app/Elements/Flyby/Flyby.h
@@ -8,7 +8,11 @@ namespace trview
     class Flyby final : public IFlyby
     {
     public:
-        explicit Flyby(const std::shared_ptr<IMesh>& mesh, const std::vector<trlevel::tr4_flyby_camera>& camera_nodes, uint32_t index);
+        explicit Flyby(
+            const IMesh::Source& mesh_source,
+            const std::shared_ptr<IMesh>& mesh,
+            const std::vector<trlevel::tr4_flyby_camera>& camera_nodes, 
+            uint32_t index);
         virtual ~Flyby() = default;
         std::vector<trlevel::tr4_flyby_camera> nodes() const override;
         uint32_t number() const override;
@@ -18,11 +22,16 @@ namespace trview
         void set_visible(bool value) override;
         [[nodiscard]] CameraState update_state(const CameraState& state, float delta) const override;
     private:
+        void generate_path(const IMesh::Source& mesh_source);
+        void state_at(CameraState& state) const;
+
         uint32_t _index{ 0u };
         std::vector<trlevel::tr4_flyby_camera> _camera_nodes;
         std::shared_ptr<IMesh> _mesh;
         bool _visible{ true };
         DirectX::SimpleMath::Color _colour;
+        std::vector<DirectX::SimpleMath::Vector3> _temp;
+        std::shared_ptr<IMesh> _path_mesh;
     };
 }
 

--- a/trview.app/Elements/Flyby/Flyby.h
+++ b/trview.app/Elements/Flyby/Flyby.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "IFlyby.h"
+#include "../../Geometry/IMesh.h"
+
+namespace trview
+{
+    class Flyby final : public IFlyby
+    {
+    public:
+        explicit Flyby(const std::shared_ptr<IMesh>& mesh, const std::vector<trlevel::tr4_flyby_camera>& camera_nodes, uint32_t index);
+        virtual ~Flyby() = default;
+        std::vector<trlevel::tr4_flyby_camera> nodes() const override;
+        uint32_t number() const override;
+        void render(const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
+        void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
+        bool visible() const override;
+        void set_visible(bool value) override;
+        [[nodiscard]] CameraState update_state(const CameraState& state, float delta) const override;
+    private:
+        uint32_t _index{ 0u };
+        std::vector<trlevel::tr4_flyby_camera> _camera_nodes;
+        std::shared_ptr<IMesh> _mesh;
+        bool _visible{ true };
+        DirectX::SimpleMath::Color _colour;
+    };
+}
+

--- a/trview.app/Elements/Flyby/Flyby.h
+++ b/trview.app/Elements/Flyby/Flyby.h
@@ -9,7 +9,7 @@ namespace trview
     class Flyby final : public IFlyby, public std::enable_shared_from_this<IFlyby>
     {
     public:
-        explicit Flyby(const std::shared_ptr<IMesh>& mesh, uint32_t index);
+        explicit Flyby(const std::shared_ptr<IMesh>& mesh);
         void initialise(const IFlybyNode::Source& flyby_node_source, const IMesh::Source& mesh_source, const std::vector<trlevel::tr4_flyby_camera>& camera_nodes);
         virtual ~Flyby() = default;
         std::vector<std::weak_ptr<IFlybyNode>> nodes() const override;

--- a/trview.app/Elements/Flyby/Flyby.h
+++ b/trview.app/Elements/Flyby/Flyby.h
@@ -9,9 +9,10 @@ namespace trview
     class Flyby final : public IFlyby, public std::enable_shared_from_this<IFlyby>
     {
     public:
-        explicit Flyby(const std::shared_ptr<IMesh>& mesh);
+        explicit Flyby(const std::shared_ptr<IMesh>& mesh, const std::weak_ptr<ILevel>& level);
         void initialise(const IFlybyNode::Source& flyby_node_source, const IMesh::Source& mesh_source, const std::vector<trlevel::tr4_flyby_camera>& camera_nodes);
         virtual ~Flyby() = default;
+        std::weak_ptr<ILevel> level() const override;
         std::vector<std::weak_ptr<IFlybyNode>> nodes() const override;
         uint32_t number() const override;
         void render(const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
@@ -24,6 +25,7 @@ namespace trview
         void generate_path(const IMesh::Source& mesh_source);
         void state_at(CameraState& state) const;
 
+        std::weak_ptr<ILevel> _level;
         uint32_t _index{ 0u };
         std::vector<std::shared_ptr<IFlybyNode>> _camera_nodes;
         std::shared_ptr<IMesh> _mesh;

--- a/trview.app/Elements/Flyby/Flyby.h
+++ b/trview.app/Elements/Flyby/Flyby.h
@@ -30,7 +30,6 @@ namespace trview
         std::shared_ptr<IMesh> _mesh;
         bool _visible{ true };
         DirectX::SimpleMath::Color _colour;
-        std::vector<DirectX::SimpleMath::Vector3> _temp;
         std::shared_ptr<IMesh> _path_mesh;
     };
 }

--- a/trview.app/Elements/Flyby/Flyby.h
+++ b/trview.app/Elements/Flyby/Flyby.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "IFlyby.h"
+#include "IFlybyNode.h"
 #include "../../Geometry/IMesh.h"
 
 namespace trview
@@ -9,12 +10,13 @@ namespace trview
     {
     public:
         explicit Flyby(
+            const IFlybyNode::Source& flyby_node_source,
             const IMesh::Source& mesh_source,
             const std::shared_ptr<IMesh>& mesh,
             const std::vector<trlevel::tr4_flyby_camera>& camera_nodes, 
             uint32_t index);
         virtual ~Flyby() = default;
-        std::vector<trlevel::tr4_flyby_camera> nodes() const override;
+        std::vector<std::weak_ptr<IFlybyNode>> nodes() const override;
         uint32_t number() const override;
         void render(const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
         void get_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour) override;
@@ -26,7 +28,7 @@ namespace trview
         void state_at(CameraState& state) const;
 
         uint32_t _index{ 0u };
-        std::vector<trlevel::tr4_flyby_camera> _camera_nodes;
+        std::vector<std::shared_ptr<IFlybyNode>> _camera_nodes;
         std::shared_ptr<IMesh> _mesh;
         bool _visible{ true };
         DirectX::SimpleMath::Color _colour;

--- a/trview.app/Elements/Flyby/Flyby.h
+++ b/trview.app/Elements/Flyby/Flyby.h
@@ -6,15 +6,11 @@
 
 namespace trview
 {
-    class Flyby final : public IFlyby
+    class Flyby final : public IFlyby, public std::enable_shared_from_this<IFlyby>
     {
     public:
-        explicit Flyby(
-            const IFlybyNode::Source& flyby_node_source,
-            const IMesh::Source& mesh_source,
-            const std::shared_ptr<IMesh>& mesh,
-            const std::vector<trlevel::tr4_flyby_camera>& camera_nodes, 
-            uint32_t index);
+        explicit Flyby(const std::shared_ptr<IMesh>& mesh, uint32_t index);
+        void initialise(const IFlybyNode::Source& flyby_node_source, const IMesh::Source& mesh_source, const std::vector<trlevel::tr4_flyby_camera>& camera_nodes);
         virtual ~Flyby() = default;
         std::vector<std::weak_ptr<IFlybyNode>> nodes() const override;
         uint32_t number() const override;

--- a/trview.app/Elements/Flyby/FlybyNode.cpp
+++ b/trview.app/Elements/Flyby/FlybyNode.cpp
@@ -13,6 +13,7 @@ namespace trview
         : _direction(Vector3(static_cast<float>(node.dx), static_cast<float>(node.dy), static_cast<float>(node.dz)) / trlevel::Scale),
         _flags(node.flags),
         _fov(node.fov),
+        _number(node.index),
         _position(Vector3(static_cast<float>(node.x), static_cast<float>(node.y), static_cast<float>(node.z)) / trlevel::Scale),
         _roll(node.roll),
         _room(node.room_id),
@@ -34,6 +35,11 @@ namespace trview
     uint16_t FlybyNode::fov() const
     {
         return _fov;
+    }
+
+    int32_t FlybyNode::number() const
+    {
+        return _number;
     }
 
     Vector3 FlybyNode::position() const

--- a/trview.app/Elements/Flyby/FlybyNode.cpp
+++ b/trview.app/Elements/Flyby/FlybyNode.cpp
@@ -9,8 +9,9 @@ namespace trview
     {
     }
 
-    FlybyNode::FlybyNode(const tr4_flyby_camera& node, const std::weak_ptr<IFlyby>& flyby)
+    FlybyNode::FlybyNode(const tr4_flyby_camera& node, const std::weak_ptr<IFlyby>& flyby, const std::weak_ptr<ILevel>& level)
         : _flyby(flyby),
+        _level(level),
         _direction(Vector3(static_cast<float>(node.dx), static_cast<float>(node.dy), static_cast<float>(node.dz)) / trlevel::Scale),
         _flags(node.flags),
         _fov(node.fov),
@@ -41,6 +42,11 @@ namespace trview
     uint16_t FlybyNode::fov() const
     {
         return _fov;
+    }
+
+    std::weak_ptr<ILevel> FlybyNode::level() const
+    {
+        return _level;
     }
 
     int32_t FlybyNode::number() const

--- a/trview.app/Elements/Flyby/FlybyNode.cpp
+++ b/trview.app/Elements/Flyby/FlybyNode.cpp
@@ -9,8 +9,9 @@ namespace trview
     {
     }
 
-    FlybyNode::FlybyNode(const tr4_flyby_camera& node)
-        : _direction(Vector3(static_cast<float>(node.dx), static_cast<float>(node.dy), static_cast<float>(node.dz)) / trlevel::Scale),
+    FlybyNode::FlybyNode(const tr4_flyby_camera& node, const std::weak_ptr<IFlyby>& flyby)
+        : _flyby(flyby),
+        _direction(Vector3(static_cast<float>(node.dx), static_cast<float>(node.dy), static_cast<float>(node.dz)) / trlevel::Scale),
         _flags(node.flags),
         _fov(node.fov),
         _number(node.index),
@@ -30,6 +31,11 @@ namespace trview
     uint16_t FlybyNode::flags() const
     {
         return _flags;
+    }
+
+    std::weak_ptr<IFlyby> FlybyNode::flyby() const
+    {
+        return _flyby;
     }
 
     uint16_t FlybyNode::fov() const

--- a/trview.app/Elements/Flyby/FlybyNode.cpp
+++ b/trview.app/Elements/Flyby/FlybyNode.cpp
@@ -1,0 +1,63 @@
+#include "FlybyNode.h"
+
+namespace trview
+{
+    using namespace trlevel;
+    using namespace DirectX::SimpleMath;
+
+    IFlybyNode::~IFlybyNode()
+    {
+    }
+
+    FlybyNode::FlybyNode(const tr4_flyby_camera& node)
+        : _direction(Vector3(static_cast<float>(node.dx), static_cast<float>(node.dy), static_cast<float>(node.dz)) / trlevel::Scale),
+        _flags(node.flags),
+        _fov(node.fov),
+        _position(Vector3(static_cast<float>(node.x), static_cast<float>(node.y), static_cast<float>(node.z)) / trlevel::Scale),
+        _roll(node.roll),
+        _room(node.room_id),
+        _speed(node.speed),
+        _timer(node.timer)
+    {
+    }
+
+    Vector3 FlybyNode::direction() const
+    {
+        return _direction;
+    }
+
+    uint16_t FlybyNode::flags() const
+    {
+        return _flags;
+    }
+
+    uint16_t FlybyNode::fov() const
+    {
+        return _fov;
+    }
+
+    Vector3 FlybyNode::position() const
+    {
+        return _position;
+    }
+
+    int16_t FlybyNode::roll() const
+    {
+        return _roll;
+    }
+
+    uint32_t FlybyNode::room() const
+    {
+        return _room;
+    }
+
+    uint16_t FlybyNode::speed() const
+    {
+        return _speed;
+    }
+
+    uint16_t FlybyNode::timer() const
+    {
+        return _timer;
+    }
+}

--- a/trview.app/Elements/Flyby/FlybyNode.h
+++ b/trview.app/Elements/Flyby/FlybyNode.h
@@ -7,12 +7,13 @@ namespace trview
     class FlybyNode final : public IFlybyNode
     {
     public:
-        explicit FlybyNode(const trlevel::tr4_flyby_camera& camera, const std::weak_ptr<IFlyby>& flyby);
+        explicit FlybyNode(const trlevel::tr4_flyby_camera& camera, const std::weak_ptr<IFlyby>& flyby, const std::weak_ptr<ILevel>& level);
         virtual ~FlybyNode() = default;
         DirectX::SimpleMath::Vector3 direction() const override;
         uint16_t flags() const override;
         std::weak_ptr<IFlyby> flyby() const override;
         uint16_t fov() const override;
+        std::weak_ptr<ILevel> level() const override;
         int32_t number() const override;
         DirectX::SimpleMath::Vector3 position() const override;
         int16_t roll() const override;
@@ -20,6 +21,7 @@ namespace trview
         uint16_t speed() const override;
         uint16_t timer() const override;
     private:
+        std::weak_ptr<ILevel> _level;
         std::weak_ptr<IFlyby> _flyby;
         DirectX::SimpleMath::Vector3 _direction;
         uint16_t _flags{ 0 };

--- a/trview.app/Elements/Flyby/FlybyNode.h
+++ b/trview.app/Elements/Flyby/FlybyNode.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "IFlybyNode.h"
+
+namespace trview
+{
+    class FlybyNode final : public IFlybyNode
+    {
+    public:
+        explicit FlybyNode(const trlevel::tr4_flyby_camera& camera);
+        virtual ~FlybyNode() = default;
+        DirectX::SimpleMath::Vector3 direction() const override;
+        uint16_t flags() const override;
+        uint16_t fov() const override;
+        DirectX::SimpleMath::Vector3 position() const override;
+        int16_t roll() const override;
+        uint32_t room() const override;
+        uint16_t speed() const override;
+        uint16_t timer() const override;
+    private:
+        DirectX::SimpleMath::Vector3 _direction;
+        uint16_t _flags{ 0 };
+        uint16_t _fov{ 0 };
+        DirectX::SimpleMath::Vector3 _position;
+        int16_t _roll{ 0 };
+        uint32_t _room{ 0 };
+        uint16_t _speed{ 0 };
+        uint16_t _timer{ 0 };
+    };
+}

--- a/trview.app/Elements/Flyby/FlybyNode.h
+++ b/trview.app/Elements/Flyby/FlybyNode.h
@@ -7,10 +7,11 @@ namespace trview
     class FlybyNode final : public IFlybyNode
     {
     public:
-        explicit FlybyNode(const trlevel::tr4_flyby_camera& camera);
+        explicit FlybyNode(const trlevel::tr4_flyby_camera& camera, const std::weak_ptr<IFlyby>& flyby);
         virtual ~FlybyNode() = default;
         DirectX::SimpleMath::Vector3 direction() const override;
         uint16_t flags() const override;
+        std::weak_ptr<IFlyby> flyby() const override;
         uint16_t fov() const override;
         int32_t number() const override;
         DirectX::SimpleMath::Vector3 position() const override;
@@ -19,6 +20,7 @@ namespace trview
         uint16_t speed() const override;
         uint16_t timer() const override;
     private:
+        std::weak_ptr<IFlyby> _flyby;
         DirectX::SimpleMath::Vector3 _direction;
         uint16_t _flags{ 0 };
         uint16_t _fov{ 0 };

--- a/trview.app/Elements/Flyby/FlybyNode.h
+++ b/trview.app/Elements/Flyby/FlybyNode.h
@@ -12,6 +12,7 @@ namespace trview
         DirectX::SimpleMath::Vector3 direction() const override;
         uint16_t flags() const override;
         uint16_t fov() const override;
+        int32_t number() const override;
         DirectX::SimpleMath::Vector3 position() const override;
         int16_t roll() const override;
         uint32_t room() const override;
@@ -21,6 +22,7 @@ namespace trview
         DirectX::SimpleMath::Vector3 _direction;
         uint16_t _flags{ 0 };
         uint16_t _fov{ 0 };
+        int32_t _number{ 0 };
         DirectX::SimpleMath::Vector3 _position;
         int16_t _roll{ 0 };
         uint32_t _room{ 0 };

--- a/trview.app/Elements/Flyby/IFlyby.h
+++ b/trview.app/Elements/Flyby/IFlyby.h
@@ -63,6 +63,7 @@ namespace trview
             uint32_t room_id{ 0 };
             uint16_t timer{ 0 };
             std::bitset<16> flags;
+            ICamera::Mode mode{ ICamera::Mode::Orbit };
         };
 
         virtual ~IFlyby() = 0;

--- a/trview.app/Elements/Flyby/IFlyby.h
+++ b/trview.app/Elements/Flyby/IFlyby.h
@@ -12,6 +12,7 @@
 #include <trview.common/Event.h>
 
 #include "../../Geometry/IRenderable.h"
+#include "../../Geometry/PickResult.h"
 
 namespace trview
 {
@@ -65,6 +66,7 @@ namespace trview
         virtual ~IFlyby() = 0;
         virtual std::vector<std::weak_ptr<IFlybyNode>> nodes() const = 0;
         virtual uint32_t number() const = 0;
+        virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;
         virtual [[nodiscard]] CameraState update_state(const CameraState& state, float delta) const = 0;
 
         Event<> on_changed;

--- a/trview.app/Elements/Flyby/IFlyby.h
+++ b/trview.app/Elements/Flyby/IFlyby.h
@@ -17,9 +17,11 @@
 namespace trview
 {
     struct IFlybyNode;
+    struct ILevel;
+
     struct IFlyby : public IRenderable
     {
-        using Source = std::function<std::shared_ptr<IFlyby>(const std::vector<trlevel::tr4_flyby_camera>&)>;
+        using Source = std::function<std::shared_ptr<IFlyby>(const std::vector<trlevel::tr4_flyby_camera>&, const std::weak_ptr<ILevel>&)>;
 
         struct CameraState
         {
@@ -64,6 +66,7 @@ namespace trview
         };
 
         virtual ~IFlyby() = 0;
+        virtual std::weak_ptr<ILevel> level() const = 0;
         virtual std::vector<std::weak_ptr<IFlybyNode>> nodes() const = 0;
         virtual uint32_t number() const = 0;
         virtual PickResult pick(const DirectX::SimpleMath::Vector3& position, const DirectX::SimpleMath::Vector3& direction) const = 0;

--- a/trview.app/Elements/Flyby/IFlyby.h
+++ b/trview.app/Elements/Flyby/IFlyby.h
@@ -19,7 +19,7 @@ namespace trview
     struct IFlybyNode;
     struct IFlyby : public IRenderable
     {
-        using Source = std::function<std::shared_ptr<IFlyby>(const std::vector<trlevel::tr4_flyby_camera>&, uint32_t)>;
+        using Source = std::function<std::shared_ptr<IFlyby>(const std::vector<trlevel::tr4_flyby_camera>&)>;
 
         struct CameraState
         {

--- a/trview.app/Elements/Flyby/IFlyby.h
+++ b/trview.app/Elements/Flyby/IFlyby.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
+#include <bitset>
+
+#include <trlevel/trtypes.h>
+
+#include "../../Geometry/IRenderable.h"
+
+namespace trview
+{
+    struct IFlyby : public IRenderable
+    {
+        using Source = std::function<std::shared_ptr<IFlyby>(const std::vector<trlevel::tr4_flyby_camera>&, uint32_t)>;
+
+        struct CameraState
+        {
+            enum class State
+            {
+                Active,
+                Ended
+            };
+
+            State state{ State::Active };
+
+            float speed{ 0 };
+
+            /// <summary>
+            /// Current node index.
+            /// </summary>
+            int32_t index{ 0u };
+            /// <summary>
+            /// Current position.
+            /// </summary>
+            DirectX::SimpleMath::Vector3 position;
+            /// <summary>
+            /// Current direction.
+            /// </summary>
+            DirectX::SimpleMath::Vector3 direction{ DirectX::SimpleMath::Vector3::Backward };
+            DirectX::SimpleMath::Vector3 raw_direction;
+            /// <summary>
+            /// FOV if set
+            /// </summary>
+            float fov{ 90.0f };
+            /// <summary>
+            /// Roll angle in degress.
+            /// </summary>
+            float roll{ 0.0f };
+            /// <summary>
+            /// Progress through the current node spline.
+            /// </summary>
+            float t{ 0.0f };
+            uint32_t room_id{ 0 };
+            uint16_t timer{ 0 };
+            std::bitset<16> flags;
+        };
+
+        virtual ~IFlyby() = 0;
+        virtual std::vector<trlevel::tr4_flyby_camera> nodes() const = 0;
+        virtual uint32_t number() const = 0;
+        virtual [[nodiscard]] CameraState update_state(const CameraState& state, float delta) const = 0;
+    };
+}

--- a/trview.app/Elements/Flyby/IFlyby.h
+++ b/trview.app/Elements/Flyby/IFlyby.h
@@ -9,6 +9,8 @@
 
 #include <trlevel/trtypes.h>
 
+#include <trview.common/Event.h>
+
 #include "../../Geometry/IRenderable.h"
 
 namespace trview
@@ -63,5 +65,7 @@ namespace trview
         virtual std::vector<trlevel::tr4_flyby_camera> nodes() const = 0;
         virtual uint32_t number() const = 0;
         virtual [[nodiscard]] CameraState update_state(const CameraState& state, float delta) const = 0;
+
+        Event<> on_changed;
     };
 }

--- a/trview.app/Elements/Flyby/IFlyby.h
+++ b/trview.app/Elements/Flyby/IFlyby.h
@@ -15,6 +15,7 @@
 
 namespace trview
 {
+    struct IFlybyNode;
     struct IFlyby : public IRenderable
     {
         using Source = std::function<std::shared_ptr<IFlyby>(const std::vector<trlevel::tr4_flyby_camera>&, uint32_t)>;
@@ -62,7 +63,7 @@ namespace trview
         };
 
         virtual ~IFlyby() = 0;
-        virtual std::vector<trlevel::tr4_flyby_camera> nodes() const = 0;
+        virtual std::vector<std::weak_ptr<IFlybyNode>> nodes() const = 0;
         virtual uint32_t number() const = 0;
         virtual [[nodiscard]] CameraState update_state(const CameraState& state, float delta) const = 0;
 

--- a/trview.app/Elements/Flyby/IFlybyNode.h
+++ b/trview.app/Elements/Flyby/IFlybyNode.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+#include <SimpleMath.h>
+
+#include <trlevel/trtypes.h>
+
+namespace trview
+{
+    struct IFlybyNode
+    {
+        using Source = std::function<std::shared_ptr<IFlybyNode>(const trlevel::tr4_flyby_camera&)>;
+
+        virtual ~IFlybyNode() = 0;
+        virtual DirectX::SimpleMath::Vector3 direction() const = 0;
+        virtual uint16_t flags() const = 0;
+        virtual uint16_t fov() const = 0;
+        virtual DirectX::SimpleMath::Vector3 position() const = 0;
+        virtual int16_t roll() const = 0;
+        virtual uint32_t room() const = 0;
+        virtual uint16_t speed() const = 0;
+        virtual uint16_t timer() const = 0;
+    };
+}

--- a/trview.app/Elements/Flyby/IFlybyNode.h
+++ b/trview.app/Elements/Flyby/IFlybyNode.h
@@ -9,13 +9,15 @@
 
 namespace trview
 {
+    struct IFlyby;
     struct IFlybyNode
     {
-        using Source = std::function<std::shared_ptr<IFlybyNode>(const trlevel::tr4_flyby_camera&)>;
+        using Source = std::function<std::shared_ptr<IFlybyNode>(const trlevel::tr4_flyby_camera&, const std::weak_ptr<IFlyby>&)>;
 
         virtual ~IFlybyNode() = 0;
         virtual DirectX::SimpleMath::Vector3 direction() const = 0;
         virtual uint16_t flags() const = 0;
+        virtual std::weak_ptr<IFlyby> flyby() const = 0;
         virtual uint16_t fov() const = 0;
         virtual int32_t number() const = 0;
         virtual DirectX::SimpleMath::Vector3 position() const = 0;

--- a/trview.app/Elements/Flyby/IFlybyNode.h
+++ b/trview.app/Elements/Flyby/IFlybyNode.h
@@ -9,16 +9,18 @@
 
 namespace trview
 {
+    struct ILevel;
     struct IFlyby;
     struct IFlybyNode
     {
-        using Source = std::function<std::shared_ptr<IFlybyNode>(const trlevel::tr4_flyby_camera&, const std::weak_ptr<IFlyby>&)>;
+        using Source = std::function<std::shared_ptr<IFlybyNode>(const trlevel::tr4_flyby_camera&, const std::weak_ptr<IFlyby>&, const std::weak_ptr<ILevel>&)>;
 
         virtual ~IFlybyNode() = 0;
         virtual DirectX::SimpleMath::Vector3 direction() const = 0;
         virtual uint16_t flags() const = 0;
         virtual std::weak_ptr<IFlyby> flyby() const = 0;
         virtual uint16_t fov() const = 0;
+        virtual std::weak_ptr<ILevel> level() const = 0;
         virtual int32_t number() const = 0;
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
         virtual int16_t roll() const = 0;

--- a/trview.app/Elements/Flyby/IFlybyNode.h
+++ b/trview.app/Elements/Flyby/IFlybyNode.h
@@ -17,6 +17,7 @@ namespace trview
         virtual DirectX::SimpleMath::Vector3 direction() const = 0;
         virtual uint16_t flags() const = 0;
         virtual uint16_t fov() const = 0;
+        virtual int32_t number() const = 0;
         virtual DirectX::SimpleMath::Vector3 position() const = 0;
         virtual int16_t roll() const = 0;
         virtual uint32_t room() const = 0;

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -6,9 +6,9 @@
 #include "../Elements/IRoom.h"
 #include "../Elements/IStaticMesh.h"
 #include "../Lua/Scriptable/IScriptable.h"
-#include "IItem.h"
 #include <trview.app/Elements/ILight.h>
 #include "CameraSink/ICameraSink.h"
+#include "Flyby/IFlyby.h"
 #include <trview.common/Event.h>
 #include "../UI/MapColours.h"
 #include <trlevel/IPack.h>
@@ -148,6 +148,7 @@ namespace trview
         virtual bool trng() const = 0;
         virtual std::weak_ptr<trlevel::IPack> pack() const = 0;
         virtual trlevel::PlatformAndVersion platform_and_version() const = 0;
+        virtual std::vector<std::weak_ptr<IFlyby>> flybys() const = 0;
 
         Event<std::weak_ptr<IItem>> on_item_selected;
         // Event raised when the level needs to change the selected room.

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -106,6 +106,7 @@ namespace trview
         virtual void set_selected_trigger(uint32_t number) = 0;
         virtual void set_selected_light(uint32_t number) = 0;
         virtual void set_selected_camera_sink(uint32_t number) = 0;
+        virtual void set_selected_flyby_node(const std::weak_ptr<IFlybyNode>& node) = 0;
         virtual void set_show_geometry(bool show) = 0;
         virtual void set_show_triggers(bool show) = 0;
         virtual void set_show_water(bool show) = 0;

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1357,7 +1357,7 @@ namespace trview
             std::ranges::to<std::vector<std::vector<trlevel::tr4_flyby_camera>>>();
         for (const auto& flyby : grouped)
         {
-            auto new_flyby = flyby_source(flyby);
+            auto new_flyby = flyby_source(flyby, shared_from_this());
             _token_store += new_flyby->on_changed += [this]() { content_changed(); };
             _flybys.push_back(new_flyby);
         }

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -780,11 +780,11 @@ namespace trview
                     continue;
                 }
 
-                // auto flyby_result = flyby->pick(position, direction);
-                // if (flyby_result.hit)
-                // {
-                //     results.push_back(flyby_result);
-                // }
+                auto flyby_result = flyby->pick(position, direction);
+                if (flyby_result.hit)
+                {
+                    results.push_back(flyby_result);
+                }
             }
         }
 

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1355,10 +1355,9 @@ namespace trview
         const auto grouped = level.flyby_cameras() |
             std::views::chunk_by([](auto&& l, auto&& r) { return l.sequence == r.sequence; }) |
             std::ranges::to<std::vector<std::vector<trlevel::tr4_flyby_camera>>>();
-        uint32_t index = 0;
         for (const auto& flyby : grouped)
         {
-            auto new_flyby = flyby_source(flyby, index++);
+            auto new_flyby = flyby_source(flyby);
             _token_store += new_flyby->on_changed += [this]() { content_changed(); };
             _flybys.push_back(new_flyby);
         }

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -300,9 +300,12 @@ namespace trview
                 }
             }
 
-            for (const auto& flyby : _flybys)
+            if (has_flag(_render_filters, RenderFilter::CameraSinks))
             {
-                flyby->render(camera, Colour::White);
+                for (const auto& flyby : _flybys)
+                {
+                    flyby->render(camera, Colour::White);
+                }
             }
 
             graphics::set_data(*_pixel_shader_data, context, PixelShaderData{ false });

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1050,6 +1050,12 @@ namespace trview
         on_level_changed();
     }
 
+    void Level::set_selected_flyby_node(const std::weak_ptr<IFlybyNode>& node)
+    {
+        _selected_flyby_node = node;
+        on_level_changed();
+    }
+
     std::shared_ptr<ILevelTextureStorage> Level::texture_storage() const
     {
         return _texture_storage;

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -771,6 +771,24 @@ namespace trview
             }
         }
 
+        if (has_flag(_render_filters, RenderFilter::CameraSinks))
+        {
+            for (const auto& flyby : _flybys)
+            {
+                if (!flyby->visible())
+                {
+                    continue;
+                }
+
+                // auto flyby_result = flyby->pick(position, direction);
+                // if (flyby_result.hit)
+                // {
+                //     results.push_back(flyby_result);
+                // }
+            }
+        }
+
+
         uint32_t index = 0;
         for (const auto& scriptable : _scriptables)
         {
@@ -1335,6 +1353,7 @@ namespace trview
         for (const auto& flyby : grouped)
         {
             auto new_flyby = flyby_source(flyby, index++);
+            _token_store += new_flyby->on_changed += [this]() { content_changed(); };
             _flybys.push_back(new_flyby);
         }
     }

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -89,6 +89,7 @@ namespace trview
         virtual void set_selected_trigger(uint32_t number) override;
         virtual void set_selected_light(uint32_t number) override;
         virtual void set_selected_camera_sink(uint32_t number) override;
+        void set_selected_flyby_node(const std::weak_ptr<IFlybyNode>& node) override;
         virtual std::shared_ptr<ILevelTextureStorage> texture_storage() const override;
         virtual std::set<uint32_t> alternate_groups() const override;
         virtual trlevel::LevelVersion version() const override;
@@ -205,6 +206,7 @@ namespace trview
         std::weak_ptr<ITrigger> _selected_trigger;
         std::weak_ptr<ILight> _selected_light;
         std::weak_ptr<ICameraSink> _selected_camera_sink;
+        std::weak_ptr<IFlybyNode> _selected_flyby_node;
         uint32_t           _neighbour_depth{ 1 };
         std::set<uint16_t> _neighbours;
 

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -17,6 +17,7 @@
 #include <trview.common/TokenStore.h>
 
 #include "SoundSource/ISoundSource.h"
+#include "Flyby/IFlyby.h"
 
 namespace trview
 {
@@ -117,6 +118,7 @@ namespace trview
             const ILight::Source& light_source,
             const ICameraSink::Source& camera_sink_source,
             const ISoundSource::Source& sound_source_source,
+            const IFlyby::Source& flyby_source,
             const trlevel::ILevel::LoadCallbacks callbacks);
         std::vector<std::weak_ptr<IStaticMesh>> static_meshes() const override;
         std::weak_ptr<IStaticMesh> static_mesh(uint32_t index) const override;
@@ -130,6 +132,7 @@ namespace trview
         bool trng() const override;
         std::weak_ptr<trlevel::IPack> pack() const override;
         trlevel::PlatformAndVersion platform_and_version() const override;
+        std::vector<std::weak_ptr<IFlyby>> flybys() const override;
     private:
         void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage);
         void generate_triggers(const ITrigger::Source& trigger_source);
@@ -139,6 +142,7 @@ namespace trview
         void generate_lights(const trlevel::ILevel& level, const ILight::Source& light_source);
         void generate_camera_sinks(const trlevel::ILevel& level, const ICameraSink::Source& camera_sink_source);
         void generate_sound_sources(const trlevel::ILevel& level, const ISoundSource::Source& sound_source_source);
+        void generate_flybys(const trlevel::ILevel& level, const IFlyby::Source& flyby_source);
 
         // Render the rooms in the level.
         // context: The device context.
@@ -226,6 +230,7 @@ namespace trview
         std::vector<std::weak_ptr<IScriptable>> _scriptables;
         std::shared_ptr<ISoundStorage> _sound_storage;
         std::vector<std::shared_ptr<ISoundSource>> _sound_sources;
+        std::vector<std::shared_ptr<IFlyby>> _flybys;
 
         std::shared_ptr<INgPlusSwitcher> _ngplus_switcher;
         bool _ng{ false };

--- a/trview.app/Geometry/IMesh.cpp
+++ b/trview.app/Geometry/IMesh.cpp
@@ -280,6 +280,61 @@ namespace trview
         return source(vertices, std::vector<std::vector<uint32_t>>(), indices, std::vector<TransparentTriangle>(), {});
     }
 
+    std::shared_ptr<IMesh> create_frustum_mesh(const IMesh::Source& source)
+    {
+        const std::vector<MeshVertex> vertices
+        {
+            // Body:
+            // + y
+            { { -0.1f, 0.1f, -0.5f }, Vector3::Down, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },       // 2
+            { { 0.1f, 0.1f, -0.5f }, Vector3::Down, { 1, 0 }, { 1.0f, 1.0f, 1.0f } },        // 1
+            { { 0.5f, 0.5f, 0.5f }, Vector3::Down, { 1, 1 }, { 1.0f, 1.0f, 1.0f } },         // 0
+            { { -0.5f, 0.5f, 0.5f }, Vector3::Down, { 0, 1 }, { 1.0f, 1.0f, 1.0f } },        // 3
+
+            // +x
+            { { 0.1f, -0.1f, -0.5f }, Vector3::Left, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },       // 5
+            { { 0.5f, -0.5f, 0.5f }, Vector3::Left, { 1, 0 }, { 1.0f, 1.0f, 1.0f } },        // 4
+            { { 0.5f, 0.5f, 0.5f }, Vector3::Left, { 1, 1 }, { 1.0f, 1.0f, 1.0f } },         // 0
+            { { 0.1f, 0.1f, -0.5f }, Vector3::Left, { 0, 1 }, { 1.0f, 1.0f, 1.0f } },        // 1
+
+            // -x 
+            { { -0.1f, 0.1f, -0.5f }, Vector3::Right, { 1, 1 }, { 1.0f, 1.0f, 1.0f } },       // 2
+            { { -0.5f, 0.5f, 0.5f }, Vector3::Right, { 0, 1 }, { 1.0f, 1.0f, 1.0f } },        // 3
+            { { -0.5f, -0.5f, 0.5f }, Vector3::Right, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },       // 7
+            { { -0.1f, -0.1f, -0.5f }, Vector3::Right, { 1, 0 }, { 1.0f, 1.0f, 1.0f } },      // 6
+
+            // +z
+            { { 0.5f, 0.5f, 0.5f }, Vector3::Forward, { 0, 1 }, { 1.0f, 1.0f, 1.0f } },         // 0
+            { { 0.5f, -0.5f, 0.5f }, Vector3::Forward, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },        // 4
+            { { -0.5f, 0.5f, 0.5f }, Vector3::Forward, { 1, 1 }, { 1.0f, 1.0f, 1.0f } },        // 3
+            { { -0.5f, -0.5f, 0.5f }, Vector3::Forward, { 1, 0 }, { 1.0f, 1.0f, 1.0f } },       // 7
+
+            // -z
+            { { 0.1f, -0.1f, -0.5f }, Vector3::Backward, { 1, 0 }, { 1.0f, 1.0f, 1.0f } },       // 5
+            { { 0.1f, 0.1f, -0.5f }, Vector3::Backward, { 1, 1 }, { 1.0f, 1.0f, 1.0f } },        // 1
+            { { -0.1f, 0.1f, -0.5f }, Vector3::Backward, { 0, 1 }, { 1.0f, 1.0f, 1.0f } },       // 2
+            { { -0.1f, -0.1f, -0.5f }, Vector3::Backward, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },      // 6
+
+            // -y
+            { { 0.5f, -0.5f, 0.5f }, Vector3::Up, { 1, 0 }, { 1.0f, 1.0f, 1.0f } },        // 4
+            { { 0.1f, -0.1f, -0.5f }, Vector3::Up, { 1, 1 }, { 1.0f, 1.0f, 1.0f } },       // 5
+            { { -0.1f, -0.1f, -0.5f }, Vector3::Up, { 0, 1 }, { 1.0f, 1.0f, 1.0f } },      // 6
+            { { -0.5f, -0.5f, 0.5f }, Vector3::Up, { 0, 0 }, { 1.0f, 1.0f, 1.0f } },        // 7
+        };
+
+        const std::vector<uint32_t> indices
+        {
+            0,  1,  2,  2,  3,  0,  // +y
+            4,  5,  6,  6,  7,  4,  // +x
+            8,  9,  10, 10, 11, 8,  // -x
+            12, 13, 14, 13, 15, 14, // +z
+            16, 17, 18, 18, 19, 16, // -z
+            20, 21, 22, 22, 23, 20  // -y
+        };
+
+        return source(vertices, std::vector<std::vector<uint32_t>>(), indices, std::vector<TransparentTriangle>(), {});
+    }
+
     std::shared_ptr<IMesh> create_sphere_mesh(const IMesh::Source& source, uint32_t stacks, uint32_t slices)
     {
         constexpr float Pi2 = 6.283185307f;

--- a/trview.app/Geometry/IMesh.h
+++ b/trview.app/Geometry/IMesh.h
@@ -48,6 +48,7 @@ namespace trview
 
     /// Create a new cube mesh.
     std::shared_ptr<IMesh> create_cube_mesh(const IMesh::Source& source);
+    std::shared_ptr<IMesh> create_frustum_mesh(const IMesh::Source& source);
 
     std::shared_ptr<IMesh> create_sphere_mesh(const IMesh::Source& source, uint32_t stacks, uint32_t slices);
 

--- a/trview.app/Geometry/PickResult.cpp
+++ b/trview.app/Geometry/PickResult.cpp
@@ -152,7 +152,10 @@ namespace trview
             {
                 if (const auto flyby_node = result.flyby_node.lock())
                 {
-                    stream << "Flyby Camera " << flyby_node->number();
+                    if (const auto flyby = flyby_node->flyby().lock())
+                    {
+                        stream << "Flyby " << flyby->number() << " Camera " << flyby_node->number();
+                    }
                 }
                 break;
             }

--- a/trview.app/Geometry/PickResult.cpp
+++ b/trview.app/Geometry/PickResult.cpp
@@ -3,6 +3,7 @@
 #include "../Elements/ILevel.h"
 #include "../Routing/IRoute.h"
 #include "../Elements/SoundSource/ISoundSource.h"
+#include "../Elements/Flyby/IFlybyNode.h"
 
 namespace trview
 {
@@ -144,6 +145,14 @@ namespace trview
                     stream << "Sound Source " << sound_source->number() << " - ";
                     const auto sample = sound_source->sample();
                     stream << (sample ? std::format("Sample {}", sample.value()) : "Missing Sample");
+                }
+                break;
+            }
+            case PickResult::Type::FlybyNode:
+            {
+                if (const auto flyby_node = result.flyby_node.lock())
+                {
+                    stream << "Flyby Camera " << flyby_node->number();
                 }
                 break;
             }

--- a/trview.app/Geometry/PickResult.h
+++ b/trview.app/Geometry/PickResult.h
@@ -7,6 +7,7 @@ namespace trview
 {
     struct Colour;
     struct ICameraSink;
+    struct IFlybyNode;
     struct IItem;
     struct ILevel;
     struct ILight;
@@ -32,7 +33,8 @@ namespace trview
             Light,
             CameraSink,
             Scriptable,
-            SoundSource
+            SoundSource,
+            FlybyNode
         };
 
         bool                         hit{ false };
@@ -55,6 +57,7 @@ namespace trview
         std::weak_ptr<IRoom>         room;
         std::weak_ptr<ITrigger>      trigger;
         std::weak_ptr<IWaypoint>     waypoint;
+        std::weak_ptr<IFlybyNode>    flyby_node;
     };
 
     /// Get the appropriate colour for a pick.

--- a/trview.app/Mocks/Camera/ICamera.h
+++ b/trview.app/Mocks/Camera/ICamera.h
@@ -40,6 +40,8 @@ namespace trview
             MOCK_METHOD(void, reset, (), (override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, target, (), (const, override));
             MOCK_METHOD(Mode, mode, (), (const, override));
+            MOCK_METHOD(void, set_forward, (const DirectX::SimpleMath::Vector3&), (override));
+            MOCK_METHOD(void, set_rotation_roll, (float), (override));
         };
     }
 }

--- a/trview.app/Mocks/Camera/ICamera.h
+++ b/trview.app/Mocks/Camera/ICamera.h
@@ -11,12 +11,14 @@ namespace trview
             MockCamera();
             virtual ~MockCamera();
             MOCK_METHOD(DirectX::SimpleMath::Vector3, forward, (), (const, override));
+            MOCK_METHOD(float, fov, (), (const, override));
             MOCK_METHOD(const DirectX::BoundingFrustum, frustum, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, rendering_position, (), (const, override));
             MOCK_METHOD(const DirectX::SimpleMath::Matrix, projection, (), (const, override));
             MOCK_METHOD(ProjectionMode, projection_mode, (), (const, override));
             MOCK_METHOD(float, rotation_pitch, (), (const, override));
+            MOCK_METHOD(float, rotation_roll, (), (const, override));
             MOCK_METHOD(float, rotation_yaw, (), (const, override));
             MOCK_METHOD(void, rotate_to_pitch, (float), (override));
             MOCK_METHOD(void, rotate_to_yaw, (float), (override));

--- a/trview.app/Mocks/Elements/IFlyby.h
+++ b/trview.app/Mocks/Elements/IFlyby.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "../../Elements/Flyby/IFlyby.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockFlyby : public IFlyby
+        {
+            explicit MockFlyby();
+            virtual ~MockFlyby();
+            MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, render, (const ICamera&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(void, set_visible, (bool), (override));
+            MOCK_METHOD(bool, visible, (), (const, override));
+        };
+    }
+}

--- a/trview.app/Mocks/Elements/IFlyby.h
+++ b/trview.app/Mocks/Elements/IFlyby.h
@@ -13,6 +13,7 @@ namespace trview
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(std::vector<std::weak_ptr<IFlybyNode>>, nodes, (), (const, override));
             MOCK_METHOD(uint32_t, number, (), (const, override));
+            MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
             MOCK_METHOD(void, render, (const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(CameraState, update_state, (const CameraState&, float), (const, override));

--- a/trview.app/Mocks/Elements/IFlyby.h
+++ b/trview.app/Mocks/Elements/IFlyby.h
@@ -12,6 +12,7 @@ namespace trview
             virtual ~MockFlyby();
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(std::vector<std::weak_ptr<IFlybyNode>>, nodes, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
             MOCK_METHOD(uint32_t, number, (), (const, override));
             MOCK_METHOD(PickResult, pick, (const DirectX::SimpleMath::Vector3&, const DirectX::SimpleMath::Vector3&), (const, override));
             MOCK_METHOD(void, render, (const ICamera&, const DirectX::SimpleMath::Color&), (override));

--- a/trview.app/Mocks/Elements/IFlyby.h
+++ b/trview.app/Mocks/Elements/IFlyby.h
@@ -11,13 +11,12 @@ namespace trview
             explicit MockFlyby();
             virtual ~MockFlyby();
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
-            MOCK_METHOD(std::vector<trlevel::tr4_flyby_camera>, nodes, (), (const, override));
+            MOCK_METHOD(std::vector<std::weak_ptr<IFlybyNode>>, nodes, (), (const, override));
             MOCK_METHOD(uint32_t, number, (), (const, override));
             MOCK_METHOD(void, render, (const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, set_visible, (bool), (override));
             MOCK_METHOD(CameraState, update_state, (const CameraState&, float), (const, override));
             MOCK_METHOD(bool, visible, (), (const, override));
-            
         };
     }
 }

--- a/trview.app/Mocks/Elements/IFlyby.h
+++ b/trview.app/Mocks/Elements/IFlyby.h
@@ -11,9 +11,13 @@ namespace trview
             explicit MockFlyby();
             virtual ~MockFlyby();
             MOCK_METHOD(void, get_transparent_triangles, (ITransparencyBuffer&, const ICamera&, const DirectX::SimpleMath::Color&), (override));
+            MOCK_METHOD(std::vector<trlevel::tr4_flyby_camera>, nodes, (), (const, override));
+            MOCK_METHOD(uint32_t, number, (), (const, override));
             MOCK_METHOD(void, render, (const ICamera&, const DirectX::SimpleMath::Color&), (override));
             MOCK_METHOD(void, set_visible, (bool), (override));
+            MOCK_METHOD(CameraState, update_state, (const CameraState&, float), (const, override));
             MOCK_METHOD(bool, visible, (), (const, override));
+            
         };
     }
 }

--- a/trview.app/Mocks/Elements/IFlybyNode.h
+++ b/trview.app/Mocks/Elements/IFlybyNode.h
@@ -14,6 +14,7 @@ namespace trview
             MOCK_METHOD(uint16_t, flags, (), (const, override));
             MOCK_METHOD(std::weak_ptr<IFlyby>, flyby, (), (const, override));
             MOCK_METHOD(uint16_t, fov, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
             MOCK_METHOD(int32_t, number, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(int16_t, roll, (), (const, override));

--- a/trview.app/Mocks/Elements/IFlybyNode.h
+++ b/trview.app/Mocks/Elements/IFlybyNode.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "../../Elements/Flyby/IFlybyNode.h"
+
+namespace trview
+{
+    namespace mocks
+    {
+        struct MockFlybyNode : public IFlybyNode
+        {
+            explicit MockFlybyNode();
+            virtual ~MockFlybyNode();
+            MOCK_METHOD(DirectX::SimpleMath::Vector3, direction, (), (const, override));
+            MOCK_METHOD(uint16_t, flags, (), (const, override));
+            MOCK_METHOD(uint16_t, fov, (), (const, override));
+            MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
+            MOCK_METHOD(int16_t, roll, (), (const, override));
+            MOCK_METHOD(uint32_t, room, (), (const, override));
+            MOCK_METHOD(uint16_t, speed, (), (const, override));
+            MOCK_METHOD(uint16_t, timer, (), (const, override));
+        };
+    }
+}

--- a/trview.app/Mocks/Elements/IFlybyNode.h
+++ b/trview.app/Mocks/Elements/IFlybyNode.h
@@ -13,6 +13,7 @@ namespace trview
             MOCK_METHOD(DirectX::SimpleMath::Vector3, direction, (), (const, override));
             MOCK_METHOD(uint16_t, flags, (), (const, override));
             MOCK_METHOD(uint16_t, fov, (), (const, override));
+            MOCK_METHOD(int32_t, number, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));
             MOCK_METHOD(int16_t, roll, (), (const, override));
             MOCK_METHOD(uint32_t, room, (), (const, override));

--- a/trview.app/Mocks/Elements/IFlybyNode.h
+++ b/trview.app/Mocks/Elements/IFlybyNode.h
@@ -12,6 +12,7 @@ namespace trview
             virtual ~MockFlybyNode();
             MOCK_METHOD(DirectX::SimpleMath::Vector3, direction, (), (const, override));
             MOCK_METHOD(uint16_t, flags, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<IFlyby>, flyby, (), (const, override));
             MOCK_METHOD(uint16_t, fov, (), (const, override));
             MOCK_METHOD(int32_t, number, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector3, position, (), (const, override));

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -85,6 +85,7 @@ namespace trview
             MOCK_METHOD(bool, trng, (), (const, override));
             MOCK_METHOD(std::weak_ptr<trlevel::IPack>, pack, (), (const, override));
             MOCK_METHOD(trlevel::PlatformAndVersion, platform_and_version, (), (const, override));
+            MOCK_METHOD(std::vector<std::weak_ptr<IFlyby>>, flybys, (), (const, override));
 
             std::shared_ptr<MockLevel> with_version(trlevel::LevelVersion version)
             {

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -59,6 +59,7 @@ namespace trview
             MOCK_METHOD(void, set_neighbour_depth, (uint32_t), (override));
             MOCK_METHOD(void, set_selected_room, (const std::weak_ptr<IRoom>&), (override));
             MOCK_METHOD(void, set_selected_item, (const std::weak_ptr<IItem>&), (override));
+            MOCK_METHOD(void, set_selected_flyby_node, (const std::weak_ptr<IFlybyNode>&), (override));
             MOCK_METHOD(bool, show_camera_sinks, (), (const, override));
             MOCK_METHOD(bool, show_lighting, (), (const, override));
             MOCK_METHOD(bool, show_geometry, (), (const, override));

--- a/trview.app/Mocks/Mocks.cpp
+++ b/trview.app/Mocks/Mocks.cpp
@@ -2,6 +2,7 @@
 #include <gmock/gmock.h>
 
 #include "Camera/ICamera.h"
+#include "Elements/IFlyby.h"
 #include "Elements/IItem.h"
 #include "Elements/ILevel.h"
 #include "Elements/ILight.h"
@@ -313,5 +314,8 @@ namespace trview
 
         MockModelStorage::MockModelStorage() {};
         MockModelStorage::~MockModelStorage() {};
+
+        MockFlyby::MockFlyby() {};
+        MockFlyby::~MockFlyby() {};
     }
 }

--- a/trview.app/Mocks/Mocks.cpp
+++ b/trview.app/Mocks/Mocks.cpp
@@ -3,6 +3,7 @@
 
 #include "Camera/ICamera.h"
 #include "Elements/IFlyby.h"
+#include "Elements/IFlybyNode.h"
 #include "Elements/IItem.h"
 #include "Elements/ILevel.h"
 #include "Elements/ILight.h"
@@ -317,5 +318,8 @@ namespace trview
 
         MockFlyby::MockFlyby() {};
         MockFlyby::~MockFlyby() {};
+
+        MockFlybyNode::MockFlybyNode() {};
+        MockFlybyNode::~MockFlybyNode() {};
     }
 }

--- a/trview.app/Mocks/Windows/ICameraSinkWindow.h
+++ b/trview.app/Mocks/Windows/ICameraSinkWindow.h
@@ -12,10 +12,13 @@ namespace trview
             virtual ~MockCameraSinkWindow();
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_camera_sinks, (const std::vector<std::weak_ptr<ICameraSink>>&), (override));
+            MOCK_METHOD(void, set_flybys, (const std::vector<std::weak_ptr<IFlyby>>&), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));
             MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
             MOCK_METHOD(void, set_current_room, (const std::weak_ptr<IRoom>&), (override));
+            MOCK_METHOD(void, set_platform_and_version, (const trlevel::PlatformAndVersion&), (override));
             MOCK_METHOD(void, set_settings, (const UserSettings&), (override));
+            MOCK_METHOD(void, update, (float), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/ICameraSinkWindow.h
+++ b/trview.app/Mocks/Windows/ICameraSinkWindow.h
@@ -15,6 +15,7 @@ namespace trview
             MOCK_METHOD(void, set_flybys, (const std::vector<std::weak_ptr<IFlyby>>&), (override));
             MOCK_METHOD(void, set_number, (int32_t), (override));
             MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
+            MOCK_METHOD(void, set_selected_flyby_node, (const std::weak_ptr<IFlybyNode>&), (override));
             MOCK_METHOD(void, set_current_room, (const std::weak_ptr<IRoom>&), (override));
             MOCK_METHOD(void, set_platform_and_version, (const trlevel::PlatformAndVersion&), (override));
             MOCK_METHOD(void, set_settings, (const UserSettings&), (override));

--- a/trview.app/Mocks/Windows/ICameraSinkWindowManager.h
+++ b/trview.app/Mocks/Windows/ICameraSinkWindowManager.h
@@ -15,6 +15,7 @@ namespace trview
             MOCK_METHOD(std::weak_ptr<ICameraSinkWindow>, create_window, (), (override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
+            MOCK_METHOD(void, set_selected_flyby_node, (const std::weak_ptr<IFlybyNode>&), (override));
             MOCK_METHOD(void, set_room, (const std::weak_ptr<IRoom>&), (override));
             MOCK_METHOD(void, set_platform_and_version, (const trlevel::PlatformAndVersion&), (override));
             MOCK_METHOD(void, set_settings, (const UserSettings&), (override));

--- a/trview.app/Mocks/Windows/ICameraSinkWindowManager.h
+++ b/trview.app/Mocks/Windows/ICameraSinkWindowManager.h
@@ -11,11 +11,14 @@ namespace trview
             MockCameraSinkWindowManager();
             virtual ~MockCameraSinkWindowManager();
             MOCK_METHOD(void, set_camera_sinks, (const std::vector<std::weak_ptr<ICameraSink>>&), (override));
+            MOCK_METHOD(void, set_flybys, (const std::vector<std::weak_ptr<IFlyby>>&), (override));
             MOCK_METHOD(std::weak_ptr<ICameraSinkWindow>, create_window, (), (override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
             MOCK_METHOD(void, set_room, (const std::weak_ptr<IRoom>&), (override));
+            MOCK_METHOD(void, set_platform_and_version, (const trlevel::PlatformAndVersion&), (override));
             MOCK_METHOD(void, set_settings, (const UserSettings&), (override));
+            MOCK_METHOD(void, update, (float), (override));
         };
     }
 }

--- a/trview.app/Mocks/Windows/IViewer.h
+++ b/trview.app/Mocks/Windows/IViewer.h
@@ -22,6 +22,7 @@ namespace trview
             MOCK_METHOD(void, select_trigger, (const std::weak_ptr<ITrigger>&), (override));
             MOCK_METHOD(void, select_waypoint, (const std::weak_ptr<IWaypoint>&), (override));
             MOCK_METHOD(void, select_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
+            MOCK_METHOD(void, select_flyby_node, (const std::weak_ptr<IFlybyNode>&), (override));
             MOCK_METHOD(void, select_static_mesh, (const std::weak_ptr<IStaticMesh>&), (override));
             MOCK_METHOD(void, select_sound_source, (const std::weak_ptr<ISoundSource>&), (override));
             MOCK_METHOD(void, set_camera_mode, (ICamera::Mode), (override));

--- a/trview.app/Mocks/Windows/IWindows.h
+++ b/trview.app/Mocks/Windows/IWindows.h
@@ -14,6 +14,7 @@ namespace trview
             MOCK_METHOD(void, update, (float), (override));
             MOCK_METHOD(void, render, (), (override));
             MOCK_METHOD(void, select, (const std::weak_ptr<ICameraSink>&), (override));
+            MOCK_METHOD(void, select, (const std::weak_ptr<IFlybyNode>&), (override));
             MOCK_METHOD(void, select, (const std::weak_ptr<IItem>&), (override));
             MOCK_METHOD(void, select, (const std::weak_ptr<ILight>&), (override));
             MOCK_METHOD(void, select, (const std::weak_ptr<ISoundSource>&), (override));

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -126,6 +126,8 @@ namespace trview
             read_attribute(json, settings.lights_window_columns, "lights_window_columns");
             read_attribute(json, settings.camera_sink_window_columns, "camera_sink_window_columns");
             read_attribute(json, settings.triggers_window_columns, "triggers_window_columns");
+            read_attribute(json, settings.flyby_columns, "flyby_columns");
+            read_attribute(json, settings.flyby_node_columns, "flyby_node_columns");
 
             settings.recent_files.resize(std::min<std::size_t>(settings.recent_files.size(), settings.max_recent_files));
         }
@@ -204,6 +206,8 @@ namespace trview
             json["lights_window_columns"] = settings.lights_window_columns;
             json["camera_sink_window_columns"] = settings.camera_sink_window_columns;
             json["triggers_window_columns"] = settings.triggers_window_columns;
+            json["flyby_columns"] = settings.flyby_columns;
+            json["flyby_node_columns"] = settings.flyby_node_columns;
             _files->save_file(file_path, json.dump());
         }
         catch (...)

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -76,6 +76,8 @@ namespace trview
         std::vector<std::string> lights_window_columns{ "#", "Type", "Room", "Hide" };
         std::vector<std::string> camera_sink_window_columns{ "#", "Type", "Room", "Hide" };
         std::vector<std::string> triggers_window_columns{ "#", "Type", "Room", "Hide" };
+        std::vector<std::string> flyby_columns{ "#", "Hide" };
+        std::vector<std::string> flyby_node_columns{ "#", "Room" };
 
         bool operator==(const UserSettings& other) const;
     };

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -261,29 +261,6 @@ namespace trview
         auto selected = _selected_camera_sink.lock();
         if (ImGui::BeginChild(Names::details_panel.c_str(), ImVec2(), true) && selected)
         {
-            const auto add_stat = [&]<typename T>(const std::string & name, const T && value)
-            {
-                const auto string_value = get_string(value);
-                ImGui::TableNextColumn();
-                ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav));
-                if (ImGui::BeginPopupContextItem())
-                {
-                    if (ImGui::MenuItem("Copy"))
-                    {
-                        _clipboard->write(to_utf16(string_value));
-                    }
-                    ImGui::EndPopup();
-                }
-                if (_tips.find(name) != _tips.end())
-                {
-                    ImGui::BeginTooltip();
-                    ImGui::Text(_tips[name].c_str());
-                    ImGui::EndTooltip();
-                }
-                ImGui::TableNextColumn();
-                ImGui::Text(string_value.c_str());
-            };
-
             if (ImGui::BeginCombo(Names::type.c_str(), to_string(selected->type()).c_str()))
             {
                 bool camera_selected = selected->type() == ICameraSink::Type::Camera;

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -933,6 +933,7 @@ namespace trview
             IFlyby::CameraState existing_state;
             existing_state.fov = camera->fov();
             existing_state.roll = camera->rotation_roll();
+            existing_state.mode = camera->mode();
             _initial_state = existing_state;
         }
     }
@@ -948,6 +949,8 @@ namespace trview
         {
             camera->set_fov(_initial_state->fov);
             camera->set_rotation_roll(_initial_state->roll);
+            camera->set_mode(_initial_state->mode);
+            camera->set_rotation_yaw(camera->rotation_yaw());
         }
 
         _initial_state.reset();

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -169,7 +169,7 @@ namespace trview
                     ImGui::EndTabItem();
                 }
 
-                if (ImGui::BeginTabItem("Flyby"))
+                if (ImGui::BeginTabItem("Flyby", 0, _go_to_details ? ImGuiTabItemFlags_SetSelected : ImGuiTabItemFlags_None))
                 {
                     render_flyby_list();
                     ImGui::SameLine();
@@ -237,7 +237,16 @@ namespace trview
 
     void CameraSinkWindow::set_local_selected_flyby_node(const std::weak_ptr<IFlybyNode>& flyby_node)
     {
+        if (auto selected_node = flyby_node.lock())
+        {
+            const auto current = _selected_flyby.lock();
+            if (current != selected_node->flyby().lock())
+            {
+                set_local_selected_flyby(selected_node->flyby());
+            }
+        }
         _selected_node = flyby_node;
+        _go_to_details = true;
     }
 
     void CameraSinkWindow::render_list()
@@ -831,8 +840,9 @@ namespace trview
                     ImGui::EndTabItem();
                 }
 
-                if (ImGui::BeginTabItem("Details"))
+                if (ImGui::BeginTabItem("Details", 0, _go_to_details ? ImGuiTabItemFlags_SetSelected : ImGuiTabItemFlags_None))
                 {
+                    _go_to_details = false;
                     render_flyby_details();
                     ImGui::EndTabItem();
                 }

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -463,8 +463,9 @@ namespace trview
 
     void CameraSinkWindow::setup_flyby_filters()
     {
-        _flyby_filters.set_columns(std::vector<std::string>{ "#" });
+        _flyby_filters.set_columns(std::vector<std::string>{ "#", "Hide" });
         _flyby_filters.add_getter<int>("#", [](auto&& flyby) { return static_cast<int>(flyby.number()); });
+        _flyby_filters.add_getter<bool>("Hide", [](auto&& flyby) { return !flyby.visible(); }, EditMode::ReadWrite);
         _flyby_filters.add_multi_getter<int>("Room", [](auto&& flyby)
             {
                 std::unordered_set<int> rooms;

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -244,9 +244,9 @@ namespace trview
             {
                 set_local_selected_flyby(selected_node->flyby());
             }
+            _go_to_details = true;
         }
         _selected_node = flyby_node;
-        _go_to_details = true;
     }
 
     void CameraSinkWindow::render_list()
@@ -397,10 +397,6 @@ namespace trview
     {
         _all_flybys = flybys;
         _state = {};
-        if (!_all_flybys.empty())
-        {
-            set_local_selected_flyby(_all_flybys[0]);
-        };
     }
 
     void CameraSinkWindow::set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink)

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -172,7 +172,7 @@ namespace trview
                 {
                     render_flyby_list();
                     ImGui::SameLine();
-                    render_flyby_details();
+                    render_flyby_tab();
                     ImGui::EndTabItem();
                 }
 
@@ -740,7 +740,7 @@ namespace trview
         }
     }
 
-    void CameraSinkWindow::render_flyby_details()
+    void CameraSinkWindow::render_flyby_tab()
     {
         auto selected = _selected_flyby.lock();
         if (ImGui::BeginChild("Flyby Details", ImVec2(), true) && selected)
@@ -755,6 +755,7 @@ namespace trview
 
                 if (ImGui::BeginTabItem("Details"))
                 {
+                    render_flyby_details();
                     ImGui::EndTabItem();
                 }
 
@@ -762,5 +763,47 @@ namespace trview
             }
         }
         ImGui::EndChild();
+    }
+
+    void CameraSinkWindow::render_flyby_details()
+    {
+        if (auto selected_flyby = _selected_flyby.lock())
+        {
+            ImGui::Text("Nodes");
+            if (ImGui::BeginTable("Nodes", 1))
+            {
+                ImGui::TableSetupColumn("#", ImGuiTableColumnFlags_WidthFixed);
+                ImGui::TableSetupScrollFreeze(0, 1);
+                ImGui::TableHeadersRow();
+
+                const auto nodes = selected_flyby->nodes();
+                uint32_t index = 0;
+                for (const auto& node : nodes)
+                {
+                    node;
+
+                    ImGui::TableNextRow();
+                    ImGui::TableNextColumn();
+                    bool selected = _selected_node.value_or(0) == index;
+                    if (ImGui::Selectable(std::to_string(index).c_str(), &selected, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav)))
+                    {
+                        _selected_node = index;
+                    }
+                    ++index;
+                }
+
+                ImGui::EndTable();
+            }
+
+            if (_selected_node.has_value())
+            {
+                const auto nodes = selected_flyby->nodes();
+                if (_selected_node.value() < nodes.size())
+                {
+                    const auto node = selected_flyby->nodes()[_selected_node.value()];
+                    ImGui::Text(std::format("{},{},{}", node.x, node.y, node.z).c_str());
+                }
+            }
+        }
     }
 }

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -459,6 +459,10 @@ namespace trview
 
         _node_filters.set_columns(std::vector<std::string>{ "#" });
         _node_filters.add_getter<int>("#", [](auto&& node) { return static_cast<int>(node.number()); });
+        _node_filters.add_getter<int>("X", [](auto&& node) { return static_cast<int>(node.position().x * trlevel::Scale_X); });
+        _node_filters.add_getter<int>("Y", [](auto&& node) { return static_cast<int>(node.position().y * trlevel::Scale_Y); });
+        _node_filters.add_getter<int>("Z", [](auto&& node) { return static_cast<int>(node.position().z * trlevel::Scale_Z); });
+        _node_filters.add_getter<int>("Room", [](auto&& node) { return node.room(); });
     }
 
     void CameraSinkWindow::set_settings(const UserSettings& settings)

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -63,6 +63,8 @@ namespace trview
         std::vector<std::weak_ptr<IFlyby>> _all_flybys;
         std::weak_ptr<IFlyby> _selected_flyby;
         Filters<IFlyby> _flyby_filters;
+        Filters<IFlybyNode> _node_filters;
+        std::weak_ptr<IFlybyNode> _selected_node;
 
         std::unordered_map<std::string, std::string> _tips;
         std::shared_ptr<IClipboard> _clipboard;
@@ -84,7 +86,6 @@ namespace trview
         TokenStore _token_store;
         IFlyby::CameraState _state;
         trlevel::PlatformAndVersion _platform_and_version;
-        std::optional<uint32_t> _selected_node;
     };
 }
 

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -42,6 +42,7 @@ namespace trview
         void render_list();
         void render_details();
         void setup_filters();
+        void setup_flyby_filters();
         void render_flybys();
         void sync_flyby();
         void render_flyby_list();

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -31,6 +31,7 @@ namespace trview
         void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) override;
         void set_flybys(const std::vector<std::weak_ptr<IFlyby>>& flybys) override;
         void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
+        void set_selected_flyby_node(const std::weak_ptr<IFlybyNode>& flyby_node) override;
         void set_current_room(const std::weak_ptr<IRoom>& room) override;
         void set_settings(const UserSettings& settings) override;
         void update(float delta) override;
@@ -48,6 +49,7 @@ namespace trview
         void render_flyby_list();
         void render_flyby_tab();
         void render_flyby_details();
+        void set_local_selected_flyby_node(const std::weak_ptr<IFlybyNode>& flyby_node);
 
         template <typename T>
         void add_stat(const std::string& name, const T&& value);
@@ -62,6 +64,7 @@ namespace trview
         // Flybys
         std::vector<std::weak_ptr<IFlyby>> _all_flybys;
         std::weak_ptr<IFlyby> _selected_flyby;
+        std::weak_ptr<IFlybyNode> _global_selected_flyby_node;
         Filters<IFlyby> _flyby_filters;
         Filters<IFlybyNode> _node_filters;
         std::weak_ptr<IFlybyNode> _selected_node;

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -56,6 +56,7 @@ namespace trview
         std::unordered_map<std::string, std::string> _tips;
         std::shared_ptr<IClipboard> _clipboard;
         Filters<ICameraSink> _filters;
+        Filters<IFlyby> _flyby_filters;
         std::weak_ptr<ITrigger> _selected_trigger;
         bool _sync{ true };
         bool _scroll_to{ false };

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -54,6 +54,9 @@ namespace trview
         template <typename T>
         void add_stat(const std::string& name, const T&& value);
 
+        void capture_camera_state();
+        void restore_camera_state();
+
         std::string _id{ "Camera/Sink 0" };
         // Camera sinks
         std::vector<std::weak_ptr<ICameraSink>> _all_camera_sinks;
@@ -82,12 +85,12 @@ namespace trview
         std::weak_ptr<ICamera> _camera;
 
         bool _playing_flyby{ false };
-        float _original_fov;
         UserSettings _settings;
         bool _columns_set{ false };
         bool _force_sort{ false };
         TokenStore _token_store;
         IFlyby::CameraState _state;
+        std::optional<IFlyby::CameraState> _initial_state;
         trlevel::PlatformAndVersion _platform_and_version;
     };
 }

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -93,6 +93,7 @@ namespace trview
         IFlyby::CameraState _state;
         std::optional<IFlyby::CameraState> _initial_state;
         trlevel::PlatformAndVersion _platform_and_version;
+        bool _go_to_details{ false };
     };
 }
 

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -24,14 +24,17 @@ namespace trview
             static inline const std::string type = "Type";
         };
 
-        explicit CameraSinkWindow(const std::shared_ptr<IClipboard>& clipboard);
+        explicit CameraSinkWindow(const std::shared_ptr<IClipboard>& clipboard, const std::weak_ptr<ICamera>& camera);
         virtual ~CameraSinkWindow() = default;
-        virtual void render() override;
-        virtual void set_number(int32_t number) override;
-        virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) override;
-        virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
+        void render() override;
+        void set_number(int32_t number) override;
+        void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) override;
+        void set_flybys(const std::vector<std::weak_ptr<IFlyby>>& flybys) override;
+        void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
         void set_current_room(const std::weak_ptr<IRoom>& room) override;
         void set_settings(const UserSettings& settings) override;
+        void update(float delta) override;
+        void set_platform_and_version(const trlevel::PlatformAndVersion& version) override;
     private:
         bool render_camera_sink_window();
         void set_sync(bool value);
@@ -39,11 +42,17 @@ namespace trview
         void render_list();
         void render_details();
         void setup_filters();
+        void render_flybys();
+        void sync_flyby();
+        void render_flyby_list();
+        void render_flyby_details();
 
         std::string _id{ "Camera/Sink 0" };
         std::vector<std::weak_ptr<ICameraSink>> _all_camera_sinks;
         std::weak_ptr<ICameraSink> _selected_camera_sink;
         std::weak_ptr<ICameraSink> _global_selected_camera_sink;
+        std::vector<std::weak_ptr<IFlyby>> _all_flybys;
+        std::weak_ptr<IFlyby> _selected_flyby;
         std::unordered_map<std::string, std::string> _tips;
         std::shared_ptr<IClipboard> _clipboard;
         Filters<ICameraSink> _filters;
@@ -54,9 +63,15 @@ namespace trview
         std::vector<std::weak_ptr<ITrigger>> _triggered_by;
         Track<Type::Room> _track;
         AutoHider _auto_hider;
+        std::weak_ptr<ICamera> _camera;
+
+        bool _playing_flyby{ false };
+        float _original_fov;
         UserSettings _settings;
         bool _columns_set{ false };
         bool _force_sort{ false };
         TokenStore _token_store;
+        IFlyby::CameraState _state;
+        trlevel::PlatformAndVersion _platform_and_version;
     };
 }

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -50,6 +50,7 @@ namespace trview
         void render_flyby_tab();
         void render_flyby_details();
         void set_local_selected_flyby_node(const std::weak_ptr<IFlybyNode>& flyby_node);
+        void set_local_selected_flyby(const std::weak_ptr<IFlyby>& flyby);
 
         template <typename T>
         void add_stat(const std::string& name, const T&& value);

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -46,6 +46,7 @@ namespace trview
         void render_flybys();
         void sync_flyby();
         void render_flyby_list();
+        void render_flyby_tab();
         void render_flyby_details();
 
         std::string _id{ "Camera/Sink 0" };
@@ -75,5 +76,6 @@ namespace trview
         TokenStore _token_store;
         IFlyby::CameraState _state;
         trlevel::PlatformAndVersion _platform_and_version;
+        std::optional<uint32_t> _selected_node;
     };
 }

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -49,16 +49,24 @@ namespace trview
         void render_flyby_tab();
         void render_flyby_details();
 
+        template <typename T>
+        void add_stat(const std::string& name, const T&& value);
+
         std::string _id{ "Camera/Sink 0" };
+        // Camera sinks
         std::vector<std::weak_ptr<ICameraSink>> _all_camera_sinks;
         std::weak_ptr<ICameraSink> _selected_camera_sink;
         std::weak_ptr<ICameraSink> _global_selected_camera_sink;
+        Filters<ICameraSink> _filters;
+
+        // Flybys
         std::vector<std::weak_ptr<IFlyby>> _all_flybys;
         std::weak_ptr<IFlyby> _selected_flyby;
+        Filters<IFlyby> _flyby_filters;
+
         std::unordered_map<std::string, std::string> _tips;
         std::shared_ptr<IClipboard> _clipboard;
-        Filters<ICameraSink> _filters;
-        Filters<IFlyby> _flyby_filters;
+
         std::weak_ptr<ITrigger> _selected_trigger;
         bool _sync{ true };
         bool _scroll_to{ false };
@@ -79,3 +87,6 @@ namespace trview
         std::optional<uint32_t> _selected_node;
     };
 }
+
+#include "CameraSinkWindow.inl"
+

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.inl
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.inl
@@ -1,0 +1,28 @@
+#pragma once
+
+namespace trview
+{
+    template <typename T>
+    void CameraSinkWindow::add_stat(const std::string& name, const T&& value)
+    {
+        const auto string_value = get_string(value);
+        ImGui::TableNextColumn();
+        ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns | static_cast<int>(ImGuiSelectableFlags_SelectOnNav));
+        if (ImGui::BeginPopupContextItem())
+        {
+            if (ImGui::MenuItem("Copy"))
+            {
+                _clipboard->write(to_utf16(string_value));
+            }
+            ImGui::EndPopup();
+        }
+        if (_tips.find(name) != _tips.end())
+        {
+            ImGui::BeginTooltip();
+            ImGui::Text(_tips[name].c_str());
+            ImGui::EndTooltip();
+        }
+        ImGui::TableNextColumn();
+        ImGui::Text(string_value.c_str());
+    }
+}

--- a/trview.app/Windows/CameraSink/CameraSinkWindowManager.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindowManager.cpp
@@ -17,14 +17,15 @@ namespace trview
     {
         auto window = _camera_sink_window_source();
         window->set_camera_sinks(_camera_sinks);
+        window->set_flybys(_flybys);
         window->set_selected_camera_sink(_selected_camera_sink);
         window->set_current_room(_current_room);
+        window->set_platform_and_version(_platform_and_version);
         window->set_settings(_settings);
         window->on_camera_sink_selected += on_camera_sink_selected;
         window->on_trigger_selected += on_trigger_selected;
         window->on_scene_changed += on_scene_changed;
         window->on_settings += on_settings;
-        
         return add_window(window);
     }
 
@@ -51,12 +52,30 @@ namespace trview
         }
     }
 
+    void CameraSinkWindowManager::set_flybys(const std::vector<std::weak_ptr<IFlyby>>& flybys)
+    {
+        _flybys = flybys;
+        for (auto& window : _windows)
+        {
+            window.second->set_flybys(_flybys);
+        }
+    }
+
     void CameraSinkWindowManager::set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink)
     {
         _selected_camera_sink = camera_sink;
         for (auto& window : _windows)
         {
             window.second->set_selected_camera_sink(_selected_camera_sink);
+        }
+    }
+
+    void CameraSinkWindowManager::set_platform_and_version(const trlevel::PlatformAndVersion& platform_and_version)
+    {
+        _platform_and_version = platform_and_version;
+        for (auto& window : _windows)
+        {
+            window.second->set_platform_and_version(_platform_and_version);
         }
     }
 
@@ -76,5 +95,10 @@ namespace trview
         {
             window.second->set_settings(_settings);
         }
+    }
+
+    void CameraSinkWindowManager::update(float delta)
+    {
+        WindowManager::update(delta);
     }
 }

--- a/trview.app/Windows/CameraSink/CameraSinkWindowManager.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindowManager.cpp
@@ -18,11 +18,13 @@ namespace trview
         auto window = _camera_sink_window_source();
         window->set_camera_sinks(_camera_sinks);
         window->set_flybys(_flybys);
+        window->set_selected_flyby_node(_selected_flyby_node);
         window->set_selected_camera_sink(_selected_camera_sink);
         window->set_current_room(_current_room);
         window->set_platform_and_version(_platform_and_version);
         window->set_settings(_settings);
         window->on_camera_sink_selected += on_camera_sink_selected;
+        window->on_flyby_node_selected += on_flyby_node_selected;
         window->on_trigger_selected += on_trigger_selected;
         window->on_scene_changed += on_scene_changed;
         window->on_settings += on_settings;
@@ -67,6 +69,15 @@ namespace trview
         for (auto& window : _windows)
         {
             window.second->set_selected_camera_sink(_selected_camera_sink);
+        }
+    }
+
+    void CameraSinkWindowManager::set_selected_flyby_node(const std::weak_ptr<IFlybyNode>& flyby_node)
+    {
+        _selected_flyby_node = flyby_node;
+        for (auto& window : _windows)
+        {
+            window.second->set_selected_flyby_node(_selected_flyby_node);
         }
     }
 

--- a/trview.app/Windows/CameraSink/CameraSinkWindowManager.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindowManager.h
@@ -12,18 +12,23 @@ namespace trview
     public:
         CameraSinkWindowManager(const Window& window, const std::shared_ptr<IShortcuts>& shortcuts, const ICameraSinkWindow::Source& camera_sink_window_source);
         virtual ~CameraSinkWindowManager() = default;
-        virtual std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
-        virtual std::weak_ptr<ICameraSinkWindow> create_window() override;
-        virtual void render() override;
-        virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) override;
-        virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
+        std::optional<int> process_message(UINT message, WPARAM wParam, LPARAM lParam) override;
+        std::weak_ptr<ICameraSinkWindow> create_window() override;
+        void render() override;
+        void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) override;
+        void set_flybys(const std::vector<std::weak_ptr<IFlyby>>& flybys) override;
+        void set_platform_and_version(const trlevel::PlatformAndVersion& platform_and_version) override;
+        void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
         void set_room(const std::weak_ptr<IRoom>& room) override;
         void set_settings(const UserSettings& settings) override;
+        void update(float delta) override;
     private:
         ICameraSinkWindow::Source _camera_sink_window_source;
         std::vector<std::weak_ptr<ICameraSink>> _camera_sinks;
         std::weak_ptr<ICameraSink> _selected_camera_sink;
         std::weak_ptr<IRoom> _current_room;
         UserSettings _settings;
+        std::vector<std::weak_ptr<IFlyby>> _flybys;
+        trlevel::PlatformAndVersion _platform_and_version;
     };
 }

--- a/trview.app/Windows/CameraSink/CameraSinkWindowManager.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindowManager.h
@@ -19,6 +19,7 @@ namespace trview
         void set_flybys(const std::vector<std::weak_ptr<IFlyby>>& flybys) override;
         void set_platform_and_version(const trlevel::PlatformAndVersion& platform_and_version) override;
         void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
+        void set_selected_flyby_node(const std::weak_ptr<IFlybyNode>& flyby_node) override;
         void set_room(const std::weak_ptr<IRoom>& room) override;
         void set_settings(const UserSettings& settings) override;
         void update(float delta) override;
@@ -26,6 +27,7 @@ namespace trview
         ICameraSinkWindow::Source _camera_sink_window_source;
         std::vector<std::weak_ptr<ICameraSink>> _camera_sinks;
         std::weak_ptr<ICameraSink> _selected_camera_sink;
+        std::weak_ptr<IFlybyNode> _selected_flyby_node;
         std::weak_ptr<IRoom> _current_room;
         UserSettings _settings;
         std::vector<std::weak_ptr<IFlyby>> _flybys;

--- a/trview.app/Windows/CameraSink/ICameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/ICameraSinkWindow.h
@@ -16,6 +16,7 @@ namespace trview
         virtual void set_flybys(const std::vector<std::weak_ptr<IFlyby>>& flybys) = 0;
         virtual void set_number(int32_t number) = 0;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
+        virtual void set_selected_flyby_node(const std::weak_ptr<IFlybyNode>& flyby_node) = 0;
         virtual void set_current_room(const std::weak_ptr<IRoom>& room) = 0;
         virtual void set_settings(const UserSettings& settings) = 0;
 
@@ -29,6 +30,7 @@ namespace trview
         Event<UserSettings> on_settings;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
+        Event<std::weak_ptr<IFlybyNode>> on_flyby_node_selected;
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
         Event<> on_scene_changed;
     };

--- a/trview.app/Windows/CameraSink/ICameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/ICameraSinkWindow.h
@@ -2,6 +2,7 @@
 
 #include "../../Elements/CameraSink/ICameraSink.h"
 #include "../../Elements/ITrigger.h"
+#include "../../Elements/Flyby/IFlyby.h"
 
 namespace trview
 {
@@ -12,11 +13,14 @@ namespace trview
         virtual ~ICameraSinkWindow() = 0;
         virtual void render() = 0;
         virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) = 0;
+        virtual void set_flybys(const std::vector<std::weak_ptr<IFlyby>>& flybys) = 0;
         virtual void set_number(int32_t number) = 0;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
         virtual void set_current_room(const std::weak_ptr<IRoom>& room) = 0;
         virtual void set_settings(const UserSettings& settings) = 0;
 
+        virtual void set_platform_and_version(const trlevel::PlatformAndVersion& platform_and_version) = 0;
+        virtual void update(float delta) = 0;
         /// <summary>
         /// Event raised when the window is closed.
         /// </summary>

--- a/trview.app/Windows/CameraSink/ICameraSinkWindowManager.h
+++ b/trview.app/Windows/CameraSink/ICameraSinkWindowManager.h
@@ -14,11 +14,13 @@ namespace trview
         virtual void set_flybys(const std::vector<std::weak_ptr<IFlyby>>& flybys) = 0;
         virtual void set_platform_and_version(const trlevel::PlatformAndVersion& platform_and_version) = 0;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
+        virtual void set_selected_flyby_node(const std::weak_ptr<IFlybyNode>& flyby_node) = 0;
         virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
         virtual void set_settings(const UserSettings& settings) = 0;
         virtual void update(float delta) = 0;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
+        Event<std::weak_ptr<IFlybyNode>> on_flyby_node_selected;
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
         Event<> on_scene_changed;
         Event<UserSettings> on_settings;

--- a/trview.app/Windows/CameraSink/ICameraSinkWindowManager.h
+++ b/trview.app/Windows/CameraSink/ICameraSinkWindowManager.h
@@ -11,9 +11,12 @@ namespace trview
         virtual std::weak_ptr<ICameraSinkWindow> create_window() = 0;
         virtual void render() = 0;
         virtual void set_camera_sinks(const std::vector<std::weak_ptr<ICameraSink>>& camera_sinks) = 0;
+        virtual void set_flybys(const std::vector<std::weak_ptr<IFlyby>>& flybys) = 0;
+        virtual void set_platform_and_version(const trlevel::PlatformAndVersion& platform_and_version) = 0;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
         virtual void set_room(const std::weak_ptr<IRoom>& room) = 0;
         virtual void set_settings(const UserSettings& settings) = 0;
+        virtual void update(float delta) = 0;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;

--- a/trview.app/Windows/ITriggersWindow.h
+++ b/trview.app/Windows/ITriggersWindow.h
@@ -32,6 +32,7 @@ namespace trview
         /// Event raised when a camera/sinkm is selected in the list.
         /// </summary>
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
+        Event<std::weak_ptr<IFlybyNode>> on_flyby_node_selected;
 
         Event<UserSettings> on_settings;
 

--- a/trview.app/Windows/ITriggersWindowManager.h
+++ b/trview.app/Windows/ITriggersWindowManager.h
@@ -20,6 +20,7 @@ namespace trview
         Event<std::weak_ptr<ITrigger>> on_add_to_route;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
+        Event<std::weak_ptr<IFlybyNode>> on_flyby_node_selected;
 
         Event<UserSettings> on_settings;
 

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -150,6 +150,7 @@ namespace trview
         virtual void select_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
         virtual void select_static_mesh(const std::weak_ptr<IStaticMesh>& static_mesh) = 0;
         virtual void select_sound_source(const std::weak_ptr<ISoundSource>& sound_source) = 0;
+        virtual void select_flyby_node(const std::weak_ptr<IFlybyNode>& flyby_node) = 0;
         virtual std::weak_ptr<ILevel> level() const = 0;
     };
 }

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -65,12 +65,10 @@ namespace trview
         Event<DirectX::SimpleMath::Vector3, DirectX::SimpleMath::Vector3, std::weak_ptr<IRoom>, IWaypoint::Type, uint32_t> on_waypoint_added;
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
-
         Event<std::string, FontSetting> on_font;
-
         Event<std::weak_ptr<IStaticMesh>> on_static_mesh_selected;
-
         Event<std::weak_ptr<ISoundSource>> on_sound_source_selected;
+        Event<std::weak_ptr<IFlybyNode>> on_flyby_node_selected;
 
         virtual std::weak_ptr<ICamera> camera() const = 0;
 

--- a/trview.app/Windows/IWindows.h
+++ b/trview.app/Windows/IWindows.h
@@ -6,6 +6,7 @@
 namespace trview
 {
     struct ICameraSink;
+    struct IFlybyNode;
     struct IItem;
     struct ILevel;
     struct ILight;
@@ -25,6 +26,7 @@ namespace trview
         virtual void update(float elapsed) = 0;
         virtual void render() = 0;
         virtual void select(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
+        virtual void select(const std::weak_ptr<IFlybyNode>& flyby_node) = 0;
         virtual void select(const std::weak_ptr<IItem>& item) = 0;
         virtual void select(const std::weak_ptr<ILight>& light) = 0;
         virtual void select(const std::weak_ptr<ISoundSource>& sound_source) = 0;
@@ -39,6 +41,7 @@ namespace trview
 
         Event<std::weak_ptr<ICameraSink>> on_camera_sink_selected;
         Event<std::weak_ptr<ILevel>> on_diff_ended;
+        Event<std::weak_ptr<IFlybyNode>> on_flyby_node_selected;
         Event<std::weak_ptr<IItem>> on_item_selected;
         Event<std::string> on_level_open;
         Event<std::string> on_level_switch;

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -380,6 +380,28 @@ namespace trview
                                 }
                             }
                         }
+                        else if (command.type() == TriggerCommandType::Flyby)
+                        {
+                            _track.set_enabled<Type::Room>(false);
+                            if (selected_trigger)
+                            {
+                                if (auto level = selected_trigger->level().lock())
+                                {
+                                    for (const auto flyby : level->flybys() | std::views::transform([](auto&& f) { return f.lock(); }))
+                                    {
+                                        if (flyby && flyby->number() == command.index())
+                                        {
+                                            const auto nodes = flyby->nodes();
+                                            if (!nodes.empty())
+                                            {
+                                                on_flyby_node_selected(nodes[0]);
+                                            }
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                     ImGui::TableNextColumn();
                     ImGui::Text(command_type_name(command.type()).c_str());

--- a/trview.app/Windows/TriggersWindowManager.cpp
+++ b/trview.app/Windows/TriggersWindowManager.cpp
@@ -35,6 +35,7 @@ namespace trview
         triggers_window->on_scene_changed += on_scene_changed;
         triggers_window->on_add_to_route += on_add_to_route;
         triggers_window->on_camera_sink_selected += on_camera_sink_selected;
+        triggers_window->on_flyby_node_selected += on_flyby_node_selected;
         triggers_window->on_settings += on_settings;
         triggers_window->set_items(_items);
         triggers_window->set_platform_and_version(_platform_and_version);

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -8,6 +8,7 @@
 #include <trview.common/Strings.h>
 
 #include "../Windows/IItemsWindow.h"
+#include "../Elements/Flyby/IFlybyNode.h"
 
 using namespace DirectX::SimpleMath;
 
@@ -1660,5 +1661,18 @@ namespace trview
     std::weak_ptr<ILevel> Viewer::level() const
     {
         return _level;
+    }
+
+    void Viewer::select_flyby_node(const std::weak_ptr<IFlybyNode>& flyby_node)
+    {
+        if (auto flyby_node_ptr = flyby_node.lock())
+        {
+            set_target(flyby_node_ptr->position());
+            if (_settings.auto_orbit)
+            {
+                set_camera_mode(ICamera::Mode::Orbit);
+            }
+            _scene_changed = true;
+        }
     }
 }

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -1438,6 +1438,11 @@ namespace trview
             on_sound_source_selected(pick.sound_source);
             break;
         }
+        case PickResult::Type::FlybyNode:
+        {
+            on_flyby_node_selected(pick.flyby_node);
+            break;
+        }
         }
     }
 

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -92,6 +92,7 @@ namespace trview
         virtual void select_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
         void select_static_mesh(const std::weak_ptr<IStaticMesh>& static_mesh) override;
         void select_sound_source(const std::weak_ptr<ISoundSource>& sound_source) override;
+        void select_flyby_node(const std::weak_ptr<IFlybyNode>& flyby_node) override;
         std::weak_ptr<ILevel> level() const override;
     private:
         void initialise_input();

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -50,6 +50,7 @@ namespace trview
         _textures_windows(std::move(textures_window_manager)), _triggers_windows(std::move(triggers_window_manager)), _pack_windows(std::move(pack_window_manager))
     {
         _camera_sink_windows->on_camera_sink_selected += on_camera_sink_selected;
+        _camera_sink_windows->on_flyby_node_selected += on_flyby_node_selected;
         _camera_sink_windows->on_trigger_selected += on_trigger_selected;
         _camera_sink_windows->on_scene_changed += on_scene_changed;
         _camera_sink_windows->on_settings += on_settings;
@@ -168,6 +169,11 @@ namespace trview
     {
         _camera_sink_windows->set_selected_camera_sink(camera_sink);
         _rooms_windows->set_selected_camera_sink(camera_sink);
+    }
+
+    void Windows::select(const std::weak_ptr<IFlybyNode>& flyby_node)
+    {
+        _camera_sink_windows->set_selected_flyby_node(flyby_node);
     }
 
     void Windows::select(const std::weak_ptr<IItem>& item)

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -127,6 +127,7 @@ namespace trview
             };
         _triggers_windows->on_camera_sink_selected += on_camera_sink_selected;
         _triggers_windows->on_scene_changed += on_scene_changed;
+        _triggers_windows->on_flyby_node_selected += on_flyby_node_selected;
     }
 
     bool Windows::is_route_window_open() const

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -135,6 +135,7 @@ namespace trview
 
     void Windows::update(float elapsed)
     {
+        _camera_sink_windows->update(elapsed);
         _items_windows->update(elapsed);
         _lights_windows->update(elapsed);
         _plugins_windows->update(elapsed);
@@ -211,6 +212,8 @@ namespace trview
         }
 
         _camera_sink_windows->set_camera_sinks(new_level->camera_sinks());
+        _camera_sink_windows->set_flybys(new_level->flybys());
+        _camera_sink_windows->set_platform_and_version(new_level->platform_and_version());
         _diff_windows->set_level(new_level);
         _items_windows->set_items(new_level->items());
         _items_windows->set_triggers(new_level->triggers());

--- a/trview.app/Windows/Windows.h
+++ b/trview.app/Windows/Windows.h
@@ -47,6 +47,7 @@ namespace trview
         void update(float elapsed) override;
         void render() override;
         void select(const std::weak_ptr<ICameraSink>& camera_sink) override;
+        void select(const std::weak_ptr<IFlybyNode>& flyby_node) override;
         void select(const std::weak_ptr<IItem>& item) override;
         void select(const std::weak_ptr<ILight>& light) override;
         void select(const std::weak_ptr<ISoundSource>& sound_source) override;

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -25,6 +25,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Camera\Camera.cpp" />
     <ClCompile Include="Camera\CameraInput.cpp" />
     <ClCompile Include="Elements\CameraSink\CameraSink.cpp" />
+    <ClCompile Include="Elements\Flyby\Flyby.cpp" />
     <ClCompile Include="Elements\Item.cpp" />
     <ClCompile Include="Elements\Floordata.cpp" />
     <ClCompile Include="Elements\ILight.cpp" />
@@ -91,6 +92,8 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Windows\Sounds\SoundsWindow.cpp" />
     <ClCompile Include="Windows\Sounds\SoundsWindowManager.cpp" />
     <ClCompile Include="Windows\Windows.cpp" />
+    <ClInclude Include="Elements\Flyby\Flyby.h" />
+    <ClInclude Include="Elements\Flyby\IFlyby.h" />
     <ClInclude Include="Elements\Remastered\INgPlusSwitcher.h" />
     <ClInclude Include="Elements\Remastered\NgPlusSwitcher.h" />
     <ClInclude Include="Elements\SoundSource\ISoundSource.h" />
@@ -103,6 +106,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Lua\Scriptable\IScriptable.h" />
     <ClInclude Include="Lua\Scriptable\Scriptable.h" />
     <ClInclude Include="Menus\ImGuiFileMenu.h" />
+    <ClInclude Include="Mocks\Elements\IFlyby.h" />
     <ClInclude Include="Mocks\Elements\INgPlusSwitcher.h" />
     <ClInclude Include="Mocks\Elements\ISoundSource.h" />
     <ClInclude Include="Mocks\Geometry\IModelStorage.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -26,6 +26,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Camera\CameraInput.cpp" />
     <ClCompile Include="Elements\CameraSink\CameraSink.cpp" />
     <ClCompile Include="Elements\Flyby\Flyby.cpp" />
+    <ClCompile Include="Elements\Flyby\FlybyNode.cpp" />
     <ClCompile Include="Elements\Item.cpp" />
     <ClCompile Include="Elements\Floordata.cpp" />
     <ClCompile Include="Elements\ILight.cpp" />
@@ -93,7 +94,9 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClCompile Include="Windows\Sounds\SoundsWindowManager.cpp" />
     <ClCompile Include="Windows\Windows.cpp" />
     <ClInclude Include="Elements\Flyby\Flyby.h" />
+    <ClInclude Include="Elements\Flyby\FlybyNode.h" />
     <ClInclude Include="Elements\Flyby\IFlyby.h" />
+    <ClInclude Include="Elements\Flyby\IFlybyNode.h" />
     <ClInclude Include="Elements\Remastered\INgPlusSwitcher.h" />
     <ClInclude Include="Elements\Remastered\NgPlusSwitcher.h" />
     <ClInclude Include="Elements\SoundSource\ISoundSource.h" />
@@ -107,6 +110,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ClInclude Include="Lua\Scriptable\Scriptable.h" />
     <ClInclude Include="Menus\ImGuiFileMenu.h" />
     <ClInclude Include="Mocks\Elements\IFlyby.h" />
+    <ClInclude Include="Mocks\Elements\IFlybyNode.h" />
     <ClInclude Include="Mocks\Elements\INgPlusSwitcher.h" />
     <ClInclude Include="Mocks\Elements\ISoundSource.h" />
     <ClInclude Include="Mocks\Geometry\IModelStorage.h" />

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -490,6 +490,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <None Include="Lua\Lua.inl" />
     <None Include="Track\Track.inl" />
     <None Include="Windows\AutoHider.inl" />
+    <None Include="Windows\CameraSink\CameraSinkWindow.inl" />
     <Text Include="Resources\Files\actions.json">
       <FileType>Document</FileType>
     </Text>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -380,6 +380,9 @@
     <ClCompile Include="Geometry\Model\ModelStorage.cpp">
       <Filter>Geometry\Model</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\Flyby\Flyby.cpp">
+      <Filter>Elements\Flyby</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -1273,6 +1276,15 @@
     <ClInclude Include="Mocks\Geometry\IModelStorage.h">
       <Filter>Mocks\Geometry</Filter>
     </ClInclude>
+    <ClInclude Include="Elements\Flyby\IFlyby.h">
+      <Filter>Elements\Flyby</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\Flyby\Flyby.h">
+      <Filter>Elements\Flyby</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\Elements\IFlyby.h">
+      <Filter>Mocks\Elements</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Windows">
@@ -1499,6 +1511,9 @@
     </Filter>
     <Filter Include="Geometry\Model">
       <UniqueIdentifier>{03a8e721-8c98-438d-a8eb-c67a9e88e956}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Elements\Flyby">
+      <UniqueIdentifier>{52dec27a-a711-4587-9a97-4ae9bdb7a050}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -383,6 +383,9 @@
     <ClCompile Include="Elements\Flyby\Flyby.cpp">
       <Filter>Elements\Flyby</Filter>
     </ClCompile>
+    <ClCompile Include="Elements\Flyby\FlybyNode.cpp">
+      <Filter>Elements\Flyby</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Camera\Camera.h">
@@ -1283,6 +1286,15 @@
       <Filter>Elements\Flyby</Filter>
     </ClInclude>
     <ClInclude Include="Mocks\Elements\IFlyby.h">
+      <Filter>Mocks\Elements</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\Flyby\IFlybyNode.h">
+      <Filter>Elements\Flyby</Filter>
+    </ClInclude>
+    <ClInclude Include="Elements\Flyby\FlybyNode.h">
+      <Filter>Elements\Flyby</Filter>
+    </ClInclude>
+    <ClInclude Include="Mocks\Elements\IFlybyNode.h">
       <Filter>Mocks\Elements</Filter>
     </ClInclude>
   </ItemGroup>

--- a/trview.app/trview.app.vcxproj.filters
+++ b/trview.app/trview.app.vcxproj.filters
@@ -1584,6 +1584,9 @@
     <None Include="Windows\AutoHider.inl">
       <Filter>Windows</Filter>
     </None>
+    <None Include="Windows\CameraSink\CameraSinkWindow.inl">
+      <Filter>Windows\CameraSink</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Resources\trview.app.rc">


### PR DESCRIPTION
Add flyby cameras and flyby playback.
Flyby cameras appear in the world showing the path that the camera will take.
Flyby cameras are shown in the camera/sink window and the flyby can be played back to show an approximation of how it will appear in-game.
Closes #1443