### PR TITLE
Re-add linear filtering as an option

### DIFF
--- a/trview.app.tests/Windows/ViewerTests.cpp
+++ b/trview.app.tests/Windows/ViewerTests.cpp
@@ -23,6 +23,7 @@
 #include <trview.common/Mocks/Windows/IClipboard.h>
 #include <trview.app/Mocks/Elements/ISector.h>
 #include <trview.app/Mocks/Elements/ISoundSource.h>
+#include <trview.graphics/Mocks/ISamplerState.h>
 
 #include <trview.tests.common/Event.h>
 
@@ -147,13 +148,14 @@ namespace
             std::unique_ptr<ISectorHighlight> sector_highlight{ mock_unique<MockSectorHighlight>() };
             std::shared_ptr<IClipboard> clipboard{ mock_shared<MockClipboard>() };
             std::shared_ptr<MockCamera> camera{ mock_shared<MockCamera>() };
+            ISamplerState::Source sampler_source{ [](auto&&...) { return mock_shared<MockSamplerState>(); } };
 
             std::unique_ptr<Viewer> build()
             {
                 EXPECT_CALL(*shortcuts, add_shortcut).WillRepeatedly([&](auto, auto) -> Event<>&{ return shortcut_handler; });
                 ON_CALL(*camera, idle_rotation).WillByDefault(Return(true));
                 return std::make_unique<Viewer>(window, device, std::move(ui), std::move(picking), std::move(mouse), shortcuts, route, sprite_source,
-                    std::move(compass), std::move(measure), render_target_source, device_window_source, std::move(sector_highlight), clipboard, camera);
+                    std::move(compass), std::move(measure), render_target_source, device_window_source, std::move(sector_highlight), clipboard, camera, sampler_source);
             }
 
             test_module& with_camera(const std::shared_ptr<MockCamera>& camera)

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -74,7 +74,7 @@ namespace trview
             _token_store += parent->on_geometry_colours_changed += [&]() { _all_geometry_meshes.clear(); };
         }
 
-        _room_sampler_state = sampler_source(graphics::ISamplerState::AddressMode::Wrap);
+        _room_sampler_state = sampler_source(graphics::ISamplerState::AddressMode::Clamp);
         _object_sampler_state = sampler_source(graphics::ISamplerState::AddressMode::Clamp);
     }
 

--- a/trview.app/Graphics/LevelTextureStorage.cpp
+++ b/trview.app/Graphics/LevelTextureStorage.cpp
@@ -12,22 +12,6 @@ namespace trview
     {
     }
 
-    void LevelTextureStorage::determine_texture_mode()
-    {
-        for (const auto& object_texture : _object_textures)
-        {
-            for (const auto& vert : object_texture.Vertices)
-            {
-                if ((vert.x_frac > 1 && vert.x_frac < 255) ||
-                    (vert.y_frac > 1 && vert.y_frac < 255))
-                {
-                    _texture_mode = TextureMode::Custom;
-                    return;
-                }
-            }
-        }
-    }
-
     void LevelTextureStorage::add_texture(const std::vector<uint32_t>& pixels, uint32_t width, uint32_t height)
     {
         _texture_storage->add_texture(pixels, width, height);
@@ -56,48 +40,12 @@ namespace trview
     DirectX::SimpleMath::Vector2 LevelTextureStorage::uv(uint32_t texture_index, uint32_t uv_index) const
     {
         using namespace DirectX::SimpleMath;
-        if (texture_index >= _object_textures.size())
-        {
-            return Vector2::Zero;
-        }
-
-        auto vert = _object_textures[texture_index].Vertices[uv_index];
-
         const auto found_repl = _texture_replacements.find(texture_index);
         if (found_repl != _texture_replacements.end())
         {
             return found_repl->second.uvs[uv_index];
         }
-
-        if (_texture_mode == TextureMode::Official)
-        {
-            float u = static_cast<float>(vert.x_whole);
-            float v = static_cast<float>(vert.y_whole);
-
-            if (vert.x_frac == 1 || vert.x_frac == 0)
-            {
-                u += 1;
-            }
-            else if (vert.x_frac == 255)
-            {
-                u -= 1;
-            }
-
-            if (vert.y_frac == 1 || vert.y_frac == 0)
-            {
-                v += 1;
-            }
-            else if (vert.y_frac == 255)
-            {
-                v -= 1;
-            }
-
-            return Vector2(u, v) / 256.0f;
-        }
-        
-        float x = static_cast<float>(vert.x_whole) + (vert.x_frac / 256.0f);
-        float y = static_cast<float>(vert.y_whole) + (vert.y_frac / 256.0f);
-        return Vector2(x, y) / 256.0f;
+        return Vector2::Zero;
     }
 
     uint32_t LevelTextureStorage::tile(uint32_t texture_index) const
@@ -106,11 +54,6 @@ namespace trview
         if (found_repl != _texture_replacements.end())
         {
             return found_repl->second.tile;
-        }
-
-        if (texture_index < _object_textures.size())
-        {
-            return _object_textures[texture_index].TileAndFlag & 0x7FFF;
         }
         return 0;
     }
@@ -209,8 +152,6 @@ namespace trview
                 _palette[i] = Color(entry.Red / 255.f, entry.Green / 255.f, entry.Blue / 255.f, 1.0f);
             }
         }
-
-        determine_texture_mode();
     }
 
     void LevelTextureStorage::add_textile(const std::vector<uint32_t>& textile, uint32_t width, uint32_t height)

--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -39,7 +39,6 @@ namespace trview
         Triangle::AnimationMode animation_mode(uint32_t texture_index) const override;
         std::vector<uint32_t> animated_texture(uint32_t texture_index) const override;
     private:
-        void determine_texture_mode();
         void generate_replacement_textures();
 
         std::weak_ptr<trlevel::ILevel> _level;
@@ -49,12 +48,6 @@ namespace trview
         std::unique_ptr<ITextureStorage> _texture_storage;
         std::array<DirectX::SimpleMath::Color, 256> _palette;
         trlevel::PlatformAndVersion _platform_and_version;
-        enum class TextureMode
-        {
-            Official,
-            Custom
-        };
-        TextureMode _texture_mode{ TextureMode::Official };
         std::unordered_map<uint32_t, std::vector<uint32_t>> _animated_textures;
 
         struct SourceTexture

--- a/trview.app/Mocks/UI/ISettingsWindow.h
+++ b/trview.app/Mocks/UI/ISettingsWindow.h
@@ -36,6 +36,7 @@ namespace trview
             MOCK_METHOD(void, set_camera_sink_startup, (bool), (override));
             MOCK_METHOD(void, set_statics_startup, (bool), (override));
             MOCK_METHOD(void, set_animated_textures, (bool), (override));
+            MOCK_METHOD(void, set_linear_filtering, (bool), (override));
         };
     }
 }

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -129,6 +129,7 @@ namespace trview
             read_attribute(json, settings.flyby_columns, "flyby_columns");
             read_attribute(json, settings.flyby_node_columns, "flyby_node_columns");
             read_attribute(json, settings.animated_textures, "animated_textures");
+            read_attribute(json, settings.linear_filtering, "linear_filtering");
 
             settings.recent_files.resize(std::min<std::size_t>(settings.recent_files.size(), settings.max_recent_files));
         }
@@ -210,6 +211,7 @@ namespace trview
             json["flyby_columns"] = settings.flyby_columns;
             json["flyby_node_columns"] = settings.flyby_node_columns;
             json["animated_textures"] = settings.animated_textures;
+            json["linear_filtering"] = settings.linear_filtering;
             _files->save_file(file_path, json.dump());
         }
         catch (...)

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -79,6 +79,7 @@ namespace trview
         std::vector<std::string> flyby_columns{ "#", "Hide" };
         std::vector<std::string> flyby_node_columns{ "#", "Room" };
         bool animated_textures{ true };
+        bool linear_filtering{ false };
 
         bool operator==(const UserSettings& other) const;
     };

--- a/trview.app/UI/ISettingsWindow.h
+++ b/trview.app/UI/ISettingsWindow.h
@@ -82,6 +82,7 @@ namespace trview
         Event<std::string, FontSetting> on_font;
         Event<bool> on_statics_startup;
         Event<bool> on_animated_textures;
+        Event<bool> on_linear_filtering;
 
         virtual void render() = 0;
         /// <summary>
@@ -185,5 +186,6 @@ namespace trview
         virtual void toggle_visibility() = 0;
         virtual void set_statics_startup(bool value) = 0;
         virtual void set_animated_textures(bool value) = 0;
+        virtual void set_linear_filtering(bool value) = 0;
     };
 }

--- a/trview.app/UI/IViewerUI.h
+++ b/trview.app/UI/IViewerUI.h
@@ -109,6 +109,7 @@ namespace trview
         Event<std::string, FontSetting> on_font;
 
         Event<std::weak_ptr<IItemsWindow>> on_filter_items_to_tile;
+        Event<bool> on_linear_filtering;
 
         /// Render the UI.
         virtual void render() = 0;

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -56,6 +56,7 @@ namespace trview
                 {
                     checkbox(Names::vsync, _vsync, on_vsync);
                     checkbox(Names::animated_textures, _animated_textures, on_animated_textures);
+                    checkbox(Names::linear_filtering, _linear_filtering, on_linear_filtering);
                     if (ImGui::ColorEdit3(Names::background_colour.c_str(), _colour))
                     {
                         on_background_colour(Colour(1.0f, _colour[0], _colour[1], _colour[2]));
@@ -342,5 +343,10 @@ namespace trview
     void SettingsWindow::set_animated_textures(bool value)
     {
         _animated_textures = value;
+    }
+
+    void SettingsWindow::set_linear_filtering(bool value)
+    {
+        _linear_filtering = value;
     }
 }

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -41,6 +41,7 @@ namespace trview
             static inline const std::string reset_fov = "Reset##Fov";
             static inline const std::string statics_startup = "Open Statics Window at startup";
             static inline const std::string animated_textures = "Animated Textures";
+            static inline const std::string linear_filtering = "Linear Filtering";
         };
 
         explicit SettingsWindow(const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IShell>& shell, const std::shared_ptr<IFonts>& fonts);
@@ -71,6 +72,7 @@ namespace trview
         virtual void set_camera_sink_startup(bool value) override;
         void set_statics_startup(bool value) override;
         void set_animated_textures(bool value) override;
+        void set_linear_filtering(bool value) override;
     private:
         std::shared_ptr<IDialogs> _dialogs;
         std::shared_ptr<IShell> _shell;
@@ -101,5 +103,6 @@ namespace trview
         std::shared_ptr<IFonts> _fonts;
         bool _statics_startup{ false };
         bool _animated_textures{ true };
+        bool _linear_filtering{ false };
     };
 }

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -156,7 +156,9 @@ namespace trview
         forward_setting(_settings_window->on_camera_sink_startup, _settings.camera_sink_startup);
         forward_setting(_settings_window->on_statics_startup, _settings.statics_startup);
         forward_setting(_settings_window->on_animated_textures, _settings.animated_textures);
+        forward_setting(_settings_window->on_linear_filtering, _settings.linear_filtering);
         _settings_window->on_font += on_font;
+        _settings_window->on_linear_filtering += on_linear_filtering;
 
         _camera_position = std::make_unique<CameraPosition>();
         _camera_position->on_position_changed += on_camera_position;
@@ -408,6 +410,7 @@ namespace trview
         _settings_window->set_camera_sink_startup(settings.camera_sink_startup);
         _settings_window->set_statics_startup(settings.statics_startup);
         _settings_window->set_animated_textures(settings.animated_textures);
+        _settings_window->set_linear_filtering(settings.linear_filtering);
         _camera_position->set_display_degrees(settings.camera_display_degrees);
         _camera_position->set_visible(settings.camera_position_window);
         _map_renderer->set_colours(settings.map_colours);

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -21,11 +21,11 @@ namespace trview
     Viewer::Viewer(const Window& window, const std::shared_ptr<graphics::IDevice>& device, std::unique_ptr<IViewerUI> ui, std::unique_ptr<IPicking> picking,
         std::unique_ptr<input::IMouse> mouse, const std::shared_ptr<IShortcuts>& shortcuts, const std::shared_ptr<IRoute> route, const graphics::ISprite::Source& sprite_source,
         std::unique_ptr<ICompass> compass, std::unique_ptr<IMeasure> measure, const graphics::IRenderTarget::SizeSource& render_target_source, const graphics::IDeviceWindow::Source& device_window_source,
-        std::unique_ptr<ISectorHighlight> sector_highlight, const std::shared_ptr<IClipboard>& clipboard, const std::shared_ptr<ICamera>& camera)
+        std::unique_ptr<ISectorHighlight> sector_highlight, const std::shared_ptr<IClipboard>& clipboard, const std::shared_ptr<ICamera>& camera, const graphics::ISamplerState::Source& sampler_source)
         : MessageHandler(window), _shortcuts(shortcuts), _timer(default_time_source()), _keyboard(window), _mouse(std::move(mouse)), _window_resizer(window),
         _alternate_group_toggler(window), _menu_detector(window), _device(device), _route(route), _ui(std::move(ui)), _picking(std::move(picking)),
         _compass(std::move(compass)), _measure(std::move(measure)), _render_target_source(render_target_source), _sector_highlight(std::move(sector_highlight)),
-        _clipboard(clipboard), _camera(camera)
+        _clipboard(clipboard), _camera(camera), _sampler_source(sampler_source)
     {
         apply_camera_settings();
 
@@ -392,6 +392,12 @@ namespace trview
                             break;
                     }
                 }
+            };
+        _token_store += _ui->on_linear_filtering += [&](bool value)
+            {
+                const auto mode = value ? graphics::ISamplerState::FilterMode::Linear : graphics::ISamplerState::FilterMode::Point;
+                _sampler_source(graphics::ISamplerState::AddressMode::Wrap)->set_filter_mode(mode);
+                _sampler_source(graphics::ISamplerState::AddressMode::Clamp)->set_filter_mode(mode);
             };
 
         _ui->set_settings(_settings);

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -37,6 +37,8 @@
 #include <trview.app/Windows/IViewer.h>
 #include <trview.common/Windows/IClipboard.h>
 
+#include <trview.graphics/Sampler/ISamplerState.h>
+
 namespace trview
 {
     /// Class that coordinates all the parts of the application.
@@ -60,7 +62,8 @@ namespace trview
             const graphics::IDeviceWindow::Source& device_window_source,
             std::unique_ptr<ISectorHighlight> sector_highlight,
             const std::shared_ptr<IClipboard>& clipboard,
-            const std::shared_ptr<ICamera>& camera);
+            const std::shared_ptr<ICamera>& camera,
+            const graphics::ISamplerState::Source& sampler_source);
         virtual ~Viewer() = default;
         std::weak_ptr<ICamera> camera() const override;
         virtual ICamera::Mode camera_mode() const override;
@@ -181,6 +184,7 @@ namespace trview
 
         Point _previous_mouse_pos;
         bool _camera_moved{ false };
+        graphics::ISamplerState::Source _sampler_source;
     };
 }
 

--- a/trview.graphics/Sampler/ISamplerState.h
+++ b/trview.graphics/Sampler/ISamplerState.h
@@ -12,9 +12,16 @@ namespace trview
                 Clamp
             };
 
+            enum class FilterMode
+            {
+                Point,
+                Linear
+            };
+
             using Source = std::function<std::shared_ptr<ISamplerState>(AddressMode)>;
             virtual ~ISamplerState();
             virtual void apply() = 0;
+            virtual void set_filter_mode(FilterMode mode) = 0;
         };
     }
 }

--- a/trview.graphics/Sampler/SamplerState.cpp
+++ b/trview.graphics/Sampler/SamplerState.cpp
@@ -1,4 +1,5 @@
 #include "SamplerState.h"
+#include "IDevice.h"
 
 namespace trview
 {
@@ -9,15 +10,29 @@ namespace trview
         }
 
         SamplerState::SamplerState(
-            const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context,
+            const std::weak_ptr<IDevice>& device,
             const Microsoft::WRL::ComPtr<ID3D11SamplerState>& sampler_state)
-            : _context(context), _sampler_state(sampler_state)
+            : _device(device), _sampler_state(sampler_state)
         {
         }
 
         void SamplerState::apply()
         {
-            _context->PSSetSamplers(0, 1, _sampler_state.GetAddressOf());
+            if (auto device = _device.lock())
+            {
+                device->context()->PSSetSamplers(0, 1, _sampler_state.GetAddressOf());
+            }
+        }
+
+        void SamplerState::set_filter_mode(FilterMode mode)
+        {
+            D3D11_SAMPLER_DESC desc;
+            _sampler_state->GetDesc(&desc);
+            desc.Filter = mode == FilterMode::Point ? D3D11_FILTER_MIN_MAG_MIP_POINT : D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+            if (auto device = _device.lock())
+            {
+                _sampler_state = device->create_sampler_state(desc);
+            }
         }
     }
 }

--- a/trview.graphics/Sampler/SamplerState.h
+++ b/trview.graphics/Sampler/SamplerState.h
@@ -9,16 +9,19 @@ namespace trview
 {
     namespace graphics
     {
+        struct IDevice;
+
         class SamplerState final : public ISamplerState
         {
         public:
             SamplerState(
-                const Microsoft::WRL::ComPtr<ID3D11DeviceContext>& context,
+                const std::weak_ptr<IDevice>& device,
                 const Microsoft::WRL::ComPtr<ID3D11SamplerState>& sampler_state);
             virtual ~SamplerState() = default;
             void apply() override;
+            void set_filter_mode(FilterMode mode) override;
         private:
-            Microsoft::WRL::ComPtr<ID3D11DeviceContext> _context;
+            std::weak_ptr<IDevice> _device;
             Microsoft::WRL::ComPtr<ID3D11SamplerState> _sampler_state;
         };
     }

--- a/trview.graphics/mocks/ISamplerState.h
+++ b/trview.graphics/mocks/ISamplerState.h
@@ -13,6 +13,7 @@ namespace trview
                 MockSamplerState();
                 virtual ~MockSamplerState();
                 MOCK_METHOD(void, apply, (), (override));
+                MOCK_METHOD(void, set_filter_mode, (FilterMode), (override));
             };
         }
     }


### PR DESCRIPTION
With the recent change to split all textures into their own texture (not using them directly from the textile) it turns out that linear filtering works a lot better than it used to as long as it is on clamp.
Add a settings window option to enable linear filtering, disabled by default.
Remove the UV tweaking from before the replacement textures were used.
Closes #1472

Examples:
Previous linear (before it was removed):
<img width="1551" height="880" alt="image" src="https://github.com/user-attachments/assets/72799414-4966-4d19-a0ad-5c8cd4cf8c96" />
New linear:
<img width="1489" height="937" alt="image" src="https://github.com/user-attachments/assets/0aba7c7f-1d65-425a-8153-5483f95c1cd6" />
Point for reference:
<img width="1686" height="972" alt="image" src="https://github.com/user-attachments/assets/4d8eddbb-65f5-4262-a93c-b51cd639bdc0" />
Setting:
<img width="373" height="176" alt="image" src="https://github.com/user-attachments/assets/138fa39d-4b73-4677-b30f-c3803f08a7d8" />
