### PR TITLE
Allow camera/sink and light to be added to route

### DIFF
--- a/trview.app.tests/Routing/RouteTests.cpp
+++ b/trview.app.tests/Routing/RouteTests.cpp
@@ -2,6 +2,8 @@
 #include <trview.app/Mocks/Graphics/ISelectionRenderer.h>
 #include <trview.app/Mocks/Routing/IWaypoint.h>
 #include <trview.app/Mocks/Camera/ICamera.h>
+#include <trview.app/Mocks/Elements/ILight.h>
+#include <trview.app/Mocks/Elements/ICameraSink.h>
 #include <trview.tests.common/Mocks.h>
 
 using namespace trview;
@@ -553,4 +555,94 @@ TEST(Route, DefaultHeightLines)
         .with_settings({ .show_route_height_labels = true })
         .build();
     ASSERT_TRUE(route2->show_height_labels());
+}
+
+TEST(Route, SetLevelBindsItemWaypoint)
+{
+    auto route = register_test_module().build();
+    auto item = mock_shared<MockItem>();
+
+    std::weak_ptr<IItem> called;
+    auto waypoint = mock_shared<MockWaypoint>();
+    EXPECT_CALL(*waypoint, set_item)
+        .Times(1)
+        .WillOnce(SaveArg<0>(&called));
+    EXPECT_CALL(*waypoint, index).Times(1).WillRepeatedly(Return(1));
+    ON_CALL(*waypoint, type).WillByDefault(Return(IWaypoint::Type::Entity));
+
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, item(1)).Times(1).WillRepeatedly(Return(item));
+
+    route->add(waypoint);
+    route->set_level(level);
+
+    ASSERT_EQ(called.lock(), item);
+}
+
+TEST(Route, SetLevelBindsTriggerWaypoint)
+{
+    auto route = register_test_module().build();
+    auto trigger = mock_shared<MockTrigger>();
+
+    std::weak_ptr<ITrigger> called;
+    auto waypoint = mock_shared<MockWaypoint>();
+    EXPECT_CALL(*waypoint, set_trigger)
+        .Times(1)
+        .WillOnce(SaveArg<0>(&called));
+    EXPECT_CALL(*waypoint, index).Times(1).WillRepeatedly(Return(1));
+    ON_CALL(*waypoint, type).WillByDefault(Return(IWaypoint::Type::Trigger));
+
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, trigger(1)).Times(1).WillRepeatedly(Return(trigger));
+
+    route->add(waypoint);
+    route->set_level(level);
+
+    ASSERT_EQ(called.lock(), trigger);
+}
+
+TEST(Route, SetLevelBindsCameraSinkWaypoint)
+{
+    auto route = register_test_module().build();
+    auto camerasink = mock_shared<MockCameraSink>();
+
+    std::weak_ptr<ICameraSink> called;
+    auto waypoint = mock_shared<MockWaypoint>();
+    EXPECT_CALL(*waypoint, set_camera_sink)
+        .Times(1)
+        .WillOnce(SaveArg<0>(&called));
+    EXPECT_CALL(*waypoint, index).Times(1).WillRepeatedly(Return(1));
+    ON_CALL(*waypoint, type).WillByDefault(Return(IWaypoint::Type::CameraSink));
+
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, camera_sink(1)).Times(1).WillRepeatedly(Return(camerasink));
+
+    route->add(waypoint);
+    route->set_level(level);
+
+    ASSERT_EQ(called.lock(), camerasink);
+}
+
+TEST(Route, SetLevelBindsLightWaypoint)
+{
+    auto route = register_test_module()
+        .build();
+
+    auto light = mock_shared<MockLight>();
+
+    std::weak_ptr<ILight> called;
+    auto waypoint = mock_shared<MockWaypoint>();
+    EXPECT_CALL(*waypoint, set_light)
+        .Times(1)
+        .WillOnce(SaveArg<0>(&called));
+    EXPECT_CALL(*waypoint, index).Times(1).WillRepeatedly(Return(1));
+    ON_CALL(*waypoint, type).WillByDefault(Return(IWaypoint::Type::Light));
+
+    auto level = mock_shared<MockLevel>();
+    EXPECT_CALL(*level, light(1)).Times(1).WillRepeatedly(Return(light));
+
+    route->add(waypoint);
+    route->set_level(level);
+
+    ASSERT_EQ(called.lock(), light);
 }

--- a/trview.app.tests/Routing/WaypointTests.cpp
+++ b/trview.app.tests/Routing/WaypointTests.cpp
@@ -5,6 +5,8 @@
 #include <trview.app/Mocks/Elements/IItem.h>
 #include <trview.app/Mocks/Elements/ITrigger.h>
 #include <trview.app/Mocks/Elements/ILevel.h>
+#include <trview.app/Mocks/Elements/ICameraSink.h>
+#include <trview.app/Mocks/Elements/ILight.h>
 
 using namespace testing;
 using namespace trview;
@@ -112,4 +114,34 @@ TEST(Waypoint, SetPositionPreservesRoom)
     ASSERT_EQ(110, waypoint.room());
     waypoint.set_position(Vector3(100, 200, 300));
     ASSERT_EQ(110, waypoint.room());
+}
+
+TEST(Waypoint, Light)
+{
+    auto light = mock_shared<MockLight>();
+    auto level = mock_shared<MockLevel>();
+    ON_CALL(*level, light(23)).WillByDefault(Return(light));
+
+    auto route = mock_shared<MockRoute>();
+    ON_CALL(*route, level).WillByDefault(Return(level));
+
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3(1, 2, 3), Vector3::Down, 12, IWaypoint::Type::Light, 23, Colour::Red, Colour::Green);
+    ASSERT_EQ(waypoint.light().lock(), nullptr);
+    waypoint.set_route(route);
+    ASSERT_EQ(waypoint.light().lock(), light);
+}
+
+TEST(Waypoint, CameraSink)
+{
+    auto camera_sink = mock_shared<MockCameraSink>();
+    auto level = mock_shared<MockLevel>();
+    ON_CALL(*level, camera_sink(23)).WillByDefault(Return(camera_sink));
+
+    auto route = mock_shared<MockRoute>();
+    ON_CALL(*route, level).WillByDefault(Return(level));
+
+    Waypoint waypoint(mock_shared<MockMesh>(), Vector3(1, 2, 3), Vector3::Down, 12, IWaypoint::Type::CameraSink, 23, Colour::Red, Colour::Green);
+    ASSERT_EQ(waypoint.camera_sink().lock(), nullptr);
+    waypoint.set_route(route);
+    ASSERT_EQ(waypoint.camera_sink().lock(), camera_sink);
 }

--- a/trview.app.ui.tests/CameraSinkWindowTests.cpp
+++ b/trview.app.ui.tests/CameraSinkWindowTests.cpp
@@ -66,6 +66,36 @@ namespace
 
 void register_camera_sink_window_tests(ImGuiTestEngine* engine)
 {
+    test<CameraSinkWindowContext>(engine, "Camera/Sink Window", "Add to Route",
+        [](ImGuiTestContext* ctx) { ctx->GetVars<CameraSinkWindowContext>().render(); },
+        [](ImGuiTestContext* ctx)
+        {
+            auto& context = ctx->GetVars<CameraSinkWindowContext>();
+            context.messaging = mock_shared<MockMessageSystem>();
+            context.ptr = register_test_module().with_messaging(context.messaging).build();
+            ON_CALL(*context.messaging, send_message).WillByDefault([&](auto&& message) { context.messages.push_back(message); });
+
+            auto camera_sink = mock_shared<MockCameraSink>()->with_number(0)->with_type(ICameraSink::Type::Camera);
+            context.camera_sinks = { camera_sink };
+            context.ptr->set_camera_sinks({ camera_sink });
+            context.ptr->set_selected_camera_sink(camera_sink);
+
+            ctx->SetRef("/Camera\\/Sink 0\\/Details_CA3F050C");
+            ctx->ItemClick("Add to Route");
+
+            if (auto found = find_message(context.messages, "add_to_route"))
+            {
+                auto route_message = messages::read_add_to_route(found.value());
+                IM_CHECK_EQ(std::get_if<std::weak_ptr<ICameraSink>>(&route_message->element)->lock(), camera_sink);
+            }
+            else
+            {
+                IM_ERRORF("Message not found");
+            }
+
+            IM_CHECK_EQ(Mock::VerifyAndClearExpectations(camera_sink.get()), true);
+        });
+
     test<CameraSinkWindowContext>(engine, "Camera/Sink Window", "List Filtered When Room Set and Track Room Enabled",
         [](ImGuiTestContext* ctx) { ctx->GetVars<CameraSinkWindowContext>().render(); },
         [](ImGuiTestContext* ctx)

--- a/trview.app.ui.tests/LightsWindowTests.cpp
+++ b/trview.app.ui.tests/LightsWindowTests.cpp
@@ -58,6 +58,35 @@ namespace
 
 void register_lights_window_tests(ImGuiTestEngine* engine)
 {
+    test<LightsWindowContext>(engine, "Lights Window", "Add to Route",
+        [](ImGuiTestContext* ctx) { ctx->GetVars<LightsWindowContext>().render(); },
+        [](ImGuiTestContext* ctx)
+        {
+            auto& context = ctx->GetVars<LightsWindowContext>();
+            context.messaging = mock_shared<MockMessageSystem>();
+            context.ptr = register_test_module().with_messaging(context.messaging).build();
+            ON_CALL(*context.messaging, send_message).WillByDefault([&](auto&& message) { context.messages.push_back(message); });
+
+            auto light = mock_shared<MockLight>()->with_number(0);
+            context.lights = { light };
+            context.ptr->set_lights({ light });
+            context.ptr->set_selected_light(light);
+
+            ctx->ItemClick("/**/Add to Route");
+
+            if (auto found = find_message(context.messages, "add_to_route"))
+            {
+                auto route_message = messages::read_add_to_route(found.value());
+                IM_CHECK_EQ(std::get_if<std::weak_ptr<ILight>>(&route_message->element)->lock(), light);
+            }
+            else
+            {
+                IM_ERRORF("Message not found");
+            }
+
+            IM_CHECK_EQ(Mock::VerifyAndClearExpectations(light.get()), true);
+        });
+
     test<LightsWindowContext>(engine, "Lights Window", "Fob Bulb Stats",
         [](ImGuiTestContext* ctx) { ctx->GetVars<LightsWindowContext>().render(); },
         [](ImGuiTestContext* ctx)

--- a/trview.app/Application.cpp
+++ b/trview.app/Application.cpp
@@ -813,6 +813,20 @@ namespace trview
                     add_waypoint(item_ptr->position(), Vector3::Down, item_room(item_ptr), IWaypoint::Type::Entity, item_ptr->number());
                 }
             }
+            else if (auto light = std::get_if<std::weak_ptr<ILight>>(&add_to_route->element))
+            {
+                if (auto light_ptr = light->lock())
+                {
+                    add_waypoint(light_ptr->position(), Vector3::Down, light_room(light_ptr), IWaypoint::Type::Light, light_ptr->number());
+                }
+            }
+            else if (auto camera_sink = std::get_if<std::weak_ptr<ICameraSink>>(&add_to_route->element))
+            {
+                if (auto camera_sink_ptr = camera_sink->lock())
+                {
+                    add_waypoint(camera_sink_ptr->position(), Vector3::Down, actual_room(*camera_sink_ptr), IWaypoint::Type::Light, camera_sink_ptr->number());
+                }
+            }
         }
         else if (auto open_filename = messages::read_open_level_filename(message))
         {

--- a/trview.app/Messages/Messages.cpp
+++ b/trview.app/Messages/Messages.cpp
@@ -138,6 +138,16 @@ namespace trview
             send_message(messaging, RouteMessage{ .element = trigger }, "add_to_route");
         }
 
+        void send_add_to_route(const std::weak_ptr<IMessageSystem>& messaging, const std::weak_ptr<ILight>& light)
+        {
+            send_message(messaging, RouteMessage{ .element = light }, "add_to_route");
+        }
+
+        void send_add_to_route(const std::weak_ptr<IMessageSystem>& messaging, const std::weak_ptr<ICameraSink>& camera_sink)
+        {
+            send_message(messaging, RouteMessage{ .element = camera_sink }, "add_to_route");
+        }
+
         std::optional<bool> read_ng_plus(const Message& message)
         {
             return read_message<bool>(message, "ng_plus");

--- a/trview.app/Messages/Messages.h
+++ b/trview.app/Messages/Messages.h
@@ -28,7 +28,7 @@ namespace trview
         struct RouteMessage
         {
             // TODO: Interfaces
-            std::variant<std::weak_ptr<ITrigger>, std::weak_ptr<IItem>> element;
+            std::variant<std::weak_ptr<ITrigger>, std::weak_ptr<IItem>, std::weak_ptr<ILight>, std::weak_ptr<ICameraSink>> element;
         };
 
         namespace commands
@@ -62,6 +62,8 @@ namespace trview
         std::optional<RouteMessage> read_add_to_route(const Message& message);
         void send_add_to_route(const std::weak_ptr<IMessageSystem>& messaging, const std::weak_ptr<IItem>& item);
         void send_add_to_route(const std::weak_ptr<IMessageSystem>& messaging, const std::weak_ptr<ITrigger>& trigger);
+        void send_add_to_route(const std::weak_ptr<IMessageSystem>& messaging, const std::weak_ptr<ILight>& light);
+        void send_add_to_route(const std::weak_ptr<IMessageSystem>& messaging, const std::weak_ptr<ICameraSink>& camera_sink);
 
         std::optional<bool> read_ng_plus(const Message& message);
         void send_ng_plus(const std::weak_ptr<IMessageSystem>& messaging, bool value);

--- a/trview.app/Mocks/Routing/IWaypoint.h
+++ b/trview.app/Mocks/Routing/IWaypoint.h
@@ -43,6 +43,10 @@ namespace trview
             MOCK_METHOD(Colour, route_colour, (), (const, override));
             MOCK_METHOD(Colour, waypoint_colour, (), (const, override));
             MOCK_METHOD(DirectX::SimpleMath::Vector2, screen_position, (), (const, override));
+            MOCK_METHOD(void, set_camera_sink, (const std::weak_ptr<ICameraSink>&), (override));
+            MOCK_METHOD(void, set_light, (const std::weak_ptr<ILight>&), (override));
+            MOCK_METHOD(std::weak_ptr<ICameraSink>, camera_sink, (), (const, override));
+            MOCK_METHOD(std::weak_ptr<ILight>, light, (), (const, override));
             /// <summary>
             /// Index used for testing ordering.
             /// </summary>

--- a/trview.app/Routing/IWaypoint.cpp
+++ b/trview.app/Routing/IWaypoint.cpp
@@ -18,6 +18,16 @@ namespace trview
             return IWaypoint::Type::Entity;
         }
 
+        if (value == "Camera/Sink")
+        {
+            return IWaypoint::Type::CameraSink;
+        }
+
+        if (value == "Light")
+        {
+            return IWaypoint::Type::Light;
+        }
+
         return IWaypoint::Type::Position;
     }
 
@@ -31,6 +41,10 @@ namespace trview
                 return "Position";
             case IWaypoint::Type::Trigger:
                 return "Trigger";
+            case IWaypoint::Type::CameraSink:
+                return "Camera/Sink";
+            case IWaypoint::Type::Light:
+                return "Light";
         }
         return "Unknown";
     }

--- a/trview.app/Routing/IWaypoint.h
+++ b/trview.app/Routing/IWaypoint.h
@@ -12,6 +12,8 @@ namespace trview
     struct IRoute;
     struct IItem;
     struct ITrigger;
+    struct ICameraSink;
+    struct ILight;
 
     /// <summary>
     /// A waypoint in a route.
@@ -34,7 +36,9 @@ namespace trview
             /// <summary>
             /// The waypoint is a trigger in the world.
             /// </summary>
-            Trigger
+            Trigger,
+            Light,
+            CameraSink
         };
 
         using WaypointRandomizerSettings = std::map<std::string, std::variant<bool, float, std::string>>;
@@ -124,6 +128,10 @@ namespace trview
         virtual void set_normal(const DirectX::SimpleMath::Vector3& normal) = 0;
         virtual void set_room_number(uint32_t room) = 0;
         virtual DirectX::SimpleMath::Vector2 screen_position() const = 0;
+        virtual void set_light(const std::weak_ptr<ILight>& light) = 0;
+        virtual void set_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) = 0;
+        virtual std::weak_ptr<ICameraSink> camera_sink() const = 0;
+        virtual std::weak_ptr<ILight> light() const = 0;
 
         Event<> on_changed;
     };

--- a/trview.app/Routing/Route.cpp
+++ b/trview.app/Routing/Route.cpp
@@ -475,6 +475,30 @@ namespace trview
                     }
                     break;
                 }
+                case IWaypoint::Type::CameraSink:
+                {
+                    if (level)
+                    {
+                        waypoint->set_camera_sink(level->camera_sink(waypoint->index()));
+                    }
+                    else
+                    {
+                        waypoint->set_camera_sink({});
+                    }
+                    break;
+                }
+                case IWaypoint::Type::Light:
+                {
+                    if (level)
+                    {
+                        waypoint->set_light(level->light(waypoint->index()));
+                    }
+                    else
+                    {
+                        waypoint->set_light({});
+                    }
+                    break;
+                }
             }
         }
     }

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -281,5 +281,33 @@ namespace trview
     {
         return _screen_position;
     }
+
+    void Waypoint::set_light(const std::weak_ptr<ILight>& light)
+    {
+        _light = light;
+        if (auto new_light = _light.lock())
+        {
+            set_properties(Type::Light, new_light->number(), light_room(new_light), new_light->position());
+        }
+    }
+
+    void Waypoint::set_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink)
+    {
+        _camera_sink = camera_sink;
+        if (auto new_camera_sink = _camera_sink.lock())
+        {
+            set_properties(Type::CameraSink, new_camera_sink->number(), room_number(actual_room(*new_camera_sink)), new_camera_sink->position());
+        }
+    }
+
+    std::weak_ptr<ICameraSink> Waypoint::camera_sink() const
+    {
+        return _camera_sink;
+    }
+
+    std::weak_ptr<ILight> Waypoint::light() const
+    {
+        return _light;
+    }
 }
 

--- a/trview.app/Routing/Waypoint.cpp
+++ b/trview.app/Routing/Waypoint.cpp
@@ -302,12 +302,41 @@ namespace trview
 
     std::weak_ptr<ICameraSink> Waypoint::camera_sink() const
     {
+        if (auto existing = _camera_sink.lock())
+        {
+            return existing;
+        }
+
+        if (type() == IWaypoint::Type::CameraSink)
+        {
+            if (auto route = _route.lock())
+            {
+                if (auto level = route->level().lock())
+                {
+                    _camera_sink = level->camera_sink(index());
+                }
+            }
+        }
         return _camera_sink;
     }
 
     std::weak_ptr<ILight> Waypoint::light() const
     {
+        if (auto existing = _light.lock())
+        {
+            return existing;
+        }
+
+        if (type() == IWaypoint::Type::Light)
+        {
+            if (auto route = _route.lock())
+            {
+                if (auto level = route->level().lock())
+                {
+                    _light = level->light(index());
+                }
+            }
+        }
         return _light;
     }
 }
-

--- a/trview.app/Routing/Waypoint.h
+++ b/trview.app/Routing/Waypoint.h
@@ -57,6 +57,10 @@ namespace trview
         void set_normal(const DirectX::SimpleMath::Vector3& normal) override;
         void set_room_number(uint32_t room) override;
         DirectX::SimpleMath::Vector2 screen_position() const override;
+        void set_light(const std::weak_ptr<ILight>& light) override;
+        void set_camera_sink(const std::weak_ptr<ICameraSink>& camera_sink) override;
+        std::weak_ptr<ICameraSink> camera_sink() const override;
+        std::weak_ptr<ILight> light() const override;
     private:
         DirectX::SimpleMath::Matrix calculate_waypoint_rotation() const;
         void set_properties(Type type, uint32_t index, uint32_t room, const DirectX::SimpleMath::Vector3& position);
@@ -77,6 +81,8 @@ namespace trview
 
         mutable std::weak_ptr<IItem> _item;
         mutable std::weak_ptr<ITrigger> _trigger;
+        mutable std::weak_ptr<ICameraSink> _camera_sink;
+        mutable std::weak_ptr<ILight> _light;
 
         DirectX::SimpleMath::Vector2 _screen_position{ -1, -1 };
     };

--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -435,7 +435,7 @@ namespace trview
                         ImGui::SetNextWindowPos(vp->Pos + ImVec2(pos.x, pos.y));
                         if (ImGui::Begin(std::format("##waypoint{}", i).c_str(), nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoFocusOnAppearing))
                         {
-                            if (diff != 0)
+                            if (route->show_height_labels() && diff != 0)
                             {
                                 const std::string sign = diff <= 0 ? "+" : "-";
                                 const int clicks = static_cast<int>(round(diff / trlevel::Click));

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -532,6 +532,11 @@ namespace trview
 
                 ImGui::EndTable();
 
+                if (ImGui::Button(Names::add_to_route_button.c_str(), ImVec2(-1, 30)))
+                {
+                    messages::send_add_to_route(_messaging, selected);
+                }
+
                 ImGui::Spacing();
 
                 ImGui::Text("Trigger References");

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.h
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.h
@@ -23,6 +23,7 @@ namespace trview
     public:
         struct Names
         {
+            static inline const std::string add_to_route_button = "Add to Route";
             static inline const std::string sync = "Sync";
             static inline const std::string camera_sink_list = "##camerasinklist";
             static inline const std::string list_panel = "Camera/Sink List";

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -227,6 +227,8 @@ namespace trview
     {
         if (ImGui::BeginChild(Names::details_panel.c_str(), ImVec2(), true))
         {
+            const auto selected_light = _selected_light.lock();
+
             ImGui::Text("Light Details");
             if (ImGui::BeginTable(Names::stats_listbox.c_str(), 2, 0, ImVec2(-1, 150)))
             {
@@ -234,7 +236,6 @@ namespace trview
                 ImGui::TableSetupColumn("Value");
                 ImGui::TableNextRow();
 
-                auto selected_light = _selected_light.lock();
                 if (selected_light)
                 {
                     auto add_stat = [&]<typename T>(const std::string& name, const T&& value, Colour colour = Colour::White)
@@ -311,6 +312,11 @@ namespace trview
                     add_stat_with_condition("Radius", radius, has_radius);
                 }
                 ImGui::EndTable();
+            }
+
+            if (selected_light && ImGui::Button(Names::add_to_route_button.c_str(), ImVec2(-1, 30)))
+            {
+                messages::send_add_to_route(_messaging, _selected_light);
             }
         }
         ImGui::EndChild();

--- a/trview.app/Windows/LightsWindow.h
+++ b/trview.app/Windows/LightsWindow.h
@@ -19,6 +19,7 @@ namespace trview
     public:
         struct Names
         {
+            static inline const std::string add_to_route_button = "Add to Route";
             static inline const std::string light_list_panel = "Light List";
             static inline const std::string lights_listbox = "Lights";
             static inline const std::string stats_listbox = "Stats";

--- a/trview.app/Windows/Viewer.cpp
+++ b/trview.app/Windows/Viewer.cpp
@@ -16,6 +16,25 @@ using namespace DirectX::SimpleMath;
 
 namespace trview
 {
+    namespace
+    {
+        IWaypoint::Type to_waypoint_type(PickResult::Type type)
+        {
+            switch (type)
+            {
+            case PickResult::Type::Entity:
+                return IWaypoint::Type::Entity;
+            case PickResult::Type::Trigger:
+                return IWaypoint::Type::Trigger;
+            case PickResult::Type::Light:
+                return IWaypoint::Type::Light;
+            case PickResult::Type::CameraSink:
+                return IWaypoint::Type::CameraSink;
+            }
+            return IWaypoint::Type::Position;
+        }
+    }
+
     IViewer::~IViewer()
     {
     }
@@ -114,9 +133,9 @@ namespace trview
         _token_store += _ui->on_camera_projection_mode += [&](ProjectionMode mode) { set_camera_projection_mode(mode); };
         _token_store += _ui->on_add_waypoint += [&]()
         {
-            auto type = _context_pick.type == PickResult::Type::Entity ? IWaypoint::Type::Entity : _context_pick.type == PickResult::Type::Trigger ? IWaypoint::Type::Trigger : IWaypoint::Type::Position;
+            const auto type = to_waypoint_type(_context_pick.type);
             Vector3 normal = _context_pick.triangle.normal();
-            if (type == IWaypoint::Type::Entity)
+            if (type != IWaypoint::Type::Position)
             {
                 normal = Vector3::Down;
             }
@@ -156,14 +175,31 @@ namespace trview
                     }
                     break;
                 }
+                case PickResult::Type::Light:
+                {
+                    if (const auto light = _context_pick.light.lock())
+                    {
+                        _context_pick.position = light->position();
+                        index = light->number();
+                    }
+                    break;
+                }
+                case PickResult::Type::CameraSink:
+                {
+                    if (const auto camera_sink = _context_pick.camera_sink.lock())
+                    {
+                        _context_pick.position = camera_sink->position();
+                        index = camera_sink->number();
+                    }
+                    break;
+                }
             }
 
             on_waypoint_added(_context_pick.position, normal, room_from_pick(_context_pick), type, index);
         };
         _token_store += _ui->on_add_mid_waypoint += [&]()
         {
-            auto type = _context_pick.type == PickResult::Type::Entity ? IWaypoint::Type::Entity : _context_pick.type == PickResult::Type::Trigger ? IWaypoint::Type::Trigger : IWaypoint::Type::Position;
-
+            const auto type = to_waypoint_type(_context_pick.type);
             uint32_t index = 0;
             if (_context_pick.type == PickResult::Type::Room)
             {
@@ -187,6 +223,22 @@ namespace trview
                 {
                     _context_pick.position = trigger->position();
                     index = trigger->number();
+                }
+            }
+            else if (_context_pick.type == PickResult::Type::Light)
+            {
+                if (const auto light = _context_pick.light.lock())
+                {
+                    _context_pick.position = light->position();
+                    index = light->number();
+                }
+            }
+            else if (_context_pick.type == PickResult::Type::CameraSink)
+            {
+                if (const auto camera_sink = _context_pick.camera_sink.lock())
+                {
+                    _context_pick.position = camera_sink->position();
+                    index = camera_sink->number();
                 }
             }
 
@@ -1254,6 +1306,22 @@ namespace trview
                 if (const auto waypoint = pick.waypoint.lock())
                 {
                     return level->room(waypoint->room());
+                }
+                break;
+            }
+            case PickResult::Type::Light:
+            {
+                if (const auto light = pick.light.lock())
+                {
+                    return light->room();
+                }
+                break;
+            }
+            case PickResult::Type::CameraSink:
+            {
+                if (const auto camera_sink = pick.camera_sink.lock())
+                {
+                    return camera_sink->room();
                 }
                 break;
             }


### PR DESCRIPTION
Add buttons for add to route to camera/sink and light windows, allow creating waypoints with context menu.
Also fix issue where height labels were still showing on routes if they were disabled but also had a note.
Closes #1084