### PR TITLE
Fix scrolling to target missing from windows

### DIFF
--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -197,7 +197,7 @@ namespace trview
         if (_sync != value)
         {
             _sync = value;
-            _scroll_to = true;
+            _filters.scroll_to_item();
             if (_sync && _global_selected_camera_sink.lock())
             {
                 set_selected_camera_sink(_global_selected_camera_sink);
@@ -406,7 +406,7 @@ namespace trview
         _global_selected_camera_sink = camera_sink;
         if (_sync)
         {
-            _scroll_to = true;
+            _filters.scroll_to_item();
             set_local_selected_camera_sink(camera_sink);
         }
     }

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -79,7 +79,6 @@ namespace trview
 
         std::weak_ptr<ITrigger> _selected_trigger;
         bool _sync{ true };
-        bool _scroll_to{ false };
         std::weak_ptr<IRoom> _current_room;
         std::vector<std::weak_ptr<ITrigger>> _triggered_by;
         Track<Type::Room> _track;

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -1088,6 +1088,7 @@ namespace trview
     void RoomsWindow::select_room(std::weak_ptr<IRoom> room)
     {
         _selected_room = room;
+        _filters.scroll_to_item();
         if (auto room_ptr = room.lock())
         {
             set_triggers(room_ptr->triggers());

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -113,7 +113,7 @@ namespace trview
         _global_selected_trigger = trigger;
         if (_sync_trigger)
         {
-            _scroll_to_trigger = true;
+            _filters.scroll_to_item();
             set_local_selected_trigger(trigger);
         }
     }
@@ -123,7 +123,7 @@ namespace trview
         if (_sync_trigger != value)
         {
             _sync_trigger = value;
-            _scroll_to_trigger = true;
+            _filters.scroll_to_item();
             if (_sync_trigger && _global_selected_trigger.lock())
             {
                 set_selected_trigger(_global_selected_trigger);

--- a/trview.app/Windows/TriggersWindow.h
+++ b/trview.app/Windows/TriggersWindow.h
@@ -77,7 +77,6 @@ namespace trview
         std::optional<VirtualCommand> _selected_command;
         std::weak_ptr<ITrigger> _selected_trigger;
         std::weak_ptr<ITrigger> _global_selected_trigger;
-        bool _scroll_to_trigger{ false };
         std::optional<float> _tooltip_timer;
         std::vector<Command> _local_selected_trigger_commands;
         std::vector<std::weak_ptr<IItem>> _local_selected_trigger_trigger_triggerers;


### PR DESCRIPTION
Some windows were still setting a now unused bool to try to scroll to their target items.
Update these to to use the `scroll_to item` function on Filters.
Closes #1513