### PR TITLE
Add scopes for registrations to Lua tests

### DIFF
--- a/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
+++ b/trview.app.tests/Lua/Elements/Lua_LevelTests.cpp
@@ -18,7 +18,7 @@ TEST(Lua_Level, AddScriptable)
     EXPECT_CALL(*level, add_scriptable).Times(1);
 
     LuaState L;
-    lua::scriptable_register(L, [](auto&&) { return mock_shared<MockScriptable>(); });
+    const reg_scope<lua::scriptable_register, lua::scriptable_unregister> scriptable_scope(L, [](auto&&) { return mock_shared<MockScriptable>(); });
     lua::level_register(L);
     lua::create_level(L, level);
     lua_setglobal(L, "l");
@@ -206,7 +206,7 @@ TEST(Lua_Level, RemoveScriptable)
     EXPECT_CALL(*level, remove_scriptable).Times(1);
 
     LuaState L;
-    lua::scriptable_register(L, [](auto&&) { return mock_shared<MockScriptable>(); });
+    const reg_scope<lua::scriptable_register, lua::scriptable_unregister> scriptable_scope(L, [](auto&&) { return mock_shared<MockScriptable>(); });
     lua::level_register(L);
     lua::create_level(L, level);
     lua_setglobal(L, "l");

--- a/trview.app.tests/Lua/Lua.h
+++ b/trview.app.tests/Lua/Lua.h
@@ -13,6 +13,21 @@ namespace trview
             operator lua_State* ();
             lua_State* L;
         };
+
+        // Helper to call Lua register functions and clean up afterwards
+        template <auto register_func, auto clear_func>
+        struct reg_scope
+        {
+            reg_scope(auto&&... args)
+            {
+                register_func(args...);
+            }
+
+            ~reg_scope()
+            {
+                clear_func();
+            }
+        };
     }
 }
 

--- a/trview.app.tests/Lua/Lua_trviewTests.cpp
+++ b/trview.app.tests/Lua/Lua_trviewTests.cpp
@@ -24,7 +24,7 @@ TEST(Lua_trview, Camera)
     ON_CALL(*application, viewer).WillByDefault(Return(viewer));
 
     LuaState L;
-    lua::trview_register(L, application.get(),
+    const reg_scope<lua::trview_register, lua::trview_unregister> trview_scope(L, application.get(),
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
@@ -46,7 +46,7 @@ TEST(Lua_trview, Level)
     EXPECT_CALL(*application, current_level).WillRepeatedly(Return(level));
 
     LuaState L;
-    lua::trview_register(L, application.get(), 
+    const reg_scope<lua::trview_register, lua::trview_unregister> trview_scope(L, application.get(),
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
@@ -71,7 +71,7 @@ TEST(Lua_trview, RecentFiles)
     EXPECT_CALL(*application, settings).WillRepeatedly(Return(settings));
 
     LuaState L;
-    lua::trview_register(L, application.get(),
+    const reg_scope<lua::trview_register, lua::trview_unregister> trview_scope(L, application.get(),
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
@@ -96,7 +96,7 @@ TEST(Lua_trview, SetLevel)
     EXPECT_CALL(*application, set_current_level).Times(1);
 
     LuaState L;
-    lua::trview_register(L, application.get(),
+    const reg_scope<lua::trview_register, lua::trview_unregister> trview_scope(L, application.get(),
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
@@ -119,7 +119,7 @@ TEST(Lua_trview, Route)
     EXPECT_CALL(*application, route).Times(1).WillRepeatedly(Return(route));
 
     LuaState L;
-    lua::trview_register(L, application.get(),
+    const reg_scope<lua::trview_register, lua::trview_unregister> trview_scope(L, application.get(),
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },
@@ -138,7 +138,7 @@ TEST(Lua_trview, SetRoute)
     EXPECT_CALL(*application, set_route).Times(1);
 
     LuaState L;
-    lua::trview_register(L, application.get(),
+    const reg_scope<lua::trview_register, lua::trview_unregister> trview_scope(L, application.get(),
         [](auto&&) { return mock_shared<MockRoute>(); },
         [](auto&&) { return mock_shared<MockRandomizerRoute>(); },
         [](auto&&...) { return mock_shared<MockWaypoint>(); },

--- a/trview.app.tests/Lua/Mesh/Lua_MeshTests.cpp
+++ b/trview.app.tests/Lua/Mesh/Lua_MeshTests.cpp
@@ -19,7 +19,7 @@ TEST(Lua_Mesh, Constructor)
 
     LuaState L;
     lua::triangle_register(L);
-    lua::mesh_register(L, mesh_source);
+    const reg_scope<lua::mesh_register, lua::mesh_unregister> mesh_scope(L, mesh_source);
 
     ASSERT_EQ(0, luaL_dostring(L, "x = Mesh({triangles = {}}) return x"));
     ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));

--- a/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
+++ b/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
@@ -13,14 +13,28 @@ using namespace trview::mocks;
 using namespace trview::tests;
 using namespace testing;
 
+namespace
+{
+    std::shared_ptr<IRoute> default_route(std::optional<IRoute::FileData>)
+    {
+        return mock_shared<MockRoute>();
+    }
+
+    std::shared_ptr<IRandomizerRoute> default_rando_route(std::optional<IRandomizerRoute::FileData>)
+    {
+        return mock_shared<MockRandomizerRoute>();
+    }
+}
+
 TEST(Lua_Route, Add)
 {
     auto route = mock_shared<MockRoute>();
     EXPECT_CALL(*route, add(A<const std::shared_ptr<IWaypoint>&>())).Times(1);
 
     LuaState L;
-    lua::waypoint_register(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+
     lua::create_waypoint(L, mock_shared<MockWaypoint>());
     lua_setglobal(L, "w");
     lua::create_route(L, route);
@@ -35,7 +49,7 @@ TEST(Lua_Route, Clear)
     EXPECT_CALL(*route, clear).Times(1);
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -48,7 +62,7 @@ TEST(Lua_Route, Colour)
     EXPECT_CALL(*route, colour).Times(1).WillOnce(Return(Colour(1, 2, 3, 4)));
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::colour_register(L);
     lua::create_route(L, route);
     lua_setglobal(L, "r");
@@ -63,7 +77,7 @@ TEST(Lua_Route, IsRandomizer)
     auto rando_route = mock_shared<MockRandomizerRoute>();
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return mock_shared<MockRoute>(); }, [=](auto&&...){ return rando_route; }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::create_route(L, rando_route);
     lua_setglobal(L, "r");
 
@@ -88,8 +102,8 @@ TEST(Lua_Route, Level)
     EXPECT_CALL(*route, level).WillRepeatedly(Return(level));
 
     LuaState L;
-    lua::level_register(L);
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::level_register, lua::level_unregister> level_scope(L);
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -103,7 +117,7 @@ TEST(Lua_Route, New)
     auto route = mock_shared<MockRoute>();
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, [=](auto&&...) { return route; }, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
 
     ASSERT_EQ(0, luaL_dostring(L, "r = Route.new() return r"));
     ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
@@ -115,7 +129,7 @@ TEST(Lua_Route, NewRandoRoute)
     auto route = mock_shared<MockRandomizerRoute>();
 
     LuaState L;
-    lua::route_register(L, [](auto&&...) { return mock_shared<MockRoute>(); }, [=](auto&&...) { return route; }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, [=](auto&&...) { return route; }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
 
     ASSERT_EQ(0, luaL_dostring(L, "r = Route.new({is_randomizer = true}) return r"));
     ASSERT_EQ(LUA_TUSERDATA, lua_type(L, -1));
@@ -128,7 +142,7 @@ TEST(Lua_Route, Reload)
     EXPECT_CALL(*route, reload);
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -141,8 +155,8 @@ TEST(Lua_Route, Remove)
     EXPECT_CALL(*route, remove(A<const std::shared_ptr<IWaypoint>&>())).Times(1);
 
     LuaState L;
-    lua::waypoint_register(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::create_waypoint(L, mock_shared<MockWaypoint>());
     lua_setglobal(L, "w");
     lua::create_route(L, route);
@@ -158,7 +172,7 @@ TEST(Lua_Route, Save)
     EXPECT_CALL(*route, save).Times(1);
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -172,7 +186,7 @@ TEST(Lua_Route, SaveNoFilename)
     EXPECT_CALL(*route, set_filename).Times(0);
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -189,7 +203,7 @@ TEST(Lua_Route, SaveChooseFile)
     EXPECT_CALL(*dialogs, save_file).WillRepeatedly(Return(IDialogs::FileResult{ .filename = "test", .filter_index = 1 }));
 
     LuaState L;
-    lua::route_register(L, [](auto&&...) { return mock_shared<MockRoute>(); }, [](auto&&...) { return mock_shared<MockRandomizerRoute>(); }, dialogs, mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, dialogs, mock_shared<MockFiles>());
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -206,11 +220,7 @@ TEST(Lua_Route, SaveAsWithFileAllowed)
     EXPECT_CALL(*dialogs, save_file).WillRepeatedly(Return(IDialogs::FileResult{.filename = "test", .filter_index = 1 }));
 
     LuaState L;
-    lua::route_register(L,
-        [](auto&&...) { return mock_shared<MockRoute>(); },
-        [](auto&&...) { return mock_shared<MockRandomizerRoute>(); },
-        dialogs,
-        mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, dialogs, mock_shared<MockFiles>());
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -227,7 +237,7 @@ TEST(Lua_Route, SaveAsWithFileRejected)
     EXPECT_CALL(*dialogs, save_file).WillRepeatedly(Return(IDialogs::FileResult{.filename = "test", .filter_index = 1 }));
 
     LuaState L;
-    lua::route_register(L, [](auto&&...) { return mock_shared<MockRoute>(); }, [](auto&&...) { return mock_shared<MockRandomizerRoute>(); }, dialogs, mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, dialogs, mock_shared<MockFiles>());
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -243,7 +253,7 @@ TEST(Lua_Route, SaveAsChoosesFile)
     EXPECT_CALL(*dialogs, save_file).WillRepeatedly(Return(IDialogs::FileResult{.filename = "test", .filter_index = 1 }));
 
     LuaState L;
-    lua::route_register(L, [](auto&&...) { return mock_shared<MockRoute>(); }, [](auto&&...) { return mock_shared<MockRandomizerRoute>(); }, dialogs, mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, dialogs, mock_shared<MockFiles>());
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -258,8 +268,8 @@ TEST(Lua_Route, SelectedWaypoint)
     ON_CALL(*route, waypoint(2)).WillByDefault(Return(waypoint));
 
     LuaState L;
-    lua::waypoint_register(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -275,7 +285,7 @@ TEST(Lua_Route, SetColour)
     EXPECT_CALL(*route, set_colour).Times(1).WillRepeatedly(SaveArg<0>(&called_colour));
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::colour_register(L);
     lua::create_route(L, route);
     lua_setglobal(L, "r");
@@ -297,7 +307,8 @@ TEST(Lua_Route, SetLevel)
     EXPECT_CALL(*route, set_level).WillRepeatedly(SaveArg<0>(&value));
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::level_register, lua::level_unregister> level_scope(L);
     lua::create_route(L, route);
     lua_setglobal(L, "r");
     lua::create_level(L, level);
@@ -320,7 +331,8 @@ TEST(Lua_Route, SetSelectedWaypoint)
     EXPECT_CALL(*route, select_waypoint).Times(1);
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_route(L, route);
     lua_setglobal(L, "r");
     lua::create_waypoint(L, waypoint);
@@ -337,7 +349,7 @@ TEST(Lua_Route, SetWaypointColour)
     EXPECT_CALL(*route, set_waypoint_colour).Times(1).WillRepeatedly(SaveArg<0>(&called_colour));
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::colour_register(L);
     lua::create_route(L, route);
     lua_setglobal(L, "r");
@@ -360,7 +372,8 @@ TEST(Lua_Route, SetWaypoints)
     EXPECT_CALL(*route, add(Eq(waypoint2)));
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_route(L, route);
     lua_setglobal(L, "r");
     lua::create_waypoint(L, waypoint1);
@@ -377,7 +390,7 @@ TEST(Lua_Route, SetShowRouteLine)
     EXPECT_CALL(*route, set_show_route_line(true));
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -390,7 +403,7 @@ TEST(Lua_Route, ShowRouteLine)
     EXPECT_CALL(*route, show_route_line).WillOnce(Return(true));
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 
@@ -405,7 +418,7 @@ TEST(Lua_Route, WaypointColour)
     EXPECT_CALL(*route, waypoint_colour).Times(1).WillOnce(Return(Colour(1, 2, 3, 4)));
 
     LuaState L;
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::colour_register(L);
     lua::create_route(L, route);
     lua_setglobal(L, "r");
@@ -428,8 +441,8 @@ TEST(Lua_Route, Waypoints)
     ON_CALL(*route, waypoint(1)).WillByDefault(Return(waypoint2));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return waypoint1; });
-    lua::route_register(L, [=](auto&&...) { return route; }, [](auto&&...){ return mock_shared<MockRandomizerRoute>(); }, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_route(L, route);
     lua_setglobal(L, "r");
 

--- a/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
+++ b/trview.app.tests/Lua/Route/Lua_RouteTests.cpp
@@ -102,7 +102,7 @@ TEST(Lua_Route, Level)
     EXPECT_CALL(*route, level).WillRepeatedly(Return(level));
 
     LuaState L;
-    const reg_scope<lua::level_register, lua::level_unregister> level_scope(L);
+    lua::level_register(L);
     const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
     lua::create_route(L, route);
     lua_setglobal(L, "r");
@@ -308,7 +308,7 @@ TEST(Lua_Route, SetLevel)
 
     LuaState L;
     const reg_scope<lua::route_register, lua::route_unregister> route_scope(L, default_route, default_rando_route, mock_shared<MockDialogs>(), mock_shared<MockFiles>());
-    const reg_scope<lua::level_register, lua::level_unregister> level_scope(L);
+    lua::level_register(L);
     lua::create_route(L, route);
     lua_setglobal(L, "r");
     lua::create_level(L, level);

--- a/trview.app.tests/Lua/Route/Lua_WaypointTests.cpp
+++ b/trview.app.tests/Lua/Route/Lua_WaypointTests.cpp
@@ -19,7 +19,7 @@ TEST(Lua_Waypoint, Colour)
     EXPECT_CALL(*waypoint, route_colour).WillRepeatedly(Return(Colour(1, 0.5f, 0.25f)));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::colour_register(L);
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
@@ -38,7 +38,7 @@ TEST(Lua_Waypoint, Item)
 
     LuaState L;
     lua::item_register(L);
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -52,7 +52,7 @@ TEST(Lua_Waypoint, Normal)
     EXPECT_CALL(*waypoint, normal).WillRepeatedly(Return(Vector3(1, 2, 3)));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::vector3_register(L);
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
@@ -65,14 +65,13 @@ TEST(Lua_Waypoint, Normal)
 TEST(Lua_Waypoint, NewItem)
 {
     auto waypoint = mock_shared<MockWaypoint>();
-    std::weak_ptr<IWaypoint> weak_waypoint = waypoint;
     EXPECT_CALL(*waypoint, set_item).Times(1);
 
     auto item = mock_shared<MockItem>();
 
     LuaState L;
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [=](auto&&...) { return waypoint; });
     lua::item_register(L);
-    lua::waypoint_register(L, [=](auto&&...) { return weak_waypoint.lock(); });
     lua::create_item(L, item);
     lua_setglobal(L, "i");
 
@@ -84,7 +83,6 @@ TEST(Lua_Waypoint, NewItem)
 TEST(Lua_Waypoint, NewPosition)
 {
     auto waypoint = mock_shared<MockWaypoint>();
-    std::weak_ptr<IWaypoint> weak_waypoint = waypoint;
     auto room = mock_shared<MockRoom>();
     EXPECT_CALL(*room, number);
 
@@ -95,7 +93,7 @@ TEST(Lua_Waypoint, NewPosition)
     lua::room_register(L);
     lua::create_room(L, room);
     lua_setglobal(L, "r");
-    lua::waypoint_register(L, [&](auto&& pos, auto&&...) { position = pos; return weak_waypoint.lock(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [&](auto&& pos, auto&&...) { position = pos; return waypoint; });
 
     ASSERT_EQ(0, luaL_dostring(L, "w = Waypoint.new({position=Vector3.new(1024, 2048, 3072), room=r})"));
     ASSERT_EQ(0, luaL_dostring(L, "return w"));
@@ -108,7 +106,6 @@ TEST(Lua_Waypoint, NewPosition)
 TEST(Lua_Waypoint, NewSector)
 {
     auto waypoint = mock_shared<MockWaypoint>();
-    std::weak_ptr<IWaypoint> weak_waypoint = waypoint;
     auto room = mock_shared<MockRoom>();
 
     auto sector = mock_shared<MockSector>();
@@ -122,7 +119,7 @@ TEST(Lua_Waypoint, NewSector)
     lua::vector3_register(L);
     lua::create_sector(L, sector);
     lua_setglobal(L, "s");
-    lua::waypoint_register(L, [&](auto&& pos, auto&&...) { position = pos; return weak_waypoint.lock(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [&](auto&& pos, auto&&...) { position = pos; return waypoint; });
 
     ASSERT_EQ(0, luaL_dostring(L, "w = Waypoint.new({sector=s})"));
     ASSERT_EQ(0, luaL_dostring(L, "return w"));
@@ -135,14 +132,13 @@ TEST(Lua_Waypoint, NewSector)
 TEST(Lua_Waypoint, NewTrigger)
 {
     auto waypoint = mock_shared<MockWaypoint>();
-    std::weak_ptr<IWaypoint> weak_waypoint = waypoint;
     EXPECT_CALL(*waypoint, set_trigger).Times(1);
 
     auto trigger = mock_shared<MockTrigger>();
 
     LuaState L;
     lua::trigger_register(L);
-    lua::waypoint_register(L, [=](auto&&...) { return weak_waypoint.lock(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [=](auto&&...) { return waypoint; });
     lua::create_trigger(L, trigger);
     lua_setglobal(L, "t");
 
@@ -157,7 +153,7 @@ TEST(Lua_Waypoint, Notes)
     EXPECT_CALL(*waypoint, notes).WillOnce(Return("These are the notes"));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -172,7 +168,7 @@ TEST(Lua_Waypoint, Position)
     EXPECT_CALL(*waypoint, position).WillRepeatedly(Return(Vector3(1, 2, 3)));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::vector3_register(L);
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
@@ -202,7 +198,7 @@ TEST(Lua_Waypoint, RandomizerSettings)
     EXPECT_CALL(*waypoint, randomizer_settings).WillRepeatedly(Return(waypoint_settings));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -232,7 +228,7 @@ TEST(Lua_Waypoint, Room)
     EXPECT_CALL(*waypoint, room).WillOnce(Return(123));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::room_register(L);
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
@@ -248,7 +244,7 @@ TEST(Lua_Waypoint, RoomNumber)
     EXPECT_CALL(*waypoint, room).WillOnce(Return(123));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -263,7 +259,7 @@ TEST(Lua_Waypoint, SetColour)
     EXPECT_CALL(*waypoint, set_route_colour(Colour(1, 2, 3)));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::colour_register(L);
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
@@ -280,7 +276,7 @@ TEST(Lua_Waypoint, SetItem)
 
     LuaState L;
     lua::item_register(L);
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
     lua::create_item(L, item);
@@ -295,7 +291,7 @@ TEST(Lua_Waypoint, SetNormal)
     EXPECT_CALL(*waypoint, set_normal(Vector3(1, 2, 3)));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::vector3_register(L);
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
@@ -309,7 +305,7 @@ TEST(Lua_Waypoint, SetNotes)
     EXPECT_CALL(*waypoint, set_notes("New notes"));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -322,7 +318,7 @@ TEST(Lua_Waypoint, SetPosition)
     EXPECT_CALL(*waypoint, set_position(Vector3(1, 2, 3)));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::vector3_register(L);
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
@@ -349,7 +345,7 @@ TEST(Lua_Waypoint, SetRandomizerSettings)
     EXPECT_CALL(*waypoint, set_randomizer_settings).Times(AtLeast(1)).WillRepeatedly(SaveArg<0>(&called_settings));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -367,17 +363,15 @@ TEST(Lua_Waypoint, SetRoom)
     auto waypoint = mock_shared<MockWaypoint>();
     EXPECT_CALL(*waypoint, set_room_number(123)).Times(1);
 
-    {
-        LuaState L;
-        lua::room_register(L);
-        lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
-        lua::create_waypoint(L, waypoint);
-        lua_setglobal(L, "w");
-        lua::create_room(L, room);
-        lua_setglobal(L, "r");
+    LuaState L;
+    lua::room_register(L);
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
+    lua::create_waypoint(L, waypoint);
+    lua_setglobal(L, "w");
+    lua::create_room(L, room);
+    lua_setglobal(L, "r");
 
-        ASSERT_EQ(0, luaL_dostring(L, "w.room = r"));
-    }
+    ASSERT_EQ(0, luaL_dostring(L, "w.room = r"));
 }
 
 TEST(Lua_Waypoint, SetRoomNumber)
@@ -386,7 +380,7 @@ TEST(Lua_Waypoint, SetRoomNumber)
     EXPECT_CALL(*waypoint, set_room_number(100));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -402,7 +396,7 @@ TEST(Lua_Waypoint, SetTrigger)
 
     LuaState L;
     lua::trigger_register(L);
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
     lua::create_trigger(L, trigger);
@@ -417,7 +411,7 @@ TEST(Lua_Waypoint, SetWaypointColour)
     EXPECT_CALL(*waypoint, set_waypoint_colour(Colour(1, 2, 3)));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::colour_register(L);
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
@@ -434,7 +428,7 @@ TEST(Lua_Waypoint, Trigger)
 
     LuaState L;
     lua::trigger_register(L);
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -448,7 +442,7 @@ TEST(Lua_Waypoint, Type)
     EXPECT_CALL(*waypoint, type).WillOnce(Return(IWaypoint::Type::Trigger));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");
 
@@ -463,7 +457,7 @@ TEST(Lua_Waypoint, WaypointColour)
     EXPECT_CALL(*waypoint, waypoint_colour).WillRepeatedly(Return(Colour(1, 0.5f, 0.25f)));
 
     LuaState L;
-    lua::waypoint_register(L, [=](auto&&...) { return mock_shared<MockWaypoint>(); });
+    const reg_scope<lua::waypoint_register, lua::waypoint_unregister> waypoint_scope(L, [](auto&&...) { return mock_shared<MockWaypoint>(); });
     lua::colour_register(L);
     lua::create_waypoint(L, waypoint);
     lua_setglobal(L, "w");

--- a/trview.app/Lua/Elements/Level/Lua_Level.ixx
+++ b/trview.app/Lua/Elements/Level/Lua_Level.ixx
@@ -9,10 +9,10 @@ import :ILevel;
 
 namespace trview
 {
-    namespace lua
+    export namespace lua
     {
-        export void level_register(lua_State* L);
-        export int create_level(lua_State* L, const std::shared_ptr<ILevel>& level);
-        export std::shared_ptr<ILevel> to_level(lua_State* L, int index);
+        void level_register(lua_State* L);
+        int create_level(lua_State* L, const std::shared_ptr<ILevel>& level);
+        std::shared_ptr<ILevel> to_level(lua_State* L, int index);
     }
 }

--- a/trview.app/Lua/Mesh/Lua_Mesh.cpp
+++ b/trview.app/Lua/Mesh/Lua_Mesh.cpp
@@ -56,5 +56,10 @@ namespace trview
                 });
             lua_setglobal(L, "Mesh");
         }
+
+        void mesh_unregister()
+        {
+            mesh_source = nullptr;
+        }
     }
 }

--- a/trview.app/Lua/Mesh/Lua_Mesh.ixx
+++ b/trview.app/Lua/Mesh/Lua_Mesh.ixx
@@ -10,9 +10,10 @@ import :IMesh;
 
 namespace trview
 {
-    namespace lua
+    export namespace lua
     {
-        export int create_mesh(lua_State* L, const std::shared_ptr<IMesh>& mesh);
-        export void mesh_register(lua_State* L, const IMesh::Source& source);
+        int create_mesh(lua_State* L, const std::shared_ptr<IMesh>& mesh);
+        void mesh_register(lua_State* L, const IMesh::Source& source);
+        void mesh_unregister();
     }
 }

--- a/trview.app/Lua/Route/Lua_Route.cpp
+++ b/trview.app/Lua/Route/Lua_Route.cpp
@@ -350,6 +350,14 @@ namespace trview
             lua_setglobal(L, "Route");
         }
 
+        void route_unregister()
+        {
+            route_source = nullptr;
+            randomizer_route_source = nullptr;
+            dialogs.reset();
+            files.reset();
+        }
+
         void route_set_settings(const UserSettings& new_settings)
         {
             user_settings = new_settings;

--- a/trview.app/Lua/Route/Lua_Route.ixx
+++ b/trview.app/Lua/Route/Lua_Route.ixx
@@ -13,11 +13,12 @@ import :IRandomizerRoute;
 
 namespace trview
 {
-    namespace lua
+    export namespace lua
     {
-        export int create_route(lua_State* L, const std::shared_ptr<IRoute>& route);
-        export std::shared_ptr<IRoute> to_route(lua_State* L, int index);
-        export void route_register(lua_State* L, const IRoute::Source& source, const IRandomizerRoute::Source& randomizer_source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
-        export void route_set_settings(const UserSettings& new_settings);
+        int create_route(lua_State* L, const std::shared_ptr<IRoute>& route);
+        std::shared_ptr<IRoute> to_route(lua_State* L, int index);
+        void route_register(lua_State* L, const IRoute::Source& source, const IRandomizerRoute::Source& randomizer_source, const std::shared_ptr<IDialogs>& dialogs, const std::shared_ptr<IFiles>& files);
+        void route_unregister();
+        void route_set_settings(const UserSettings& new_settings);
     }
 }

--- a/trview.app/Lua/Route/Lua_Waypoint.cpp
+++ b/trview.app/Lua/Route/Lua_Waypoint.cpp
@@ -397,6 +397,11 @@ namespace trview
             lua_setglobal(L, "Waypoint");
         }
 
+        void waypoint_unregister()
+        {
+            waypoint_source = nullptr;
+        }
+
         std::shared_ptr<IWaypoint> to_waypoint(lua_State* L, int index)
         {
             return get_userdata<std::shared_ptr<IWaypoint>>(L, index);

--- a/trview.app/Lua/Route/Lua_Waypoint.ixx
+++ b/trview.app/Lua/Route/Lua_Waypoint.ixx
@@ -11,12 +11,13 @@ import :UserSettings;
 
 namespace trview
 {
-    namespace lua
+    export namespace lua
     {
-        export int create_waypoint(lua_State* L, const std::shared_ptr<IWaypoint>& waypoint);
-        export void waypoint_register(lua_State* L, IWaypoint::Source source);
-        export std::shared_ptr<IWaypoint> to_waypoint(lua_State* L, int index);
-        export void waypoint_set_settings(const UserSettings& settings);
+        int create_waypoint(lua_State* L, const std::shared_ptr<IWaypoint>& waypoint);
+        void waypoint_register(lua_State* L, IWaypoint::Source source);
+        void waypoint_unregister();
+        std::shared_ptr<IWaypoint> to_waypoint(lua_State* L, int index);
+        void waypoint_set_settings(const UserSettings& settings);
     }
 }
 

--- a/trview.app/Lua/Scriptable/IScriptable.ixx
+++ b/trview.app/Lua/Scriptable/IScriptable.ixx
@@ -40,10 +40,11 @@ namespace trview
         Event<> on_changed;
     };
 
-    namespace lua
+    export namespace lua
     {
-        export int create_scriptable(lua_State* L, const std::shared_ptr<IScriptable>& scriptable);
-        export void scriptable_register(lua_State* L, const IScriptable::Source& source);
-        export std::shared_ptr<IScriptable> to_scriptable(lua_State* L, int index);
+        int create_scriptable(lua_State* L, const std::shared_ptr<IScriptable>& scriptable);
+        void scriptable_register(lua_State* L, const IScriptable::Source& source);
+        void scriptable_unregister();
+        std::shared_ptr<IScriptable> to_scriptable(lua_State* L, int index);
     }
 }

--- a/trview.app/Lua/Scriptable/Scriptable.cpp
+++ b/trview.app/Lua/Scriptable/Scriptable.cpp
@@ -115,6 +115,11 @@ namespace trview
             lua_setglobal(L, "Scriptable");
         }
 
+        void scriptable_unregister()
+        {
+            scriptable_source = nullptr;
+        }
+
         std::shared_ptr<IScriptable> to_scriptable(lua_State* L, int index)
         {
             return get_userdata<std::shared_ptr<IScriptable>>(L, index);

--- a/trview.app/Lua/trview/trview.cpp
+++ b/trview.app/Lua/trview/trview.cpp
@@ -196,6 +196,14 @@ namespace trview
             trigger_register(L);
         }
 
+        void trview_unregister()
+        {
+            route_unregister();
+            waypoint_unregister();
+            scriptable_unregister();
+            mesh_unregister();
+        }
+
         void set_settings(const UserSettings& settings)
         {
             waypoint_set_settings(settings);

--- a/trview.app/Lua/trview/trview.ixx
+++ b/trview.app/Lua/trview/trview.ixx
@@ -15,9 +15,9 @@ import :Forward;
 
 namespace trview
 {
-    namespace lua
+    export namespace lua
     {
-        export void trview_register(lua_State* L,
+        void trview_register(lua_State* L,
             IApplication* application,
             const IRoute::Source& route_source,
             const IRandomizerRoute::Source& randomizer_route_source,
@@ -26,6 +26,7 @@ namespace trview
             const std::shared_ptr<IDialogs>& dialogs,
             const std::shared_ptr<IFiles>& files,
             const IMesh::Source& mesh_source);
-        export void set_settings(const UserSettings& settings);
+        void trview_unregister();
+        void set_settings(const UserSettings& settings);
     }
 }


### PR DESCRIPTION
Add a scope helper that will unregister Lua registrations (mostly).
The main thing that needs unregistering are the source functions as they can keep mocks alive, causing tests to fail in the next test when ran in sequence.
#1619