### PR TITLE
Convert camera movement to scan codes

### DIFF
--- a/trview.app.tests/Camera/CameraInputTests.cpp
+++ b/trview.app.tests/Camera/CameraInputTests.cpp
@@ -2,6 +2,19 @@
 
 using namespace trview;
 
+namespace
+{
+    constexpr uint16_t Scan_Q = 0x0010;
+    constexpr uint16_t Scan_W = 0x0011;
+    constexpr uint16_t Scan_E = 0x0012;
+    constexpr uint16_t Scan_O = 0x0018;
+    constexpr uint16_t Scan_A = 0x001E;
+    constexpr uint16_t Scan_S = 0x001F;
+    constexpr uint16_t Scan_D = 0x0020;
+    constexpr uint16_t Scan_F = 0x0021;
+    constexpr uint16_t Scan_X = 0x002D;
+}
+
 /// Tests that when the appropriate shortcut key is pressed the event
 /// for entering free mode is raised.
 TEST(CameraInput, EnterFreeMode)
@@ -14,7 +27,7 @@ TEST(CameraInput, EnterFreeMode)
         mode = new_mode;
     };
 
-    subject.key_down(L'F', false);
+    subject.key_down(Scan_F, false);
 
     ASSERT_TRUE(mode.has_value());
     ASSERT_EQ(ICamera::Mode::Free, mode.value());
@@ -32,7 +45,7 @@ TEST(CameraInput, EnterAxisMode)
         mode = new_mode;
     };
 
-    subject.key_down(L'X', false);
+    subject.key_down(Scan_X, false);
 
     ASSERT_TRUE(mode.has_value());
     ASSERT_EQ(ICamera::Mode::Axis, mode.value());
@@ -50,7 +63,7 @@ TEST(CameraInput, EnterOrbitMode)
         mode = new_mode;
     };
 
-    subject.key_down(L'O', false);
+    subject.key_down(Scan_O, false);
 
     ASSERT_TRUE(mode.has_value());
     ASSERT_EQ(ICamera::Mode::Orbit, mode.value());
@@ -121,28 +134,28 @@ TEST(CameraInput, Movement)
 
     ASSERT_EQ(Vector3::Zero, subject.movement());
 
-    subject.key_down(L'W', false);
+    subject.key_down(Scan_W, false);
     ASSERT_EQ(Vector3(0, 0, 1), subject.movement());
 
-    subject.key_down(L'A', false);
+    subject.key_down(Scan_A, false);
     ASSERT_EQ(Vector3(-1, 0, 1), subject.movement());
 
-    subject.key_up(L'A');
+    subject.key_up(Scan_A);
     ASSERT_EQ(Vector3(0, 0, 1), subject.movement());
 
-    subject.key_down(L'D', false);
+    subject.key_down(Scan_D, false);
     ASSERT_EQ(Vector3(1, 0, 1), subject.movement());
 
-    subject.key_up(L'W');
+    subject.key_up(Scan_W);
     ASSERT_EQ(Vector3(1, 0, 0), subject.movement());
 
-    subject.key_down(L'S', false);
+    subject.key_down(Scan_S, false);
     ASSERT_EQ(Vector3(1, 0, -1), subject.movement());
 
-    subject.key_up(L'S');
+    subject.key_up(Scan_S);
     ASSERT_EQ(Vector3(1, 0, 0), subject.movement());
 
-    subject.key_up(L'D');
+    subject.key_up(Scan_D);
     ASSERT_EQ(Vector3::Zero, subject.movement());
 }
 
@@ -159,17 +172,17 @@ TEST(CameraInput, ControlBlocks)
         modes.insert(mode);
     };
 
-    subject.key_down('F', true);
-    subject.key_down('O', true);
-    subject.key_down('X', true);
+    subject.key_down(Scan_F, true);
+    subject.key_down(Scan_O, true);
+    subject.key_down(Scan_X, true);
     ASSERT_TRUE(modes.empty());
 
-    subject.key_down('W', true);
-    subject.key_down('A', true);
+    subject.key_down(Scan_W, true);
+    subject.key_down(Scan_A, true);
     ASSERT_EQ(Vector3::Zero, subject.movement());
 
-    subject.key_down('S', true);
-    subject.key_down('D', true);
+    subject.key_down(Scan_S, true);
+    subject.key_down(Scan_D, true);
     ASSERT_EQ(Vector3::Zero, subject.movement());
 }
 
@@ -221,8 +234,8 @@ TEST(CameraInput, Reset)
 
     CameraInput subject;
 
-    subject.key_down('W', false);
-    subject.key_down('A', false);
+    subject.key_down(Scan_W, false);
+    subject.key_down(Scan_A, false);
     ASSERT_NE(Vector3::Zero, subject.movement());
 
     subject.reset();

--- a/trview.app/Camera/CameraInput.cpp
+++ b/trview.app/Camera/CameraInput.cpp
@@ -2,6 +2,19 @@
 
 namespace trview
 {
+    namespace
+    {
+        constexpr uint16_t Scan_Q = 0x0010;
+        constexpr uint16_t Scan_W = 0x0011;
+        constexpr uint16_t Scan_E = 0x0012;
+        constexpr uint16_t Scan_O = 0x0018;
+        constexpr uint16_t Scan_A = 0x001E;
+        constexpr uint16_t Scan_S = 0x001F;
+        constexpr uint16_t Scan_D = 0x0020;
+        constexpr uint16_t Scan_F = 0x0021;
+        constexpr uint16_t Scan_X = 0x002D;
+    }
+
     DirectX::SimpleMath::Vector3 CameraInput::movement() const
     {
         return DirectX::SimpleMath::Vector3(
@@ -19,47 +32,47 @@ namespace trview
 
         switch (key)
         {
-            case 'F':
+            case Scan_F:
             {
                 on_mode_change(ICamera::Mode::Free);
                 break;
             }
-            case 'O':
+            case Scan_O:
             {
                 on_mode_change(ICamera::Mode::Orbit);
                 break;
             }
-            case 'X':
+            case Scan_X:
             {
                 on_mode_change(ICamera::Mode::Axis);
                 break;
             }
-            case 'Q':
+            case Scan_Q:
             {
                 _free_down = true;
                 break;
             }
-            case 'E':
+            case Scan_E:
             {
                 _free_up = true;
                 break;
             }
-            case 'W':
+            case Scan_W:
             {
                 _free_forward = true;
                 break;
             }
-            case 'A':
+            case Scan_A:
             {
                 _free_left = true;
                 break;
             }
-            case 'D':
+            case Scan_D:
             {
                 _free_right = true;
                 break;
             }
-            case 'S':
+            case Scan_S:
             {
                 _free_backward = true;
                 break;
@@ -71,32 +84,32 @@ namespace trview
     {
         switch (key)
         {
-            case 'Q':
+            case Scan_Q:
             {
                 _free_down = false;
                 break;
             }
-            case 'E':
+            case Scan_E:
             {
                 _free_up = false;
                 break;
             }
-            case 'W':
+            case Scan_W:
             {
                 _free_forward = false;
                 break;
             }
-            case 'A':
+            case Scan_A:
             {
                 _free_left = false;
                 break;
             }
-            case 'D':
+            case Scan_D:
             {
                 _free_right = false;
                 break;
             }
-            case 'S':
+            case Scan_S:
             {
                 _free_backward = false;
                 break;
@@ -152,12 +165,12 @@ namespace trview
 
     void CameraInput::reset(bool ignore_key_states)
     {
-        _free_forward = ignore_key_states ? false : GetAsyncKeyState('W') & 0x8000;
-        _free_left = ignore_key_states ? false : GetAsyncKeyState('A') & 0x8000;
-        _free_right = ignore_key_states ? false : GetAsyncKeyState('D') & 0x8000;
-        _free_backward = ignore_key_states ? false : GetAsyncKeyState('S') & 0x8000;
-        _free_up = ignore_key_states ? false : GetAsyncKeyState('E') & 0x8000;
-        _free_down = ignore_key_states ? false : GetAsyncKeyState('Q') & 0x8000;
+        _free_forward = ignore_key_states ? false : GetAsyncKeyState(MapVirtualKey(Scan_W, MAPVK_VSC_TO_VK)) & 0x8000;
+        _free_left = ignore_key_states ? false : GetAsyncKeyState(MapVirtualKey(Scan_A, MAPVK_VSC_TO_VK)) & 0x8000;
+        _free_right = ignore_key_states ? false : GetAsyncKeyState(MapVirtualKey(Scan_D, MAPVK_VSC_TO_VK)) & 0x8000;
+        _free_backward = ignore_key_states ? false : GetAsyncKeyState(MapVirtualKey(Scan_S, MAPVK_VSC_TO_VK)) & 0x8000;
+        _free_up = ignore_key_states ? false : GetAsyncKeyState(MapVirtualKey(Scan_E, MAPVK_VSC_TO_VK)) & 0x8000;
+        _free_down = ignore_key_states ? false : GetAsyncKeyState(MapVirtualKey(Scan_Q, MAPVK_VSC_TO_VK)) & 0x8000;
         _rotating = false;
         _panning = false;
         _panning_vertical = false;

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -582,10 +582,6 @@ namespace trview
             {
                 _camera_input.key_down(key, control);
             }
-            else if (_ui->show_context_menu() && key == VK_ESCAPE)
-            {
-                _ui->set_show_context_menu(false);
-            }
         };
 
         setup_camera_input();

--- a/trview.input.tests/KeyboardTests.cpp
+++ b/trview.input.tests/KeyboardTests.cpp
@@ -20,10 +20,10 @@ TEST(Keyboard, KeyDownEventRaised)
         key_received = key;
     };
 
-    keyboard.process_message(WM_KEYDOWN, VK_SPACE, 0);
+    keyboard.process_message(WM_KEYDOWN, VK_SPACE, MAKELPARAM(0, MAKEWORD(0x39, 0)));
 
     ASSERT_EQ(1, times_called);
-    ASSERT_EQ(static_cast<int>(VK_SPACE), static_cast<int>(key_received));
+    ASSERT_EQ(static_cast<int>(0x39), static_cast<int>(key_received));
 }
 
 /// Tests that when a WM_KEYUP message is posted to the window that the keyboard is watching
@@ -41,10 +41,10 @@ TEST(Keyboard, KeyUpEventRaised)
         key_received = key;
     };
 
-    keyboard.process_message(WM_KEYUP, VK_SPACE, 0);
+    keyboard.process_message(WM_KEYUP, VK_SPACE, MAKELPARAM(0, MAKEWORD(0x39, 0)));
 
     ASSERT_EQ(1, times_called);
-    ASSERT_EQ(static_cast<int>(VK_SPACE), static_cast<int>(key_received));
+    ASSERT_EQ(static_cast<int>(0x39), static_cast<int>(key_received));
 }
 
 /// Tests that when a WM_CHAR message is posted to the window that the keyboard is watching

--- a/trview.input/Keyboard.cpp
+++ b/trview.input/Keyboard.cpp
@@ -23,7 +23,7 @@ namespace trview
             return GetKeyState(VK_SHIFT) & 0x8000;
         }
 
-        std::optional<int> Keyboard::process_message(UINT message, WPARAM wParam, LPARAM)
+        std::optional<int> Keyboard::process_message(UINT message, WPARAM wParam, LPARAM lParam)
         {
             bool control_pressed = control();
             bool shift_pressed = shift();
@@ -31,7 +31,7 @@ namespace trview
             {
                 case WM_KEYDOWN:
                 {
-                    on_key_down(static_cast<uint16_t>(wParam), control_pressed, shift_pressed);
+                    on_key_down(LOBYTE(HIWORD(lParam)), control_pressed, shift_pressed);
                     break;
                 }
                 case WM_CHAR:
@@ -41,7 +41,7 @@ namespace trview
                 }
                 case WM_KEYUP:
                 {
-                    on_key_up(static_cast<uint16_t>(wParam), control_pressed, shift_pressed);
+                    on_key_up(LOBYTE(HIWORD(lParam)), control_pressed, shift_pressed);
                     break;
                 }
             }


### PR DESCRIPTION
Use scan codes for keyboard down/up events.
This means that AZERTY keyboard users don't have to switch to QWERTY to use WASD in free cam.
Possibly keys will be bindable in future instead.
Closes #1574