### PR TITLE
Handle multiple portals on a sector

### DIFF
--- a/trview.app.tests/Elements/SectorTests.cpp
+++ b/trview.app.tests/Elements/SectorTests.cpp
@@ -25,5 +25,5 @@ TEST(Sector, HighNumberedPortal)
 
     Sector s(level, tr_room, sector, 0, room, 0);
 
-    ASSERT_EQ(s.portal(), 378);
+    ASSERT_EQ(s.portals(), std::vector<uint16_t>{ 378 });
 }

--- a/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
@@ -209,6 +209,31 @@ TEST(Lua_Sector, Portal)
     ASSERT_EQ(10, lua_tointeger(L, -1));
 }
 
+TEST(Lua_Sector, Portals)
+{
+    auto level = mock_shared<MockLevel>();
+    auto room_10 = mock_shared<MockRoom>()->with_level(level)->with_number(10);
+    ON_CALL(*level, room(10)).WillByDefault(Return(room_10));
+    auto room_12 = mock_shared<MockRoom>()->with_level(level)->with_number(12);
+    ON_CALL(*level, room(12)).WillByDefault(Return(room_12));
+
+    auto sector = mock_shared<MockSector>()->with_room(room_10)->with_portals({ 10, 12 });
+    ON_CALL(*sector, is_portal).WillByDefault(Return(true));
+
+    LuaState L;
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.portals"));
+    ASSERT_EQ(LUA_TTABLE, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.portals[1].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(10, lua_tointeger(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.portals[2].number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(12, lua_tointeger(L, -1));
+}
+
 TEST(Lua_Sector, Room)
 {
     auto room = mock_shared<MockRoom>()->with_number(10);

--- a/trview.app/Elements/ISector.h
+++ b/trview.app/Elements/ISector.h
@@ -94,7 +94,7 @@ namespace trview
         };
 
         virtual ~ISector() = 0;
-        virtual std::uint16_t portal() const = 0;
+        virtual std::vector<std::uint16_t> portals() const = 0;
         virtual int id() const = 0;
         virtual std::set<std::uint16_t> neighbours() const = 0;
         virtual std::uint16_t room_below() const = 0;

--- a/trview.app/Elements/Room.h
+++ b/trview.app/Elements/Room.h
@@ -113,7 +113,7 @@ namespace trview
         void render_contained(const ICamera& camera, const DirectX::SimpleMath::Color& colour, RenderFilter render_filter);
         void get_contained_transparent_triangles(ITransparencyBuffer& transparency, const ICamera& camera, const DirectX::SimpleMath::Color& colour, RenderFilter render_filter);
         void generate_sectors(const trlevel::ILevel& level, const trlevel::tr3_room& room, const ISector::Source& sector_source, uint32_t sector_base_index);
-        ISector* get_trigger_sector(int32_t x, int32_t z);
+        ISector* get_trigger_sector(const ITrigger& trigger, int32_t dx, int32_t dz);
         uint32_t get_sector_id(int32_t x, int32_t z) const;
 
         /// Find any transparent triangles that match floor data geometry.

--- a/trview.app/Elements/Sector.cpp
+++ b/trview.app/Elements/Sector.cpp
@@ -17,13 +17,9 @@ namespace trview
         calculate_neighbours(level);
     }
 
-    std::uint16_t
-    Sector::portal() const
+    std::vector<std::uint16_t> Sector::portals() const
     {
-        if (!has_flag(_flags, SectorFlag::Portal))
-            throw std::runtime_error("Sector does not have portal function");
-
-        return _portal;
+        return _portals;
     }
 
     std::set<std::uint16_t> 
@@ -75,7 +71,7 @@ namespace trview
                 case Function::Portal:
                 {
                     _flags |= SectorFlag::Portal;
-                    _portal = command.data[1];
+                    _portals.push_back(command.data[1]);
                     break;
                 }
                 case Function::FloorSlant:
@@ -386,7 +382,10 @@ namespace trview
 
         if (has_flag(_flags, SectorFlag::Portal))
         {
-            add_neighbour(_portal);
+            for (const auto& portal : _portals)
+            {
+                add_neighbour(portal);
+            }
         }
 
         if (has_flag(_flags, SectorFlag::RoomAbove))

--- a/trview.app/Elements/Sector.h
+++ b/trview.app/Elements/Sector.h
@@ -13,7 +13,7 @@ namespace trview
         Sector(const trlevel::ILevel& level, const trlevel::tr3_room& room, const trlevel::tr_room_sector& sector, int sector_id, const std::weak_ptr<IRoom>& room_ptr, uint32_t sector_number);
         virtual ~Sector() = default;
         // Returns the id of the room that this floor data points to 
-        virtual std::uint16_t portal() const override;
+        virtual std::vector<std::uint16_t> portals() const override;
         // Gets/sets id of the sector. Used by map renderer. 
         virtual int id() const override { return _sector_id; }
         // Returns all neighbours for the current sector, maximum of 3 (up, down, portal). 
@@ -62,7 +62,7 @@ namespace trview
         SectorFlag _flags{ SectorFlag::None };
 
         // Holds the "wall portal" that this sector points to - this is the id of the room 
-        std::uint16_t _portal;
+        std::vector<uint16_t> _portals;
         std::uint8_t _room_above;
         std::uint8_t _room_below;
 

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -171,7 +171,25 @@ namespace trview
                         {
                             if (auto level = room->level().lock())
                             {
-                                return create_room(L, level->room(sector->portal()).lock());
+                                return create_room(L, level->room(sector->portals()[0]).lock());
+                            }
+                        }
+                    }
+                    lua_pushnil(L);
+                }
+                else if (key == "portals")
+                {
+                    if (sector->is_portal())
+                    {
+                        if (auto room = sector->room().lock())
+                        {
+                            if (auto level = room->level().lock())
+                            {
+                                lua_newtable(L);
+                                push_list(L,
+                                    sector->portals(),
+                                    [&](auto L, auto f) { create_room(L, level->room(f).lock()); });
+                                return 1;
                             }
                         }
                     }

--- a/trview.app/Mocks/Elements/ISector.h
+++ b/trview.app/Mocks/Elements/ISector.h
@@ -10,7 +10,7 @@ namespace trview
         {
             MockSector();
             virtual ~MockSector();
-            MOCK_METHOD(std::uint16_t, portal, (), (const, override));
+            MOCK_METHOD(std::vector<std::uint16_t>, portals, (), (const, override));
             MOCK_METHOD(int, id, (), (const, override));
             MOCK_METHOD(std::set<std::uint16_t>, neighbours, (), (const, override));
             MOCK_METHOD(std::uint16_t, room_below, (), (const, override));
@@ -74,7 +74,13 @@ namespace trview
 
             std::shared_ptr<MockSector> with_portal(uint16_t portal)
             {
-                ON_CALL(*this, portal).WillByDefault(testing::Return(portal));
+                ON_CALL(*this, portals).WillByDefault(testing::Return(std::vector<uint16_t>{ portal }));
+                return shared_from_this();
+            }
+
+            std::shared_ptr<MockSector> with_portals(const std::vector<uint16_t>& portals)
+            {
+                ON_CALL(*this, portals).WillByDefault(testing::Return(portals));
                 return shared_from_this();
             }
 

--- a/trview.app/UI/MapRenderer.cpp
+++ b/trview.app/UI/MapRenderer.cpp
@@ -127,7 +127,8 @@ namespace trview
 
             if (has_flag(tile.sector->flags(), SectorFlag::Portal))
             {
-                _font->render(context, std::to_wstring(tile.sector->portal()), tile.position.x - 1, tile.position.y, tile.size.width, tile.size.height, text_color);
+                const std::wstring text = std::format(L"{}{}", tile.sector->portals()[0], tile.sector->portals().size() > 1 ? L"+" : L"");
+                _font->render(context, text, tile.position.x - 1, tile.position.y, tile.size.width, tile.size.height, text_color);
             }
 
             if (_selected_sector.lock() == tile.sector)

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -401,7 +401,7 @@ namespace trview
                                     {
                                         if (auto level = room->level().lock())
                                         {
-                                            on_room_selected(level->room(sector->portal()));
+                                            on_room_selected(level->room(sector->portals()[0]));
                                         }
                                     }
                                     else if (sector->room_below() != 0xff)

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -659,7 +659,7 @@ namespace trview
                         {
                             if (has_flag(sector->flags(), SectorFlag::Portal))
                             {
-                                on_room_selected(level->room(sector->portal()));
+                                on_room_selected(level->room(sector->portals()[0]));
                             }
                             else if (!_settings.invert_map_controls && has_flag(sector->flags(), SectorFlag::RoomBelow))
                             {


### PR DESCRIPTION
Sometimes sectors can have several portals on a sector - forward and up usually. Previous the second portal was overwriting the original. This changes it to store all of them and act on the 0th one - this is usually the forward portal. At some point will rewrite the minimap to be able to display the extra portals.

This won't fix geometry mode issues that were caused by the overwritten portals, that is in a separate issue.

Closes #1496