### PR TITLE
Fix off-by-one in size for textures

### DIFF
--- a/trview.app/Graphics/LevelTextureStorage.cpp
+++ b/trview.app/Graphics/LevelTextureStorage.cpp
@@ -222,8 +222,8 @@ namespace trview
                 .uvs = ot.Vertices | std::views::transform([&](auto&& v) -> Vector2
                 {
                     return Vector2(
-                        (static_cast<float>(v.x_whole - min_x) / (width - 1)),
-                        (static_cast<float>(v.y_whole - min_y) / (height - 1)));
+                        (static_cast<float>(v.x_whole - min_x) / width),
+                        (static_cast<float>(v.y_whole - min_y) / height));
                 }) | std::ranges::to<std::vector>(),
                 .tile = _texture_storage->num_textures()
             };


### PR DESCRIPTION
Change the `x or y +1` into `max(x or y, 1)` for texture size calculation in texture replacement.
The +1 was to avoid 0 width/height textures but the max does this in a way that actually makes sense. 
Closes #1505