### PR TITLE
Only reverse light direction if not TR5 PC/DC

### DIFF
--- a/trview.app/Elements/Light.h
+++ b/trview.app/Elements/Light.h
@@ -60,6 +60,6 @@ namespace trview
         float _cutoff{ 0 };
         float _radius{ 0 };
         float _density{ 0 };
-        trlevel::LevelVersion _level_version{ trlevel::LevelVersion::Unknown };
+        trlevel::PlatformAndVersion _version;
     };
 }


### PR DESCRIPTION
Only need to flip the light direction if this is TR3/4 (any platform) or TR5 PSX.
Closes #1526