### PR TITLE
Fix Sync functionality for Rooms Window

### DIFF
--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -397,9 +397,9 @@ namespace trview
             };
         auto imgui_backend = std::make_shared<DX11ImGuiBackend>(window, device, files);
         auto fonts = std::make_shared<Fonts>(files, imgui_backend);
-        auto map_renderer_source = [=]()
+        auto map_renderer_source = [=](bool load_room_from_message)
             { 
-                auto renderer = std::make_shared<MapRenderer>(fonts, messaging);
+                auto renderer = std::make_shared<MapRenderer>(fonts, messaging, load_room_from_message);
                 messaging->add_recipient(renderer);
                 renderer->initialise();
                 return renderer;

--- a/trview.app/UI/IMapRenderer.h
+++ b/trview.app/UI/IMapRenderer.h
@@ -14,7 +14,7 @@ namespace trview
             Select
         };
 
-        using Source = std::function<std::shared_ptr<IMapRenderer>()>;
+        using Source = std::function<std::shared_ptr<IMapRenderer>(bool)>;
 
         virtual ~IMapRenderer() = 0;
 

--- a/trview.app/UI/MapRenderer.cpp
+++ b/trview.app/UI/MapRenderer.cpp
@@ -19,8 +19,10 @@ namespace trview
     {
     }
 
-    MapRenderer::MapRenderer(const std::shared_ptr<IFonts>& fonts, const std::weak_ptr<IMessageSystem>& messaging)
-        : _fonts(fonts), _messaging(messaging)
+    MapRenderer::MapRenderer(const std::shared_ptr<IFonts>& fonts,
+        const std::weak_ptr<IMessageSystem>& messaging,
+        bool load_room_from_message)
+        : _fonts(fonts), _messaging(messaging), _load_room_from_message(load_room_from_message)
     {
     }
 
@@ -398,7 +400,10 @@ namespace trview
         }
         else if (auto selected_room = messages::read_select_room(message))
         {
-            load(selected_room.value().lock());
+            if (_load_room_from_message)
+            {
+                load(selected_room.value().lock());
+            }
         }
     }
 

--- a/trview.app/UI/MapRenderer.h
+++ b/trview.app/UI/MapRenderer.h
@@ -37,7 +37,9 @@ namespace trview
     class MapRenderer final : public IMapRenderer, public IRecipient, public std::enable_shared_from_this<IRecipient>
     {
     public:
-        MapRenderer(const std::shared_ptr<IFonts>& fonts, const std::weak_ptr<IMessageSystem>& messaging);
+        MapRenderer(const std::shared_ptr<IFonts>& fonts,
+            const std::weak_ptr<IMessageSystem>& messaging,
+            bool load_room_from_message);
         virtual ~MapRenderer() = default;
         // Renders the map 
         void render(bool window) override;
@@ -88,5 +90,6 @@ namespace trview
         ImGuiAnchor _anchor;
 
         int _reset_cycles{ 2 };
+        bool _load_room_from_message{ true };
     };
 };

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -131,7 +131,7 @@ namespace trview
                 messages::send_settings(_messaging, _settings);
             };
 
-        _map_renderer = map_renderer_source();
+        _map_renderer = map_renderer_source(true);
     }
 #pragma warning(pop)
 

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -422,7 +422,7 @@ namespace trview
     }
 
     RoomsWindow::RoomsWindow(const IMapRenderer::Source& map_renderer_source, const std::shared_ptr<IClipboard>& clipboard, const std::shared_ptr<IFilterStore>& filter_store, const std::weak_ptr<IMessageSystem>& messaging)
-        : _map_renderer(map_renderer_source()), _clipboard(clipboard), _messaging(messaging), _filters(filter_store)
+        : _map_renderer(map_renderer_source(false)), _clipboard(clipboard), _messaging(messaging), _filters(filter_store)
     {
         _token_store += _map_renderer->on_sector_selected += [&](auto sector) { _local_selected_sector = sector; };
 
@@ -476,8 +476,7 @@ namespace trview
 
     void RoomsWindow::load_room_details(std::weak_ptr<IRoom> room)
     {
-        room;
-        // _map_renderer->load(room.lock());
+        _map_renderer->load(room.lock());
     }
 
     void RoomsWindow::set_items(const std::vector<std::weak_ptr<IItem>>& items)
@@ -1436,7 +1435,7 @@ namespace trview
         }
         else if (auto selected_room = messages::read_select_room(message))
         {
-            select_room(selected_room.value());
+            set_current_room(selected_room.value());
         }
         else if (auto selected_light = messages::read_select_light(message))
         {


### PR DESCRIPTION
Make the Sync checkbox do something again and allow the map renderer to not listen to messages for room load and instead have the room window do this.
Eventually this should be changed so that the room window sends a message instead of calling directly.
Closes #1570