### PR TITLE
Add RGB values for ambient intensity 1/2

### DIFF
--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -268,7 +268,7 @@ namespace trview
 
                     auto format_colour = [](const Colour& colour)
                     {
-                        return std::format("R: {}, G: {}, B: {}", static_cast<int>(colour.r * 255), static_cast<int>(colour.g * 255), static_cast<int>(colour.b * 255));
+                        return std::format("R: {}, G: {}, B: {}", static_cast<int>(colour.r * 255 + 0.5f), static_cast<int>(colour.g * 255 + 0.5f), static_cast<int>(colour.b * 255 + 0.5f));
                     };
 
                     add_stat("Type", to_string(selected_light->type()));

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -277,7 +277,12 @@ namespace trview
 
                     if (has_colour(*selected_light))
                     {
-                        add_stat("Colour", format_colour(selected_light->colour()), selected_light->colour());
+                        auto colour = selected_light->colour();
+                        ImGui::SetNextItemAllowOverlap();
+                        add_stat("Colour", format_colour(colour), colour);
+                        ImGui::SameLine();
+                        ImGui::SetCursorPosY(ImGui::GetCursorPosY() - 2.0f);
+                        read_only_colour_button("##colourbutton", ImVec4(colour.r, colour.g, colour.b, 1.0f), *_clipboard);
                     }
 
                     if (has_position(*selected_light))

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -788,6 +788,7 @@ namespace trview
         {
             const auto string_value = get_string(value);
             ImGui::TableNextColumn();
+            ImGui::SetNextItemAllowOverlap();
             if (ImGui::Selectable(name.c_str(), false, ImGuiSelectableFlags_SpanAllColumns))
             {
                 if (click)
@@ -841,7 +842,7 @@ namespace trview
                 ImGui::Text("%.2f%%", ambient_intensity * 100.0f);
                 ImGui::SameLine();
                 ImGui::SetCursorPosY(ImGui::GetCursorPosY() - 2.0f);
-                ImGui::ColorButton("##ambientintensitybutton", ImVec4(ambient_intensity, ambient_intensity, ambient_intensity, 1.0f), 0, ImVec2(16, 16));
+                read_only_colour_button("##ambientintensitybutton", ImVec4(ambient_intensity, ambient_intensity, ambient_intensity, 1.0f), *_clipboard);
                 if (_level_version > trlevel::LevelVersion::Tomb1)
                 {
                     if (_level_version == trlevel::LevelVersion::Tomb2)
@@ -852,7 +853,7 @@ namespace trview
                         ImGui::Text("%.2f%%", ambient_intensity2 * 100.0f);
                         ImGui::SameLine();
                         ImGui::SetCursorPosY(ImGui::GetCursorPosY() - 2.0f);
-                        ImGui::ColorButton("##ambientintensity2button", ImVec4(ambient_intensity2, ambient_intensity2, ambient_intensity2, 1.0f), 0, ImVec2(16, 16));
+                        read_only_colour_button("##ambientintensity2button", ImVec4(ambient_intensity2, ambient_intensity2, ambient_intensity2, 1.0f), *_clipboard);
                     }
                     add_stat("Light Mode", std::format("{} ({})", room->light_mode(), light_mode_name(room->light_mode())));
                 }
@@ -863,7 +864,7 @@ namespace trview
                 auto ambient = room->ambient();
                 ImGui::SameLine();
                 ImGui::SetCursorPosY(ImGui::GetCursorPosY() - 2.0f);
-                ImGui::ColorButton("##ambientbutton", ImVec4(ambient.r, ambient.g, ambient.b, 1.0f), 0, ImVec2(16, 16));
+                read_only_colour_button("##ambientbutton", ImVec4(ambient.r, ambient.g, ambient.b, 1.0f), *_clipboard);
             }
 
             if (_level_version >= trlevel::LevelVersion::Tomb3)

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -831,7 +831,7 @@ namespace trview
 
             auto format_colour = [](const Colour& colour)
             {
-                return std::format("R: {}, G: {}, B: {}", static_cast<int>(colour.r * 255), static_cast<int>(colour.g * 255), static_cast<int>(colour.b * 255));
+                return std::format("R: {}, G: {}, B: {}", static_cast<int>(colour.r * 255 + 0.5f), static_cast<int>(colour.g * 255 + 0.5f), static_cast<int>(colour.b * 255 + 0.5f));
             };
 
             if (_level_version < trlevel::LevelVersion::Tomb4)
@@ -840,6 +840,8 @@ namespace trview
                 float ambient_intensity = ambient_percentage(room->ambient_intensity_1());
                 ImGui::SameLine();
                 ImGui::Text("%.2f%%", ambient_intensity * 100.0f);
+                ImGui::SameLine();
+                ImGui::Text(format_colour(Colour(ambient_intensity, ambient_intensity, ambient_intensity)).c_str());
                 ImGui::SameLine();
                 ImGui::SetCursorPosY(ImGui::GetCursorPosY() - 2.0f);
                 read_only_colour_button("##ambientintensitybutton", ImVec4(ambient_intensity, ambient_intensity, ambient_intensity, 1.0f), *_clipboard);
@@ -851,6 +853,8 @@ namespace trview
                         float ambient_intensity2 = ambient_percentage(room->ambient_intensity_2());
                         ImGui::SameLine();
                         ImGui::Text("%.2f%%", ambient_intensity2 * 100.0f);
+                        ImGui::SameLine();
+                        ImGui::Text(format_colour(Colour(ambient_intensity2, ambient_intensity2, ambient_intensity2)).c_str());
                         ImGui::SameLine();
                         ImGui::SetCursorPosY(ImGui::GetCursorPosY() - 2.0f);
                         read_only_colour_button("##ambientintensity2button", ImVec4(ambient_intensity2, ambient_intensity2, ambient_intensity2, 1.0f), *_clipboard);

--- a/trview.app/trview_imgui.cpp
+++ b/trview.app/trview_imgui.cpp
@@ -1,4 +1,5 @@
 #include "trview_imgui.h"
+#include <trview.common/Windows/IClipboard.h>
 
 namespace trview
 {
@@ -159,5 +160,53 @@ namespace trview
     void ImGuiAnchor::record_size()
     {
         last_size = ImGui::GetWindowSize();
+    }
+
+    namespace
+    {
+        bool copy_button(const std::string& text, IClipboard& clipboard)
+        {
+            if (ImGui::Selectable(text.c_str()))
+            {
+                clipboard.write(to_utf16(text));
+                return true;
+            }
+            return false;
+        }
+    }
+
+    void read_only_colour_button(const std::string& name, const ImVec4& colour, IClipboard& clipboard)
+    {
+        const std::string popup_name = std::format("{}-picker", name);
+        const bool open_popup = ImGui::ColorButton(name.c_str(), colour, 0, ImVec2(16, 16));
+        if (open_popup)
+        {
+            ImGui::OpenPopup(popup_name.c_str());
+        }
+
+        if (ImGui::BeginPopup(popup_name.c_str()))
+        {
+            if (ImGui::Button("Copy as.."))
+            {
+                ImGui::OpenPopup("Copy");
+            }
+
+            bool close_popup = false;
+            if (ImGui::BeginPopup("Copy"))
+            {
+                close_popup =
+                    copy_button(std::format("#{:0>2X}{:0>2X}{:0>2X}", static_cast<int>(colour.x * 255.0f + 0.5f), static_cast<int>(colour.y * 255.0f + 0.5f), static_cast<int>(colour.z * 255.0f + 0.5f)), clipboard) ||
+                    copy_button(std::format("{},{},{}", static_cast<int>(colour.x * 255.0f + 0.5f), static_cast<int>(colour.y * 255.0f + 0.5f), static_cast<int>(colour.z * 255.0f + 0.5f)), clipboard) ||
+                    copy_button(std::format("{:.3f},{:.3f},{:.3f}", colour.x, colour.y, colour.z), clipboard);
+                ImGui::EndPopup();
+            }
+
+            if (close_popup)
+            {
+                ImGui::CloseCurrentPopup();
+            }
+
+            ImGui::EndPopup();
+        }
     }
 }

--- a/trview.app/trview_imgui.h
+++ b/trview.app/trview_imgui.h
@@ -51,6 +51,9 @@ namespace trview
         void record_position(ImVec2 intended_client_size);
         void record_size();
     };
+
+    struct IClipboard;
+    void read_only_colour_button(const std::string& name, const ImVec4& colour, IClipboard& clipboard);
 }
 
 #include "trview_imgui.hpp"


### PR DESCRIPTION
Add RGB values for ambient intensity 1 and 2 in the rooms window.
Change the colour button to actually be clickable - gives a hover preview and clicking it allows you to copy the values.

<img width="546" height="56" alt="image" src="https://github.com/user-attachments/assets/a2640ffd-ec08-4d59-98e2-a971458d1fcc" />
<img width="773" height="105" alt="image" src="https://github.com/user-attachments/assets/8aa11554-4c28-401b-bc43-7caff2d0ff93" />
<img width="672" height="109" alt="image" src="https://github.com/user-attachments/assets/89d0c58e-a063-4b63-ae6a-2201c293e1ca" />

#1568 