### PR TITLE
Re-run diff when 'A' level changes

### DIFF
--- a/trview.app/Windows/Diff/DiffWindow.cpp
+++ b/trview.app/Windows/Diff/DiffWindow.cpp
@@ -476,7 +476,19 @@ namespace trview
     void DiffWindow::set_level(const std::weak_ptr<ILevel>& level)
     {
         _level = level;
-        _diff.reset();
+        if (_diff && !_load.valid())
+        {
+            const auto new_level = level.lock();
+            _load = std::async(std::launch::async, [=]() -> LoadOperation
+                {
+                    return
+                    {
+                        .level = _diff->level,
+                        .filename = _diff->filename,
+                        .diff = do_diff(new_level, _diff->level)
+                    };
+                });
+        }
     }
 
     void DiffWindow::set_number(int32_t number)

--- a/trview.app/Windows/Diff/DiffWindow.cpp
+++ b/trview.app/Windows/Diff/DiffWindow.cpp
@@ -479,15 +479,22 @@ namespace trview
         if (_diff && !_load.valid())
         {
             const auto new_level = level.lock();
-            _load = std::async(std::launch::async, [=]() -> LoadOperation
-                {
-                    return
+            if (new_level)
+            {
+                _load = std::async(std::launch::async, [=]() -> LoadOperation
                     {
-                        .level = _diff->level,
-                        .filename = _diff->filename,
-                        .diff = do_diff(new_level, _diff->level)
-                    };
-                });
+                        return
+                        {
+                            .level = _diff->level,
+                            .filename = _diff->filename,
+                            .diff = do_diff(new_level, _diff->level)
+                        };
+                    });
+            }
+            else
+            {
+                _diff.reset();
+            }
         }
     }
 


### PR DESCRIPTION
When 'A' level changes and there is a diff active, re-run the diff with the new 'A' against the current 'B'.
Closes #1584