### PR TITLE
Select sector in room window when selected in diff

### DIFF
--- a/external/DirectXTK/DirectXTK_Desktop.vcxproj
+++ b/external/DirectXTK/DirectXTK_Desktop.vcxproj
@@ -59,7 +59,7 @@
     <ProjectGuid>{A11566D3-4081-42C9-94C5-F4057EDD9D50}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>DirectXTK</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/external/freetype/builds/windows/vc2010/freetype.vcxproj
+++ b/external/freetype/builds/windows/vc2010/freetype.vcxproj
@@ -25,6 +25,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}</ProjectGuid>
     <RootNamespace>FreeType</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="PlatformToolset">

--- a/external/googlemock/googlemock.vcxproj
+++ b/external/googlemock/googlemock.vcxproj
@@ -62,7 +62,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{6e37091e-954c-4654-9b42-5980410791f4}</ProjectGuid>
     <RootNamespace>googlemock</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/external/googletest/googletest.vcxproj
+++ b/external/googletest/googletest.vcxproj
@@ -71,7 +71,7 @@
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="src\gtest.cc">      
+    <ClCompile Include="src\gtest.cc">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
@@ -85,7 +85,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{eafd7489-57e3-4b6d-a704-f7c5ef640434}</ProjectGuid>
     <RootNamespace>googletest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/external/imgui/imgui.vcxproj
+++ b/external/imgui/imgui.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{6aabd08e-3361-4d84-88f0-851ee588162a}</ProjectGuid>
     <RootNamespace>imgui</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/external/imgui_test_engine/imgui_test_engine.vcxproj
+++ b/external/imgui_test_engine/imgui_test_engine.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E6FAC6EF-4B54-45C4-9E76-3B063B51D4B9}</ProjectGuid>
     <RootNamespace>imgui_test_engine</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/external/lua/lua.vcxproj
+++ b/external/lua/lua.vcxproj
@@ -77,7 +77,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{2a4f1e89-71ac-46c3-a711-1a4d67accdf5}</ProjectGuid>
     <RootNamespace>lua</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/external/zlib/contrib/vstudio/vc14/zlibstat.vcxproj
+++ b/external/zlib/contrib/vstudio/vc14/zlibstat.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">

--- a/trlevel.tests/trlevel.tests.vcxproj
+++ b/trlevel.tests/trlevel.tests.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{49a67578-3b2c-4ae2-a2a1-fd00ef9148eb}</ProjectGuid>
     <RootNamespace>trleveltests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trlevel/trlevel.vcxproj
+++ b/trlevel/trlevel.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{8FFB19FA-1C9D-4D9C-AB96-844BF695E79C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trlevel</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.app.tests/RoomsWindowManagerTests.cpp
+++ b/trview.app.tests/RoomsWindowManagerTests.cpp
@@ -167,3 +167,21 @@ TEST(RoomsWindowManager, SetTrngPassedToWindows)
     manager->create_window();
     manager->set_trng(true);
 }
+
+TEST(RoomsWindowManager, SetSelectedSectorForwarded)
+{
+    auto mock_window = mock_shared<MockRoomsWindow>();
+    EXPECT_CALL(*mock_window, set_selected_sector).Times(2);
+
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+    manager->set_selected_sector(mock_shared<MockSector>());
+}
+
+TEST(RoomsWindowManager, SelectedSectorPassedToNewWindows)
+{
+    auto mock_window = mock_shared<MockRoomsWindow>();
+    EXPECT_CALL(*mock_window, set_selected_sector).Times(1);
+    auto manager = register_test_module().with_window_source([&](auto&&...) { return mock_window; }).build();
+    manager->create_window();
+}

--- a/trview.app.tests/Windows/WindowsTests.cpp
+++ b/trview.app.tests/Windows/WindowsTests.cpp
@@ -857,3 +857,18 @@ TEST(Windows, WindowsUpdated)
 
     windows->update(1.0f);
 }
+
+TEST(Windows, SectorSelectedForwarded)
+{
+    auto [rooms_ptr, rooms] = create_mock<MockRoomsWindowManager>();
+    EXPECT_CALL(rooms, set_selected_sector).Times(1);
+
+    auto [diffs_ptr, diffs] = create_mock<MockDiffWindowManager>();
+
+    auto windows = register_test_module()
+        .with_rooms(std::move(rooms_ptr))
+        .with_diffs(std::move(diffs_ptr))
+        .build();
+
+    diffs.on_sector_selected(mock_shared<MockSector>());
+}

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -130,7 +130,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{5305889D-8CCB-4A81-B77E-D46F03131114}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.app.ui.tests/trview.app.ui.tests.vcxproj
+++ b/trview.app.ui.tests/trview.app.ui.tests.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{6c2653fe-19d4-4696-924f-c313ecbc69b2}</ProjectGuid>
     <RootNamespace>trviewappuitests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.app/Mocks/Windows/IRoomsWindow.h
+++ b/trview.app/Mocks/Windows/IRoomsWindow.h
@@ -24,6 +24,7 @@ namespace trview
             MOCK_METHOD(void, set_floordata, (const std::vector<uint16_t>&), (override));
             MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
             MOCK_METHOD(void, set_selected_light, (const std::weak_ptr<ILight>&), (override));
+            MOCK_METHOD(void, set_selected_sector, (const std::weak_ptr<ISector>&), (override));
             MOCK_METHOD(void, clear_selected_light, (), (override));
             MOCK_METHOD(void, clear_selected_camera_sink, (), (override));
             MOCK_METHOD(void, set_ng_plus, (bool), (override));

--- a/trview.app/Mocks/Windows/IRoomsWindowManager.h
+++ b/trview.app/Mocks/Windows/IRoomsWindowManager.h
@@ -24,6 +24,7 @@ namespace trview
             MOCK_METHOD(void, set_floordata, (const std::vector<uint16_t>&), (override));
             MOCK_METHOD(void, set_selected_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
             MOCK_METHOD(void, set_selected_light, (const std::weak_ptr<ILight>&), (override));
+            MOCK_METHOD(void, set_selected_sector, (const std::weak_ptr<ISector>&), (override));
             MOCK_METHOD(void, set_ng_plus, (bool), (override));
             MOCK_METHOD(void, set_trng, (bool), (override));
             MOCK_METHOD(std::vector<std::weak_ptr<IRoomsWindow>>, windows, (), (const, override));

--- a/trview.app/Type.h
+++ b/trview.app/Type.h
@@ -8,6 +8,7 @@ namespace trview
         Item,
         Light,
         Room,
+        Sector,
         Trigger
     };
 

--- a/trview.app/Type.inl
+++ b/trview.app/Type.inl
@@ -14,6 +14,8 @@ namespace trview
             return "Light";
         case Type::Room:
             return "Room";
+        case Type::Sector:
+            return "Sector";
         case Type::Trigger:
             return "Trigger";
         }

--- a/trview.app/Windows/IRoomsWindow.h
+++ b/trview.app/Windows/IRoomsWindow.h
@@ -89,5 +89,6 @@ namespace trview
         virtual void set_trng(bool value) = 0;
         virtual std::string name() const = 0;
         virtual void set_filters(std::vector<Filters<IRoom>::Filter> filters) = 0;
+        virtual void set_selected_sector(const std::weak_ptr<ISector>& sector) = 0;
     };
 }

--- a/trview.app/Windows/IRoomsWindowManager.h
+++ b/trview.app/Windows/IRoomsWindowManager.h
@@ -61,6 +61,7 @@ namespace trview
         virtual void set_floordata(const std::vector<uint16_t>& data) = 0;
         virtual void set_selected_light(const std::weak_ptr<ILight>& light) = 0;
         virtual void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
+        virtual void set_selected_sector(const std::weak_ptr<ISector>& sector) = 0;
         virtual void set_ng_plus(bool value) = 0;
         virtual void set_trng(bool value) = 0;
         virtual std::vector<std::weak_ptr<IRoomsWindow>> windows() const = 0;

--- a/trview.app/Windows/RoomsWindow.h
+++ b/trview.app/Windows/RoomsWindow.h
@@ -54,6 +54,7 @@ namespace trview
         void set_trng(bool value) override;
         std::string name() const override;
         void set_filters(std::vector<Filters<IRoom>::Filter> filters) override;
+        void set_selected_sector(const std::weak_ptr<ISector>& sector) override;
     private:
         void set_sync_room(bool value);
         void render_rooms_list();
@@ -66,7 +67,6 @@ namespace trview
         void render_items_tab(const std::shared_ptr<IRoom>& room);
         void render_triggers_tab();
         void render_floordata_tab(const std::shared_ptr<IRoom>& room);
-        void set_selected_sector(const std::shared_ptr<ISector>& sector);
         void render_camera_sink_tab();
         void render_lights_tab();
         void set_triggers(const std::vector<std::weak_ptr<ITrigger>>& triggers);
@@ -104,6 +104,9 @@ namespace trview
         std::weak_ptr<IStaticMesh> _local_selected_static_mesh;
         bool _scroll_to_static_mesh{ false };
 
+        std::weak_ptr<ISector> _global_selected_sector;
+        std::weak_ptr<ISector> _local_selected_sector;
+
         std::weak_ptr<IRoom> _current_room;
         std::weak_ptr<IRoom> _selected_room;
 
@@ -124,9 +127,8 @@ namespace trview
         std::vector<uint16_t> _floordata;
         bool _simple_mode{ true };
         bool _in_floordata_mode{ false };
-        std::weak_ptr<ISector> _selected_sector;
         uint32_t _selected_floordata{ 0 };
-        Track<Type::Item, Type::Trigger, Type::Light, Type::CameraSink> _track;
+        Track<Type::Item, Type::Trigger, Type::Light, Type::CameraSink, Type::Sector> _track;
 
         bool _ng_plus{ false };
         AutoHider _auto_hider;

--- a/trview.app/Windows/RoomsWindowManager.cpp
+++ b/trview.app/Windows/RoomsWindowManager.cpp
@@ -117,6 +117,7 @@ namespace trview
         rooms_window->set_selected_trigger(_selected_trigger);
         rooms_window->set_selected_camera_sink(_selected_camera_sink);
         rooms_window->set_selected_light(_selected_light);
+        rooms_window->set_selected_sector(_selected_sector);
         rooms_window->set_ng_plus(_ng_plus);
         rooms_window->set_trng(_trng);
         return add_window(rooms_window);
@@ -151,6 +152,15 @@ namespace trview
         for (auto& window : _windows)
         {
             window.second->set_selected_camera_sink(camera_sink);
+        }
+    }
+
+    void RoomsWindowManager::set_selected_sector(const std::weak_ptr<ISector>& sector)
+    {
+        _selected_sector = sector;
+        for (auto& window : _windows)
+        {
+            window.second->set_selected_sector(sector);
         }
     }
 

--- a/trview.app/Windows/RoomsWindowManager.h
+++ b/trview.app/Windows/RoomsWindowManager.h
@@ -45,6 +45,7 @@ namespace trview
         void set_floordata(const std::vector<uint16_t>& data) override;
         void set_selected_light(const std::weak_ptr<ILight>& light) override;
         void set_selected_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
+        void set_selected_sector(const std::weak_ptr<ISector>& sector) override;
         void set_ng_plus(bool value) override;
         void set_trng(bool value) override;
         std::vector<std::weak_ptr<IRoomsWindow>> windows() const override;
@@ -61,6 +62,7 @@ namespace trview
         std::vector<std::weak_ptr<ICameraSink>> _all_camera_sinks;
         std::weak_ptr<ICameraSink> _selected_camera_sink;
         std::weak_ptr<ILight> _selected_light;
+        std::weak_ptr<ISector> _selected_sector;
         bool _ng_plus{ false };
         bool _trng{ false };
     };

--- a/trview.app/Windows/Windows.cpp
+++ b/trview.app/Windows/Windows.cpp
@@ -62,7 +62,11 @@ namespace trview
         _diff_windows->on_static_mesh_selected += on_static_selected;
         _diff_windows->on_sound_source_selected += on_sound_source_selected;
         _diff_windows->on_room_selected += on_room_selected;
-        _diff_windows->on_sector_selected += on_sector_selected;
+        _token_store += _diff_windows->on_sector_selected += [this](auto sector)
+            {
+                on_sector_selected(sector);
+                _rooms_windows->set_selected_sector(sector);
+            };
         _diff_windows->on_settings += on_settings;
 
         _token_store += _items_windows->on_add_to_route += [this](auto item)

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -529,7 +529,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ProjectGuid>{A087AF08-5371-47DE-A896-AFA21DD9D383}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewapp</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.common.tests/trview.common.tests.vcxproj
+++ b/trview.common.tests/trview.common.tests.vcxproj
@@ -40,7 +40,7 @@
     <ProjectGuid>{9BBDFA49-4033-49B3-8EE2-E75C5950D5B0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewcommontests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -85,7 +85,7 @@
     <ProjectGuid>{D0633291-23A6-4B3F-9A5E-E94D20F66A07}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewcommon</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.graphics.tests/trview.graphics.tests.vcxproj
+++ b/trview.graphics.tests/trview.graphics.tests.vcxproj
@@ -33,7 +33,7 @@
     <ProjectGuid>{6E6B151D-DF48-4FE2-B7AF-2D07FB3451D2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewgraphicstests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.graphics/trview.graphics.vcxproj
+++ b/trview.graphics/trview.graphics.vcxproj
@@ -103,7 +103,7 @@
     <ProjectGuid>{3270FD29-EDAB-40BE-8CA1-DABC5E261E4C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewgraphics</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.input.tests/trview.input.tests.vcxproj
+++ b/trview.input.tests/trview.input.tests.vcxproj
@@ -37,7 +37,7 @@
     <PlatformToolset>v143</PlatformToolset>
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/trview.input/trview.input.vcxproj
+++ b/trview.input/trview.input.vcxproj
@@ -39,7 +39,7 @@
     <ProjectGuid>{0B28C3CD-D28A-4923-9577-50EB1EE29212}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewinput</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.lau/trview.lau.vcxproj
+++ b/trview.lau/trview.lau.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{2ac76373-f9a6-426d-b732-80e6bd6bfab4}</ProjectGuid>
     <RootNamespace>trviewlau</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.lua.imgui/trview.lua.imgui.vcxproj
+++ b/trview.lua.imgui/trview.lua.imgui.vcxproj
@@ -33,7 +33,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{cdbc4705-e8e2-4c5c-a1a6-ea66fe4b699b}</ProjectGuid>
     <RootNamespace>trviewluaimgui</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.shaders/trview.shaders.vcxproj
+++ b/trview.shaders/trview.shaders.vcxproj
@@ -14,7 +14,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{9E86C96A-6192-462C-A2A2-263990A53C1F}</ProjectGuid>
     <RootNamespace>trviewshaders</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.tests.common/trview.tests.common.vcxproj
+++ b/trview.tests.common/trview.tests.common.vcxproj
@@ -24,7 +24,7 @@
     <ProjectGuid>{3AB44A93-DBBA-405E-8164-E5B20866EE1D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewtestscommon</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview/trview.vcxproj
+++ b/trview/trview.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{8406D3CD-8C08-45C2-AF2C-844014A687A1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trview</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">


### PR DESCRIPTION
When user clicks on a sector in the diff window select that sector in the rooms window so the floordata mode can be more easily used to know exactly which sector it is that has changed.
Also update the windows SDK because the GitHub agents don't have the current one.
Closes #1340