### PR TITLE
Update to version 2.9.2

### DIFF
--- a/trview.app.ui.tests/trview.app.ui.tests.vcxproj
+++ b/trview.app.ui.tests/trview.app.ui.tests.vcxproj
@@ -166,7 +166,10 @@
     <ClCompile Include="PluginsWindowTests.cpp" />
     <ClCompile Include="RoomNavigatorTests.cpp" />
     <ClCompile Include="RoomsWindowTests.cpp" />
-    <ClCompile Include="RouteWindowTests.cpp" />
+    <ClCompile Include="RouteWindowTests.cpp">
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'">/bigobj %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
     <ClCompile Include="SettingsWindowTests.cpp" />
     <ClCompile Include="StaticsWindowTests.cpp" />
     <ClCompile Include="TestHelpers.cpp" />

--- a/trview.app/Resources/trview.app.rc
+++ b/trview.app/Resources/trview.app.rc
@@ -73,7 +73,7 @@ BEGIN
         MENUITEM "Camera/Sink\tCtrl+K"          ID_WINDOWS_CAMERA_SINK
         MENUITEM "Log"                          ID_WINDOWS_LOG
         MENUITEM "Textures"                     ID_WINDOWS_TEXTURES
-        MENUITEM "Console\tF11"                 ID_WINDOWS_CONSOLE
+        MENUITEM "Console\tF9"                 ID_WINDOWS_CONSOLE
         MENUITEM "Plugins\tCtrl+P"              ID_WINDOWS_PLUGINS
         MENUITEM "Statics\tCtrl+S"              ID_WINDOWS_STATICS
         MENUITEM "Sounds"                       ID_WINDOWS_SOUNDS
@@ -164,8 +164,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,9,1,0
- PRODUCTVERSION 2,9,1,0
+ FILEVERSION 2,9,2,0
+ PRODUCTVERSION 2,9,2,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -181,12 +181,12 @@ BEGIN
         BLOCK "080904b0"
         BEGIN
             VALUE "FileDescription", "TRView"
-            VALUE "FileVersion", "2.9.1.0"
+            VALUE "FileVersion", "2.9.2.0"
             VALUE "InternalName", "trview.exe"
             VALUE "LegalCopyright", "Copyright (C) chreden 2026"
             VALUE "OriginalFilename", "trview.exe"
             VALUE "ProductName", "TRView"
-            VALUE "ProductVersion", "2.9.1.0"
+            VALUE "ProductVersion", "2.9.2.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/trview.common/Version.ixx
+++ b/trview.common/Version.ixx
@@ -6,6 +6,6 @@ namespace trview
 {
     export constexpr std::string version()
     {
-        return "2.9.1";
+        return "2.9.2";
     }
 }


### PR DESCRIPTION
Also add `/bigobj` to route window tests since it needs it now apparently.
Update console shortcut in menu after it was changed.
Closes #1617