### PR TITLE
Ignore unused texture vertices, deduplicate replacement textures

### DIFF
--- a/trview.app/Graphics/LevelTextureStorage.h
+++ b/trview.app/Graphics/LevelTextureStorage.h
@@ -39,7 +39,27 @@ namespace trview
         Triangle::AnimationMode animation_mode(uint32_t texture_index) const override;
         std::vector<uint32_t> animated_texture(uint32_t texture_index) const override;
     private:
+        struct SourceTexture
+        {
+            uint32_t width{ 0 };
+            uint32_t height{ 0 };
+            std::vector<uint32_t> bytes;
+        };
+
+        struct TextureReplacement
+        {
+            std::vector<DirectX::SimpleMath::Vector2> uvs;
+            uint32_t tile{ 0 };
+            uint8_t min_x{ 0 };
+            uint8_t min_y{ 0 };
+            uint8_t max_x{ 0 };
+            uint8_t max_y{ 0 };
+            uint32_t source_tile{ 0 };
+        };
+
         void generate_replacement_textures();
+        uint32_t copy_subtexture(uint32_t source_texture_index, uint32_t min_x, uint32_t min_y, uint32_t width, uint32_t height);
+        bool find_matching_replacement(TextureReplacement& repl) const;
 
         std::weak_ptr<trlevel::ILevel> _level;
         std::shared_ptr<graphics::IDevice> _device;
@@ -49,19 +69,6 @@ namespace trview
         std::array<DirectX::SimpleMath::Color, 256> _palette;
         trlevel::PlatformAndVersion _platform_and_version;
         std::unordered_map<uint32_t, std::vector<uint32_t>> _animated_textures;
-
-        struct SourceTexture
-        {
-            uint32_t width;
-            uint32_t height;
-            std::vector<uint32_t> bytes;
-        };
-
-        struct TextureReplacement
-        {
-            std::vector<DirectX::SimpleMath::Vector2> uvs;
-            uint32_t tile;
-        };
         std::vector<SourceTexture> _source_textures;
         std::unordered_map<uint32_t, TextureReplacement> _texture_replacements;
         uint32_t _num_textiles{ 0u };


### PR DESCRIPTION
Ignore the unused vertices in object textures so the minimum x and y coords are actually based on the minimum used values. This makes the cut out textures much smaller.

Also deduplicate these textures - this cuts the number of replacement textures in half more or less - down from ~1600 to ~700 on The Great Wall.

Before: 
<img width="172" height="236" alt="image" src="https://github.com/user-attachments/assets/933cf647-826a-489d-9573-447ee028829e" />

After:
<img width="47" height="34" alt="image" src="https://github.com/user-attachments/assets/d2cd1315-d340-4a9f-95eb-3e362720d376" />


Closes #1509 