### PR TITLE
Add support for nested filters

### DIFF
--- a/trview.app.tests/Filters/FiltersTests.cpp
+++ b/trview.app.tests/Filters/FiltersTests.cpp
@@ -81,6 +81,12 @@ namespace
                 return *this;
             }
 
+            FilterBuilder& invert(bool value)
+            {
+                filter.invert = value;
+                return *this;
+            }
+
             operator Filters<Object>::Filter() const
             {
                 return filter;
@@ -422,4 +428,18 @@ TEST(Filters, DoubleNested)
     ASSERT_FALSE(filters.match(Object().with_number(5).with_text("test2")));
     ASSERT_TRUE(filters.match(Object().with_number(5).with_text("test2").with_option(0)));
     ASSERT_TRUE(filters.match(Object().with_number(5).with_text("test").with_option(0)));
+}
+
+TEST(Filters, UnaryNot)
+{
+    Filters<Object> filters;
+    filters.add_getter<std::string>("text", [](auto&& o) { return o.text; });
+
+    // Filter: !(text starts with s)
+    Filters<Object>::Filter text = make_filter().key("text").compare_op(CompareOp::StartsWith).value("s").invert(true);
+
+    filters.add_filter(text);
+
+    ASSERT_TRUE(filters.match(Object().with_text("test")));
+    ASSERT_FALSE(filters.match(Object().with_text("six")));
 }

--- a/trview.app/Filters/Filters.h
+++ b/trview.app/Filters/Filters.h
@@ -64,6 +64,7 @@ namespace trview
             std::string value2;
             std::vector<Filter> children;
             Op op{ Op::And };
+            bool invert{ false };
 
             auto operator <=> (const Filter&) const = default;
 

--- a/trview.app/Filters/Filters.hpp
+++ b/trview.app/Filters/Filters.hpp
@@ -315,7 +315,7 @@ namespace trview
             }
         }
 
-        return filter_result;
+        return filter_result ^ filter.invert;
     }
 
     template <typename T>
@@ -375,6 +375,10 @@ namespace trview
 
                             break;
                         }
+                        if (ImGui::IsItemHovered())
+                        {
+                            ImGui::SetTooltip("Move this condition into the parent condition");
+                        }
                     }
 
                     ImGui::SameLine();
@@ -384,6 +388,10 @@ namespace trview
                         child = {};
                         child.children.push_back(filter_to_group);
                         break;
+                    }
+                    if (ImGui::IsItemHovered())
+                    {
+                        ImGui::SetTooltip("Make this condition a child of the current condition");
                     }
 
                     if (child_index != filter.children.size() - 1)
@@ -418,6 +426,30 @@ namespace trview
         else
         {
             const std::string suffix = std::format("{}-{}", depth, index);
+
+            const std::string not_id = "!##" + suffix;
+            const bool inverted = filter.invert;
+            if (inverted)
+            {
+                ImGui::PushID(not_id.c_str());
+                ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.06f, 0.53f, 0.98f, 1.00f));
+                ImGui::PopID();
+            }
+            if (ImGui::Button(not_id.c_str()))
+            {
+                _changed = true;
+                filter.invert = !filter.invert;
+            }
+            if (ImGui::IsItemHovered())
+            {
+                ImGui::SetTooltip("Invert the condition");
+            }
+            if (inverted)
+            {
+                ImGui::PopStyleColor();
+            }
+            ImGui::SameLine();
+
             if (ImGui::BeginCombo((Names::FilterKey + suffix).c_str(), filter.key.c_str()))
             {
                 for (const auto& key : keys)
@@ -518,6 +550,10 @@ namespace trview
             {
                 _changed = true;
                 return Action::Remove;
+            }
+            if (ImGui::IsItemHovered())
+            {
+                ImGui::SetTooltip("Remove this condition");
             }
         }
 


### PR DESCRIPTION
Add nested filters. Conditions can become sub-conditions for logical grouping.
Also adds unary not operator to conditions.
Closes #1547 