### PR TITLE
Fix docking of filter windows

### DIFF
--- a/trview.app/Filters/Filters.cpp
+++ b/trview.app/Filters/Filters.cpp
@@ -481,11 +481,14 @@ namespace trview
         {
             toggle_visible();
         }
+    }
 
+    void Filters::render_window()
+    {
         if (_show_filters)
         {
             ImGui::SetNextWindowSizeConstraints(ImVec2(200, 50), ImVec2(FLT_MAX, FLT_MAX));
-            if (ImGui::Begin(std::format("{} ({})", Names::Popup, _id).c_str(), &_show_filters, ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDocking))
+            if (ImGui::Begin(std::format("{} ({})", Names::Popup, _id).c_str(), &_show_filters, ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_AlwaysAutoResize))
             {
                 render_menu_bar();
                 render_filter_name_modal();

--- a/trview.app/Filters/Filters.cpp
+++ b/trview.app/Filters/Filters.cpp
@@ -485,7 +485,7 @@ namespace trview
         if (_show_filters)
         {
             ImGui::SetNextWindowSizeConstraints(ImVec2(200, 50), ImVec2(FLT_MAX, FLT_MAX));
-            if (ImGui::Begin(std::format("{} ({})", Names::Popup, _id).c_str(), &_show_filters, ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_AlwaysAutoResize))
+            if (ImGui::Begin(std::format("{} ({})", Names::Popup, _id).c_str(), &_show_filters, ImGuiWindowFlags_MenuBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoDocking))
             {
                 render_menu_bar();
                 render_filter_name_modal();

--- a/trview.app/Filters/Filters.h
+++ b/trview.app/Filters/Filters.h
@@ -170,6 +170,7 @@ namespace trview
         bool match(const IFilterable& value) const;
         bool match(const Filter& filter, const IFilterable& value, const std::string& type_key) const;
         void render();
+        void render_window();
         void render_settings();
         void render_table(const std::ranges::forward_range auto& items,
             std::ranges::forward_range auto& all_items,

--- a/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
+++ b/trview.app/Windows/CameraSink/CameraSinkWindow.cpp
@@ -373,6 +373,9 @@ namespace trview
         }
         ImGui::End();
         ImGui::PopStyleVar();
+        _filters.render_window();
+        _flyby_filters.render_window();
+        _node_filters.render_window();
         return stay_open;
     }
 

--- a/trview.app/Windows/ItemsWindow.cpp
+++ b/trview.app/Windows/ItemsWindow.cpp
@@ -381,6 +381,7 @@ namespace trview
         }
         ImGui::End();
         ImGui::PopStyleVar();
+        _filters.render_window();
         return stay_open;
     }
 

--- a/trview.app/Windows/LightsWindow.cpp
+++ b/trview.app/Windows/LightsWindow.cpp
@@ -341,6 +341,7 @@ namespace trview
         }
         ImGui::End();
         ImGui::PopStyleVar();
+        _filters.render_window();
         return stay_open;
     }
 

--- a/trview.app/Windows/RoomsWindow.cpp
+++ b/trview.app/Windows/RoomsWindow.cpp
@@ -605,6 +605,7 @@ namespace trview
         }
         ImGui::End();
         ImGui::PopStyleVar();
+        _filters.render_window();
         return stay_open;
     }
 

--- a/trview.app/Windows/Sounds/SoundsWindow.cpp
+++ b/trview.app/Windows/Sounds/SoundsWindow.cpp
@@ -138,6 +138,7 @@ namespace trview
         }
         ImGui::End();
         ImGui::PopStyleVar();
+        _filters.render_window();
         return stay_open;
     }
 

--- a/trview.app/Windows/Statics/StaticsWindow.cpp
+++ b/trview.app/Windows/Statics/StaticsWindow.cpp
@@ -94,6 +94,7 @@ namespace trview
         }
         ImGui::End();
         ImGui::PopStyleVar();
+        _filters.render_window();
         return stay_open;
     }
 

--- a/trview.app/Windows/TriggersWindow.cpp
+++ b/trview.app/Windows/TriggersWindow.cpp
@@ -636,6 +636,7 @@ namespace trview
         }
         ImGui::End();
         ImGui::PopStyleVar();
+        _filters.render_window();
         return stay_open;
     }
 


### PR DESCRIPTION
Stops filter windows from rapidly flickering in and out of existence when they're docked inside their parent.
Splits the rendering of the filter window out from the button and always calls this even if the host window is hidden - that way when the filter is docked and effectively causing the host not to be rendered it will still exist and not disappear for a frame.
Closes #1589