### PR TITLE
Remove on_level_changed event

### DIFF
--- a/trview.app.tests/Elements/LevelTests.cpp
+++ b/trview.app.tests/Elements/LevelTests.cpp
@@ -366,17 +366,6 @@ TEST(Level, BoundingBoxesRenderedWhenEnabled)
     level->render(camera, false);
 }
 
-TEST(Level, SetShowBoundingBoxesRaisesLevelChangedEvent)
-{
-    auto level = register_test_module().build();
-
-    uint32_t times_called = 0;
-    auto token = level->on_level_changed += [&](auto&&...) { ++times_called; };
-
-    level->set_show_bounding_boxes(true);
-    ASSERT_EQ(times_called, 1u);
-}
-
 TEST(Level, ItemsNotRenderedWhenDisabled)
 {
     auto [mock_level_ptr, mock_level] = create_mock<trlevel::mocks::MockLevel>();
@@ -713,17 +702,6 @@ TEST(Level, MeshSetBuilt)
     ASSERT_FALSE(level->has_model(123));
 }
 
-TEST(Level, SetShowRoomsRaisesLevelChangedEvent)
-{
-    auto level = register_test_module().build();
-
-    uint32_t times_called = 0;
-    auto token = level->on_level_changed += [&](auto&&...) { ++times_called; };
-
-    level->set_show_rooms(true);
-    ASSERT_EQ(times_called, 1u);
-}
-
 TEST(Level, CameraSinksNotRenderedWhenDisabled)
 {
     auto [mock_level_ptr, mock_level] = create_mock<trlevel::mocks::MockLevel>();
@@ -790,17 +768,6 @@ TEST(Level, CameraSinksRenderedWhenEnabled)
     level->render(camera, false);
 }
 
-TEST(Level, SetShowLightingRaisesLevelChangedEvent)
-{
-    auto level = register_test_module().build();
-
-    uint32_t times_called = 0;
-    auto token = level->on_level_changed += [&](auto&&...) { ++times_called; };
-
-    level->set_show_lighting(true);
-    ASSERT_EQ(times_called, 1u);
-}
-
 TEST(Level, SkidooGenerated)
 {
     const tr2_entity driver { .TypeID = 52 };
@@ -824,41 +791,6 @@ TEST(Level, SkidooGenerated)
     ASSERT_EQ(entities.size(), 2);
     ASSERT_EQ(entities[0].TypeID, 52);
     ASSERT_EQ(entities[1].TypeID, 51);
-}
-
-TEST(Level, StaticMeshChangingRaisesLevelChangedEvent)
-{
-    auto static_mesh = mock_shared<MockStaticMesh>();
-
-    auto room = mock_shared<MockRoom>();
-    ON_CALL(*room, static_meshes).WillByDefault(Return(std::vector<std::weak_ptr<IStaticMesh>>{ static_mesh }));
-
-    auto [mock_level_ptr, mock_level] = create_mock<trlevel::mocks::MockLevel>();
-    EXPECT_CALL(mock_level, num_rooms()).WillRepeatedly(Return(1));
-
-    auto level = register_test_module().with_level(std::move(mock_level_ptr))
-        .with_room_source(
-            [&](auto&&...)
-            {
-                return room;
-            }).build();
-
-    uint32_t times_called = 0;
-    auto token = level->on_level_changed += [&](auto&&...) { ++times_called; };
-
-    static_mesh->on_changed();
-    ASSERT_EQ(times_called, 1u);
-}
-
-TEST(Level, SetShowSoundSourcesRaisesLevelChangedEvent)
-{
-    auto level = register_test_module().build();
-
-    bool raised = false;
-    auto token = level->on_level_changed += capture_called(raised);
-
-    level->set_show_sound_sources(true);
-    ASSERT_EQ(raised, true);
 }
 
 TEST(Level, RoomNotUpdatedIfAnimationsDisabled)

--- a/trview.app.tests/Lua/Elements/Lua_CameraSinkTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_CameraSinkTests.cpp
@@ -206,13 +206,6 @@ TEST(Lua_CameraSink, Visible)
 TEST(Lua_CameraSink, SetType)
 {
     auto level = mock_shared<MockLevel>();
-
-    bool level_changed_raised = false;
-    auto token = level->on_level_changed += [&]()
-    {
-        level_changed_raised = true;
-    };
-
     auto cs = mock_shared<MockCameraSink>();
     EXPECT_CALL(*cs, level).WillRepeatedly(Return(level));
     EXPECT_CALL(*cs, set_type(ICameraSink::Type::Sink)).Times(1);
@@ -226,7 +219,6 @@ TEST(Lua_CameraSink, SetType)
     ASSERT_STREQ("Camera", lua_tostring(L, -1));
 
     ASSERT_EQ(0, luaL_dostring(L, "c.type = \"Sink\""));
-    ASSERT_TRUE(level_changed_raised);
 }
 
 TEST(Lua_CameraSink, SetVisible)

--- a/trview.app/Elements/ILevel.h
+++ b/trview.app/Elements/ILevel.h
@@ -162,9 +162,6 @@ namespace trview
         Event<bool> on_alternate_mode_selected;
         /// Event raised when the level needs to change the alternate group mode.
         Event<uint16_t, bool> on_alternate_group_selected;
-        /// Event raised when something has changed in the appearance of the level or the
-        /// items that are contained within.
-        Event<> on_level_changed;
         mutable Event<> on_geometry_colours_changed;
         Event<std::weak_ptr<ITrigger>> on_trigger_selected;
         Event<bool> on_ng_plus;

--- a/trview.app/Elements/Level.cpp
+++ b/trview.app/Elements/Level.cpp
@@ -230,7 +230,6 @@ namespace trview
 
         regenerate_neighbours();
         _regenerate_transparency = true;
-        on_level_changed();
     }
 
     bool Level::highlight_mode_enabled(RoomHighlightMode mode) const
@@ -266,7 +265,6 @@ namespace trview
             }
         }
 
-        on_level_changed();
         on_room_selected(room);
     }
 
@@ -276,7 +274,6 @@ namespace trview
         if (_selected_item.lock() != selected_item)
         {
             _selected_item = selected_item;
-            on_level_changed();
             on_item_selected(_selected_item);
         }
     }
@@ -285,7 +282,6 @@ namespace trview
     {
         _neighbour_depth = depth;
         regenerate_neighbours();
-        on_level_changed();
     }
 
     trlevel::Platform Level::platform() const
@@ -933,7 +929,6 @@ namespace trview
             }
         }
 
-        on_level_changed();
         on_alternate_mode_selected(enabled);
     }
 
@@ -959,8 +954,6 @@ namespace trview
                 on_room_selected(level->room(current_room->alternate_room()));
             }
         }
-
-        on_level_changed();
     }
 
     bool Level::alternate_group(uint32_t group) const
@@ -1000,14 +993,12 @@ namespace trview
     {
         _render_filters = set_flag(_render_filters, RenderFilter::Triggers, show);
         _regenerate_transparency = true;
-        on_level_changed();
     }
 
     void Level::set_show_geometry(bool show)
     {
         _render_filters = set_flag(_render_filters, RenderFilter::AllGeometry, show);
         _regenerate_transparency = true;
-        on_level_changed();
     }
 
     bool Level::show_geometry() const
@@ -1019,49 +1010,42 @@ namespace trview
     {
         _render_filters = set_flag(_render_filters, RenderFilter::Water, show);
         _regenerate_transparency = true;
-        on_level_changed();
     }
 
     void Level::set_show_wireframe(bool show)
     {
         _show_wireframe = show;
         _regenerate_transparency = true;
-        on_level_changed();
     }
 
     void Level::set_show_bounding_boxes(bool show)
     {
         _render_filters = set_flag(_render_filters, RenderFilter::BoundingBoxes, show);
         _regenerate_transparency = true;
-        on_level_changed();
     }
 
     void Level::set_show_lighting(bool show)
     {
         _render_filters = set_flag(_render_filters, RenderFilter::Lighting, show);
         _regenerate_transparency = true;
-        on_level_changed();
     }
 
     void Level::set_show_lights(bool show)
     {
         _render_filters = set_flag(_render_filters, RenderFilter::Lights, show);
         _regenerate_transparency = true;
-        on_level_changed();
     }
 
     void Level::set_show_items(bool show)
     {
         _render_filters = set_flag(_render_filters, RenderFilter::Entities, show);
         _regenerate_transparency = true;
-        on_level_changed();
     }
 
     void Level::set_show_rooms(bool show)
     {
         _render_filters = set_flag(_render_filters, RenderFilter::Rooms, show);
         _regenerate_transparency = true;
-        on_level_changed();
     }
 
     bool Level::show_triggers() const
@@ -1090,7 +1074,6 @@ namespace trview
         if (_selected_trigger.lock() != selected_trigger)
         {
             _selected_trigger = selected_trigger;
-            on_level_changed();
             on_trigger_selected(_selected_trigger);
         }
     }
@@ -1098,19 +1081,16 @@ namespace trview
     void Level::set_selected_light(uint32_t number)
     {
         _selected_light = _lights[number];
-        on_level_changed();
     }
 
     void Level::set_selected_camera_sink(uint32_t number)
     {
         _selected_camera_sink = _camera_sinks[number];
-        on_level_changed();
     }
 
     void Level::set_selected_flyby_node(const std::weak_ptr<IFlybyNode>& node)
     {
         _selected_flyby_node = node;
-        on_level_changed();
     }
 
     std::shared_ptr<ILevelTextureStorage> Level::texture_storage() const
@@ -1424,7 +1404,6 @@ namespace trview
     {
         _render_filters = set_flag(_render_filters, RenderFilter::CameraSinks, show);
         _regenerate_transparency = true;
-        on_level_changed();
     }
 
     std::optional<uint32_t> Level::selected_camera_sink() const
@@ -1522,7 +1501,6 @@ namespace trview
     void Level::content_changed()
     {
         _regenerate_transparency = true;
-        on_level_changed();
     }
 
     std::weak_ptr<IStaticMesh> Level::static_mesh(uint32_t index) const
@@ -1579,7 +1557,6 @@ namespace trview
     {
         _render_filters = set_flag(_render_filters, RenderFilter::SoundSources, show);
         _regenerate_transparency = true;
-        on_level_changed();
     }
 
     bool Level::show_sound_sources() const
@@ -1616,7 +1593,6 @@ namespace trview
                     {
                         _selected_item = *alternate;
                         on_item_selected(_selected_item);
-                        on_level_changed();
                     }
                 }
             }

--- a/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.cpp
+++ b/trview.app/Lua/Elements/CameraSink/Lua_CameraSink.cpp
@@ -86,12 +86,10 @@ namespace trview
                             if (type == "Camera")
                             {
                                 camera_sink->set_type(ICameraSink::Type::Camera);
-                                level->on_level_changed();
                             }
                             else if (type == "Sink")
                             {
                                 camera_sink->set_type(ICameraSink::Type::Sink);
-                                level->on_level_changed();
                             }
                             else
                             {


### PR DESCRIPTION
This event isn't listened to any more since the viewer doesn't do lazy rendering.
Closes #1533