### PR TITLE
Add diff and pack window to messaging system

### DIFF
--- a/trview.app/ApplicationCreate.cpp
+++ b/trview.app/ApplicationCreate.cpp
@@ -499,12 +499,14 @@ namespace trview
         auto diff_window_source = [=]()
             {
                 auto diff_window = std::make_shared<DiffWindow>(dialogs, level_source, imgui_file_menu, messaging);
+                messaging->add_recipient(diff_window);
                 diff_window->initialise();
                 return diff_window;
             };
         auto pack_window_source = [=]()
             {
                 auto pack_window = std::make_shared<PackWindow>(files, dialogs, messaging);
+                messaging->add_recipient(pack_window);
                 pack_window->initialise();
                 return pack_window;
             };


### PR DESCRIPTION
Diff window was not registered to receive messages so wasn't noticing level changes.
Same for Pack window.
Closes #1582