### PR TITLE
Add sector_above/below Lua bindings

### DIFF
--- a/doc/lua/sector.md
+++ b/doc/lua/sector.md
@@ -15,6 +15,8 @@ The Sector library provides information about a sector in a [Level](level.md)/[R
 | number | number | R | Sector number |
 | portal | [Room](room.md) | R | Destination room for portal or `nil` |
 | room | [Room](room.md) | R | Room that the sector is in |
+| sector_above | [Sector](sector.md) | R | Sector directly above this one |
+| sector_below | [Sector](sector.md) | R | Sector directly below this one |
 | tilt_x | Number | R | X tilt value for the sector. Only check if `FloorSlant` flag is true |
 | tilt_z | Number | R | Z tilt value for the sector. Only check if `FloorSlant` flag is true |
 | triangulation | string | R | Triangulation direction (`None`/`NWSE`/`NESW`) |

--- a/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_SectorTests.cpp
@@ -250,6 +250,52 @@ TEST(Lua_Sector, Room)
     ASSERT_EQ(10, lua_tointeger(L, -1));
 }
 
+TEST(Lua_Sector, SectorAbove)
+{
+    auto other_sector = mock_shared<MockSector>()->with_id(123);
+    auto other_room = mock_shared<MockRoom>();
+    EXPECT_CALL(*other_room, sector).WillRepeatedly(testing::Return(other_sector));
+
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, room(10)).WillRepeatedly(testing::Return(other_room));
+
+    auto room = mock_shared<MockRoom>()->with_level(level);
+    auto sector = mock_shared<MockSector>()->with_room(room)->with_room_above(10);
+
+    LuaState L;
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.sector_above"));
+    ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.sector_above.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
+TEST(Lua_Sector, SectorBelow)
+{
+    auto other_sector = mock_shared<MockSector>()->with_id(123);
+    auto other_room = mock_shared<MockRoom>();
+    EXPECT_CALL(*other_room, sector).WillRepeatedly(testing::Return(other_sector));
+
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, room(10)).WillRepeatedly(testing::Return(other_room));
+
+    auto room = mock_shared<MockRoom>()->with_level(level);
+    auto sector = mock_shared<MockSector>()->with_room(room)->with_room_below(10);
+
+    LuaState L;
+    lua::create_sector(L, sector);
+    lua_setglobal(L, "s");
+
+    ASSERT_EQ(0, luaL_dostring(L, "return s.sector_below"));
+    ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
+    ASSERT_EQ(0, luaL_dostring(L, "return s.sector_below.number"));
+    ASSERT_EQ(LUA_TNUMBER, lua_type(L, -1));
+    ASSERT_EQ(123, lua_tointeger(L, -1));
+}
+
 TEST(Lua_Sector, Trigger)
 {
     auto trigger = mock_shared<MockTrigger>()->with_number(10);

--- a/trview.app/Elements/IRoom.h
+++ b/trview.app/Elements/IRoom.h
@@ -343,5 +343,15 @@ namespace trview
 
     std::string light_mode_name(int16_t light_mode);
     uint32_t room_number(const std::weak_ptr<IRoom>& room);
+
+    struct VerticalPortalInfo
+    {
+        std::shared_ptr<ISector>        sector;
+        DirectX::SimpleMath::Vector3    offset;
+        std::shared_ptr<IRoom>          room;
+    };
+
+    std::optional<VerticalPortalInfo> sector_above(const std::shared_ptr<ISector>& sector);
+    std::optional<VerticalPortalInfo> sector_below(const std::shared_ptr<ISector>& sector);
 }
 

--- a/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
+++ b/trview.app/Lua/Elements/Sector/Lua_Sector.cpp
@@ -199,6 +199,14 @@ namespace trview
                 {
                     return create_room(L, sector->room().lock());
                 }
+                else if (key == "sector_above")
+                {
+                    return create_sector(L, sector_above(sector).value_or({}).sector);
+                }
+                else if (key == "sector_below")
+                {
+                    return create_sector(L, sector_below(sector).value_or({}).sector);
+                }
                 else if (key == "tilt_x")
                 {
                     lua_pushnumber(L, sector->tilt_x());


### PR DESCRIPTION
Add Lua bindings for `sector_above` and `sector_below` to the `Sector` Lua class.
Reuse and expose the code from the room class for this.
Closes #1262