### PR TITLE
Reverse version of light line for TR3

### DIFF
--- a/trview.app/Elements/Light.cpp
+++ b/trview.app/Elements/Light.cpp
@@ -60,9 +60,9 @@ namespace trview
 
         if (_type == trlevel::LightType::Spot || _type == trlevel::LightType::Sun)
         {
-            // Invert direction - it's stored negated in Tomb4
+            // Invert direction - it's stored negated in Tomb3/4
             auto d = _direction;
-            if (_level_version == trlevel::LevelVersion::Tomb4)
+            if (equals_any(_level_version, trlevel::LevelVersion::Tomb3, trlevel::LevelVersion::Tomb4))
             {
                 d = -d;
             }


### PR DESCRIPTION
TR3 lights also need their light line flipped like TR4.
Closes #1523