### PR TITLE
Add water scheme to room properties

### DIFF
--- a/doc/lua/room.md
+++ b/doc/lua/room.md
@@ -22,6 +22,7 @@ The Room library provides information about a room in a [level](level.md).
 | static_meshes | [StaticMesh](staticmesh.md)[] | R | Static meshes in the room |
 | triggers | [Trigger](trigger.md)[] | R | Triggers in the room |
 | visible | boolean | RW | Whether the room is visible in the viewer |
+| water_scheme | number | R | Water scheme value for room (TR3+) |
 
 # Functions
 

--- a/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_RoomTests.cpp
@@ -367,3 +367,15 @@ TEST(Lua_Room, SetVisible)
     ASSERT_EQ(0, luaL_dostring(L, "r.visible = true"));
 }
 
+TEST(Lua_Room, WaterScheme)
+{
+    auto room = mock_shared<MockRoom>()->with_water_scheme(9);
+
+    LuaState L;
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return r.water_scheme"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(9, lua_tonumber(L, -1));
+}

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -328,6 +328,7 @@ namespace trview
         virtual std::weak_ptr<ILevel> level() const = 0;
         virtual std::vector<std::weak_ptr<IStaticMesh>> static_meshes() const = 0;
         virtual void update(float delta) = 0;
+        virtual uint16_t water_scheme() const = 0;
     };
 
     /// <summary>

--- a/trview.app/Elements/Room.cpp
+++ b/trview.app/Elements/Room.cpp
@@ -57,7 +57,8 @@ namespace trview
         _ambient(room.colour),
         _ambient_intensity_1(room.ambient_intensity_1),
         _ambient_intensity_2(room.ambient_intensity_2),
-        _light_mode(room.light_mode)
+        _light_mode(room.light_mode),
+        _water_scheme(room.water_scheme)
     {
         _ambient.a = 1.0f;
 
@@ -1168,6 +1169,11 @@ namespace trview
         {
             _mesh->update(delta);
         }
+    }
+
+    uint16_t Room::water_scheme() const
+    {
+        return _water_scheme;
     }
 
     std::shared_ptr<ISector> sector_from_point(const IRoom& room, const Vector3& point)

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -104,6 +104,7 @@ namespace trview
             const Activity& activity);
         std::vector<std::weak_ptr<IStaticMesh>> static_meshes() const override;
         void update(float delta) override;
+        uint16_t water_scheme() const override;
     private:
         void generate_geometry(const IMesh::Source& mesh_source, const trlevel::tr3_room& room);
         void generate_adjacency();
@@ -169,5 +170,7 @@ namespace trview
 
         std::shared_ptr<graphics::ISamplerState> _geometry_sampler_state;
         std::shared_ptr<graphics::ISamplerState> _sampler_state;
+
+        uint16_t _water_scheme{ 0u };
     };
 }

--- a/trview.app/Lua/Elements/Room/Lua_Room.cpp
+++ b/trview.app/Lua/Elements/Room/Lua_Room.cpp
@@ -147,6 +147,11 @@ namespace trview
                     lua_pushboolean(L, room->visible());
                     return 1;
                 }
+                else if (key == "water_scheme")
+                {
+                    lua_pushnumber(L, room->water_scheme());
+                    return 1;
+                }
 
                 return 0;
             }

--- a/trview.app/Mocks/Elements/IRoom.h
+++ b/trview.app/Mocks/Elements/IRoom.h
@@ -63,6 +63,7 @@ namespace trview
             MOCK_METHOD(std::weak_ptr<ILevel>, level, (), (const, override));
             MOCK_METHOD(std::vector<std::weak_ptr<IStaticMesh>>, static_meshes, (), (const));
             MOCK_METHOD(void, update, (float), (override));
+            MOCK_METHOD(uint16_t, water_scheme, (), (const, override));
 
             bool _visible_state{ false };
 
@@ -119,6 +120,12 @@ namespace trview
                 _visible_state = value;
                 ON_CALL(*this, visible).WillByDefault([&]() { return _visible_state; });
                 ON_CALL(*this, set_visible).WillByDefault([&](auto v) { _visible_state = v; });
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockRoom> with_water_scheme(uint16_t value)
+            {
+                ON_CALL(*this, water_scheme).WillByDefault(testing::Return(value));
                 return shared_from_this();
             }
         };

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -631,6 +631,10 @@ namespace trview
             });
         _filters.add_getter<bool>("Hide", [](auto&& room) { return !room.visible(); }, EditMode::ReadWrite);
         _filters.add_getter<bool>("Water", [](auto&& room) { return room.water(); });
+        if (_level_version >= trlevel::LevelVersion::Tomb3)
+        {
+            _filters.add_getter<int>("Water Scheme", [](auto&& room) { return room.water_scheme(); });
+        }
         _filters.add_getter<bool>("Bit 1", [](auto&& room) { return room.flag(IRoom::Flag::Bit1); });
         _filters.add_getter<bool>("Bit 2", [](auto&& room) { return room.flag(IRoom::Flag::Bit2); });
         _filters.add_getter<bool>("Outside/Bit 3", [](auto&& room) { return room.outside(); });
@@ -771,6 +775,12 @@ namespace trview
                 ImGui::SetCursorPosY(ImGui::GetCursorPosY() - 2.0f);
                 ImGui::ColorButton("##ambientbutton", ImVec4(ambient.r, ambient.g, ambient.b, 1.0f), 0, ImVec2(16, 16));
             }
+
+            if (_level_version >= trlevel::LevelVersion::Tomb3)
+            {
+                add_stat("Water Scheme", room->water_scheme());
+            }
+
             add_room_flags(*_clipboard, _level_version, *room);
             ImGui::EndTable();
         }


### PR DESCRIPTION
Add the water scheme to room properties in the rooms window when the level version is >= 3 (when the property appears).
Add to filters.
Add Lua binding and docs.
Closes #1490