### PR TITLE
Use correct sampler in transparency to apply point

### DIFF
--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -24,6 +24,7 @@
 #include <trview.graphics/mocks/IBuffer.h>
 #include <trview.tests.common/Event.h>
 #include <trview.app/Mocks/Elements/INgPlusSwitcher.h>
+#include <trview.graphics/mocks/ISamplerState.h>
 
 using namespace trview;
 using namespace trview::mocks;
@@ -63,11 +64,12 @@ namespace
             ISoundSource::Source sound_source_source{ [](auto&&...) { return mock_shared<MockSoundSource>(); } };
             std::shared_ptr<ISoundStorage> sound_storage{ mock_shared<MockSoundStorage>() };
             std::shared_ptr<INgPlusSwitcher> ngplus_switcher{ mock_shared<MockNgPlusSwitcher>() };
+            std::shared_ptr<ISamplerState> sampler_state{ mock_shared<MockSamplerState>() };
             IFlyby::Source flyby_source{ [](auto&&...) { return mock_shared<MockFlyby>(); } };
 
             std::shared_ptr<Level> build()
             {
-                auto new_level = std::make_shared<Level>(device, shader_storage, level_texture_storage, std::move(transparency_buffer), std::move(selection_renderer), log, buffer_source, sound_storage, ngplus_switcher);
+                auto new_level = std::make_shared<Level>(device, shader_storage, level_texture_storage, std::move(transparency_buffer), std::move(selection_renderer), log, buffer_source, sound_storage, ngplus_switcher, sampler_state);
                 new_level->initialise(std::move(level), mesh_storage, model_storage, entity_source, ai_source, room_source, trigger_source, light_source, camera_sink_source, sound_source_source, flyby_source, callbacks);
                 return new_level;
             }

--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -352,7 +352,8 @@ namespace trview
                     log,
                     buffer_source,
                     sound_storage,
-                    ngplus);
+                    ngplus,
+                    clamp_sampler_state);
                 new_level->initialise(level,
                     mesh_storage,
                     model_storage,

--- a/trview.app/Elements/Level.h
+++ b/trview.app/Elements/Level.h
@@ -8,6 +8,9 @@
 
 #include <trlevel/ILevel.h>
 #include "ILevel.h"
+
+#include <trview.graphics/Sampler/ISamplerState.h>
+
 #include "../Geometry/ITransparencyBuffer.h"
 #include "../Graphics/ISelectionRenderer.h"
 #include "../Graphics/IMeshStorage.h"
@@ -42,7 +45,8 @@ namespace trview
             const std::shared_ptr<ILog>& log,
             const graphics::IBuffer::ConstantSource& buffer_source,
             std::shared_ptr<ISoundStorage> sound_storage,
-            std::shared_ptr<INgPlusSwitcher> ngplus_switcher);
+            std::shared_ptr<INgPlusSwitcher> ngplus_switcher,
+            const std::shared_ptr<graphics::ISamplerState>& sampler_state);
         virtual ~Level() = default;
         virtual std::vector<graphics::Texture> level_textures() const override;
         virtual std::optional<uint32_t> selected_item() const override;
@@ -196,8 +200,7 @@ namespace trview
 
         graphics::IShader*          _vertex_shader;
         graphics::IShader*          _pixel_shader;
-        Microsoft::WRL::ComPtr<ID3D11SamplerState> _room_sampler_state;
-        Microsoft::WRL::ComPtr<ID3D11SamplerState> _object_sampler_state;
+        std::shared_ptr<graphics::ISamplerState> _room_sampler_state;
         Microsoft::WRL::ComPtr<ID3D11RasterizerState> _default_rasterizer;
         Microsoft::WRL::ComPtr<ID3D11RasterizerState> _wireframe_rasterizer;
         std::unique_ptr<graphics::IBuffer> _pixel_shader_data;


### PR DESCRIPTION
Point filtering was not applying to transparency as Level was still creating its own sampler without reading the settings.
Pass in one of the shared samplers that will be updated when the setting changes.
Closes #1484