### PR TITLE
Don't draw scriptable notes if notes toggle is off

### DIFF
--- a/trview.app/UI/ViewerUI.cpp
+++ b/trview.app/UI/ViewerUI.cpp
@@ -456,7 +456,7 @@ namespace trview
     void ViewerUI::render_scriptable_notes()
     {
         const auto level = _level.lock();
-        if (!level)
+        if (!level || !toggle(IViewer::Options::notes))
         {
             return;
         }


### PR DESCRIPTION
If user has hidden notes then don't show scriptable notes.
Closes #1598