### PR TITLE
Clear shader input after rendering to address D3D warning

### DIFF
--- a/trview.app/Geometry/Mesh.cpp
+++ b/trview.app/Geometry/Mesh.cpp
@@ -262,6 +262,9 @@ namespace trview
                 }
             }
         }
+
+        constexpr std::array<ID3D11ShaderResourceView*, 1> null{ nullptr };
+        context->PSSetShaderResources(0, 1, &null[0]);
     }
 
     void Mesh::render(const Matrix& world_view_projection, const graphics::Texture& replacement_texture, const DirectX::SimpleMath::Color& colour, float light_intensity, Vector3 light_direction)

--- a/trview.app/Geometry/TransparencyBuffer.cpp
+++ b/trview.app/Geometry/TransparencyBuffer.cpp
@@ -133,6 +133,8 @@ namespace trview
 
         context->OMSetDepthStencilState(old_depth_state.Get(), 1);
         context->OMSetBlendState(old_blend_state.Get(), nullptr, 0xffffffff);
+        constexpr std::array<ID3D11ShaderResourceView*, 1> null{ nullptr };
+        context->PSSetShaderResources(0, 1, &null[0]);
     }
 
     void TransparencyBuffer::reset()

--- a/trview.app/Graphics/SelectionRenderer.cpp
+++ b/trview.app/Graphics/SelectionRenderer.cpp
@@ -199,5 +199,7 @@ namespace trview
         context->DrawIndexed(4, 0, 0);
 
         context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+        constexpr std::array<ID3D11ShaderResourceView*, 1> null{ nullptr };
+        context->PSSetShaderResources(0, 1, &null[0]);
     }
 }

--- a/trview.graphics/Sprite.cpp
+++ b/trview.graphics/Sprite.cpp
@@ -3,6 +3,7 @@
 #include "IShader.h"
 #include "Texture.h"
 #include <trview.app/Geometry/IMesh.h>
+#include <array>
 
 using namespace Microsoft::WRL;
 
@@ -103,6 +104,9 @@ namespace trview
             context->VSSetConstantBuffers(0, 1, _matrix_buffer.GetAddressOf());
             context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP);
             context->DrawIndexed(4, 0, 0);
+
+            constexpr std::array<ID3D11ShaderResourceView*, 1> null{ nullptr };
+            context->PSSetShaderResources(0, 1, &null[0]);
         }
 
         void Sprite::create_matrix()


### PR DESCRIPTION
Clear the shader input when rendering a render target.
Currently when we get around to rendering to the render target again next time it warns that it already set on input and unbinds it.
Closes #1456