### PR TITLE
Restore Windows 7 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - uses: fbactions/setup-winsdk@v2
+      with:
+        winsdk-build-version: 19041
+
     - name: setup-msbuild
       uses: microsoft/setup-msbuild@v2
       with:

--- a/external/DirectXTK/DirectXTK_Desktop.vcxproj
+++ b/external/DirectXTK/DirectXTK_Desktop.vcxproj
@@ -59,7 +59,7 @@
     <ProjectGuid>{A11566D3-4081-42C9-94C5-F4057EDD9D50}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>DirectXTK</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/external/freetype/builds/windows/vc2010/freetype.vcxproj
+++ b/external/freetype/builds/windows/vc2010/freetype.vcxproj
@@ -25,7 +25,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{78B079BD-9FC7-4B9E-B4A6-96DA0F00248B}</ProjectGuid>
     <RootNamespace>FreeType</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="PlatformToolset">

--- a/external/googlemock/googlemock.vcxproj
+++ b/external/googlemock/googlemock.vcxproj
@@ -62,7 +62,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{6e37091e-954c-4654-9b42-5980410791f4}</ProjectGuid>
     <RootNamespace>googlemock</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/external/googletest/googletest.vcxproj
+++ b/external/googletest/googletest.vcxproj
@@ -85,7 +85,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{eafd7489-57e3-4b6d-a704-f7c5ef640434}</ProjectGuid>
     <RootNamespace>googletest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/external/imgui/imgui.vcxproj
+++ b/external/imgui/imgui.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{6aabd08e-3361-4d84-88f0-851ee588162a}</ProjectGuid>
     <RootNamespace>imgui</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/external/imgui_test_engine/imgui_test_engine.vcxproj
+++ b/external/imgui_test_engine/imgui_test_engine.vcxproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E6FAC6EF-4B54-45C4-9E76-3B063B51D4B9}</ProjectGuid>
     <RootNamespace>imgui_test_engine</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/external/lua/lua.vcxproj
+++ b/external/lua/lua.vcxproj
@@ -77,7 +77,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{2a4f1e89-71ac-46c3-a711-1a4d67accdf5}</ProjectGuid>
     <RootNamespace>lua</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/external/zlib/contrib/vstudio/vc14/zlibstat.vcxproj
+++ b/external/zlib/contrib/vstudio/vc14/zlibstat.vcxproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{745DEC58-EBB3-47A9-A9B8-4C6627C01BF8}</ProjectGuid>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">

--- a/trlevel.tests/trlevel.tests.vcxproj
+++ b/trlevel.tests/trlevel.tests.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{49a67578-3b2c-4ae2-a2a1-fd00ef9148eb}</ProjectGuid>
     <RootNamespace>trleveltests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trlevel/Hasher.cpp
+++ b/trlevel/Hasher.cpp
@@ -2,6 +2,7 @@
 #include <bcrypt.h>
 #include <format>
 #include <ranges>
+#include <versionhelpers.h>
 
 namespace trlevel
 {
@@ -11,16 +12,6 @@ namespace trlevel
 
     Hasher::Hasher()
     {
-        DWORD object_length = 0;
-        DWORD data_length = 0;
-        BCryptGetProperty(BCRYPT_SHA256_ALG_HANDLE, BCRYPT_OBJECT_LENGTH, reinterpret_cast<PBYTE>(&object_length), sizeof(DWORD), &data_length, 0);
-        hash_object.resize(object_length, 0);
-
-        DWORD hash_length = 0;
-        BCryptGetProperty(BCRYPT_SHA256_ALG_HANDLE, BCRYPT_HASH_LENGTH, (PBYTE)&hash_length, sizeof(DWORD), &data_length, 0);
-        hash_buffer.resize(hash_length, 0);
-
-        BCryptCreateHash(BCRYPT_SHA256_ALG_HANDLE, &_hash, &hash_object[0], object_length, nullptr, 0, BCRYPT_HASH_REUSABLE_FLAG);
     }
 
     Hasher::~Hasher()
@@ -28,8 +19,45 @@ namespace trlevel
         BCryptDestroyHash(_hash);
     }
 
+    void Hasher::create_hash() const
+    {
+        const bool reusable = IsWindows8OrGreater();
+        if (reusable && _hash != nullptr)
+        {
+            return;
+        }
+
+        BCryptDestroyHash(_hash);
+        _hash = nullptr;
+
+        const bool use_pseudo_handle = IsWindows10OrGreater();
+
+        BCRYPT_ALG_HANDLE algorithm = BCRYPT_SHA256_ALG_HANDLE;
+        if (!use_pseudo_handle)
+        {
+            BCryptOpenAlgorithmProvider(&algorithm, L"SHA256", NULL, 0);
+        }
+        
+        DWORD object_length = 0;
+        DWORD data_length = 0;
+        BCryptGetProperty(algorithm, BCRYPT_OBJECT_LENGTH, reinterpret_cast<PBYTE>(&object_length), sizeof(DWORD), &data_length, 0);
+        hash_object.resize(object_length, 0);
+
+        DWORD hash_length = 0;
+        BCryptGetProperty(algorithm, BCRYPT_HASH_LENGTH, (PBYTE)&hash_length, sizeof(DWORD), &data_length, 0);
+        hash_buffer.resize(hash_length, 0);
+
+        BCryptCreateHash(algorithm, &_hash, &hash_object[0], object_length, nullptr, 0, reusable ? BCRYPT_HASH_REUSABLE_FLAG : 0);
+
+        if (!use_pseudo_handle)
+        {
+            BCryptCloseAlgorithmProvider(&algorithm, 0);
+        }
+    }
+
     std::string Hasher::hash(const std::vector<uint8_t>& data) const
     {
+        create_hash();
         BCryptHashData(_hash, const_cast<uint8_t*>(&data[0]), static_cast<ULONG>(data.size()), 0);
         BCryptFinishHash(_hash, const_cast<uint8_t*>(&hash_buffer[0]), static_cast<ULONG>(hash_buffer.size()), 0);
         return hash_buffer

--- a/trlevel/Hasher.h
+++ b/trlevel/Hasher.h
@@ -11,8 +11,10 @@ namespace trlevel
         virtual ~Hasher();
         std::string hash(const std::vector<uint8_t>& data) const;
     private:
-        BCRYPT_HASH_HANDLE _hash{ nullptr };
-        std::vector<uint8_t> hash_object;
-        std::vector<uint8_t> hash_buffer;
+        void create_hash() const;
+
+        mutable BCRYPT_HASH_HANDLE _hash{ nullptr };
+        mutable std::vector<uint8_t> hash_object;
+        mutable std::vector<uint8_t> hash_buffer;
     };
 }

--- a/trlevel/trlevel.vcxproj
+++ b/trlevel/trlevel.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{8FFB19FA-1C9D-4D9C-AB96-844BF695E79C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trlevel</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.app.tests/trview.app.tests.vcxproj
+++ b/trview.app.tests/trview.app.tests.vcxproj
@@ -118,7 +118,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{5305889D-8CCB-4A81-B77E-D46F03131114}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.app.ui.tests/trview.app.ui.tests.vcxproj
+++ b/trview.app.ui.tests/trview.app.ui.tests.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{6c2653fe-19d4-4696-924f-c313ecbc69b2}</ProjectGuid>
     <RootNamespace>trviewappuitests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.app/trview.app.vcxproj
+++ b/trview.app/trview.app.vcxproj
@@ -463,7 +463,7 @@ copy ""$(OutDir)*.cso"" ""$(ProjectDir)Resources\Generated""</Command>
     <ProjectGuid>{A087AF08-5371-47DE-A896-AFA21DD9D383}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewapp</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.common.tests/trview.common.tests.vcxproj
+++ b/trview.common.tests/trview.common.tests.vcxproj
@@ -40,7 +40,7 @@
     <ProjectGuid>{9BBDFA49-4033-49B3-8EE2-E75C5950D5B0}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewcommontests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.common/trview.common.vcxproj
+++ b/trview.common/trview.common.vcxproj
@@ -92,7 +92,7 @@
     <ProjectGuid>{D0633291-23A6-4B3F-9A5E-E94D20F66A07}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewcommon</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.graphics.tests/trview.graphics.tests.vcxproj
+++ b/trview.graphics.tests/trview.graphics.tests.vcxproj
@@ -32,7 +32,7 @@
     <ProjectGuid>{6E6B151D-DF48-4FE2-B7AF-2D07FB3451D2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewgraphicstests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.graphics/trview.graphics.vcxproj
+++ b/trview.graphics/trview.graphics.vcxproj
@@ -91,7 +91,7 @@
     <ProjectGuid>{3270FD29-EDAB-40BE-8CA1-DABC5E261E4C}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewgraphics</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.input.tests/trview.input.tests.vcxproj
+++ b/trview.input.tests/trview.input.tests.vcxproj
@@ -37,7 +37,7 @@
     <PlatformToolset>v145</PlatformToolset>
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/trview.input/trview.input.vcxproj
+++ b/trview.input/trview.input.vcxproj
@@ -39,7 +39,7 @@
     <ProjectGuid>{0B28C3CD-D28A-4923-9577-50EB1EE29212}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewinput</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.lau/trview.lau.vcxproj
+++ b/trview.lau/trview.lau.vcxproj
@@ -15,7 +15,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{2ac76373-f9a6-426d-b732-80e6bd6bfab4}</ProjectGuid>
     <RootNamespace>trviewlau</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.lua.imgui/trview.lua.imgui.vcxproj
+++ b/trview.lua.imgui/trview.lua.imgui.vcxproj
@@ -33,7 +33,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{cdbc4705-e8e2-4c5c-a1a6-ea66fe4b699b}</ProjectGuid>
     <RootNamespace>trviewluaimgui</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.shaders/trview.shaders.vcxproj
+++ b/trview.shaders/trview.shaders.vcxproj
@@ -14,7 +14,7 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{9E86C96A-6192-462C-A2A2-263990A53C1F}</ProjectGuid>
     <RootNamespace>trviewshaders</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview.tests.common/trview.tests.common.vcxproj
+++ b/trview.tests.common/trview.tests.common.vcxproj
@@ -26,7 +26,7 @@
     <ProjectGuid>{3AB44A93-DBBA-405E-8164-E5B20866EE1D}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trviewtestscommon</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">

--- a/trview/trview.vcxproj
+++ b/trview/trview.vcxproj
@@ -15,7 +15,7 @@
     <ProjectGuid>{8406D3CD-8C08-45C2-AF2C-844014A687A1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>trview</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.19041.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">


### PR DESCRIPTION
Target old Windows SDK `10.0.19041.0`
Only use `BCRYPT_HASH_REUSABLE_FLAG` if on Win8 or later.
Only use the pseudo algo handles if on Win10 or later.
Closes #1609 