### PR TITLE
Move animated textures option to view options

### DIFF
--- a/trview.app.tests/ApplicationTests.cpp
+++ b/trview.app.tests/ApplicationTests.cpp
@@ -1047,34 +1047,13 @@ TEST(Application, OnStaticMeshSelected)
     windows.on_static_selected(static_mesh);
 }
 
-TEST(Application, LevelUpdatedWithAnimationsEnabled)
+TEST(Application, LevelUpdated)
 {
     auto level = mock_shared<trview::mocks::MockLevel>();
     EXPECT_CALL(*level, update).Times(1);
 
-    UserSettings settings;
-    settings.animated_textures = true;
-    auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
-    ON_CALL(settings_loader, load_user_settings).WillByDefault(Return(settings));
-    auto application = register_test_module()
-        .with_settings_loader(std::move(settings_loader_ptr))
-        .build();
-    application->set_current_level(level, ILevel::OpenMode::Full, false);
-    application->render();
-}
+    auto application = register_test_module().build();
 
-TEST(Application, LevelNotUpdatedWithAnimationsDisabled)
-{
-    auto level = mock_shared<trview::mocks::MockLevel>();
-    EXPECT_CALL(*level, update).Times(0);
-
-    UserSettings settings;
-    settings.animated_textures = false;
-    auto [settings_loader_ptr, settings_loader] = create_mock<MockSettingsLoader>();
-    ON_CALL(settings_loader, load_user_settings).WillByDefault(Return(settings));
-    auto application = register_test_module()
-        .with_settings_loader(std::move(settings_loader_ptr))
-        .build();
     application->set_current_level(level, ILevel::OpenMode::Full, false);
     application->render();
 }

--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -857,7 +857,31 @@ TEST(Level, SetShowSoundSourcesRaisesLevelChangedEvent)
     ASSERT_EQ(raised, true);
 }
 
-TEST(Level, RoomUpdated)
+TEST(Level, RoomNotUpdatedIfAnimationsDisabled)
+{
+    auto [mock_level_ptr, mock_level] = create_mock<trlevel::mocks::MockLevel>();
+    EXPECT_CALL(mock_level, get_version).WillRepeatedly(Return(LevelVersion::Tomb4));
+    EXPECT_CALL(mock_level, num_rooms()).WillRepeatedly(Return(1));
+
+    auto room = mock_shared<MockRoom>();
+    EXPECT_CALL(*room, update(1.0f)).Times(0);
+
+    int room_called = 0;
+    auto level = register_test_module().with_level(std::move(mock_level_ptr))
+        .with_room_source(
+            [&](auto&&...)
+            {
+                ++room_called;
+                return room;
+            }).build();
+
+    ASSERT_EQ(room_called, 1);
+    level->set_show_animation(false);
+    level->update(1.0f);
+}
+
+
+TEST(Level, RoomUpdatedIfAnimationsEnabled)
 {
     auto [mock_level_ptr, mock_level] = create_mock<trlevel::mocks::MockLevel>();
     EXPECT_CALL(mock_level, get_version).WillRepeatedly(Return(LevelVersion::Tomb4));
@@ -876,5 +900,6 @@ TEST(Level, RoomUpdated)
             }).build();
 
     ASSERT_EQ(room_called, 1);
+    level->set_show_animation(true);
     level->update(1.0f);
 }

--- a/trview.app.tests/Settings/SettingsLoaderTests.cpp
+++ b/trview.app.tests/Settings/SettingsLoaderTests.cpp
@@ -802,28 +802,3 @@ TEST(SettingsLoader, PluginsSaved)
     loader->save_user_settings(settings);
     EXPECT_THAT(output, HasSubstr("\"plugins\":{\"Default\":{\"enabled\":true}}"));
 }
-
-TEST(SettingsLoader, AnimatedTexturesLoaded)
-{
-    auto loader = setup_setting("{\"animated_textures\":false}");
-    auto settings = loader->load_user_settings();
-    ASSERT_EQ(settings.animated_textures, false);
-
-    auto loader_true = setup_setting("{\"animated_textures\":true}");
-    auto settings_true = loader_true->load_user_settings();
-    ASSERT_EQ(settings_true.animated_textures, true);
-}
-
-TEST(SettingsLoader, AnimatedTexturesSaved)
-{
-    std::string output;
-    auto loader = setup_save_setting(output);
-    UserSettings settings;
-    settings.animated_textures = false;
-    loader->save_user_settings(settings);
-    EXPECT_THAT(output, HasSubstr("\"animated_textures\":false"));
-
-    settings.animated_textures = true;
-    loader->save_user_settings(settings);
-    EXPECT_THAT(output, HasSubstr("\"animated_textures\":true"));
-}

--- a/trview.app.tests/UI/ViewerUITests.cpp
+++ b/trview.app.tests/UI/ViewerUITests.cpp
@@ -531,15 +531,3 @@ TEST(ViewerUI, SetTileFilterEnabled)
 
     ui->set_tile_filter_enabled(true);
 }
-
-TEST(ViewerUI, SetAnimatedTexturesUpdatesSettingsWindow)
-{
-    auto [settings_window_ptr, settings_window] = create_mock<MockSettingsWindow>();
-    EXPECT_CALL(settings_window, set_animated_textures(true)).Times(1);
-
-    auto ui = register_test_module().with_settings_window(std::move(settings_window_ptr)).build();
-
-    UserSettings settings{};
-    settings.animated_textures = true;
-    ui->set_settings(settings);
-}

--- a/trview.app.ui.tests/SettingsWindowTests.cpp
+++ b/trview.app.ui.tests/SettingsWindowTests.cpp
@@ -957,43 +957,4 @@ void register_settings_window_tests(ImGuiTestEngine* engine)
             ctx->Yield();
             IM_CHECK_EQ(ctx->ItemIsChecked("TabBar/Visuals/Vsync"), true);
         });
-
-    test<MockWrapper<SettingsWindow>>(engine, "Settings Window", "Clicking Animated Textures Raises Event",
-        [](ImGuiTestContext* ctx) { render(ctx->GetVars<MockWrapper<SettingsWindow>>()); },
-        [](ImGuiTestContext* ctx)
-        {
-            auto& controls = ctx->GetVars<MockWrapper<SettingsWindow>>();
-            controls.ptr = register_test_module().build();
-            controls.ptr->toggle_visibility();
-
-            std::optional<bool> received_value;
-            auto token = controls.ptr->on_animated_textures += [&](bool value)
-                {
-                    received_value = value;
-                };
-
-            ctx->SetRef("Settings");
-            ctx->ItemClick("TabBar/Visuals");
-            IM_CHECK_EQ(ctx->ItemIsChecked("TabBar/Visuals/Animated Textures"), true);
-            ctx->ItemUncheck("TabBar/Visuals/Animated Textures");
-            IM_CHECK_EQ(ctx->ItemIsChecked("TabBar/Visuals/Animated Textures"), false);
-            IM_CHECK_EQ(received_value.has_value(), true);
-            IM_CHECK_EQ(received_value.value(), false);
-        });
-
-    test<MockWrapper<SettingsWindow>>(engine, "Settings Window", "Set Animated Textures Updates Checkbox",
-        [](ImGuiTestContext* ctx) { render(ctx->GetVars<MockWrapper<SettingsWindow>>()); },
-        [](ImGuiTestContext* ctx)
-        {
-            auto& controls = ctx->GetVars<MockWrapper<SettingsWindow>>();
-            controls.ptr = register_test_module().build();
-            controls.ptr->toggle_visibility();
-
-            ctx->SetRef("Settings");
-            ctx->ItemClick("TabBar/Visuals");
-            IM_CHECK_EQ(ctx->ItemIsChecked("TabBar/Visuals/Animated Textures"), true);
-            controls.ptr->set_animated_textures(false);
-            ctx->Yield();
-            IM_CHECK_EQ(ctx->ItemIsChecked("TabBar/Visuals/Animated Textures"), false);
-        });
 }

--- a/trview.app.ui.tests/ViewOptionsTests.cpp
+++ b/trview.app.ui.tests/ViewOptionsTests.cpp
@@ -714,4 +714,40 @@ void register_view_options_tests(ImGuiTestEngine* engine)
 
             IM_CHECK_EQ(ctx->ItemIsChecked("flags/Wireframe"), true);
         });
+
+    test<ViewOptionsContext>(engine, "View Options", "Animation Checkbox Toggle",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ViewOptionsContext>()); },
+        [](ImGuiTestContext* ctx)
+        {
+            auto& context = ctx->GetVars<ViewOptionsContext>();
+            context.ptr = register_test_module().build();
+            std::optional<std::tuple<std::string, bool>> clicked;
+            auto token = context.ptr->on_toggle_changed += [&](const std::string& name, bool value)
+                {
+                    clicked = { name, value };
+                };
+
+            ctx->SetRef("View Options");
+            ctx->ItemUncheck("flags/Animation");
+
+            IM_CHECK_EQ(clicked.has_value(), true);
+            IM_CHECK_EQ(std::get<0>(clicked.value()), IViewer::Options::animation);
+            IM_CHECK_EQ(std::get<1>(clicked.value()), false);
+        });
+
+    test<ViewOptionsContext>(engine, "View Options", "Animation Checkbox Updated",
+        [](ImGuiTestContext* ctx) { render(ctx->GetVars<ViewOptionsContext>()); },
+        [](ImGuiTestContext* ctx)
+        {
+            auto& context = ctx->GetVars<ViewOptionsContext>();
+            context.ptr = register_test_module().build();
+
+            ctx->SetRef("View Options");
+            IM_CHECK_EQ(ctx->ItemIsChecked("flags/Animation"), true);
+
+            context.ptr->set_toggle(IViewer::Options::animation, true);
+            ctx->Yield();
+
+            IM_CHECK_EQ(ctx->ItemIsChecked("flags/Wireframe"), false);
+        });
 }

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -511,7 +511,7 @@ namespace trview
         _timer.update();
         const auto elapsed = _timer.elapsed();
         _windows->update(elapsed);
-        if (_level && _settings.animated_textures)
+        if (_level)
         {
             _level->update(elapsed);
         }

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -118,6 +118,7 @@ namespace trview
         virtual void set_show_rooms(bool show) = 0;
         virtual void set_show_camera_sinks(bool show) = 0;
         virtual void set_show_sound_sources(bool show) = 0;
+        virtual void set_show_animation(bool show) = 0;
         virtual void set_neighbour_depth(uint32_t depth) = 0;
         virtual void set_selected_room(const std::weak_ptr<IRoom>& room) = 0;
         virtual void set_selected_item(const std::weak_ptr<IItem>& item) = 0;

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -1612,10 +1612,20 @@ namespace trview
 
     void Level::update(float delta)
     {
+        if (!_show_animation)
+        {
+            return;
+        }
+
         for (auto& room : _rooms)
         {
             room->update(delta);
         }
+    }
+
+    void Level::set_show_animation(bool show)
+    {
+        _show_animation = show;
     }
 
     bool find_item_by_type_id(const ILevel& level, uint32_t type_id, std::weak_ptr<IItem>& output_item)

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -135,6 +135,7 @@ namespace trview
         trlevel::PlatformAndVersion platform_and_version() const override;
         std::vector<std::weak_ptr<IFlyby>> flybys() const override;
         void update(float delta) override;
+        void set_show_animation(bool show) override;
     private:
         void generate_rooms(const trlevel::ILevel& level, const IRoom::Source& room_source, const IMeshStorage& mesh_storage);
         void generate_triggers(const ITrigger::Source& trigger_source);
@@ -241,6 +242,7 @@ namespace trview
         std::shared_ptr<trlevel::IPack> _pack;
         trlevel::PlatformAndVersion _platform_and_version;
         std::shared_ptr<IModelStorage> _model_storage;
+        bool _show_animation{ true };
     };
 
     /// Find the first item with the type id specified.

--- a/trview.app/Mocks/Elements/ILevel.h
+++ b/trview.app/Mocks/Elements/ILevel.h
@@ -88,6 +88,7 @@ namespace trview
             MOCK_METHOD(trlevel::PlatformAndVersion, platform_and_version, (), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<IFlyby>>, flybys, (), (const, override));
             MOCK_METHOD(void, update, (float), (override));
+            MOCK_METHOD(void, set_show_animation, (bool), (override));
 
             std::shared_ptr<MockLevel> with_version(trlevel::LevelVersion version)
             {

--- a/trview.app/Mocks/UI/ISettingsWindow.h
+++ b/trview.app/Mocks/UI/ISettingsWindow.h
@@ -35,7 +35,6 @@ namespace trview
             MOCK_METHOD(void, set_fov, (float), (override));
             MOCK_METHOD(void, set_camera_sink_startup, (bool), (override));
             MOCK_METHOD(void, set_statics_startup, (bool), (override));
-            MOCK_METHOD(void, set_animated_textures, (bool), (override));
             MOCK_METHOD(void, set_linear_filtering, (bool), (override));
         };
     }

--- a/trview.app/Settings/SettingsLoader.cpp
+++ b/trview.app/Settings/SettingsLoader.cpp
@@ -128,7 +128,6 @@ namespace trview
             read_attribute(json, settings.triggers_window_columns, "triggers_window_columns");
             read_attribute(json, settings.flyby_columns, "flyby_columns");
             read_attribute(json, settings.flyby_node_columns, "flyby_node_columns");
-            read_attribute(json, settings.animated_textures, "animated_textures");
             read_attribute(json, settings.linear_filtering, "linear_filtering");
 
             settings.recent_files.resize(std::min<std::size_t>(settings.recent_files.size(), settings.max_recent_files));
@@ -210,7 +209,6 @@ namespace trview
             json["triggers_window_columns"] = settings.triggers_window_columns;
             json["flyby_columns"] = settings.flyby_columns;
             json["flyby_node_columns"] = settings.flyby_node_columns;
-            json["animated_textures"] = settings.animated_textures;
             json["linear_filtering"] = settings.linear_filtering;
             _files->save_file(file_path, json.dump());
         }

--- a/trview.app/Settings/UserSettings.h
+++ b/trview.app/Settings/UserSettings.h
@@ -78,7 +78,6 @@ namespace trview
         std::vector<std::string> triggers_window_columns{ "#", "Type", "Room", "Hide" };
         std::vector<std::string> flyby_columns{ "#", "Hide" };
         std::vector<std::string> flyby_node_columns{ "#", "Room" };
-        bool animated_textures{ true };
         bool linear_filtering{ false };
 
         bool operator==(const UserSettings& other) const;

--- a/trview.app/UI/ISettingsWindow.h
+++ b/trview.app/UI/ISettingsWindow.h
@@ -81,7 +81,6 @@ namespace trview
         Event<bool> on_camera_sink_startup;
         Event<std::string, FontSetting> on_font;
         Event<bool> on_statics_startup;
-        Event<bool> on_animated_textures;
         Event<bool> on_linear_filtering;
 
         virtual void render() = 0;
@@ -185,7 +184,6 @@ namespace trview
         /// </summary>
         virtual void toggle_visibility() = 0;
         virtual void set_statics_startup(bool value) = 0;
-        virtual void set_animated_textures(bool value) = 0;
         virtual void set_linear_filtering(bool value) = 0;
     };
 }

--- a/trview.app/UI/SettingsWindow.cpp
+++ b/trview.app/UI/SettingsWindow.cpp
@@ -55,7 +55,6 @@ namespace trview
                 if (ImGui::BeginTabItem("Visuals"))
                 {
                     checkbox(Names::vsync, _vsync, on_vsync);
-                    checkbox(Names::animated_textures, _animated_textures, on_animated_textures);
                     checkbox(Names::linear_filtering, _linear_filtering, on_linear_filtering);
                     if (ImGui::ColorEdit3(Names::background_colour.c_str(), _colour))
                     {
@@ -338,11 +337,6 @@ namespace trview
     void SettingsWindow::set_statics_startup(bool value)
     {
         _statics_startup = value;
-    }
-
-    void SettingsWindow::set_animated_textures(bool value)
-    {
-        _animated_textures = value;
     }
 
     void SettingsWindow::set_linear_filtering(bool value)

--- a/trview.app/UI/SettingsWindow.h
+++ b/trview.app/UI/SettingsWindow.h
@@ -40,7 +40,6 @@ namespace trview
             static inline const std::string camera_sink_startup = "Open Camera/Sink Window at startup";
             static inline const std::string reset_fov = "Reset##Fov";
             static inline const std::string statics_startup = "Open Statics Window at startup";
-            static inline const std::string animated_textures = "Animated Textures";
             static inline const std::string linear_filtering = "Linear Filtering";
         };
 
@@ -71,7 +70,6 @@ namespace trview
         virtual void set_fov(float value) override;
         virtual void set_camera_sink_startup(bool value) override;
         void set_statics_startup(bool value) override;
-        void set_animated_textures(bool value) override;
         void set_linear_filtering(bool value) override;
     private:
         std::shared_ptr<IDialogs> _dialogs;
@@ -102,7 +100,6 @@ namespace trview
         std::vector<FontSetting> _all_fonts;
         std::shared_ptr<IFonts> _fonts;
         bool _statics_startup{ false };
-        bool _animated_textures{ true };
         bool _linear_filtering{ false };
     };
 }

--- a/trview.app/UI/ViewOptions.cpp
+++ b/trview.app/UI/ViewOptions.cpp
@@ -62,6 +62,7 @@ namespace trview
         _toggles[IViewer::Options::rooms] = true;
         _toggles[IViewer::Options::camera_sinks] = false;
         _toggles[IViewer::Options::lighting] = true;
+        _toggles[IViewer::Options::animation] = true;
         _toggles[IViewer::Options::notes] = true;
         _toggles[IViewer::Options::sound_sources] = false;
         _toggles[IViewer::Options::ng_plus] = false;
@@ -110,9 +111,11 @@ namespace trview
                 add_toggle(IViewer::Options::geometry);
                 ImGui::TableNextRow();
                 add_toggle(IViewer::Options::lighting);
-                add_toggle(IViewer::Options::notes);
+                add_toggle(IViewer::Options::animation);
                 ImGui::TableNextRow();
+                add_toggle(IViewer::Options::notes);
                 add_toggle(IViewer::Options::sound_sources);
+                ImGui::TableNextRow();
                 ImGui::BeginDisabled(!_ng_plus_enabled); 
                 add_toggle(IViewer::Options::ng_plus);
                 ImGui::EndDisabled();

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -155,7 +155,6 @@ namespace trview
         forward_setting(_settings_window->on_camera_fov, _settings.fov);
         forward_setting(_settings_window->on_camera_sink_startup, _settings.camera_sink_startup);
         forward_setting(_settings_window->on_statics_startup, _settings.statics_startup);
-        forward_setting(_settings_window->on_animated_textures, _settings.animated_textures);
         forward_setting(_settings_window->on_linear_filtering, _settings.linear_filtering);
         _settings_window->on_font += on_font;
         _settings_window->on_linear_filtering += on_linear_filtering;
@@ -409,7 +408,6 @@ namespace trview
         _settings_window->set_fov(settings.fov);
         _settings_window->set_camera_sink_startup(settings.camera_sink_startup);
         _settings_window->set_statics_startup(settings.statics_startup);
-        _settings_window->set_animated_textures(settings.animated_textures);
         _settings_window->set_linear_filtering(settings.linear_filtering);
         _camera_position->set_display_degrees(settings.camera_display_degrees);
         _camera_position->set_visible(settings.camera_position_window);

--- a/trview.app/Windows/IViewer.h
+++ b/trview.app/Windows/IViewer.h
@@ -30,6 +30,7 @@ namespace trview
             inline static const std::string rooms = "Rooms";
             inline static const std::string camera_sinks = "Camera/Sink";
             inline static const std::string lighting = "Lighting";
+            inline static const std::string animation = "Animation";
             inline static const std::string notes = "Notes";
             inline static const std::string sound_sources = "Sounds";
             inline static const std::string ng_plus = "NG+";

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -70,6 +70,7 @@ namespace trview
         toggles[Options::rooms] = [this](bool value) { set_show_rooms(value); };
         toggles[Options::camera_sinks] = [this](bool value) { set_show_camera_sinks(value); };
         toggles[Options::lighting] = [this](bool value) { set_show_lighting(value); };
+        toggles[Options::animation] = [this](bool value) { set_show_animation(value); };
         toggles[Options::notes] = [](bool) {};
         toggles[Options::sound_sources] = [this](bool value) { set_show_sound_sources(value); };
         toggles[Options::ng_plus] = [this](bool value) { set_ng_plus(value); };
@@ -777,6 +778,7 @@ namespace trview
         new_level->set_show_lighting(_ui->toggle(Options::lighting));
         new_level->set_show_sound_sources(_ui->toggle(Options::sound_sources));
         new_level->set_ng_plus(_ui->toggle(Options::ng_plus));
+        new_level->set_show_animation(_ui->toggle(Options::animation));
 
         // Set up the views.
         auto rooms = new_level->rooms();
@@ -1652,5 +1654,14 @@ namespace trview
                 set_camera_mode(ICamera::Mode::Orbit);
             }
         }
+    }
+
+    void Viewer::set_show_animation(bool show)
+    {
+        if (auto level = _level.lock())
+        {
+            level->set_show_animation(show);
+        }
+        set_toggle(Options::animation, show);
     }
 }

--- a/trview.app/Windows/Viewer.h
+++ b/trview.app/Windows/Viewer.h
@@ -137,6 +137,7 @@ namespace trview
         void set_toggle(const std::string& name, bool value);
         void set_show_sound_sources(bool show);
         void set_ng_plus(bool show);
+        void set_show_animation(bool show);
 
         const std::shared_ptr<graphics::IDevice> _device;
         const std::shared_ptr<IShortcuts>& _shortcuts;


### PR DESCRIPTION
Move the toggle for animated textures to the view options flags area.
Should be easier to find and matches placement of lighting.
Closes #1476