### PR TITLE
Use correct texture mask based on version

### DIFF
--- a/external/DirectXTK/DirectXTK_Desktop.vcxproj
+++ b/external/DirectXTK/DirectXTK_Desktop.vcxproj
@@ -98,7 +98,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
-      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <WarningLevel>TurnOffAllWarnings</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_WIN32_WINNT=0x0601;_WIN7_PLATFORM_UPDATE;WIN32;_DEBUG;_LIB;_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
@@ -123,7 +123,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>EnableAllWarnings</WarningLevel>
+      <WarningLevel>TurnOffAllWarnings</WarningLevel>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
       <PreprocessorDefinitions>_WIN32_WINNT=0x0601;_WIN7_PLATFORM_UPDATE;WIN32;NDEBUG;_LIB;_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/external/freetype/builds/windows/vc2010/freetype.vcxproj
+++ b/external/freetype/builds/windows/vc2010/freetype.vcxproj
@@ -59,7 +59,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DisableLanguageExtensions>false</DisableLanguageExtensions>
-      <WarningLevel>Level4</WarningLevel>
+      <WarningLevel>TurnOffAllWarnings</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <CompileAs>Default</CompileAs>
       <DisableSpecificWarnings>4001;4267</DisableSpecificWarnings>
@@ -86,7 +86,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <DisableLanguageExtensions>true</DisableLanguageExtensions>
-      <WarningLevel>Level4</WarningLevel>
+      <WarningLevel>TurnOffAllWarnings</WarningLevel>
       <CompileAs>Default</CompileAs>
       <DisableSpecificWarnings>4001;4267</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/external/imgui_test_engine/imgui_test_engine.vcxproj
+++ b/external/imgui_test_engine/imgui_test_engine.vcxproj
@@ -51,7 +51,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level4</WarningLevel>
+      <WarningLevel>TurnOffAllWarnings</WarningLevel>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..;$(SolutionDir)\external\imgui;$(SolutionDir)\external\imgui\backends;..\imgui_test_suite\thirdparty\implot;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_UNICODE;UNICODE;IMGUI_USER_CONFIG="imgui_test_suite/imgui_test_suite_imconfig.h";IMGUI_APP_WIN32_DX11;IMGUI_TEST_ENGINE_ENABLE_COROUTINE_STDTHREAD_IMPL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -68,7 +68,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level4</WarningLevel>
+      <WarningLevel>TurnOffAllWarnings</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>

--- a/external/lua/lua.vcxproj
+++ b/external/lua/lua.vcxproj
@@ -113,7 +113,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>TurnOffAllWarnings</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
@@ -131,7 +131,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>TurnOffAllWarnings</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>

--- a/trview.app/Geometry/IMesh.cpp
+++ b/trview.app/Geometry/IMesh.cpp
@@ -9,7 +9,10 @@ namespace trview
 {
     namespace
     {
-        const uint16_t Texture_Mask = 0x7fff;
+        constexpr uint16_t texture_mask(const trlevel::PlatformAndVersion& platform_and_version) noexcept
+        {
+            return platform_and_version.version == trlevel::LevelVersion::Tomb5 ? 0x3fff : 0x7fff;
+        }
 
         void add_rect(std::vector<Triangle>& triangles, const Vector3& v0, const Vector3& v1, const Vector3& v2, const Vector3& v3, const Vector3& normal)
         {
@@ -397,7 +400,7 @@ namespace trview
                 colors[i] = input_vertices[rect.vertices[i]].colour;
             }
 
-            uint16_t texture = rect.texture & Texture_Mask;
+            uint16_t texture = rect.texture & texture_mask(version);
             if (needs_rect_texture_abs(version))
             {
                 texture = static_cast<uint16_t>(std::abs(static_cast<int16_t>(rect.texture)));
@@ -513,7 +516,7 @@ namespace trview
                 colors[i] = input_vertices[tri.vertices[i]].colour;
             }
 
-            uint16_t texture = tri.texture & Texture_Mask;
+            uint16_t texture = tri.texture & texture_mask(version);
 
             if (needs_tri_texture_mask(version))
             {
@@ -589,7 +592,7 @@ namespace trview
     {
         for (const auto& rect : rectangles)
         {
-            const uint16_t texture = rect.texture & Texture_Mask;
+            const uint16_t texture = rect.texture & texture_mask(platform_and_version);
             const bool double_sided = platform_and_version.platform == trlevel::Platform::Saturn ? false : rect.texture & 0x8000;
 
             std::array<Vector3, 4> verts;
@@ -632,7 +635,7 @@ namespace trview
     {
         for (const auto& tri : triangles)
         {
-            const uint16_t texture = tri.texture & Texture_Mask;
+            const uint16_t texture = tri.texture & texture_mask(platform_and_version);
             const bool double_sided = platform_and_version.platform == trlevel::Platform::Saturn ? false : tri.texture & 0x8000;
 
             std::array<Vector3, 3> verts;

--- a/trview.app/Geometry/IMesh.cpp
+++ b/trview.app/Geometry/IMesh.cpp
@@ -9,7 +9,7 @@ namespace trview
 {
     namespace
     {
-        const uint16_t Texture_Mask = 0x3fff;
+        const uint16_t Texture_Mask = 0x7fff;
 
         void add_rect(std::vector<Triangle>& triangles, const Vector3& v0, const Vector3& v1, const Vector3& v2, const Vector3& v3, const Vector3& normal)
         {
@@ -589,7 +589,7 @@ namespace trview
     {
         for (const auto& rect : rectangles)
         {
-            const uint16_t texture = rect.texture & 0x7fff;
+            const uint16_t texture = rect.texture & Texture_Mask;
             const bool double_sided = platform_and_version.platform == trlevel::Platform::Saturn ? false : rect.texture & 0x8000;
 
             std::array<Vector3, 4> verts;
@@ -632,7 +632,7 @@ namespace trview
     {
         for (const auto& tri : triangles)
         {
-            const uint16_t texture = tri.texture & 0x7fff;
+            const uint16_t texture = tri.texture & Texture_Mask;
             const bool double_sided = platform_and_version.platform == trlevel::Platform::Saturn ? false : tri.texture & 0x8000;
 
             std::array<Vector3, 3> verts;


### PR DESCRIPTION
TR5 uses `0x3fff` for texture mask, others use `0x7fff`. Previously this was changed to be `0x3fff` for everything which works in most cases but some customs trip it up.
Add a check on the version in mesh loading.
Also disable some warnings on external projects.
Closes #1594