### PR TITLE
Retransform to remove scaling in picking

### DIFF
--- a/trview.app/Elements/Item.cpp
+++ b/trview.app/Elements/Item.cpp
@@ -183,6 +183,7 @@ namespace trview
             if (result.hit)
             {
                 result.item = std::const_pointer_cast<IItem>(shared_from_this());
+                result.type = PickResult::Type::Entity;
                 return result;
             }
         }


### PR DESCRIPTION
If the mesh contains a scaling matrix the distance calculation on the pick was coming out scaled - it needs to be retransformed and the distance calculated again.
Mainly affected the null mesh as it was the only thing with a scale.
Closes #1483